### PR TITLE
Python3: hotfix (VS2015)

### DIFF
--- a/modules/python3/interface/pyglmtypes.h
+++ b/modules/python3/interface/pyglmtypes.h
@@ -29,9 +29,11 @@
 
 #ifndef IVW_PYGLMTYPES_H
 #define IVW_PYGLMTYPES_H
-#include <pybind11/pybind11.h>
 
 #include <inviwo/core/util/glm.h>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl_bind.h>
 
 // Manually expand PYBIND11_MAKE_OPAQUE because macros and commas in template arguments mix poorly.
 namespace pybind11 {

--- a/modules/python3/interface/pymesh.cpp
+++ b/modules/python3/interface/pymesh.cpp
@@ -45,8 +45,9 @@
 
 namespace inviwo {
 
+namespace py = pybind11;
+
 void exposeMesh(pybind11::module &m) {
-    namespace py = pybind11;
     py::class_<Mesh::MeshInfo>(m, "MeshInfo")
         .def(py::init<>())
         .def(py::init<DrawType, ConnectivityType>())


### PR DESCRIPTION
This fixes build errors in VS 2015 caused by 27a8967