### PR TITLE
QtWidgets: fixed loading of settings

### DIFF
--- a/modules/qtwidgets/qtwidgetssettings.cpp
+++ b/modules/qtwidgets/qtwidgetssettings.cpp
@@ -113,6 +113,8 @@ QtWidgetsSettings::QtWidgetsSettings()
     pythonSyntax_.addProperty(pyTextColor_);
     pythonSyntax_.addProperty(pyCommentsColor_);
     pythonSyntax_.addProperty(pyTypeColor_);
+    
+    load();
 }
 
 }  // namespace inviwo


### PR DESCRIPTION
This fix will enable loading previously changed Qt settings like syntax colors. Before, any changes were saved but never restored.