### PR TITLE
Plotting: Fix for text position

### DIFF
--- a/modules/plottinggl/processors/parallelcoordinates.cpp
+++ b/modules/plottinggl/processors/parallelcoordinates.cpp
@@ -840,9 +840,9 @@ void ParallelCoordinates::renderText(size2_t outputsize, std::vector<AxisBase *>
     utilgl::BlendModeState blending(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
     const vec2 outputSizeWOMargins(
-        static_cast<float>(outputsize.x) - margins_.getRight() + margins_.getLeft() +
-            extraMargins.y + extraMargins.w,
-        static_cast<float>(outputsize.y) - margins_.getTop() + margins_.getBottom());
+        static_cast<float>(outputsize.x) -
+            (margins_.getRight() + margins_.getLeft() + extraMargins.y + extraMargins.w),
+        static_cast<float>(outputsize.y) - (margins_.getTop() + margins_.getBottom()));
 
     float dx = 1.0f / (enabledAxis.size() - 1);
 


### PR DESCRIPTION
It was accidentally broken in 070cff1042b4482d7761981ae6690d9d61fbee0d 
by changing an expresion in the form of `a - (b+c+d)` to `a - b+c+d`


