### PR TITLE
Regression: Fix for listing which test to include

### DIFF
--- a/tools/ivwpy/regression/app.py
+++ b/tools/ivwpy/regression/app.py
@@ -228,9 +228,9 @@ class App:
 		printfun("List of regression tests")
 		printfun("-"*80)
 
-		selected = self.filterTests(testrange, testfilter)
+		selected, reasons = self.filterTests(testrange, testfilter)
 		for i, test in enumerate(self.tests):
-			active = "Enabled" if i in selected and testfilter(test) else "Disabled"
+			active = "Enabled" if i in selected and testfilter(test) else "Disabled (Reason: %s)" % reasons[i]
 			printfun("{:3d} {:8s} {}".format(i, active, test))
 
 	def saveJson(self):


### PR DESCRIPTION
The -l (list regresion tests) in regresion.py was broken since a quite while back. 
The `filterTests` method was changed from returning just a list to returning a list and the reason for filtering it out. This change was not reflected in the list regression test part, only for the running test part. 