### PR TITLE
Fix/reader search paths

### DIFF
--- a/modules/assimp/assimpreader.cpp
+++ b/modules/assimp/assimpreader.cpp
@@ -77,7 +77,6 @@ public:
     }
 };
 
-
 AssimpReader::AssimpReader()
     : DataReaderType<Mesh>()
     , logLevel_(AssimpLogLevel::Warn)
@@ -106,33 +105,13 @@ void AssimpReader::setLogLevel(AssimpLogLevel level, bool verbose) {
     verboseLog_ = verbose;
 }
 
-AssimpLogLevel AssimpReader::getLogLevel() const {
-    return logLevel_;
-}
+AssimpLogLevel AssimpReader::getLogLevel() const { return logLevel_; }
 
+void AssimpReader::setFixInvalidDataFlag(bool enable) { fixInvalidData_ = enable; }
 
-void AssimpReader::setFixInvalidDataFlag(bool enable) {
-    fixInvalidData_ = enable;
-}
+bool AssimpReader::getFixInvalidDataFlag() const { return fixInvalidData_; }
 
-bool AssimpReader::getFixInvalidDataFlag() const {
-    return fixInvalidData_;
-}
-
-std::shared_ptr<Mesh> AssimpReader::readData(const std::string& fileName) {
-    // Search both given file path and relative to application
-    auto filePath = fileName;
-    if (!filesystem::fileExists(filePath)) {
-        std::string newPath = filesystem::addBasePath(filePath);
-
-        if (filesystem::fileExists(newPath)) {
-            filePath = newPath;
-        }
-        else {
-            throw DataReaderException("Error could not find input file: " + filePath, IvwContext);
-        }
-    }
-
+std::shared_ptr<Mesh> AssimpReader::readData(const std::string& filePath) {
     Assimp::Importer importer;
 
     std::clock_t start_readmetadata = std::clock();
@@ -159,7 +138,6 @@ std::shared_ptr<Mesh> AssimpReader::readData(const std::string& fileName) {
                                                        Assimp::Logger::ErrorSeverity::Debugging);
         }
     }
-
 
     //#define AI_CONFIG_PP_SBP_REMOVE "aiPrimitiveType_POINTS | aiPrimitiveType_LINES"
     //#define AI_CONFIG_PP_FD_REMOVE 1
@@ -409,4 +387,4 @@ std::shared_ptr<Mesh> AssimpReader::readData(const std::string& fileName) {
     return mesh;
 }
 
-}  // namespace
+}  // namespace inviwo

--- a/modules/assimp/assimpreader.cpp
+++ b/modules/assimp/assimpreader.cpp
@@ -119,7 +119,20 @@ bool AssimpReader::getFixInvalidDataFlag() const {
     return fixInvalidData_;
 }
 
