### PR TITLE
Fix/deprecated callbacks, #34

### DIFF
--- a/cmake/compileoptions.cmake
+++ b/cmake/compileoptions.cmake
@@ -61,7 +61,6 @@ function(ivw_define_standard_properties)
             list(APPEND comp_opts "/wd4201") # nameless struct/union https://msdn.microsoft.com/en-us/library/c89bw853.aspx
             list(APPEND comp_opts "/wd4251") # needs dll-interface   https://msdn.microsoft.com/en-us/library/esew7y1w.aspx
             list(APPEND comp_opts "/wd4505") # unreferenced funtion  https://msdn.microsoft.com/en-us/library/mt694070.aspx
-            list(APPEND comp_opts "/wd4996") # ignore deprication    https://msdn.microsoft.com/en-us/library/ttcz0bys.aspx
             if(MSVC_VERSION GREATER_EQUAL 1910)
                 list(APPEND comp_opts "/w35038") # class member reorder
                 if(NOT OpenMP_ON)

--- a/include/inviwo/core/datastructures/transferfunction.h
+++ b/include/inviwo/core/datastructures/transferfunction.h
@@ -118,6 +118,7 @@ public:
     /**
      * Deprecated. Add a transfer function point at pos.x() with value color, pos.y is not used.
      */
+    [[deprecated("was declared deprecated. Use `addPoint(const float& pos, const vec4& color)` instead")]]
     void addPoint(const vec2& pos, const vec4& color);
 
     void removePoint(TransferFunctionDataPoint* dataPoint);

