### PR TITLE
Doxygen: Added a separate target for generating previews

### DIFF
--- a/tools/doxygen/doxygen.cmake
+++ b/tools/doxygen/doxygen.cmake
@@ -423,7 +423,7 @@ function(make_doxygen_target modules_var)
     add_custom_target("DOXY-generate-processor-previews"
         COMMAND inviwo --save-previews "${output_dir}/inviwo/html" --quit
         WORKING_DIRECTORY ${output_dir}
-        COMMENT "Generating Inviwo API documentation with Doxygen"
+        COMMENT "Generate preview images of processors to be used in Inviwo Doxygen API documentation"
         VERBATIM
     )
     set_target_properties("DOXY-generate-processor-previews" 

--- a/tools/doxygen/doxygen.cmake
+++ b/tools/doxygen/doxygen.cmake
@@ -406,11 +406,11 @@ function(make_doxygen_target modules_var)
         GENERATE_IMG
     )
 
+
     add_custom_target("DOXY-Inviwo"
         COMMAND ${CMAKE_COMMAND} -E echo "Building doxygen Inviwo"
         COMMAND ${CMAKE_COMMAND} -E remove_directory "${output_dir}/inviwo"
         COMMAND ${CMAKE_COMMAND} -E make_directory "${output_dir}/inviwo/html"
-        COMMAND inviwo --save-previews "${output_dir}/inviwo/html" --quit
         COMMAND ${DOXYGEN_EXECUTABLE} "${output_dir}/inviwo.doxy"
         WORKING_DIRECTORY ${output_dir}
         COMMENT "Generating Inviwo API documentation with Doxygen"
@@ -419,7 +419,19 @@ function(make_doxygen_target modules_var)
     set_target_properties("DOXY-Inviwo" PROPERTIES FOLDER "doc" EXCLUDE_FROM_ALL TRUE)
     add_dependencies("DOXY-ALL" "DOXY-Inviwo")
 
-    # Help, used for the help inside invowo
+
+    add_custom_target("DOXY-generate-processor-previews"
+        COMMAND inviwo --save-previews "${output_dir}/inviwo/html" --quit
+        WORKING_DIRECTORY ${output_dir}
+        COMMENT "Generating Inviwo API documentation with Doxygen"
+        VERBATIM
+    )
+    set_target_properties("DOXY-generate-processor-previews" 
+                            PROPERTIES FOLDER "doc" EXCLUDE_FROM_ALL TRUE)
+    add_dependencies("DOXY-ALL" "DOXY-generate-processor-previews")
+    add_dependencies("DOXY-generate-processor-previews" "DOXY-Inviwo")
+
+    # Help, used for the help inside inviwo
     set(module_bases "")
     foreach(mod ${${modules_var}})
         if(${${mod}_opt}) # Only include enabled modules


### PR DESCRIPTION
In the PR I have move the the generating of processor previews from DOXY-inviwo to its own target. 
This way, one can modify the doc in core and then "quickly" generate the html. Before, Doxy-inviwo had an dependency on the inviwo.exe project which made it impossible to build DOXY-inviwo whithout building the whole source. 