-std::shared_ptr<Mesh> AssimpReader::readData(const std::string& filePath) {
+std::shared_ptr<Mesh> AssimpReader::readData(const std::string& fileName) {
+    // Search both given file path and relative to application
+    auto filePath = fileName;
+    if (!filesystem::fileExists(filePath)) {
+        std::string newPath = filesystem::addBasePath(filePath);
+
+        if (filesystem::fileExists(newPath)) {
+            filePath = newPath;
+        }
+        else {
+            throw DataReaderException("Error could not find input file: " + filePath, IvwContext);
+        }
+    }
+
     Assimp::Importer importer;
 
     std::clock_t start_readmetadata = std::clock();

--- a/modules/base/io/ivfvolumereader.cpp
+++ b/modules/base/io/ivfvolumereader.cpp
@@ -50,20 +50,13 @@ IvfVolumeReader::IvfVolumeReader()
 IvfVolumeReader* IvfVolumeReader::clone() const { return new IvfVolumeReader(*this); }
 
 std::shared_ptr<Volume> IvfVolumeReader::readData(const std::string& filePath) {
-    std::string fileName = filePath;
-    if (!filesystem::fileExists(fileName)) {
-        std::string newPath = filesystem::addBasePath(fileName);
-
-        if (filesystem::fileExists(newPath)) {
-            fileName = newPath;
-        } else {
-            throw DataReaderException("Error could not find input file: " + fileName, IvwContext);
-        }
+    if (!filesystem::fileExists(filePath)) {
+        throw DataReaderException("Error could not find input file: " + filePath, IvwContext);
     }
 
-    std::string fileDirectory = filesystem::getFileDirectory(fileName);
+    std::string fileDirectory = filesystem::getFileDirectory(filePath);
 
-    Deserializer d(fileName);
+    Deserializer d(filePath);
 
     d.registerFactory(InviwoApplication::getPtr()->getMetaDataFactory());
     d.deserialize("RawFile", rawFile_);

--- a/modules/cimg/cimglayerreader.cpp
+++ b/modules/cimg/cimglayerreader.cpp
@@ -58,18 +58,11 @@ CImgLayerReader::CImgLayerReader() : DataReaderType<Layer>() {
 CImgLayerReader* CImgLayerReader::clone() const { return new CImgLayerReader(*this); }
 
 std::shared_ptr<Layer> CImgLayerReader::readData(const std::string& filePath) {
-    std::string fileName = filePath; 
-    if (!filesystem::fileExists(fileName)) {
-        std::string newPath = filesystem::addBasePath(fileName);
-
-        if (filesystem::fileExists(newPath)) {
-            fileName = newPath;
-        } else {
-            throw DataReaderException("Error could not find input file: " + fileName, IvwContext);
-        }
+    if (!filesystem::fileExists(filePath)) {
+        throw DataReaderException("Error could not find input file: " + filePath, IvwContext);
     }
 
-    auto layerDisk = std::make_shared<LayerDisk>(fileName);
+    auto layerDisk = std::make_shared<LayerDisk>(filePath);
     layerDisk->setLoader(new CImgLayerRAMLoader(layerDisk.get()));
     auto layer = std::make_shared<Layer>(layerDisk);
     return layer;
@@ -77,9 +70,7 @@ std::shared_ptr<Layer> CImgLayerReader::readData(const std::string& filePath) {
 
 CImgLayerRAMLoader::CImgLayerRAMLoader(LayerDisk* layerDisk) : layerDisk_(layerDisk) {}
 
-CImgLayerRAMLoader* CImgLayerRAMLoader::clone() const {
-    return new CImgLayerRAMLoader(*this);
-}
+CImgLayerRAMLoader* CImgLayerRAMLoader::clone() const { return new CImgLayerRAMLoader(*this); }
 
 std::shared_ptr<LayerRepresentation> CImgLayerRAMLoader::createRepresentation() const {
     void* data = nullptr;
@@ -162,10 +153,9 @@ void CImgLayerRAMLoader::updateSwizzleMask(LayerDisk* layerDisk) {
             default:
                 return swizzlemasks::rgba;
         }
-
     };
 
     layerDisk->setSwizzleMask(swizzleMask(layerDisk->getDataFormat()->getComponents()));
 }
 
-}  // namespace
+}  // namespace inviwo

--- a/modules/cimg/cimgvolumereader.cpp
+++ b/modules/cimg/cimgvolumereader.cpp
@@ -43,20 +43,12 @@ CImgVolumeReader::CImgVolumeReader() : DataReaderType<Volume>() {
 CImgVolumeReader* CImgVolumeReader::clone() const { return new CImgVolumeReader(*this); }
 
 std::shared_ptr<Volume> CImgVolumeReader::readData(const std::string& filePath) {
-    std::string fileName = filePath; 
-    if (!filesystem::fileExists(fileName)) {
-        std::string newPath = filesystem::addBasePath(fileName);
-
-        if (filesystem::fileExists(newPath)) {
-            fileName = newPath;
-        }
-        else {
-            throw DataReaderException("Error could not find input file: " + fileName, IvwContext);
-        }
+    if (!filesystem::fileExists(filePath)) {
+        throw DataReaderException("Error could not find input file: " + filePath, IvwContext);
     }
 
     auto volume = std::make_shared<Volume>();
-    auto volumeDisk = std::make_shared<VolumeDisk>(fileName);
+    auto volumeDisk = std::make_shared<VolumeDisk>(filePath);
     volumeDisk->setLoader(new CImgVolumeRAMLoader(volumeDisk.get()));
     volume->addRepresentation(volumeDisk);
 
@@ -71,11 +63,9 @@ void CImgVolumeReader::printMetaInfo(const MetaDataOwner& metaDataOwner, std::st
     }
 }
 
-CImgVolumeRAMLoader::CImgVolumeRAMLoader(VolumeDisk* volumeDisk) :volumeDisk_(volumeDisk) {}
+CImgVolumeRAMLoader::CImgVolumeRAMLoader(VolumeDisk* volumeDisk) : volumeDisk_(volumeDisk) {}
 
-CImgVolumeRAMLoader* CImgVolumeRAMLoader::clone() const {
-    return new CImgVolumeRAMLoader(*this);
-}
+CImgVolumeRAMLoader* CImgVolumeRAMLoader::clone() const { return new CImgVolumeRAMLoader(*this); }
 
 std::shared_ptr<VolumeRepresentation> CImgVolumeRAMLoader::createRepresentation() const {
     void* data = nullptr;
@@ -123,4 +113,4 @@ void CImgVolumeRAMLoader::updateRepresentation(std::shared_ptr<VolumeRepresentat
     volumeDisk_->setDimensions(dimensions);
 }
 
-}  // namespace
+}  // namespace inviwo

--- a/modules/pvm/mpvmvolumereader.cpp
+++ b/modules/pvm/mpvmvolumereader.cpp
@@ -29,11 +29,12 @@
 
 #include <modules/pvm/mpvmvolumereader.h>
 #include <inviwo/core/datastructures/volume/volumeramprecision.h>
+#include <inviwo/core/util/exception.h>
 #include <inviwo/core/util/filesystem.h>
 #include <inviwo/core/util/formatconversion.h>
 #include <inviwo/core/util/stringconversion.h>
 #include <inviwo/core/io/datareaderexception.h>
-#include <inviwo/core/util/exception.h>
+
 #include "ext/tidds/ddsbase.h"
 #include "pvmvolumereader.h"
 
@@ -46,27 +47,17 @@ MPVMVolumeReader::MPVMVolumeReader() : DataReaderType<Volume>() {
 MPVMVolumeReader* MPVMVolumeReader::clone() const { return new MPVMVolumeReader(*this); }
 
 std::shared_ptr<Volume> MPVMVolumeReader::readData(const std::string& filePath) {
-    std::string fileName = filePath;
-    if (!filesystem::fileExists(fileName)) {
-        std::string newPath = filesystem::addBasePath(fileName);
 
-        if (filesystem::fileExists(newPath)) {
-            fileName = newPath;
-        } else {
-            throw DataReaderException("Error could not find input file: " + fileName, IvwContext);
-        }
-    }
-
-    std::string fileDirectory = filesystem::getFileDirectory(fileName);
+    std::string fileDirectory = filesystem::getFileDirectory(filePath);
 
     // Read the mpvm file content
 
     std::string textLine;
     std::vector<std::string> files;
     {
-        auto f = filesystem::ifstream(fileName);
+        auto f = filesystem::ifstream(filePath);
         if (!f.is_open()) {
-            throw FileException("Could not open input file: " + fileName, IvwContext);
+            throw FileException("Could not open input file: " + filePath, IvwContext);
         }
 
         while (!f.eof()) {
@@ -77,10 +68,10 @@ std::shared_ptr<Volume> MPVMVolumeReader::readData(const std::string& filePath) 
     }
 
     if (files.empty())
-        throw DataReaderException("Error: No PVM files found in " + fileName, IvwContext);
+        throw DataReaderException("Error: No PVM files found in " + filePath, IvwContext);
 
     if (files.size() > 4)
-        throw DataReaderException("Error: Maximum 4 pvm files are supported, file: " + fileName,
+        throw DataReaderException("Error: Maximum 4 pvm files are supported, file: " + filePath,
                                   IvwContext);
 
     // Read all pvm volumes
@@ -94,7 +85,7 @@ std::shared_ptr<Volume> MPVMVolumeReader::readData(const std::string& filePath) 
     }
 
     if (volumes.empty())
-        throw DataReaderException("No PVM volumes could be read from file: " + fileName,
+        throw DataReaderException("No PVM volumes could be read from file: " + filePath,
                                   IvwContext);
 
     if (volumes.size() == 1) {
@@ -161,7 +152,7 @@ std::shared_ptr<Volume> MPVMVolumeReader::readData(const std::string& filePath) 
     }
 
     volume->addRepresentation(mvolRAM);
-    printPVMMeta(*volume, fileName);
+    printPVMMeta(*volume, filePath);
     return volume;
 }
 
@@ -185,4 +176,4 @@ void MPVMVolumeReader::printMetaInfo(const MetaDataOwner& metaDataOwner, std::st
     }
 }
 
-}  // namespace
+}  // namespace inviwo

--- a/modules/pvm/pvmvolumereader.cpp
+++ b/modules/pvm/pvmvolumereader.cpp
@@ -29,6 +29,7 @@
 
 #include <modules/pvm/pvmvolumereader.h>
 #include <inviwo/core/datastructures/volume/volumeramprecision.h>
+#include <inviwo/core/util/exception.h>
 #include <inviwo/core/util/filesystem.h>
 #include <inviwo/core/util/formatconversion.h>
 #include <inviwo/core/util/stringconversion.h>
@@ -44,6 +45,9 @@ PVMVolumeReader::PVMVolumeReader() : DataReaderType<Volume>() {
 PVMVolumeReader* PVMVolumeReader::clone() const { return new PVMVolumeReader(*this); }
 
 std::shared_ptr<Volume> PVMVolumeReader::readData(const std::string& filePath) {
+    if (!filesystem::fileExists(filePath)) {
+        throw DataReaderException("Error could not find input file: " + filePath, IvwContext);
+    }
     auto volume = readPVMData(filePath);
 
     if (!volume) return std::shared_ptr<Volume>();
@@ -62,16 +66,6 @@ std::shared_ptr<Volume> PVMVolumeReader::readData(const std::string& filePath) {
 }
 
 std::shared_ptr<Volume> PVMVolumeReader::readPVMData(std::string filePath) {
-    if (!filesystem::fileExists(filePath)) {
-        std::string newPath = filesystem::addBasePath(filePath);
-
-        if (filesystem::fileExists(newPath)) {
-            filePath = newPath;
-        } else {
-            throw DataReaderException("Error could not find input file: " + filePath,
-                                      IvwContextCustom("PVMVolumeReader"));
-        }
-    }
 
     size3_t dim(0);
     glm::mat3 basis(2.0f);
@@ -87,8 +81,9 @@ std::shared_ptr<Volume> PVMVolumeReader::readPVMData(std::string filePath) {
 
     try {
         uvec3 udim{0};
-        data = readPVMvolume(filePath.c_str(), &udim.x, &udim.y, &udim.z, &bytesPerVoxel, &spacing.x,
-                             &spacing.y, &spacing.z, &description, &courtesy, &parameter, &comment);
+        data =
+            readPVMvolume(filePath.c_str(), &udim.x, &udim.y, &udim.z, &bytesPerVoxel, &spacing.x,
+                          &spacing.y, &spacing.z, &description, &courtesy, &parameter, &comment);
         dim = udim;
 
     } catch (Exception& e) {
@@ -195,4 +190,4 @@ void PVMVolumeReader::printMetaInfo(const MetaDataOwner& metaDataOwner, std::str
     }
 }
 
-}  // namespace
+}  // namespace inviwo

--- a/src/core/io/rawvolumereader.cpp
+++ b/src/core/io/rawvolumereader.cpp
@@ -81,18 +81,11 @@ void RawVolumeReader::setParameters(const DataFormatBase* format, ivec3 dimensio
 }
 
 std::shared_ptr<Volume> RawVolumeReader::readData(const std::string& filePath) {
-    std::string fileName = filePath;
-    if (!filesystem::fileExists(fileName)) {
-        std::string newPath = filesystem::addBasePath(fileName);
-
-        if (filesystem::fileExists(newPath)) {
-            fileName = newPath;
-        } else {
-            throw DataReaderException("Error could not find input file: " + fileName, IvwContext);
-        }
+    if (!filesystem::fileExists(filePath)) {
+        throw DataReaderException("Error could not find input file: " + filePath, IvwContext);
     }
 
-    rawFile_ = fileName;
+    rawFile_ = filePath;
 
     if (!parametersSet_) {
         auto readerDialog = util::dynamic_unique_ptr_cast<DataReaderDialog>(
@@ -128,7 +121,7 @@ std::shared_ptr<Volume> RawVolumeReader::readData(const std::string& filePath) {
         volume->setWorldMatrix(wtm);
         volume->setDimensions(dimensions_);
         volume->setDataFormat(format_);
-        auto vd = std::make_shared<VolumeDisk>(fileName, dimensions_, format_);
+        auto vd = std::make_shared<VolumeDisk>(filePath, dimensions_, format_);
 
         auto loader =
             util::make_unique<RawVolumeRAMLoader>(rawFile_, 0u, dimensions_, littleEndian_, format_);
@@ -136,7 +129,7 @@ std::shared_ptr<Volume> RawVolumeReader::readData(const std::string& filePath) {
         volume->addRepresentation(vd);
         std::string size = util::formatBytesToString(dimensions_.x * dimensions_.y * dimensions_.z *
                                                (format_->getSize()));
-        LogInfo("Loaded volume: " << fileName << " size: " << size);
+        LogInfo("Loaded volume: " << filePath << " size: " << size);
         return volume;
     } else {
         throw DataReaderException("Raw data import could not determine format", IvwContext);


### PR DESCRIPTION
Removed relative file path search from readers since it is taken care of by FileProperty, see PR #77