--- a/include/inviwo/core/ports/inport.h
+++ b/include/inviwo/core/ports/inport.h
@@ -185,19 +185,16 @@ const BaseCallBack* Inport::onChange(T* o, void (T::*m)()) {
 
 template <typename T>
 const BaseCallBack* Inport::onInvalid(T* o, void (T::*m)()) {
-    ivwDeprecatedMethod("const BaseCallBack* onInvalid(std::function<void()> lambda)");
     return onInvalidCallback_.addMemberFunction(o, m);
 }
 
 template <typename T>
 void Inport::removeOnChange(T* o) {
-    ivwDeprecatedMethod("void removeOnChange(const BaseCallBack* callback)");
     onChangeCallback_.removeMemberFunction(o);
 }
 
 template <typename T>
 void Inport::removeOnInvalid(T* o) {
-    ivwDeprecatedMethod("void removeOnInvalid(const BaseCallBack* callback)");
     onInvalidCallback_.removeMemberFunction(o);
 }
 

--- a/include/inviwo/core/ports/inport.h
+++ b/include/inviwo/core/ports/inport.h
@@ -105,6 +105,7 @@ public:
      * going to be called.
      */
     template <typename T>
+    [[deprecated("was declared deprecated. Use `onChange(std::function<void()>)` instead")]]
     const BaseCallBack* onChange(T* o, void (T::*m)());
     const BaseCallBack* onChange(std::function<void()> lambda);
 
@@ -113,6 +114,7 @@ public:
      *    called once for each transition from valid to invalid.
      */
     template <typename T>
+    [[deprecated("was declared deprecated. Use `onInvalid(std::function<void()>)` instead")]]
     const BaseCallBack* onInvalid(T* o, void (T::*m)());
     const BaseCallBack* onInvalid(std::function<void()> lambda);
 
@@ -121,10 +123,12 @@ public:
 
     void removeOnChange(const BaseCallBack* callback);
     template <typename T>
+    [[deprecated("was declared deprecated. Use `removeOnChange(const BaseCallBack*)` instead")]]
     void removeOnChange(T* o);
 
     void removeOnInvalid(const BaseCallBack* callback);
     template <typename T>
+    [[deprecated("was declared deprecated. Use `removeOnInvalid(const BaseCallBack*)` instead")]]
     void removeOnInvalid(T* o);
 
     void removeOnConnect(const BaseCallBack* callback);
@@ -181,16 +185,19 @@ const BaseCallBack* Inport::onChange(T* o, void (T::*m)()) {
 
 template <typename T>
 const BaseCallBack* Inport::onInvalid(T* o, void (T::*m)()) {
+    ivwDeprecatedMethod("const BaseCallBack* onInvalid(std::function<void()> lambda)");
     return onInvalidCallback_.addMemberFunction(o, m);
 }
 
 template <typename T>
 void Inport::removeOnChange(T* o) {
+    ivwDeprecatedMethod("void removeOnChange(const BaseCallBack* callback)");
     onChangeCallback_.removeMemberFunction(o);
 }
 
 template <typename T>
 void Inport::removeOnInvalid(T* o) {
+    ivwDeprecatedMethod("void removeOnInvalid(const BaseCallBack* callback)");
     onInvalidCallback_.removeMemberFunction(o);
 }
 

--- a/include/inviwo/core/properties/property.h
+++ b/include/inviwo/core/properties/property.h
@@ -143,13 +143,13 @@ public:
      * Register a widget for the property. Registered widgets will receive updateFromProperty calls
      * when the value state of the property changes. One Property can have multiple widgets.
      * The property does not take ownership of the widget.
-     * @see deregisterProperty 
+     * @see deregisterProperty
      * @see PropertyWidget
      */
     void registerWidget(PropertyWidget* propertyWidget);
 
     /**
-     * Deregister a widget, the widget will no longer receive updateFromProperty calls. 
+     * Deregister a widget, the widget will no longer receive updateFromProperty calls.
      * @see registerProperty
      * @see PropertyWidget
      */
@@ -211,8 +211,10 @@ public:
     const BaseCallBack* onChange(std::function<void()> callback);
     void removeOnChange(const BaseCallBack* callback);
     template <typename T>
+    [[deprecated("was declared deprecated. Use `onChange(std::function<void()>)` instead")]]
     const BaseCallBack* onChange(T* object, void (T::*method)());
     template <typename T>
+    [[deprecated("was declared deprecated. Use `removeOnChange(const BaseCallBack*)` instead")]]
     void removeOnChange(T* object);
 
     virtual void setUsageMode(UsageMode usageMode);
@@ -277,7 +279,7 @@ private:
 };
 
 template <typename T>
-void inviwo::Property::removeOnChange(T* o) {
+void Property::removeOnChange(T* o) {
     onChangeCallback_.removeMemberFunction(o);
 }
 

--- a/include/inviwo/core/util/callback.h
+++ b/include/inviwo/core/util/callback.h
@@ -59,6 +59,7 @@ public:
     }
 
     template <typename T>
+    [[deprecated("was declared deprecated. Use `addLambdaCallback(std::function<void()>)` instead")]]
     const BaseCallBack* addMemberFunction(T* o, void (T::*m)()) {
         auto cb = dispatcher_.add([o, m](){if (m) (*o.*m)();});
         callBackList_.push_back(cb);
@@ -94,6 +95,7 @@ public:
      * \brief Remove all callbacks associated with the object.
      */
     template <typename T>
+    [[deprecated("was declared deprecated. Use `remove(const BaseCallBack* callback)` instead")]]
     void removeMemberFunction(T* o) {
         auto it = objMap_.find(static_cast<void*>(o));
         if(it != objMap_.end()) {

--- a/modules/python3/pybindutils.h
+++ b/modules/python3/pybindutils.h
@@ -33,8 +33,10 @@
 #include <modules/python3/python3moduledefine.h>
 #include <inviwo/core/common/inviwo.h>
 
+#include <warn/push>
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
+#include <warn/pop>
 
 #include <inviwo/core/common/inviwoapplication.h>
 #include <inviwo/core/network/processornetwork.h>

--- a/modules/python3/pybindutils.h
+++ b/modules/python3/pybindutils.h
@@ -33,6 +33,7 @@
 #include <modules/python3/python3moduledefine.h>
 #include <inviwo/core/common/inviwo.h>
 
+// push/pop warning state to prevent disabling some warnings by pybind headers
 #include <warn/push>
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>

--- a/src/core/datastructures/transferfunction.cpp
+++ b/src/core/datastructures/transferfunction.cpp
@@ -110,9 +110,6 @@ void TransferFunction::addPoint(const vec2& pos) {
 }
 
 void TransferFunction::addPoint(const vec2& pos, const vec4& color) {
-    LogWarn(
-        "TransferFunction::addPoint(const vec2& pos, const vec4& color) is deprecated. Use "
-        "addPoint(const float& pos, const vec4& color) instead");
     addPoint(util::make_unique<TransferFunctionDataPoint>(pos.x, color));
 }
 

--- a/src/core/util/tinydirinterface.cpp
+++ b/src/core/util/tinydirinterface.cpp
@@ -34,7 +34,11 @@
 #define NOMINMAX // tinydir.h includes windows.h... 
 #define WIN32_LEAN_AND_MEAN
 #endif
+
+#include <warn/push>
 #include <tinydir.h>
+#include <warn/pop>
+
 #include <algorithm>
 #include <cerrno>
 

--- a/src/core/util/tinydirinterface.cpp
+++ b/src/core/util/tinydirinterface.cpp
@@ -35,6 +35,8 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 
+// push/pop warning state to prevent disabling of some warnings by tinydir header
+
 #include <warn/push>
 #include <tinydir.h>
 #include <warn/pop>


### PR DESCRIPTION
As discussed in #34, CallBacks to member functions are to be deprecated and will be removed shortly. In the mean time, the compiler should print deprecation warnings.

E.g.:
```c++
    template <typename T>
    [[deprecated("was declared deprecated. Use `onChange(std::function<void()>)` instead")]]
    const BaseCallBack* onChange(T* o, void (T::*m)());
```
will result in
```
openslidetovolume2.cpp(109): warning C4996: 'inviwo::Inport::onChange': was declared deprecated. Use `onChange(std::function<void()>)` instead
inviwo/core/ports/inport.h(179): note: see declaration of 'inviwo::Inport::onChange'
```