### PR TITLE
Feedback: push docs to gh pages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -198,8 +198,8 @@ node {
             ])
         }
         
-        if ( "${env.BRANCH_NAME}" == "test/jenkins-gh-pages") {
-            stage('Push doc to gh-pages') {
+        if ( "${env.BRANCH_NAME}" == "feature/push-docs-to-gh-pages") {
+            stage('Push generated Doxygen HTML to gh-pages') {
                 dir('gh-pages') {                    
                     git branch: 'gh-pages', 
                         changelog: false, 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -214,7 +214,7 @@ node {
                                 git rm -r --ignore-unmatch doc-master 
                             fi
                             
-                            cp -R ../build/doc/inviwo doc-master
+                            cp -R ../build/doc/inviwo/html doc-master
                             git add . 
                             git commit -m "Doxygen update from jenkins"                           
                         """

--- a/tools/doxygen/doxygen.cmake
+++ b/tools/doxygen/doxygen.cmake
@@ -214,6 +214,7 @@ DOT_CLEANUP            = YES
 PREDEFINED             = DOXYGEN_SHOULD_SKIP_THIS
 SHOW_INCLUDE_FILES     = YES
 ALPHABETICAL_INDEX     = YES
+HTML_TIMESTAMP         = YES
 
 ${additional_flags}
 ")


### PR DESCRIPTION
**This PR is not for merging, its for feedback/discussion**

I did some experimenting with getting the master branch pipeline build to automatically update the doxygen pages on out github pages. 

The changes in the jenkinsfile adds a stage when building on specific branch. The stage  checksout the gh-pages, copied the generated doxygen files, add, commits and puhses to the gh-pages branch. 

This means we have would have the doxygen doc on out github pages that are allways up to date with master.   In addition, I have added a landing page that links to the latest docs and the docs for releases. (https://inviwo.github.io/inviwo/)

What we need to do before this could be merged is: 
* FIx a jenkins github user, now it looks like peter is pushing :) 
* Change  `if ( "${env.BRANCH_NAME}" == "feature/push-docs-to-gh-pages") {` to use master 

