### PR TITLE
Drag and Drop

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "modules/eigenutils/ext/eigen"]
     path = modules/eigenutils/ext/eigen
-    url = https://github.com/RLovelett/eigen
+    url = https://github.com/eigenteam/eigen-git-mirror.git
 [submodule "modules/hdf5/ext/hdf5"]
     path = modules/hdf5/ext/hdf5
     url = https://github.com/live-clones/hdf5.git
@@ -11,7 +11,7 @@
     url = https://github.com/pybind/pybind11.git
 [submodule "tools/codegen/warn/warn"]
     path = tools/codegen/warn/warn
-    url = https://petersteneteg@github.com/petersteneteg/warn.git
+    url = https://github.com/petersteneteg/warn.git
 [submodule "ext/utf/utfcpp"]
     path = ext/utf/utfcpp
     url = https://github.com/nemtrif/utfcpp

--- a/include/inviwo/core/common/inviwoapplication.h
+++ b/include/inviwo/core/common/inviwoapplication.h
@@ -82,6 +82,8 @@ class InportFactory;
 class PortInspectorFactory;
 class PortInspectorManager;
 
+class DataVisualizerManager;
+
 class Settings;
 class SystemSettings;
 class Capabilities;
@@ -167,6 +169,7 @@ public:
     WorkspaceManager* getWorkspaceManager();
     PropertyPresetManager* getPropertyPresetManager();
     PortInspectorManager* getPortInspectorManager();
+    DataVisualizerManager* getDataVisualizerManager();
 
     CommandLineParser& getCommandLineParser();
     const CommandLineParser& getCommandLineParser() const;
@@ -327,6 +330,7 @@ protected:
     std::unique_ptr<OutportFactory> outportFactory_;
     std::unique_ptr<InportFactory> inportFactory_;
     std::unique_ptr<PortInspectorFactory> portInspectorFactory_;
+    std::unique_ptr<DataVisualizerManager> dataVisualizerManager_;
     std::unique_ptr<ProcessorFactory> processorFactory_;
     std::unique_ptr<ProcessorWidgetFactory> processorWidgetFactory_;
     std::unique_ptr<PropertyConverterManager> propertyConverterManager_;
@@ -342,7 +346,6 @@ protected:
     std::unique_ptr<WorkspaceManager> workspaceManager_;
     std::unique_ptr<PropertyPresetManager> propertyPresetManager_;
     std::unique_ptr<PortInspectorManager> portInspectorManager_;
-
     WorkspaceManager::ClearHandle networkClearHandle_;
     WorkspaceManager::SerializationHandle networkSerializationHandle_;
     WorkspaceManager::DeserializationHandle networkDeserializationHandle_;

--- a/include/inviwo/core/common/inviwomodule.h
+++ b/include/inviwo/core/common/inviwomodule.h
@@ -73,6 +73,7 @@ class PortInspectorFactoryObject;
 class MeshDrawer;
 class PropertyConverter;
 class VersionConverter;
+class DataVisualizer;
 
 enum class ModulePath {
     Data,             // /data
@@ -196,6 +197,8 @@ protected:
 
     void registerPortInspector(std::string portClassIdentifier, std::string inspectorPath);
 
+    void registerDataVisualizer(std::unique_ptr<DataVisualizer> visualizer);
+
     /**
      * Register port type T, PortTraits<T>::classIdentifier has to be defined and return a non
      * empty and unique string. We use reverse DNS for class identifiers, i.e. org.inviwo.classname
@@ -294,6 +297,7 @@ private:
     std::vector<std::unique_ptr<BaseRepresentationConverterFactory>>
         representationConverterFactories_;
     std::vector<std::unique_ptr<Settings>> settings_;
+    std::vector<std::unique_ptr<DataVisualizer>> dataVisualizers_;
 };
 
 template <typename T>

--- a/include/inviwo/core/network/networkutils.h
+++ b/include/inviwo/core/network/networkutils.h
@@ -160,10 +160,26 @@ private:
     std::map<const Property*, vec2> cache_;
 };
 
+
+/**
+ * Retrieve the positions of the processors in the list.
+ */
+IVW_CORE_API std::vector<ivec2> getPositions(const std::vector<Processor*>& processors);
+
+/**
+ * Retrieve the positions of the processors in the network.
+ */
+IVW_CORE_API std::vector<ivec2> getPositions(ProcessorNetwork* network);
+
 /**
  * Retrieve the mean position of the processors in the list.
  */
 IVW_CORE_API ivec2 getCenterPosition(const std::vector<Processor*>& processors);
+
+/**
+ * Retrieve the mean position of the processors in the network.
+ */
+IVW_CORE_API ivec2 getCenterPosition(ProcessorNetwork* network);
 
 /**
  * Retrieve bounding box of the processors in the list.
@@ -172,9 +188,15 @@ IVW_CORE_API ivec2 getCenterPosition(const std::vector<Processor*>& processors);
 IVW_CORE_API std::pair<ivec2, ivec2> getBoundingBox(const std::vector<Processor*>& processors);
 
 /**
+ * Retrieve bounding box of the processors in the network.
+ * The return value is pair of the min x,y and the max x,y
+ */
+IVW_CORE_API std::pair<ivec2, ivec2> getBoundingBox(ProcessorNetwork* network);
+
+/**
  * Offset all the positions of the processors in the list by offset
  */
-IVW_CORE_API void offsetPosition(const std::vector<Processor*>& processors, const ivec2& offset);
+IVW_CORE_API void offsetPosition(const std::vector<Processor*>& processors, ivec2 offset);
 
 /**
  * Set the listed processors as selected or unSelected.
@@ -182,7 +204,6 @@ IVW_CORE_API void offsetPosition(const std::vector<Processor*>& processors, cons
 IVW_CORE_API void setSelected(const std::vector<Processor*>& processors, bool selected);
 
 IVW_CORE_API void autoLinkProcessor(ProcessorNetwork* network, Processor* processor);
-
 
 IVW_CORE_API void serializeSelected(ProcessorNetwork* network, std::ostream& os,
                                     const std::string& refPath);

--- a/include/inviwo/core/network/processornetwork.h
+++ b/include/inviwo/core/network/processornetwork.h
@@ -83,6 +83,14 @@ public:
      * @param[in] processor The Processor to be added.
      * @see removeProcessor(), Processor::setIdentifier()
      */
+    Processor* addProcessor(std::unique_ptr<Processor> processor);
+
+    /**
+     * Adds a Processor to the ProcessorNetwork. The identifiers of all processors in the
+     * ProcessorNetwork should be unique.
+     * @param[in] processor The Processor to be added. The network will take ownership.
+     * @see removeProcessor(), Processor::setIdentifier()
+     */
     bool addProcessor(Processor* processor);
 
     /**

--- a/include/inviwo/core/ports/portinspectormanager.h
+++ b/include/inviwo/core/ports/portinspectormanager.h
@@ -60,6 +60,8 @@ public:
     PortInspectorManager& operator=(const PortInspectorManager& that) = delete;
     PortInspectorManager& operator=(PortInspectorManager&& that) = default;
 
+    bool isPortInspectorSupported(const Outport* outport);
+
     bool hasPortInspector(Outport* outport) const;
     ProcessorWidget* addPortInspector(Outport* outport, ivec2 pos);
     void removePortInspector(Outport* outport);

--- a/include/inviwo/core/processors/processorutils.h
+++ b/include/inviwo/core/processors/processorutils.h
@@ -1,0 +1,105 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2018 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#ifndef IVW_PROCESSORUTILS_H
+#define IVW_PROCESSORUTILS_H
+
+#include <inviwo/core/common/inviwocoredefine.h>
+#include <inviwo/core/common/inviwo.h>
+
+namespace inviwo {
+
+class Processor;
+class ProcessorMetaData;
+
+namespace util {
+
+/**
+ * Retrieve the meta data of the processor.
+ */
+IVW_CORE_API const ProcessorMetaData* getMetaData(const Processor* processor);
+
+/**
+ * Retrieve the meta data of the processor.
+ */
+IVW_CORE_API ProcessorMetaData* getMetaData(Processor* processor);
+
+/**
+ * Retrieve the position of the processor.
+ */
+IVW_CORE_API ivec2 getPosition(const Processor* processor);
+
+/**
+ * Set the position of processor to pos
+ */
+IVW_CORE_API void setPosition(Processor* processor, ivec2 pos);
+
+/**
+ * Retrieve the position of the processor.
+ */
+IVW_CORE_API bool isSelected(const Processor* processor);
+
+/**
+ * Set the position of processor to pos
+ */
+IVW_CORE_API void setSelected(Processor* processor, bool selected);
+
+
+struct IVW_CORE_API GridPos {
+    GridPos(int x, int y) : pos_{x, y} {};
+    explicit GridPos(ivec2 pos) : pos_{pos} {}
+
+    operator ivec2() const { return pos_ * ivec2{25, 25}; }
+private:
+    ivec2 pos_;
+};
+
+
+/**
+ * A utility function to create a processor and set identifier, display name, and position
+ */
+template <typename T, typename... Args>
+std::unique_ptr<Processor> makeProcessor(ivec2 pos, Args&&... args) {
+    auto name = ProcessorTraits<T>::getProcessorInfo().displayName;
+    auto p = std::make_unique<T>(std::forward<Args>(args)...);
+    if (p->getIdentifier().empty()) p->setIdentifier(name);
+    if (p->getDisplayName().empty()) p->setDisplayName(name);
+
+    setPosition(p.get(), pos);
+
+    return std::move(p);
+}
+
+
+
+}
+
+}  // namespace inviwo
+
+#endif  // IVW_PROCESSORUTILS_H

--- a/include/inviwo/core/rendering/datavisualizer.h
+++ b/include/inviwo/core/rendering/datavisualizer.h
@@ -1,0 +1,124 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2018 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#ifndef IVW_DATAVISUALIZER_H
+#define IVW_DATAVISUALIZER_H
+
+#include <inviwo/core/common/inviwocoredefine.h>
+#include <inviwo/core/common/inviwo.h>
+
+#include <inviwo/core/ports/inport.h>
+#include <inviwo/core/ports/outport.h>
+#include <inviwo/core/processors/processor.h>
+#include <inviwo/core/util/fileextension.h>
+
+#include <inviwo/core/util/document.h>
+
+namespace inviwo {
+
+/**
+ * A Data Visualizer can be used to quickly add a visualization of a data type.
+ * The DataVisualizerManager keeps a list of registered Data Visualizers.
+ * A Inviwo module can call registerDataVisualizer to register a Data Visualizer
+ * With the DataVisualizerManager
+ * Three mode are available:
+ *    1) Adding a source processor that can load the requested file
+ *    2) Adding a set of processors that will take input from a existing port to create
+ *       a visualization
+ *    3) Both 1 and 2
+ */
+class IVW_CORE_API DataVisualizer {
+public:
+    DataVisualizer() = default;
+    virtual ~DataVisualizer() = default;
+
+    /**
+     * A descriptive name of the visualizer
+     */
+    virtual std::string getName() const = 0;
+
+    /**
+     * A detailed description
+     */ 
+    virtual Document getDescription() const = 0;
+
+    /**
+     * A list of file formats that the visualizer can open
+     */
+    virtual std::vector<FileExtension> getSupportedFileExtensions() const = 0;
+
+    /**
+     * Test if the visualizer can be connected to the given outport
+     */ 
+    virtual bool isOutportSupported(const Outport* port) const = 0;
+
+    /**
+     * Does the visualizer provide a source processor
+     */ 
+    virtual bool hasSourceProcessor() const = 0;
+
+    /**
+     * Does the visualizer provide a visualization network
+     */
+    virtual bool hasVisualizerNetwork() const = 0;
+
+    /**
+     * Adds a source processor with the requested file to the network
+     * @param filename The file to load in the source processor. The extension of the filename
+     *        should be in the list of extensions returned by getSupportedFileExtensions.
+     * @param network The network to add the processor to.
+     * @return a pair or the added source processor and the outport in the source processor
+     *         with data from the given file.
+     */
+    virtual std::pair<Processor*, Outport*> addSourceProcessor(const std::string& filename,
+                                                               ProcessorNetwork* network) const = 0;
+    /**
+     * Adds a set of processors that generate a visualization of the data in the given outport.
+     * @param outport The port to get data from.
+     * @param network The network to add the processor to.
+     * @return A list of added processors.
+     */
+    virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
+                                                         ProcessorNetwork* network) const = 0;
+
+    /**
+     * Adds a source processor with the requested file and a set of processors that generate
+     * a visualization of the data.
+     * @param filename The file to load in the source processor. The extension of the filename
+     *        should be in the list of extensions returned by getSupportedFileExtensions.
+     * @param network The network to add the processor to.
+     * @return A list of added processors.
+     */
+    virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
+        const std::string& filename, ProcessorNetwork* network) const = 0;
+};
+
+}  // namespace inviwo
+
+#endif  // IVW_DATAVISUALIZER_H

--- a/include/inviwo/core/rendering/datavisualizermanager.h
+++ b/include/inviwo/core/rendering/datavisualizermanager.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2012-2018 Inviwo Foundation
+ * Copyright (c) 2018 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,52 +24,44 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  *********************************************************************************/
 
-#ifndef IVW_IMAGESOURCE_H
-#define IVW_IMAGESOURCE_H
+#ifndef IVW_DATAVISUALIZERMANAGER_H
+#define IVW_DATAVISUALIZERMANAGER_H
 
-#include <modules/base/basemoduledefine.h>
+#include <inviwo/core/common/inviwocoredefine.h>
 #include <inviwo/core/common/inviwo.h>
-#include <inviwo/core/processors/processor.h>
-#include <inviwo/core/properties/fileproperty.h>
-#include <inviwo/core/ports/imageport.h>
-#include <inviwo/core/properties/ordinalproperty.h>
+
+#include <inviwo/core/rendering/datavisualizer.h>
+#include <memory>
 
 namespace inviwo {
 
-/** \docpage{org.inviwo.ImageSource, Image Source}
- * ![](org.inviwo.ImageSource.png?classIdentifier=org.inviwo.ImageSource)
+/**
  *
- * Loads a image
- * 
- * ### Outports
- *   * __Outport__ The loaded image
- * 
- * ### Properties
- *   * __File name__ The name of the file to load
- *   * __Dimensions__ Readonly, the dimensions of the loaded image.
  */
-
-class IVW_MODULE_BASE_API ImageSource : public Processor {
+class IVW_CORE_API DataVisualizerManager {
 public:
-    ImageSource(InviwoApplication* app, const std::string& file = "");
-    virtual ~ImageSource() = default;
+    DataVisualizerManager();
+    ~DataVisualizerManager() = default;
+    DataVisualizerManager(const DataVisualizerManager&) = delete;
+    DataVisualizerManager(DataVisualizerManager&&) = default;
+    DataVisualizerManager& operator=(const DataVisualizerManager& that) = delete;
+    DataVisualizerManager& operator=(DataVisualizerManager&& that) = default;
 
-    virtual const ProcessorInfo getProcessorInfo() const override;
-    static const ProcessorInfo processorInfo_;
+    void registerObject(DataVisualizer* visualizer);
+    void unRegisterObject(DataVisualizer* visualizer);
 
-    virtual void process() override;
-    virtual void deserialize(Deserializer& d) override;
+    std::vector<FileExtension> getSupportedFileExtensions() const;
+
+    std::vector<DataVisualizer*> getDataVisualizersForExtension(const std::string& ext) const;
+    std::vector<DataVisualizer*> getDataVisualizersForOutport(const Outport* port) const;
 
 private:
-    InviwoApplication* app_;
-    ImageOutport outport_;
-    FileProperty file_;
-    IntVec2Property imageDimension_;
+    std::vector<DataVisualizer*> visualizers_;
 };
 
-} // namespace
+}  // namespace inviwo
 
-#endif // IVW_IMAGESOURCE_H
+#endif  // IVW_DATAVISUALIZERMANAGER_H

--- a/include/inviwo/core/util/stdextensions.h
+++ b/include/inviwo/core/util/stdextensions.h
@@ -388,6 +388,20 @@ bool contains_if(T& cont, Pred pred) {
     return std::find_if(begin(cont), end(cont), pred) != end(cont);
 }
 
+template <typename T, typename V>
+bool contains(const T& cont, const V& elem) {
+    using std::cbegin;
+    using std::cend;
+    return std::find(cbegin(cont), cend(cont), elem) != end(cont);
+}
+
+template <typename T, typename Pred>
+bool contains_if(const T& cont, Pred pred) {
+    using std::cbegin;
+    using std::cend;
+    return std::find_if(cbegin(cont), cend(cont), pred) != end(cont);
+}
+
 template <typename T, typename P>
 auto find_if_or_null(T& cont, P pred) -> typename T::value_type {
     using std::begin;

--- a/include/inviwo/qt/editor/dataopener.h
+++ b/include/inviwo/qt/editor/dataopener.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2012-2018 Inviwo Foundation
+ * Copyright (c) 2018 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,52 +24,26 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  *********************************************************************************/
 
-#ifndef IVW_IMAGESOURCE_H
-#define IVW_IMAGESOURCE_H
+#ifndef IVW_DATAOPENER_H
+#define IVW_DATAOPENER_H
 
-#include <modules/base/basemoduledefine.h>
+#include <inviwo/qt/editor/inviwoqteditordefine.h>
 #include <inviwo/core/common/inviwo.h>
-#include <inviwo/core/processors/processor.h>
-#include <inviwo/core/properties/fileproperty.h>
-#include <inviwo/core/ports/imageport.h>
-#include <inviwo/core/properties/ordinalproperty.h>
 
 namespace inviwo {
 
-/** \docpage{org.inviwo.ImageSource, Image Source}
- * ![](org.inviwo.ImageSource.png?classIdentifier=org.inviwo.ImageSource)
- *
- * Loads a image
- * 
- * ### Outports
- *   * __Outport__ The loaded image
- * 
- * ### Properties
- *   * __File name__ The name of the file to load
- *   * __Dimensions__ Readonly, the dimensions of the loaded image.
- */
+class ProcessorNetwork;
 
-class IVW_MODULE_BASE_API ImageSource : public Processor {
-public:
-    ImageSource(InviwoApplication* app, const std::string& file = "");
-    virtual ~ImageSource() = default;
+namespace util {
 
-    virtual const ProcessorInfo getProcessorInfo() const override;
-    static const ProcessorInfo processorInfo_;
+void IVW_QTEDITOR_API insertNetworkForData(const std::string& dataFile, ProcessorNetwork* net,
+                                           bool alwaysFirst = false, bool onlySource = false);
 
-    virtual void process() override;
-    virtual void deserialize(Deserializer& d) override;
+}
 
-private:
-    InviwoApplication* app_;
-    ImageOutport outport_;
-    FileProperty file_;
-    IntVec2Property imageDimension_;
-};
+}  // namespace inviwo
 
-} // namespace
-
-#endif // IVW_IMAGESOURCE_H
+#endif  // IVW_DATAOPENER_H

--- a/include/inviwo/qt/editor/fileassociations.h
+++ b/include/inviwo/qt/editor/fileassociations.h
@@ -1,0 +1,152 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2018 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+// Windows implementation based on
+// https://wiki.qt.io/Assigning_a_file_type_to_an_Application_on_Windows
+
+// ————————————————————————————————-
+/**
+ * @file
+ * @brief
+ * @author Gerolf Reinwardt
+ * @date 30. march 2011
+ *
+ * Copyright © 2011, Gerolf Reinwardt. All rights reserved.
+ *
+ * Simplified BSD License
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those of the
+ * authors and should not be interpreted as representing official policies, either expressed
+ * or implied, of Gerolf Reinwardt.
+ */
+// ————————————————————————————————-
+
+#ifndef IVW_FILEASSOCIATIONS_H
+#define IVW_FILEASSOCIATIONS_H
+
+#include <inviwo/qt/editor/inviwoqteditordefine.h>
+#include <inviwo/core/common/inviwo.h>
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <QAbstractNativeEventFilter>
+#include <string>
+#include <functional>
+#include <warn/pop>
+
+namespace inviwo {
+
+/*
+ * Tools for creating file associations for inviwo.
+ * At this point this is only supported under windows.
+ */
+
+struct IVW_QTEDITOR_API FileAssociationCommand {
+    /**
+     * Construct a FileAssociationCommand
+     * @param command       Name of the command, this will be shown in the context menu in the
+     *                      explorer for example.
+     * @param cmdLineArg    The command line argument to pass to inviwo to invoke the command, the
+     *                      passed file is available as '%1'. E.g. for 'open' we would pass '-w %1'
+     * @param ddeCommand    The runtime command use to intercept the command when Inviwo is running
+     * @param callback      A callback that will be called whenever the command is executed and
+                            Inviwo is running
+     */
+    FileAssociationCommand(const std::string& command, const std::string& cmdLineArg,
+                           const std::string& ddeCommand,
+                           std::function<void(const std::string&)> callback)
+        : command_{command}
+        , cmdLineArg_{cmdLineArg}
+        , ddeCommand_{ddeCommand}
+        , callback_{callback} {}
+    std::string command_;
+    std::string cmdLineArg_;
+    std::string ddeCommand_;
+    std::function<void(const std::string&)> callback_;
+};
+
+class FileAssociationData;
+
+class IVW_QTEDITOR_API FileAssociations : public QAbstractNativeEventFilter {
+    friend FileAssociationData;
+
+public:
+    FileAssociations(QMainWindow* win);
+    virtual ~FileAssociations();
+
+    /**
+     * Register a file type for opening with Inviwo
+     *
+     * @param documentId     Id of the document, e.g. "Inviwo.workspace"
+     * @param fileTypeName   Name of the file type, e.g. "Inviwo Workspace"
+     * @param fileExtension  File extension, including the dot (e.g. ".inv")
+     * @param appIconIndex   Index of the app icon to use for the file in the windows explorer,
+     *                       typically the application icon
+     * @param commands       Vector FileAssociationCommands see @FileAssociationCommand
+     */
+    void registerFileType(const std::string& documentId, const std::string& fileTypeName,
+                          const std::string& fileExtension, int appIconIndex = 0,
+                          std::vector<FileAssociationCommand> commands = {});
+
+    // QAbstractNativeEventFilter overrides
+    bool nativeEventFilter(const QByteArray& eventType, void* message, long* result) override;
+
+private:
+    /**
+     * This method is called to by the FileAssociationData on the execution of a ddeCommand
+     */
+    void executeCommand(const std::string& command, const std::string& param);
+
+    std::unique_ptr<FileAssociationData> data_;
+    std::unordered_map<std::string, std::function<void(const std::string&)>> commands_;
+};
+
+}  // namespace inviwo
+
+#endif  // IVW_FILEASSOCIATIONS_H

--- a/include/inviwo/qt/editor/inviwomainwindow.h
+++ b/include/inviwo/qt/editor/inviwomainwindow.h
@@ -63,6 +63,7 @@ class NetworkSearch;
 class InviwoEditMenu;
 class InviwoAboutWindow;
 class ResourceManagerDockWidget;
+class FileAssociations;
 
 class IVW_QTEDITOR_API InviwoMainWindow : public QMainWindow, public NetworkEditorObserver {
 public:
@@ -113,7 +114,8 @@ private:
 
     void openWorkspace(QString workspaceFileName, bool exampleWorkspace);
     void saveWorkspace(QString workspaceFileName);
-
+    void appendWorkspace(const std::string& workspaceFileName);
+    
     void addActions();
 
     void closeEvent(QCloseEvent* event) override;
@@ -161,6 +163,8 @@ private:
     InviwoEditMenu* editMenu_ = nullptr;
     QMenu* exampleMenu_ = nullptr;
     QMenu* testMenu_ = nullptr;
+
+    std::unique_ptr<FileAssociations> fileAssociations_;
 
     // settings
     bool maximized_;

--- a/include/inviwo/qt/editor/inviwomainwindow.h
+++ b/include/inviwo/qt/editor/inviwomainwindow.h
@@ -146,15 +146,17 @@ private:
     void updateWindowTitle();
 
     InviwoApplicationQt* app_;
+    InviwoEditMenu* editMenu_ = nullptr;
+    QMenu* exampleMenu_ = nullptr;
+    QMenu* testMenu_ = nullptr;
+    std::shared_ptr<ConsoleWidget> consoleWidget_;
     std::unique_ptr<NetworkEditor> networkEditor_;
     NetworkEditorView* networkEditorView_;
  
-    // dock widgets
     SettingsWidget* settingsWidget_;
     ProcessorTreeWidget* processorTreeWidget_;
     ResourceManagerDockWidget* resourceManagerDockWidget_;
     PropertyListWidget* propertyListWidget_;
-    std::shared_ptr<ConsoleWidget> consoleWidget_;
     HelpWidget* helpWidget_;
     NetworkSearch* networkSearch_;
     InviwoAboutWindow* inviwoAboutWindow_ = nullptr;
@@ -162,10 +164,6 @@ private:
     std::vector<QAction*> workspaceActionRecent_;
     QAction* clearRecentWorkspaces_;
     QAction* visibilityModeAction_;
-
-    InviwoEditMenu* editMenu_ = nullptr;
-    QMenu* exampleMenu_ = nullptr;
-    QMenu* testMenu_ = nullptr;
 
     std::unique_ptr<FileAssociations> fileAssociations_;
 
@@ -183,6 +181,7 @@ private:
     TCLAP::ValueArg<std::string> snapshotArg_;
     TCLAP::ValueArg<std::string> screenGrabArg_;
     TCLAP::ValueArg<std::string> saveProcessorPreviews_;
+    TCLAP::ValueArg<std::string> openData_;
     TCLAP::SwitchArg updateWorkspaces_;
     
     UndoManager undoManager_;

--- a/include/inviwo/qt/editor/inviwomainwindow.h
+++ b/include/inviwo/qt/editor/inviwomainwindow.h
@@ -76,6 +76,7 @@ public:
 
     void openLastWorkspace(std::string workspace = "");
     void openWorkspace(QString workspaceFileName);
+    bool openWorkspaceAskToSave(QString workspaceFileName);
     std::string getCurrentWorkspace();
 
     NetworkEditor* getNetworkEditor() const;
@@ -105,7 +106,9 @@ public:
 
 protected:
     virtual void dragEnterEvent(QDragEnterEvent* event) override;
+    virtual void dragMoveEvent(QDragMoveEvent* event) override;
     virtual void dropEvent(QDropEvent* event) override;
+
 
 private:
     virtual void onModifiedStatusChanged(const bool& newStatus) override;

--- a/include/inviwo/qt/editor/networkeditor.h
+++ b/include/inviwo/qt/editor/networkeditor.h
@@ -91,6 +91,7 @@ public:
     QByteArray copy() const;
     QByteArray cut();
     void paste(QByteArray data);
+    void append(std::istream& is, const std::string& refPath = "");
     void selectAll();
     void deleteSelection();
 

--- a/include/inviwo/qt/editor/networkeditor.h
+++ b/include/inviwo/qt/editor/networkeditor.h
@@ -115,8 +115,6 @@ public:
     void initiateLink(ProcessorLinkGraphicsItem* item, QPointF pos);
 
     // Port inspectors
-    bool addPortInspector(Outport* port, QPointF pos);
-    void removePortInspector(Outport* port);
     std::shared_ptr<const Image> renderPortInspectorImage(Outport* port);
     
     ProcessorGraphicsItem* getProcessorGraphicsItem(Processor* key) const;
@@ -132,8 +130,6 @@ public:
     QRectF getProcessorsBoundingRect() const;
 
     static std::string getMimeTag();
-public slots:
-    void contextMenuShowInspector(EditorGraphicsItem*);
     void resetAllTimeMeasurements();
 
 protected:

--- a/include/inviwo/qt/editor/networkeditorview.h
+++ b/include/inviwo/qt/editor/networkeditorview.h
@@ -54,6 +54,7 @@ public:
     ~NetworkEditorView();
 
     void hideNetwork(bool);
+    void fitNetwork();
     virtual void onNetworkEditorFileChanged(const std::string& newFilename) override;
 
     void exportViewToFile(const QString& filename, bool entireScene, bool backgroundVisible);
@@ -72,8 +73,6 @@ protected:
 
 private:
     void zoom(double dz);
-    void fitNetwork();
-
     virtual void onSceneSizeChanged() override;
 
     InviwoMainWindow* mainwindow_;

--- a/include/inviwo/qt/editor/networkeditorview.h
+++ b/include/inviwo/qt/editor/networkeditorview.h
@@ -67,9 +67,6 @@ protected:
     virtual void keyPressEvent(QKeyEvent* keyEvent) override;
     virtual void keyReleaseEvent(QKeyEvent* keyEvent) override;
     virtual void focusOutEvent(QFocusEvent*) override;
-    
-    virtual void dragEnterEvent(QDragEnterEvent* event) override;
-    virtual void dropEvent(QDropEvent* event) override;
 
 private:
     void zoom(double dz);

--- a/modules/base/processors/cubeproxygeometryprocessor.cpp
+++ b/modules/base/processors/cubeproxygeometryprocessor.cpp
@@ -27,7 +27,7 @@
  *
  *********************************************************************************/
 
-#include "cubeproxygeometryprocessor.h"
+#include <modules/base/processors/cubeproxygeometryprocessor.h>
 #include <inviwo/core/datastructures/geometry/simplemeshcreator.h>
 #include <inviwo/core/network/networklock.h>
 #include <inviwo/core/util/volumeutils.h>

--- a/modules/base/processors/datasource.h
+++ b/modules/base/processors/datasource.h
@@ -48,7 +48,8 @@ namespace inviwo {
 template <typename DataType, typename PortType>
 class DataSource : public Processor {
 public:
-    DataSource();
+    DataSource(InviwoApplication* app = InviwoApplication::getPtr(), const std::string& file = "",
+               const std::string& content = "");
     virtual ~DataSource() = default;
 
     virtual void process() override;
@@ -62,6 +63,7 @@ protected:
     // Called when we deserialized old data.
     virtual void dataDeserialized(std::shared_ptr<DataType> data){};
 
+    InviwoApplication* app_;
     PortType port_;
     FileProperty file_;
     ButtonProperty reload_;
@@ -72,8 +74,13 @@ private:
 };
 
 template <typename DataType, typename PortType>
-DataSource<DataType, PortType>::DataSource()
-    : Processor(), port_("data"), file_("filename", "File"), reload_("reload", "Reload data") {
+DataSource<DataType, PortType>::DataSource(InviwoApplication* app, const std::string& file,
+                                           const std::string& content)
+    : Processor()
+    , app_(app)
+    , port_("data")
+    , file_("filename", "File", file, content)
+    , reload_("reload", "Reload data") {
 
     // make sure that we always process even if not connected
     isSink_.setUpdate([]() { return true; });
@@ -85,7 +92,7 @@ DataSource<DataType, PortType>::DataSource()
     addProperty(file_);
     addProperty(reload_);
 
-    auto rf = InviwoApplication::getPtr()->getDataReaderFactory();
+    auto rf = app_->getDataReaderFactory();
     file_.clearNameFilters();
     file_.addNameFilter(FileExtension("*", "All Files"));
     file_.addNameFilters(rf->template getExtensionsForType<DataType>());
@@ -104,7 +111,7 @@ void DataSource<DataType, PortType>::load(bool deserialized) {
     if (file_.get().empty()) return;
 
     std::string ext = filesystem::getFileExtension(file_.get());
-    auto rf = InviwoApplication::getPtr()->getDataReaderFactory();
+    auto rf = app_->getDataReaderFactory();
     if (auto reader = rf->template getReaderForTypeAndExtension<DataType>(ext)) {
         try {
             auto data = reader->readData(file_.get());
@@ -126,7 +133,7 @@ void DataSource<DataType, PortType>::load(bool deserialized) {
 template <typename DataType, typename PortType>
 void DataSource<DataType, PortType>::deserialize(Deserializer& d) {
     Processor::deserialize(d);
-    auto rf = InviwoApplication::getPtr()->getDataReaderFactory();
+    auto rf = app_->getDataReaderFactory();
     file_.clearNameFilters();
     file_.addNameFilter(FileExtension("*", "All Files"));
     file_.addNameFilters(rf->template getExtensionsForType<DataType>());

--- a/modules/base/processors/imagesource.cpp
+++ b/modules/base/processors/imagesource.cpp
@@ -46,16 +46,17 @@ const ProcessorInfo ImageSource::processorInfo_{
 };
 const ProcessorInfo ImageSource::getProcessorInfo() const { return processorInfo_; }
 
-ImageSource::ImageSource()
+ImageSource::ImageSource(InviwoApplication* app, const std::string& file)
     : Processor()
+    , app_(app)
     , outport_("image", DataVec4UInt8::get(), false)
-    , file_("imageFileName", "File name", "", "image")
+    , file_("imageFileName", "File name", file, "image")
     , imageDimension_("imageDimension_", "Dimension", ivec2(0), ivec2(0), ivec2(10000), ivec2(1),
                       InvalidationLevel::Valid, PropertySemantics("Text")) {
 
     addPort(outport_);
 
-    auto rf = InviwoApplication::getPtr()->getDataReaderFactory();
+    auto rf = app_->getDataReaderFactory();
     file_.clearNameFilters();
     file_.addNameFilter(FileExtension("*", "All Files"));
     file_.addNameFilters(rf->getExtensionsForType<Layer>());
@@ -73,7 +74,7 @@ void ImageSource::process() {
     if (file_.get().empty()) return;
 
     std::string ext = filesystem::getFileExtension(file_.get());
-    auto factory = getNetwork()->getApplication()->getDataReaderFactory();
+    auto factory = app_->getDataReaderFactory();
     if (auto reader = factory->getReaderForTypeAndExtension<Layer>(ext)) {
         try {
             auto outLayer = reader->readData(file_.get());
@@ -103,7 +104,7 @@ void ImageSource::process() {
 
 void ImageSource::deserialize(Deserializer& d) {
     Processor::deserialize(d);
-    auto rf = InviwoApplication::getPtr()->getDataReaderFactory();
+    auto rf = app_->getDataReaderFactory();
     file_.clearNameFilters();
     file_.addNameFilter(FileExtension("*", "All Files"));
     file_.addNameFilters(rf->getExtensionsForType<Layer>());

--- a/modules/base/processors/meshsource.cpp
+++ b/modules/base/processors/meshsource.cpp
@@ -24,7 +24,7 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  *********************************************************************************/
 
 #include "meshsource.h"
@@ -38,15 +38,11 @@ const ProcessorInfo MeshSource::processorInfo_{
     CodeState::Stable,            // Code state
     Tags::CPU,                    // Tags
 };
-const ProcessorInfo MeshSource::getProcessorInfo() const {
-    return processorInfo_;
-}
+const ProcessorInfo MeshSource::getProcessorInfo() const { return processorInfo_; }
 
-MeshSource::MeshSource() : DataSource<Mesh, MeshOutport>() {
-    DataSource<Mesh, MeshOutport>::file_.setContentType("geometry");
+MeshSource::MeshSource(InviwoApplication* app, const std::string& file)
+    : DataSource<Mesh, MeshOutport>(app, file, "geometry") {
     DataSource<Mesh, MeshOutport>::file_.setDisplayName("Geometry file");
 }
 
-} // namespace
-
-
+}  // namespace inviwo

--- a/modules/base/processors/meshsource.h
+++ b/modules/base/processors/meshsource.h
@@ -50,7 +50,7 @@ namespace inviwo {
  */
 class IVW_MODULE_BASE_API MeshSource : public DataSource<Mesh, MeshOutport> {
 public:
-    MeshSource();
+    MeshSource(InviwoApplication* app, const std::string& file = "");
     virtual ~MeshSource() = default;
 
     virtual const ProcessorInfo getProcessorInfo() const override;

--- a/modules/base/processors/volumeboundingbox.cpp
+++ b/modules/base/processors/volumeboundingbox.cpp
@@ -27,7 +27,7 @@
  *
  *********************************************************************************/
 
-#include "volumeboundingbox.h"
+#include <modules/base/processors/volumeboundingbox.h>
 #include <modules/base/algorithm/meshutils.h>
 #include <inviwo/core/datastructures/geometry/basicmesh.h>
 
@@ -38,7 +38,7 @@ const ProcessorInfo VolumeBoundingBox::processorInfo_{
     "org.inviwo.VolumeBoundingBox",  // Class identifier
     "Volume Bounding Box",           // Display name
     "Volume Operation",              // Category
-    CodeState::Experimental,         // Code state
+    CodeState::Stable,               // Code state
     Tags::None,                      // Tags
 };
 const ProcessorInfo VolumeBoundingBox::getProcessorInfo() const { return processorInfo_; }
@@ -47,8 +47,7 @@ VolumeBoundingBox::VolumeBoundingBox()
     : Processor()
     , volume_("volume")
     , mesh_("mesh")
-    , color_("color", "Color", vec4(1.0f), vec4(0.0f), vec4(1.0f))
-{
+    , color_("color", "Color", vec4(1.0f), vec4(0.0f), vec4(1.0f)) {
 
     addPort(volume_);
     addPort(mesh_);

--- a/modules/base/processors/volumesource.cpp
+++ b/modules/base/processors/volumesource.cpp
@@ -27,7 +27,7 @@
  *
  *********************************************************************************/
 
-#include "volumesource.h"
+#include <modules/base/processors/volumesource.h>
 #include <inviwo/core/common/inviwoapplication.h>
 #include <inviwo/core/util/filesystem.h>
 #include <inviwo/core/util/raiiutils.h>
@@ -53,10 +53,11 @@ const ProcessorInfo VolumeSource::processorInfo_{
 };
 const ProcessorInfo VolumeSource::getProcessorInfo() const { return processorInfo_; }
 
-VolumeSource::VolumeSource()
+VolumeSource::VolumeSource(InviwoApplication* app, const std::string& file)
     : Processor()
+    , app_(app)
     , outport_("data")
-    , file_("filename", "File")
+    , file_("filename", "File", file, "volume")
     , reload_("reload", "Reload data")
     , basis_("Basis", "Basis and offset")
     , information_("Information", "Data information")
@@ -84,9 +85,8 @@ VolumeSource::VolumeSource()
 void VolumeSource::load(bool deserialize) {
     if (file_.get().empty()) return;
 
-    auto app = InviwoApplication::getPtr();
-    auto rf = app->getDataReaderFactory();
-    auto rm = app->getResourceManager();
+    auto rf = app_->getDataReaderFactory();
+    auto rm = app_->getResourceManager();
     std::string ext = filesystem::getFileExtension(file_.get());
 
     // use resource unless the "Reload data"-button (reload_) was pressed,
@@ -124,7 +124,7 @@ void VolumeSource::load(bool deserialize) {
 }
 
 void VolumeSource::addFileNameFilters() {
-    auto rf = InviwoApplication::getPtr()->getDataReaderFactory();
+    auto rf = app_->getDataReaderFactory();
 
     file_.clearNameFilters();
     file_.addNameFilter(FileExtension("*", "All Files"));

--- a/modules/base/processors/volumesource.h
+++ b/modules/base/processors/volumesource.h
@@ -42,6 +42,8 @@
 
 namespace inviwo {
 
+class InviwoApplication;
+
 /** \docpage{org.inviwo.VolumeSource, Volume Source}
  * ![](org.inviwo.VolumeSource.png?classIdentifier=org.inviwo.VolumeSource)
  *
@@ -59,7 +61,7 @@ public:
     virtual const ProcessorInfo getProcessorInfo() const override;
     static const ProcessorInfo processorInfo_;
 
-    VolumeSource();
+    VolumeSource(InviwoApplication* app, const std::string& file = "");
     virtual ~VolumeSource() = default;
 
     virtual void deserialize(Deserializer& d) override;
@@ -69,6 +71,7 @@ private:
     void load(bool deserialize = false);
     void addFileNameFilters();
 
+    InviwoApplication* app_;
     std::shared_ptr<VolumeSequence> volumes_;
 
     VolumeOutport outport_;

--- a/modules/basegl/CMakeLists.txt
+++ b/modules/basegl/CMakeLists.txt
@@ -7,6 +7,10 @@ ivw_module(BaseGL)
 set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/algorithm/entryexitpoints.h
     ${CMAKE_CURRENT_SOURCE_DIR}/algorithm/imageconvolution.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/datavisualizer/imagevisualizer.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/datavisualizer/meshvisualizer.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/datavisualizer/volumeraycastvisualizer.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/datavisualizer/volumeslicevisualizer.h
     ${CMAKE_CURRENT_SOURCE_DIR}/processors/axisalignedcutplane.h
     ${CMAKE_CURRENT_SOURCE_DIR}/processors/background.h
     ${CMAKE_CURRENT_SOURCE_DIR}/processors/cuberenderer.h
@@ -67,6 +71,10 @@ ivw_group("Header Files" ${HEADER_FILES})
 set(SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/algorithm/entryexitpoints.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/algorithm/imageconvolution.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/datavisualizer/imagevisualizer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/datavisualizer/meshvisualizer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/datavisualizer/volumeraycastvisualizer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/datavisualizer/volumeslicevisualizer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/processors/axisalignedcutplane.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/processors/background.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/processors/cuberenderer.cpp

--- a/modules/basegl/baseglmodule.cpp
+++ b/modules/basegl/baseglmodule.cpp
@@ -79,6 +79,10 @@
 #include <modules/basegl/processors/volumeraycaster.h>
 #include <modules/basegl/processors/volumeslicegl.h>
 #include <modules/basegl/processors/volumeprocessing/volumeshader.h>
+#include <modules/basegl/datavisualizer/volumeraycastvisualizer.h>
+#include <modules/basegl/datavisualizer/volumeslicevisualizer.h>
+#include <modules/basegl/datavisualizer/imagevisualizer.h>
+#include <modules/basegl/datavisualizer/meshvisualizer.h>
  
 #include <modules/opengl/shader/shadermanager.h>
 
@@ -144,6 +148,11 @@ BaseGLModule::BaseGLModule(InviwoApplication* app) : InviwoModule(app, "BaseGL")
     registerProcessor<VolumeMapping>();
     registerProcessor<VolumeMerger>();
     registerProcessor<VolumeShader>();
+
+    registerDataVisualizer(std::make_unique<VolumeRaycastVisualizer>(app));
+    registerDataVisualizer(std::make_unique<VolumeSliceVisualizer>(app));
+    registerDataVisualizer(std::make_unique<ImageVisualizer>(app));
+    registerDataVisualizer(std::make_unique<MeshVisualizer>(app));
 }
 
 int BaseGLModule::getVersion() const { return 3; }

--- a/modules/basegl/datavisualizer/imagevisualizer.cpp
+++ b/modules/basegl/datavisualizer/imagevisualizer.cpp
@@ -1,0 +1,102 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2018 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <modules/basegl/datavisualizer/imagevisualizer.h>
+
+#include <modules/base/processors/imagesource.h>
+#include <modules/opengl/canvasprocessorgl.h>
+#include <inviwo/core/processors/processorutils.h>
+#include <inviwo/core/ports/imageport.h>
+
+#include <inviwo/core/io/datareaderfactory.h>
+
+namespace inviwo {
+
+using GP = util::GridPos;
+
+ImageVisualizer::ImageVisualizer(InviwoApplication* app) : DataVisualizer{}, app_(app) {}
+
+std::string ImageVisualizer::getName() const { return "Image Canvas"; }
+
+Document ImageVisualizer::getDescription() const { 
+    Document doc;
+    using P = Document::PathComponent;
+    auto b = doc.append("html").append("body");
+    b.append("", "Construct a image source and canvas");
+    return doc;
+}
+
+std::vector<FileExtension> ImageVisualizer::getSupportedFileExtensions() const {
+    auto rf = app_->getDataReaderFactory();
+    auto exts = rf->getExtensionsForType<Layer>();
+    return exts;
+}
+
+bool ImageVisualizer::isOutportSupported(const Outport* port) const {
+    return dynamic_cast<const ImageOutport*>(port) != nullptr;
+}
+
+bool ImageVisualizer::hasSourceProcessor() const { return true; }
+bool ImageVisualizer::hasVisualizerNetwork() const { return true; }
+
+std::pair<Processor*, Outport*> ImageVisualizer::addSourceProcessor(const std::string& filename,
+                                                                    ProcessorNetwork* net) const {
+
+    auto source = net->addProcessor(util::makeProcessor<ImageSource>(GP{0, 0}, app_, filename));
+    auto outport = source->getOutports().front();
+    return {source, outport};
+}
+
+std::vector<Processor*> ImageVisualizer::addVisualizerNetwork(Outport* outport,
+                                                              ProcessorNetwork* net) const {
+
+    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 3}));
+    net->addConnection(outport, cvs->getInports()[0]);
+
+    return {cvs};
+}
+
+std::vector<Processor*> ImageVisualizer::addSourceAndVisualizerNetwork(
+    const std::string& filename, ProcessorNetwork* net) const {
+
+    auto sourceAndOutport = addSourceProcessor(filename, net);
+    auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
+
+    net->addLink(sourceAndOutport.first->getPropertyByIdentifier("imageDimension_"),
+                 processors.front()->getPropertyByPath({"inputSize", "dimensions"}));
+
+    net->evaluateLinksFromProperty(
+        sourceAndOutport.first->getPropertyByIdentifier("imageDimension_"));
+
+    processors.push_back(sourceAndOutport.first);
+
+    return processors;
+}
+
+}  // namespace inviwo

--- a/modules/basegl/datavisualizer/imagevisualizer.h
+++ b/modules/basegl/datavisualizer/imagevisualizer.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2012-2018 Inviwo Foundation
+ * Copyright (c) 2018 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,52 +24,43 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  *********************************************************************************/
 
-#ifndef IVW_IMAGESOURCE_H
-#define IVW_IMAGESOURCE_H
+#ifndef IVW_IMAGEVISUALIZER_H
+#define IVW_IMAGEVISUALIZER_H
 
-#include <modules/base/basemoduledefine.h>
+#include <modules/basegl/baseglmoduledefine.h>
 #include <inviwo/core/common/inviwo.h>
-#include <inviwo/core/processors/processor.h>
-#include <inviwo/core/properties/fileproperty.h>
-#include <inviwo/core/ports/imageport.h>
-#include <inviwo/core/properties/ordinalproperty.h>
+
+#include <inviwo/core/rendering/datavisualizer.h>
 
 namespace inviwo {
 
-/** \docpage{org.inviwo.ImageSource, Image Source}
- * ![](org.inviwo.ImageSource.png?classIdentifier=org.inviwo.ImageSource)
- *
- * Loads a image
- * 
- * ### Outports
- *   * __Outport__ The loaded image
- * 
- * ### Properties
- *   * __File name__ The name of the file to load
- *   * __Dimensions__ Readonly, the dimensions of the loaded image.
- */
-
-class IVW_MODULE_BASE_API ImageSource : public Processor {
+class IVW_MODULE_BASEGL_API ImageVisualizer : public DataVisualizer {
 public:
-    ImageSource(InviwoApplication* app, const std::string& file = "");
-    virtual ~ImageSource() = default;
+    ImageVisualizer(InviwoApplication* app);
+    virtual ~ImageVisualizer() = default;
 
-    virtual const ProcessorInfo getProcessorInfo() const override;
-    static const ProcessorInfo processorInfo_;
+    virtual std::string getName() const override;
+    virtual Document getDescription() const override;
+    virtual std::vector<FileExtension> getSupportedFileExtensions() const override;
+    virtual bool isOutportSupported(const Outport* port) const override;
 
-    virtual void process() override;
-    virtual void deserialize(Deserializer& d) override;
+    virtual bool hasSourceProcessor() const override;
+    virtual bool hasVisualizerNetwork() const override;
+
+    virtual std::pair<Processor*, Outport*> addSourceProcessor(
+        const std::string& filename, ProcessorNetwork* network) const override;
+    virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
+                                                         ProcessorNetwork* network) const override;
+    virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
+        const std::string& filename, ProcessorNetwork* network) const override;
 
 private:
     InviwoApplication* app_;
-    ImageOutport outport_;
-    FileProperty file_;
-    IntVec2Property imageDimension_;
 };
 
-} // namespace
+}  // namespace inviwo
 
-#endif // IVW_IMAGESOURCE_H
+#endif  // IVW_IMAGEVISUALIZER_H

--- a/modules/basegl/datavisualizer/meshvisualizer.cpp
+++ b/modules/basegl/datavisualizer/meshvisualizer.cpp
@@ -1,0 +1,103 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2018 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <modules/basegl/datavisualizer/meshvisualizer.h>
+
+#include <modules/base/processors/meshsource.h>
+#include <modules/basegl/processors/background.h>
+#include <modules/basegl/processors/meshrenderprocessorgl.h>
+#include <modules/opengl/canvasprocessorgl.h>
+#include <inviwo/core/processors/processorutils.h>
+#include <inviwo/core/ports/meshport.h>
+
+#include <inviwo/core/io/datareaderfactory.h>
+
+namespace inviwo {
+
+using GP = util::GridPos;
+
+MeshVisualizer::MeshVisualizer(InviwoApplication* app) : DataVisualizer{}, app_(app) {}
+
+std::string MeshVisualizer::getName() const { return "Mesh Renderer"; }
+
+Document MeshVisualizer::getDescription() const { 
+    Document doc;
+    using P = Document::PathComponent;
+    auto b = doc.append("html").append("body");
+    b.append("", "Construct a standard mesh renderer");
+    return doc;
+}
+
+std::vector<FileExtension> MeshVisualizer::getSupportedFileExtensions() const {
+    auto rf = app_->getDataReaderFactory();
+    auto exts = rf->getExtensionsForType<Mesh>();
+    return exts;
+}
+
+bool MeshVisualizer::isOutportSupported(const Outport* port) const {
+    return dynamic_cast<const MeshOutport*>(port) != nullptr;
+}
+
+bool MeshVisualizer::hasSourceProcessor() const { return true; }
+bool MeshVisualizer::hasVisualizerNetwork() const { return true; }
+
+std::pair<Processor*, Outport*> MeshVisualizer::addSourceProcessor(const std::string& filename,
+                                                                   ProcessorNetwork* net) const {
+
+    auto source = net->addProcessor(util::makeProcessor<MeshSource>(GP{0, 0}, app_, filename));
+    auto outport = source->getOutports().front();
+    return {source, outport};
+}
+
+std::vector<Processor*> MeshVisualizer::addVisualizerNetwork(Outport* outport,
+                                                             ProcessorNetwork* net) const {
+
+    auto bak = net->addProcessor(util::makeProcessor<Background>(GP{1, 3}));
+    auto mrp = net->addProcessor(util::makeProcessor<MeshRenderProcessorGL>(GP{0, 6}));
+    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 9}));
+
+    net->addConnection(bak->getOutports()[0], mrp->getInports()[1]);
+    net->addConnection(mrp->getOutports()[0], cvs->getInports()[0]);
+
+    net->addConnection(outport, mrp->getInports()[0]);
+
+    return {bak, mrp, cvs};
+}
+
+std::vector<Processor*> MeshVisualizer::addSourceAndVisualizerNetwork(const std::string& filename,
+                                                                      ProcessorNetwork* net) const {
+
+    auto sourceAndOutport = addSourceProcessor(filename, net);
+    auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
+
+    processors.push_back(sourceAndOutport.first);
+    return processors;
+}
+
+}  // namespace inviwo

--- a/modules/basegl/datavisualizer/meshvisualizer.h
+++ b/modules/basegl/datavisualizer/meshvisualizer.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2012-2018 Inviwo Foundation
+ * Copyright (c) 2018 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,52 +24,41 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  *********************************************************************************/
 
-#ifndef IVW_IMAGESOURCE_H
-#define IVW_IMAGESOURCE_H
+#ifndef IVW_MESHVISUALIZER_H
+#define IVW_MESHVISUALIZER_H
 
-#include <modules/base/basemoduledefine.h>
+#include <modules/basegl/baseglmoduledefine.h>
 #include <inviwo/core/common/inviwo.h>
-#include <inviwo/core/processors/processor.h>
-#include <inviwo/core/properties/fileproperty.h>
-#include <inviwo/core/ports/imageport.h>
-#include <inviwo/core/properties/ordinalproperty.h>
+#include <inviwo/core/rendering/datavisualizer.h>
 
 namespace inviwo {
 
-/** \docpage{org.inviwo.ImageSource, Image Source}
- * ![](org.inviwo.ImageSource.png?classIdentifier=org.inviwo.ImageSource)
- *
- * Loads a image
- * 
- * ### Outports
- *   * __Outport__ The loaded image
- * 
- * ### Properties
- *   * __File name__ The name of the file to load
- *   * __Dimensions__ Readonly, the dimensions of the loaded image.
- */
-
-class IVW_MODULE_BASE_API ImageSource : public Processor {
+class IVW_MODULE_BASEGL_API MeshVisualizer : public DataVisualizer {
 public:
-    ImageSource(InviwoApplication* app, const std::string& file = "");
-    virtual ~ImageSource() = default;
+    MeshVisualizer(InviwoApplication* app);
+    virtual ~MeshVisualizer() = default;
+    virtual std::string getName() const override;
+    virtual Document getDescription() const override;
+    virtual std::vector<FileExtension> getSupportedFileExtensions() const override;
+    virtual bool isOutportSupported(const Outport* port) const override;
 
-    virtual const ProcessorInfo getProcessorInfo() const override;
-    static const ProcessorInfo processorInfo_;
+    virtual bool hasSourceProcessor() const override;
+    virtual bool hasVisualizerNetwork() const override;
 
-    virtual void process() override;
-    virtual void deserialize(Deserializer& d) override;
+    virtual std::pair<Processor*, Outport*> addSourceProcessor(
+        const std::string& filename, ProcessorNetwork* network) const override;
+    virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
+                                                         ProcessorNetwork* network) const override;
+    virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
+        const std::string& filename, ProcessorNetwork* network) const override;
 
 private:
     InviwoApplication* app_;
-    ImageOutport outport_;
-    FileProperty file_;
-    IntVec2Property imageDimension_;
 };
 
-} // namespace
+}  // namespace inviwo
 
-#endif // IVW_IMAGESOURCE_H
+#endif  // IVW_MESHVISUALIZER_H

--- a/modules/basegl/datavisualizer/volumeraycastvisualizer.cpp
+++ b/modules/basegl/datavisualizer/volumeraycastvisualizer.cpp
@@ -1,0 +1,130 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2018 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <modules/basegl/datavisualizer/volumeraycastvisualizer.h>
+#include <modules/base/processors/volumesource.h>
+#include <modules/base/processors/cubeproxygeometryprocessor.h>
+#include <modules/base/processors/volumeboundingbox.h>
+#include <modules/basegl/processors/volumeraycaster.h>
+#include <modules/basegl/processors/entryexitpointsprocessor.h>
+#include <modules/basegl/processors/background.h>
+#include <modules/basegl/processors/meshrenderprocessorgl.h>
+#include <modules/opengl/canvasprocessorgl.h>
+#include <inviwo/core/processors/processorutils.h>
+#include <inviwo/core/ports/volumeport.h>
+
+#include <inviwo/core/io/datareaderfactory.h>
+
+namespace inviwo {
+
+using GP = util::GridPos;
+
+VolumeRaycastVisualizer::VolumeRaycastVisualizer(InviwoApplication* app)
+    : DataVisualizer{}, app_(app) {}
+
+std::string VolumeRaycastVisualizer::getName() const { return "Volume Raycaster"; }
+
+Document VolumeRaycastVisualizer::getDescription() const {
+    Document doc;
+    using P = Document::PathComponent;
+    auto b = doc.append("html").append("body");
+    b.append("", "Construct a standard volume raycaster");
+    return doc;
+}
+
+std::vector<FileExtension> VolumeRaycastVisualizer::getSupportedFileExtensions() const {
+    auto rf = app_->getDataReaderFactory();
+    auto exts = rf->getExtensionsForType<Volume>();
+    auto exts2 = rf->getExtensionsForType<VolumeSequence>();
+    exts.insert(exts.end(), exts2.begin(), exts2.end());
+    return exts;
+}
+
+bool VolumeRaycastVisualizer::isOutportSupported(const Outport* port) const {
+    return dynamic_cast<const VolumeOutport*>(port) != nullptr;
+}
+
+bool VolumeRaycastVisualizer::hasSourceProcessor() const { return true; }
+bool VolumeRaycastVisualizer::hasVisualizerNetwork() const { return true; }
+
+std::pair<Processor*, Outport*> VolumeRaycastVisualizer::addSourceProcessor(
+    const std::string& filename, ProcessorNetwork* net) const {
+
+    auto source =
+        net->addProcessor(util::makeProcessor<VolumeSource>(GP{0, 0}, app_, filename));
+    auto outport = source->getOutports().front();
+    return {source, outport};
+}
+
+std::vector<Processor*> VolumeRaycastVisualizer::addVisualizerNetwork(Outport* outport,
+                                                                      ProcessorNetwork* net) const {
+
+    auto cpg = net->addProcessor(util::makeProcessor<CubeProxyGeometry>(GP{1, 3}));
+    auto eep = net->addProcessor(util::makeProcessor<EntryExitPoints>(GP{1, 6}));
+    auto vrc = net->addProcessor(util::makeProcessor<VolumeRaycaster>(GP{0, 9}));
+    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 12}));
+
+    auto vbb = net->addProcessor(util::makeProcessor<VolumeBoundingBox>(GP{8, 3}));
+    auto bak = net->addProcessor(util::makeProcessor<Background>(GP{15, 3}));
+    auto mrp = net->addProcessor(util::makeProcessor<MeshRenderProcessorGL>(GP{8, 6}));
+
+    net->addConnection(outport, cpg->getInports()[0]);
+    net->addConnection(cpg->getOutports()[0], eep->getInports()[0]);
+
+    net->addConnection(eep->getOutports()[0], vrc->getInports()[1]);
+    net->addConnection(eep->getOutports()[1], vrc->getInports()[2]);
+
+    net->addConnection(outport, vrc->getInports()[0]);
+    net->addConnection(vrc->getOutports()[0], cvs->getInports()[0]);
+
+    net->addConnection(outport, vbb->getInports()[0]);
+    net->addConnection(vbb->getOutports()[0], mrp->getInports()[0]);
+    net->addConnection(bak->getOutports()[0], mrp->getInports()[1]);
+    net->addConnection(mrp->getOutports()[0], vrc->getInports()[3]);
+
+    net->addLink(eep->getPropertyByIdentifier("camera"), vrc->getPropertyByIdentifier("camera"));
+    net->addLink(vrc->getPropertyByIdentifier("camera"), eep->getPropertyByIdentifier("camera"));
+
+    net->addLink(eep->getPropertyByIdentifier("camera"), mrp->getPropertyByIdentifier("camera"));
+    net->addLink(mrp->getPropertyByIdentifier("camera"), eep->getPropertyByIdentifier("camera"));
+
+    return {cpg, eep, vrc, cvs, vbb, bak, mrp};
+}
+
+std::vector<Processor*> VolumeRaycastVisualizer::addSourceAndVisualizerNetwork(
+    const std::string& filename, ProcessorNetwork* net) const {
+
+    auto sourceAndOutport = addSourceProcessor(filename, net);
+    auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
+
+    processors.push_back(sourceAndOutport.first);
+    return processors;
+}
+
+}  // namespace inviwo

--- a/modules/basegl/datavisualizer/volumeraycastvisualizer.h
+++ b/modules/basegl/datavisualizer/volumeraycastvisualizer.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2012-2018 Inviwo Foundation
+ * Copyright (c) 2018 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,52 +24,42 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  *********************************************************************************/
 
-#ifndef IVW_IMAGESOURCE_H
-#define IVW_IMAGESOURCE_H
+#ifndef IVW_VOLUMERAYCASTVISUALIZER_H
+#define IVW_VOLUMERAYCASTVISUALIZER_H
 
-#include <modules/base/basemoduledefine.h>
+#include <modules/basegl/baseglmoduledefine.h>
 #include <inviwo/core/common/inviwo.h>
-#include <inviwo/core/processors/processor.h>
-#include <inviwo/core/properties/fileproperty.h>
-#include <inviwo/core/ports/imageport.h>
-#include <inviwo/core/properties/ordinalproperty.h>
+#include <inviwo/core/rendering/datavisualizer.h>
 
 namespace inviwo {
 
-/** \docpage{org.inviwo.ImageSource, Image Source}
- * ![](org.inviwo.ImageSource.png?classIdentifier=org.inviwo.ImageSource)
- *
- * Loads a image
- * 
- * ### Outports
- *   * __Outport__ The loaded image
- * 
- * ### Properties
- *   * __File name__ The name of the file to load
- *   * __Dimensions__ Readonly, the dimensions of the loaded image.
- */
-
-class IVW_MODULE_BASE_API ImageSource : public Processor {
+class IVW_MODULE_BASEGL_API VolumeRaycastVisualizer : public DataVisualizer {
 public:
-    ImageSource(InviwoApplication* app, const std::string& file = "");
-    virtual ~ImageSource() = default;
+    VolumeRaycastVisualizer(InviwoApplication* app);
+    virtual ~VolumeRaycastVisualizer() = default;
 
-    virtual const ProcessorInfo getProcessorInfo() const override;
-    static const ProcessorInfo processorInfo_;
+    virtual std::string getName() const override;
+    virtual Document getDescription() const override;
+    virtual std::vector<FileExtension> getSupportedFileExtensions() const override;
+    virtual bool isOutportSupported(const Outport* port) const override;
 
-    virtual void process() override;
-    virtual void deserialize(Deserializer& d) override;
+    virtual bool hasSourceProcessor() const override;
+    virtual bool hasVisualizerNetwork() const override;
+
+    virtual std::pair<Processor*, Outport*> addSourceProcessor(
+        const std::string& filename, ProcessorNetwork* network) const override;
+    virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
+                                                         ProcessorNetwork* network) const override;
+    virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
+        const std::string& filename, ProcessorNetwork* network) const override;
 
 private:
     InviwoApplication* app_;
-    ImageOutport outport_;
-    FileProperty file_;
-    IntVec2Property imageDimension_;
 };
 
-} // namespace
+}  // namespace inviwo
 
-#endif // IVW_IMAGESOURCE_H
+#endif  // IVW_VOLUMERAYCASTVISUALIZER_H

--- a/modules/basegl/datavisualizer/volumeslicevisualizer.cpp
+++ b/modules/basegl/datavisualizer/volumeslicevisualizer.cpp
@@ -1,0 +1,100 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2018 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <modules/basegl/datavisualizer/volumeslicevisualizer.h>
+#include <modules/base/processors/volumesource.h>
+#include <modules/basegl/processors/volumeslicegl.h>
+#include <modules/opengl/canvasprocessorgl.h>
+#include <inviwo/core/processors/processorutils.h>
+#include <inviwo/core/ports/volumeport.h>
+
+#include <inviwo/core/io/datareaderfactory.h>
+
+namespace inviwo {
+
+using GP = util::GridPos;
+
+VolumeSliceVisualizer::VolumeSliceVisualizer(InviwoApplication* app)
+    : DataVisualizer{}, app_(app) {}
+
+std::string VolumeSliceVisualizer::getName() const { return "Volume Slicer"; }
+
+Document VolumeSliceVisualizer::getDescription() const {
+    Document doc;
+    using P = Document::PathComponent;
+    auto b = doc.append("html").append("body");
+    b.append("", "Construct a standard volume slicer");
+    return doc;
+}
+
+std::vector<FileExtension> VolumeSliceVisualizer::getSupportedFileExtensions() const {
+    auto rf = app_->getDataReaderFactory();
+    auto exts = rf->getExtensionsForType<Volume>();
+    auto exts2 = rf->getExtensionsForType<VolumeSequence>();
+    exts.insert(exts.end(), exts2.begin(), exts2.end());
+    return exts;
+}
+
+bool VolumeSliceVisualizer::isOutportSupported(const Outport* port) const {
+    return dynamic_cast<const VolumeOutport*>(port) != nullptr;
+}
+
+bool VolumeSliceVisualizer::hasSourceProcessor() const { return true; }
+bool VolumeSliceVisualizer::hasVisualizerNetwork() const { return true; }
+
+std::pair<Processor*, Outport*> VolumeSliceVisualizer::addSourceProcessor(
+    const std::string& filename, ProcessorNetwork* net) const {
+
+    auto source = net->addProcessor(util::makeProcessor<VolumeSource>(GP{0, 0}, app_, filename));
+    auto outport = source->getOutports().front();
+    return {source, outport};
+}
+
+std::vector<Processor*> VolumeSliceVisualizer::addVisualizerNetwork(Outport* outport,
+                                                                    ProcessorNetwork* net) const {
+    auto vsl = net->addProcessor(util::makeProcessor<VolumeSliceGL>(GP{0, 3}));
+    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 6}));
+
+    net->addConnection(outport, vsl->getInports()[0]);
+    net->addConnection(vsl->getOutports()[0], cvs->getInports()[0]);
+
+    return {vsl, cvs};
+}
+
+std::vector<Processor*> VolumeSliceVisualizer::addSourceAndVisualizerNetwork(
+    const std::string& filename, ProcessorNetwork* net) const {
+
+    auto sourceAndOutport = addSourceProcessor(filename, net);
+    auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
+
+    processors.push_back(sourceAndOutport.first);
+    return processors;
+}
+
+}  // namespace inviwo

--- a/modules/basegl/datavisualizer/volumeslicevisualizer.h
+++ b/modules/basegl/datavisualizer/volumeslicevisualizer.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2012-2018 Inviwo Foundation
+ * Copyright (c) 2018 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,52 +24,42 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  *********************************************************************************/
 
-#ifndef IVW_IMAGESOURCE_H
-#define IVW_IMAGESOURCE_H
+#ifndef IVW_VOLUMESLICEVISUALIZER_H
+#define IVW_VOLUMESLICEVISUALIZER_H
 
-#include <modules/base/basemoduledefine.h>
+#include <modules/basegl/baseglmoduledefine.h>
 #include <inviwo/core/common/inviwo.h>
-#include <inviwo/core/processors/processor.h>
-#include <inviwo/core/properties/fileproperty.h>
-#include <inviwo/core/ports/imageport.h>
-#include <inviwo/core/properties/ordinalproperty.h>
+#include <inviwo/core/rendering/datavisualizer.h>
 
 namespace inviwo {
 
-/** \docpage{org.inviwo.ImageSource, Image Source}
- * ![](org.inviwo.ImageSource.png?classIdentifier=org.inviwo.ImageSource)
- *
- * Loads a image
- * 
- * ### Outports
- *   * __Outport__ The loaded image
- * 
- * ### Properties
- *   * __File name__ The name of the file to load
- *   * __Dimensions__ Readonly, the dimensions of the loaded image.
- */
-
-class IVW_MODULE_BASE_API ImageSource : public Processor {
+class IVW_MODULE_BASEGL_API VolumeSliceVisualizer : public DataVisualizer {
 public:
-    ImageSource(InviwoApplication* app, const std::string& file = "");
-    virtual ~ImageSource() = default;
+    VolumeSliceVisualizer(InviwoApplication* app);
+    virtual ~VolumeSliceVisualizer() = default;
 
-    virtual const ProcessorInfo getProcessorInfo() const override;
-    static const ProcessorInfo processorInfo_;
+    virtual std::string getName() const override;
+    virtual Document getDescription() const override;
+    virtual std::vector<FileExtension> getSupportedFileExtensions() const override;
+    virtual bool isOutportSupported(const Outport* port) const override;
 
-    virtual void process() override;
-    virtual void deserialize(Deserializer& d) override;
+    virtual bool hasSourceProcessor() const override;
+    virtual bool hasVisualizerNetwork() const override;
+
+    virtual std::pair<Processor*, Outport*> addSourceProcessor(
+        const std::string& filename, ProcessorNetwork* network) const override;
+    virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
+                                                         ProcessorNetwork* network) const override;
+    virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
+        const std::string& filename, ProcessorNetwork* network) const override;
 
 private:
     InviwoApplication* app_;
-    ImageOutport outport_;
-    FileProperty file_;
-    IntVec2Property imageDimension_;
 };
 
-} // namespace
+}  // namespace inviwo
 
-#endif // IVW_IMAGESOURCE_H
+#endif  // IVW_VOLUMESLICEVISUALIZER_H

--- a/modules/basegl/processors/entryexitpointsprocessor.cpp
+++ b/modules/basegl/processors/entryexitpointsprocessor.cpp
@@ -27,7 +27,7 @@
  *
  *********************************************************************************/
 
-#include "entryexitpointsprocessor.h"
+#include <modules/basegl/processors/entryexitpointsprocessor.h>
 #include <inviwo/core/interaction/cameratrackball.h>
 #include <inviwo/core/common/inviwoapplication.h>
 #include <inviwo/core/io/serialization/versionconverter.h>

--- a/modules/basegl/processors/meshrenderprocessorgl.cpp
+++ b/modules/basegl/processors/meshrenderprocessorgl.cpp
@@ -27,7 +27,7 @@
  *
  *********************************************************************************/
 
-#include "meshrenderprocessorgl.h"
+#include <modules/basegl/processors/meshrenderprocessorgl.h>
 #include <modules/opengl/geometry/meshgl.h>
 #include <inviwo/core/datastructures/buffer/bufferramprecision.h>
 #include <inviwo/core/interaction/trackball.h>

--- a/modules/basegl/processors/volumeraycaster.cpp
+++ b/modules/basegl/processors/volumeraycaster.cpp
@@ -27,7 +27,7 @@
  *
  *********************************************************************************/
 
-#include "volumeraycaster.h"
+#include <modules/basegl/processors/volumeraycaster.h>
 #include <inviwo/core/io/serialization/serialization.h>
 #include <inviwo/core/io/serialization/versionconverter.h>
 #include <inviwo/core/interaction/events/keyboardevent.h>

--- a/modules/opengl/canvasprocessorgl.cpp
+++ b/modules/opengl/canvasprocessorgl.cpp
@@ -27,8 +27,8 @@
  * 
  *********************************************************************************/
 
-#include "canvasprocessorgl.h"
-#include "canvasgl.h"
+#include <modules/opengl/canvasprocessorgl.h>
+#include <modules/opengl/canvasgl.h>
 #include <inviwo/core/processors/processor.h>
 
 namespace inviwo {

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -34,7 +34,6 @@ set(HEADER_FILES
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/datatraits.h
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/diskrepresentation.h
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/geometry/basicmesh.h
-    ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/geometry/typedmesh.h
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/geometry/edge.h
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/geometry/geometrytype.h
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/geometry/mesh.h
@@ -44,6 +43,7 @@ set(HEADER_FILES
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/geometry/polygon.h
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/geometry/simplemesh.h
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/geometry/simplemeshcreator.h
+    ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/geometry/typedmesh.h
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/histogram.h
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/image/image.h
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/image/imageram.h
@@ -183,6 +183,7 @@ set(HEADER_FILES
     ${IVW_INCLUDE_DIR}/inviwo/core/processors/processorstate.h
     ${IVW_INCLUDE_DIR}/inviwo/core/processors/processortags.h
     ${IVW_INCLUDE_DIR}/inviwo/core/processors/processortraits.h
+    ${IVW_INCLUDE_DIR}/inviwo/core/processors/processorutils.h
     ${IVW_INCLUDE_DIR}/inviwo/core/processors/processorwidget.h
     ${IVW_INCLUDE_DIR}/inviwo/core/processors/processorwidgetfactory.h
     ${IVW_INCLUDE_DIR}/inviwo/core/processors/processorwidgetfactoryobject.h
@@ -235,6 +236,8 @@ set(HEADER_FILES
     ${IVW_INCLUDE_DIR}/inviwo/core/properties/transferfunctionproperty.h
     ${IVW_INCLUDE_DIR}/inviwo/core/properties/valuewrapper.h
     ${IVW_INCLUDE_DIR}/inviwo/core/properties/volumeindicatorproperty.h
+    ${IVW_INCLUDE_DIR}/inviwo/core/rendering/datavisualizer.h
+    ${IVW_INCLUDE_DIR}/inviwo/core/rendering/datavisualizermanager.h
     ${IVW_INCLUDE_DIR}/inviwo/core/rendering/meshdrawer.h
     ${IVW_INCLUDE_DIR}/inviwo/core/rendering/meshdrawerfactory.h
     ${IVW_INCLUDE_DIR}/inviwo/core/resourcemanager/resource.h
@@ -452,6 +455,7 @@ set(SOURCE_FILES
     processors/processorinfo.cpp
     processors/processorpair.cpp
     processors/processortags.cpp
+    processors/processorutils.cpp
     processors/processorwidget.cpp
     processors/processorwidgetfactory.cpp
     processors/processorwidgetfactoryobject.cpp
@@ -498,6 +502,8 @@ set(SOURCE_FILES
     properties/tfpropertyconcept.cpp
     properties/transferfunctionproperty.cpp
     properties/volumeindicatorproperty.cpp
+    rendering/datavisualizer.cpp
+    rendering/datavisualizermanager.cpp
     rendering/meshdrawerfactory.cpp
     resourcemanager/resource.cpp
     resourcemanager/resourcemanager.cpp

--- a/src/core/common/inviwoapplication.cpp
+++ b/src/core/common/inviwoapplication.cpp
@@ -52,6 +52,7 @@
 #include <inviwo/core/properties/propertypresetmanager.h>
 #include <inviwo/core/properties/propertywidgetfactory.h>
 #include <inviwo/core/rendering/meshdrawerfactory.h>
+#include <inviwo/core/rendering/datavisualizermanager.h>
 #include <inviwo/core/resourcemanager/resourcemanager.h>
 #include <inviwo/core/util/capabilities.h>
 #include <inviwo/core/util/dialogfactory.h>
@@ -132,32 +133,33 @@ InviwoApplication::InviwoApplication(int argc, char** argv, std::string displayN
         PickingManager::deleteInstance();
         RenderContext::deleteInstance();
     }}
-    , resourceManager_{util::make_unique<ResourceManager>()}
-    , cameraFactory_{util::make_unique<CameraFactory>()}
-    , dataReaderFactory_{util::make_unique<DataReaderFactory>()}
-    , dataWriterFactory_{util::make_unique<DataWriterFactory>()}
-    , dialogFactory_{util::make_unique<DialogFactory>()}
-    , meshDrawerFactory_{util::make_unique<MeshDrawerFactory>()}
-    , metaDataFactory_{util::make_unique<MetaDataFactory>()}
-    , outportFactory_{util::make_unique<OutportFactory>()}
-    , inportFactory_{util::make_unique<InportFactory>()}
-    , portInspectorFactory_{util::make_unique<PortInspectorFactory>()}
-    , processorFactory_{util::make_unique<ProcessorFactory>(this)}
-    , processorWidgetFactory_{util::make_unique<ProcessorWidgetFactory>()}
-    , propertyConverterManager_{util::make_unique<PropertyConverterManager>()}
-    , propertyFactory_{util::make_unique<PropertyFactory>()}
-    , propertyWidgetFactory_{util::make_unique<PropertyWidgetFactory>()}
-    , representationConverterMetaFactory_{util::make_unique<RepresentationConverterMetaFactory>()}
+    , resourceManager_{std::make_unique<ResourceManager>()}
+    , cameraFactory_{std::make_unique<CameraFactory>()}
+    , dataReaderFactory_{std::make_unique<DataReaderFactory>()}
+    , dataWriterFactory_{std::make_unique<DataWriterFactory>()}
+    , dialogFactory_{std::make_unique<DialogFactory>()}
+    , meshDrawerFactory_{std::make_unique<MeshDrawerFactory>()}
+    , metaDataFactory_{std::make_unique<MetaDataFactory>()}
+    , outportFactory_{std::make_unique<OutportFactory>()}
+    , inportFactory_{std::make_unique<InportFactory>()}
+    , portInspectorFactory_{std::make_unique<PortInspectorFactory>()}
+    , dataVisualizerManager_{std::make_unique<DataVisualizerManager>()}
+    , processorFactory_{std::make_unique<ProcessorFactory>(this)}
+    , processorWidgetFactory_{std::make_unique<ProcessorWidgetFactory>()}
+    , propertyConverterManager_{std::make_unique<PropertyConverterManager>()}
+    , propertyFactory_{std::make_unique<PropertyFactory>()}
+    , propertyWidgetFactory_{std::make_unique<PropertyWidgetFactory>()}
+    , representationConverterMetaFactory_{std::make_unique<RepresentationConverterMetaFactory>()}
     , systemSettings_{std::make_unique<SystemSettings>(this)}
     , systemCapabilities_{std::make_unique<SystemCapabilities>()}
     , moduleCallbackActions_{}
     , moduleManager_{this}
-    , processorNetwork_{util::make_unique<ProcessorNetwork>(this)}
-    , processorNetworkEvaluator_{util::make_unique<ProcessorNetworkEvaluator>(
+    , processorNetwork_{std::make_unique<ProcessorNetwork>(this)}
+    , processorNetworkEvaluator_{std::make_unique<ProcessorNetworkEvaluator>(
           processorNetwork_.get())}
-    , workspaceManager_{util::make_unique<WorkspaceManager>(this)}
-    , propertyPresetManager_{util::make_unique<PropertyPresetManager>(this)}
-    , portInspectorManager_{util::make_unique<PortInspectorManager>(this)} {
+    , workspaceManager_{std::make_unique<WorkspaceManager>(this)}
+    , propertyPresetManager_{std::make_unique<PropertyPresetManager>(this)}
+    , portInspectorManager_{std::make_unique<PortInspectorManager>(this)} {
 
     // Keep the pool at size 0 if are quiting directly to make sure that we don't have
     // unfinished results in the worker threads
@@ -270,6 +272,10 @@ PropertyPresetManager* InviwoApplication::getPropertyPresetManager() {
 
 PortInspectorManager* InviwoApplication::getPortInspectorManager() {
     return portInspectorManager_.get();
+}
+
+DataVisualizerManager* InviwoApplication::getDataVisualizerManager() {
+    return dataVisualizerManager_.get();
 }
 
 const CommandLineParser& InviwoApplication::getCommandLineParser() const {
@@ -396,7 +402,7 @@ void InviwoApplication::waitForPool() {
 
 TimerThread& InviwoApplication::getTimerThread() {
     if (!timerThread_) {
-        timerThread_ = util::make_unique<TimerThread>();
+        timerThread_ = std::make_unique<TimerThread>();
     }
     return *timerThread_;
 }

--- a/src/core/common/inviwomodule.cpp
+++ b/src/core/common/inviwomodule.cpp
@@ -45,6 +45,8 @@
 #include <inviwo/core/properties/propertyconvertermanager.h>
 #include <inviwo/core/rendering/meshdrawer.h>
 #include <inviwo/core/rendering/meshdrawerfactory.h>
+#include <inviwo/core/rendering/datavisualizer.h>
+#include <inviwo/core/rendering/datavisualizermanager.h>
 #include <inviwo/core/util/capabilities.h>
 #include <inviwo/core/util/filesystem.h>
 #include <inviwo/core/util/settings/settings.h>
@@ -110,6 +112,10 @@ InviwoModule::~InviwoModule() {
     for (auto& elem : representationConverterFactories_) {
         app_->getRepresentationConverterMetaFactory()->unRegisterObject(elem.get());
     }
+    for (auto& elem : dataVisualizers_) {
+        app_->getDataVisualizerManager()->unRegisterObject(elem.get());
+    }
+
     // Remove any potential ModuleCallbackAction associated with this module
     auto& callbackActions = app_->getCallbackActions();
     util::erase_remove_if(callbackActions, [&](auto& a) {
@@ -288,6 +294,11 @@ void InviwoModule::registerPortInspector(std::string portClassIdentifier,
     if (app_->getPortInspectorFactory()->registerObject(portInspector.get())) {
         portInspectors_.push_back(std::move(portInspector));
     }
+}
+
+void InviwoModule::registerDataVisualizer(std::unique_ptr<DataVisualizer> visualizer) {
+    app_->getDataVisualizerManager()->registerObject(visualizer.get());
+    dataVisualizers_.push_back(std::move(visualizer));
 }
 
 }  // namespace

--- a/src/core/network/processornetwork.cpp
+++ b/src/core/network/processornetwork.cpp
@@ -56,6 +56,12 @@ ProcessorNetwork::~ProcessorNetwork() {
     clear();
 }
 
+Processor* ProcessorNetwork::addProcessor(std::unique_ptr<Processor> processor) {
+    auto p = processor.get();
+    addProcessor(processor.release());
+    return p;
+}
+
 bool ProcessorNetwork::addProcessor(Processor* processor) {
     NetworkLock lock(this);
 

--- a/src/core/ports/portinspectormanager.cpp
+++ b/src/core/ports/portinspectormanager.cpp
@@ -74,6 +74,11 @@ std::unique_ptr<PortInspector> PortInspectorManager::getPortInspector(Outport* o
     }
 }
 
+bool PortInspectorManager::isPortInspectorSupported(const Outport* outport) {
+    auto factory = app_->getPortInspectorFactory();
+    return factory->hasKey(outport->getClassIdentifier());
+}
+
 void PortInspectorManager::returnPortInspector(std::unique_ptr<PortInspector> pi) {
     unUsedInspectors_.push_back(std::move(pi));
 }

--- a/src/core/processors/processorutils.cpp
+++ b/src/core/processors/processorutils.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2012-2018 Inviwo Foundation
+ * Copyright (c) 2018 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,52 +24,57 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  *********************************************************************************/
 
-#ifndef IVW_IMAGESOURCE_H
-#define IVW_IMAGESOURCE_H
+#include <inviwo/core/processors/processorutils.h>
 
-#include <modules/base/basemoduledefine.h>
-#include <inviwo/core/common/inviwo.h>
 #include <inviwo/core/processors/processor.h>
-#include <inviwo/core/properties/fileproperty.h>
-#include <inviwo/core/ports/imageport.h>
-#include <inviwo/core/properties/ordinalproperty.h>
+#include <inviwo/core/metadata/processormetadata.h>
 
 namespace inviwo {
+namespace util {
 
-/** \docpage{org.inviwo.ImageSource, Image Source}
- * ![](org.inviwo.ImageSource.png?classIdentifier=org.inviwo.ImageSource)
- *
- * Loads a image
- * 
- * ### Outports
- *   * __Outport__ The loaded image
- * 
- * ### Properties
- *   * __File name__ The name of the file to load
- *   * __Dimensions__ Readonly, the dimensions of the loaded image.
- */
+const ProcessorMetaData* getMetaData(const Processor* processor) {
+    if (processor) {
+        return processor->getMetaData<ProcessorMetaData>(ProcessorMetaData::CLASS_IDENTIFIER);
+    }
+    return nullptr;
+}
 
-class IVW_MODULE_BASE_API ImageSource : public Processor {
-public:
-    ImageSource(InviwoApplication* app, const std::string& file = "");
-    virtual ~ImageSource() = default;
+ProcessorMetaData* getMetaData(Processor* processor) {
+    if (processor) {
+        return processor->getMetaData<ProcessorMetaData>(ProcessorMetaData::CLASS_IDENTIFIER);
+    }
+    return nullptr;
+}
 
-    virtual const ProcessorInfo getProcessorInfo() const override;
-    static const ProcessorInfo processorInfo_;
+ivec2 getPosition(const Processor* processor) {
+    if (auto meta = getMetaData(processor)) {
+        return meta->getPosition();
+    }
+    return {0, 0};
+}
 
-    virtual void process() override;
-    virtual void deserialize(Deserializer& d) override;
+void setPosition(Processor* processor, ivec2 pos) {
+    if (auto meta = getMetaData(processor)) {
+        meta->setPosition(pos);
+    }
+}
 
-private:
-    InviwoApplication* app_;
-    ImageOutport outport_;
-    FileProperty file_;
-    IntVec2Property imageDimension_;
-};
+bool isSelected(const Processor* processor) {
+    if (auto meta = getMetaData(processor)) {
+        return meta->isSelected();
+    }
+    return false;
+}
 
-} // namespace
+void setSelected(Processor* processor, bool selected) {
+    if (auto meta = getMetaData(processor)) {
+        meta->setSelected(selected);
+    }
+}
 
-#endif // IVW_IMAGESOURCE_H
+}  // namespace util
+
+}  // namespace inviwo

--- a/src/core/properties/property.cpp
+++ b/src/core/properties/property.cpp
@@ -48,7 +48,7 @@ Property::Property(const std::string& identifier, const std::string& displayName
     , semantics_("semantics", semantics)
     , usageMode_("usageMode", UsageMode::Development)
     , visible_("visible", true)
-    , propertyModified_(false)
+    , propertyModified_(true)
     , invalidationLevel_(invalidationLevel)
     , owner_(nullptr)
     , initiatingWidget_(nullptr) {

--- a/src/core/rendering/datavisualizer.cpp
+++ b/src/core/rendering/datavisualizer.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2012-2018 Inviwo Foundation
+ * Copyright (c) 2018 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,52 +24,11 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  *********************************************************************************/
 
-#ifndef IVW_IMAGESOURCE_H
-#define IVW_IMAGESOURCE_H
-
-#include <modules/base/basemoduledefine.h>
-#include <inviwo/core/common/inviwo.h>
-#include <inviwo/core/processors/processor.h>
-#include <inviwo/core/properties/fileproperty.h>
-#include <inviwo/core/ports/imageport.h>
-#include <inviwo/core/properties/ordinalproperty.h>
+#include <inviwo/core/rendering/datavisualizer.h>
 
 namespace inviwo {
 
-/** \docpage{org.inviwo.ImageSource, Image Source}
- * ![](org.inviwo.ImageSource.png?classIdentifier=org.inviwo.ImageSource)
- *
- * Loads a image
- * 
- * ### Outports
- *   * __Outport__ The loaded image
- * 
- * ### Properties
- *   * __File name__ The name of the file to load
- *   * __Dimensions__ Readonly, the dimensions of the loaded image.
- */
-
-class IVW_MODULE_BASE_API ImageSource : public Processor {
-public:
-    ImageSource(InviwoApplication* app, const std::string& file = "");
-    virtual ~ImageSource() = default;
-
-    virtual const ProcessorInfo getProcessorInfo() const override;
-    static const ProcessorInfo processorInfo_;
-
-    virtual void process() override;
-    virtual void deserialize(Deserializer& d) override;
-
-private:
-    InviwoApplication* app_;
-    ImageOutport outport_;
-    FileProperty file_;
-    IntVec2Property imageDimension_;
-};
-
-} // namespace
-
-#endif // IVW_IMAGESOURCE_H
+}  // namespace inviwo

--- a/src/qt/editor/CMakeLists.txt
+++ b/src/qt/editor/CMakeLists.txt
@@ -17,6 +17,7 @@ set(MOC_FILES
 set(HEADER_FILES
     ${IVW_INCLUDE_DIR}/inviwo/qt/editor/connectiongraphicsitem.h
     ${IVW_INCLUDE_DIR}/inviwo/qt/editor/editorgrapicsitem.h
+    ${IVW_INCLUDE_DIR}/inviwo/qt/editor/fileassociations.h
     ${IVW_INCLUDE_DIR}/inviwo/qt/editor/helpwidget.h
     ${IVW_INCLUDE_DIR}/inviwo/qt/editor/inviwoaboutwindow.h
     ${IVW_INCLUDE_DIR}/inviwo/qt/editor/inviwoeditmenu.h
@@ -51,6 +52,7 @@ set(SOURCE_FILES
     connectiongraphicsitem.cpp
     consolewidget.cpp
     editorgrapicsitem.cpp
+    fileassociations.cpp
     helpwidget.cpp
     inviwoaboutwindow.cpp
     inviwoeditmenu.cpp

--- a/src/qt/editor/CMakeLists.txt
+++ b/src/qt/editor/CMakeLists.txt
@@ -16,6 +16,7 @@ set(MOC_FILES
 # Add header files
 set(HEADER_FILES
     ${IVW_INCLUDE_DIR}/inviwo/qt/editor/connectiongraphicsitem.h
+    ${IVW_INCLUDE_DIR}/inviwo/qt/editor/dataopener.h
     ${IVW_INCLUDE_DIR}/inviwo/qt/editor/editorgrapicsitem.h
     ${IVW_INCLUDE_DIR}/inviwo/qt/editor/fileassociations.h
     ${IVW_INCLUDE_DIR}/inviwo/qt/editor/helpwidget.h
@@ -51,6 +52,7 @@ ivw_group("Header Files" ${HEADER_FILES})
 set(SOURCE_FILES
     connectiongraphicsitem.cpp
     consolewidget.cpp
+    dataopener.cpp
     editorgrapicsitem.cpp
     fileassociations.cpp
     helpwidget.cpp

--- a/src/qt/editor/dataopener.cpp
+++ b/src/qt/editor/dataopener.cpp
@@ -1,0 +1,141 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2018 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/qt/editor/dataopener.h>
+
+#include <inviwo/core/network/processornetwork.h>
+#include <inviwo/core/network/networkutils.h>
+#include <inviwo/core/rendering/datavisualizer.h>
+#include <inviwo/core/rendering/datavisualizermanager.h>
+#include <inviwo/core/util/filesystem.h>
+#include <inviwo/core/util/stringconversion.h>
+
+#include <modules/qtwidgets/inviwoqtutils.h>
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <QDialog>
+#include <QLabel>
+#include <QSpinBox>
+#include <QDialogButtonBox>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QCheckBox>
+#include <QTextEdit>
+#include <warn/pop>
+
+namespace inviwo {
+
+namespace {
+
+class SelectVisualizerDialog : public QDialog {
+public:
+    SelectVisualizerDialog(const std::string& file, const std::vector<DataVisualizer*>& visualizers)
+        : QDialog{} {
+
+        setWindowTitle("Select Data Visualizer");
+
+        auto mainLayout = new QGridLayout(this);
+        auto fileNameLabel = new QLabel(utilqt::toQString(file));
+        mainLayout->addWidget(fileNameLabel, 0, 0);
+
+        int i = 1;
+        for (auto visualizer : visualizers) {
+            auto box = new QGroupBox(utilqt::toQString(visualizer->getName()), this);
+            mainLayout->addWidget(box, i++, 0);
+            auto layout = new QGridLayout();
+            box->setLayout(layout);
+            auto use = new QCheckBox("Use");
+            layout->addWidget(use, 0, 0, Qt::AlignLeft);
+            useVisualuzers.push_back(use);
+            auto source = new QCheckBox("Source Only");
+            layout->addWidget(source, 1, 0, Qt::AlignLeft);
+            sourceVisualuzers.push_back(source);
+            auto text = new QLabel(utilqt::toQString(visualizer->getDescription()));
+            text->setWordWrap(true);
+            // text->setReadOnly(true);
+            layout->addWidget(text, 0, 1, 2, 1);
+        }
+
+        auto buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+        connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+        connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+        mainLayout->addWidget(buttons, i++, 0);
+    }
+    virtual ~SelectVisualizerDialog() = default;
+
+    std::vector<QCheckBox*> useVisualuzers;
+    std::vector<QCheckBox*> sourceVisualuzers;
+};
+
+}  // namespace
+
+void util::insertNetworkForData(const std::string& dataFile, ProcessorNetwork* net,
+                                bool alwaysFirst, bool onlySource) {
+    auto app = net->getApplication();
+
+    auto visualizers = app->getDataVisualizerManager()->getDataVisualizersForExtension(
+        toLower(filesystem::getFileExtension(dataFile)));
+
+    if (visualizers.empty()) return;
+
+    auto addVisualizer = [&](DataVisualizer* visualizer, bool onlySource) {
+        const auto orgBounds = util::getBoundingBox(net);
+
+        std::vector<Processor*> added;
+        if(onlySource) {
+            auto addedAndSource = visualizer->addSourceProcessor(dataFile, net);
+            added.push_back(addedAndSource.first);
+        } else {
+            added = visualizer->addSourceAndVisualizerNetwork(dataFile, net);
+        }
+
+        // add to top right
+        const auto bounds = util::getBoundingBox(added);
+        const auto offset = ivec2{orgBounds.second.x, orgBounds.first.y} + ivec2{25, 0} +
+                            ivec2{150, 0} - ivec2{bounds.first.x, bounds.first.y};
+        util::offsetPosition(added, offset);
+    };
+
+    if (visualizers.size() == 1 || alwaysFirst) {
+        addVisualizer(visualizers.front(), onlySource);
+
+    } else {
+        auto dialog = new SelectVisualizerDialog(dataFile, visualizers);
+        if (dialog->exec() == QDialog::Accepted) {
+            for (int i = 0; i < visualizers.size(); ++i) {
+                if (dialog->useVisualuzers[i]->isChecked()) {
+                    addVisualizer(visualizers[i], dialog->sourceVisualuzers[i]->isChecked());
+                }
+            }
+        }
+    }
+}
+
+}  // namespace inviwo

--- a/src/qt/editor/fileassociations.cpp
+++ b/src/qt/editor/fileassociations.cpp
@@ -1,0 +1,369 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2018 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+// ————————————————————————————————-
+/**
+ * @file
+ * @brief
+ * @author Gerolf Reinwardt
+ * @date 30.01.2011
+ *
+ * Copyright © 2011, Gerolf Reinwardt. All rights reserved.
+ *
+ * Simplified BSD License
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those of the
+ * authors and should not be interpreted as representing official policies, either expressed
+ * or implied, of Gerolf Reinwardt.
+ */
+// ————————————————————————————————-
+
+#include <inviwo/qt/editor/fileassociations.h>
+#include <modules/qtwidgets/inviwoqtutils.h>
+
+#include <warn/push>
+#include <warn/ignore/all>
+
+#ifdef WIN32
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
+struct IUnknown;  // Workaround for "combaseapi.h(229): error C2187: syntax error: 'identifier' was
+                  // unexpected here" when using /permissive-
+#include <windows.h>
+#include <dde.h>
+#endif
+
+#include <QMessageBox>
+#include <QApplication>
+#include <QDir>
+#include <QFileInfo>
+#include <QRegExp>
+#include <warn/pop>
+
+namespace inviwo {
+
+#ifdef WIN32
+class FileAssociationData {
+public:
+    FileAssociationData(FileAssociations& fa, QMainWindow* win) : fa_{fa}, win_{win} {
+
+        QFileInfo fi(qApp->applicationFilePath());
+        appAtomName_ = fi.baseName();
+        appAtom_ = ::GlobalAddAtomW((const wchar_t*)appAtomName_.utf16());
+        systemTopicAtom_ = ::GlobalAddAtomW((const wchar_t*)systemTopicAtomName_.utf16());
+    }
+
+    ~FileAssociationData() {
+        if (0 != appAtom_) {
+            ::GlobalDeleteAtom(appAtom_);
+        }
+        if (0 != systemTopicAtom_) {
+            ::GlobalDeleteAtom(systemTopicAtom_);
+        }
+    }
+
+    bool nativeEvent(void* message, long* result) {
+        auto m = static_cast<MSG*>(message);
+        switch (m->message) {
+            case WM_DDE_INITIATE:
+                return ddeInitiate(m, result);
+                break;
+            case WM_DDE_EXECUTE:
+                return ddeExecute(m, result);
+                break;
+            case WM_DDE_TERMINATE:
+                return ddeTerminate(m, result);
+                break;
+        }
+        return false;
+    };
+
+    void registerFileType(const std::string& documentId, const std::string& fileTypeName,
+                          const std::string& fileExtension, int appIconIndex,
+                          const std::vector<FileAssociationCommand>& commands) {
+        auto dId = utilqt::toQString(documentId);
+
+        // first register the type ID of our server
+        if (!SetHkcrUserRegKey(dId, utilqt::toQString(fileTypeName))) {
+            LogError("Failed to register file type: " << fileTypeName << " for document type "
+                                                      << documentId);
+            return;
+        }
+
+        auto appPath = QDir::toNativeSeparators(qApp->applicationFilePath());
+        appPath.prepend(QLatin1String("\""));
+        appPath.append(QLatin1String("\""));
+        if (!SetHkcrUserRegKey(QString("%1\\DefaultIcon").arg(dId),
+                               QString("%1,%2").arg(appPath).arg(appIconIndex))) {
+            return;
+        }
+
+        {
+            // Remove any old shells we have set.
+            auto shells = QString("Software\\Classes\\%1\\shell").arg(dId);
+            ::RegDeleteTree(HKEY_CURRENT_USER, (const wchar_t*)shells.utf16());
+        }
+        for (const auto& command : commands) {
+            auto cmd = utilqt::toQString(command.command_);
+            if (!command.cmdLineArg_.empty()) {
+                QString commandLine = appPath;
+                commandLine.append(QChar(' '));
+                commandLine.append(utilqt::toQString(command.cmdLineArg_));
+
+                if (!SetHkcrUserRegKey(QString("%1\\shell\\%2\\command").arg(dId).arg(cmd),
+                                       commandLine)) {
+                    return;  // just skip it
+                }
+            }
+
+            if (!command.ddeCommand_.empty()) {
+                if (!SetHkcrUserRegKey(QString("%1\\shell\\%2\\ddeexec").arg(dId).arg(cmd),
+                                       QString("[%1(\"%2\")]")
+                                           .arg(utilqt::toQString(command.ddeCommand_))
+                                           .arg("%1")))
+                    return;
+
+                if (!SetHkcrUserRegKey(
+                        QString("%1\\shell\\%2\\ddeexec\\application").arg(dId).arg(cmd),
+                        appAtomName_))
+                    return;
+
+                if (!SetHkcrUserRegKey(QString("%1\\shell\\%2\\ddeexec\\topic").arg(dId).arg(cmd),
+                                       systemTopicAtomName_))
+                    return;
+            }
+        }
+
+        auto ext = utilqt::toQString(fileExtension);
+
+        LONG lSize = _MAX_PATH * 2;
+        wchar_t szTempBuffer[_MAX_PATH * 2];
+        LONG lResult =
+            ::RegQueryValue(HKEY_CLASSES_ROOT, (const wchar_t*)ext.utf16(), szTempBuffer, &lSize);
+
+        QString temp = QString::fromUtf16((unsigned short*)szTempBuffer);
+
+        if (lResult != ERROR_SUCCESS || temp.isEmpty() || temp == dId) {
+            // no association for that suffix
+            if (!SetHkcrUserRegKey(ext, dId)) return;
+
+            SetHkcrUserRegKey(QString("%1\\ShellNew").arg(ext), QLatin1String(""),
+                              QLatin1String("NullFile"));
+        }
+    }
+
+private:
+    // implementation of the WM_DDE_INITIATE windows message
+    bool ddeInitiate(MSG* message, long* result) {
+        if ((0 != LOWORD(message->lParam)) && (0 != HIWORD(message->lParam)) &&
+            (LOWORD(message->lParam) == appAtom_) &&
+            (HIWORD(message->lParam) == systemTopicAtom_)) {
+
+            // make duplicates of the incoming atoms (really adding a reference)
+            wchar_t atomName[_MAX_PATH];
+            IVW_ASSERT(::GlobalGetAtomNameW(appAtom_, atomName, _MAX_PATH - 1) != 0, "");
+            IVW_ASSERT(::GlobalAddAtomW(atomName) == appAtom_, "");
+            IVW_ASSERT(::GlobalGetAtomNameW(systemTopicAtom_, atomName, _MAX_PATH - 1) != 0, "");
+            IVW_ASSERT(::GlobalAddAtomW(atomName) == systemTopicAtom_, "");
+
+            // send the WM_DDE_ACK (caller will delete duplicate atoms)
+            ::SendMessage((HWND)message->wParam, WM_DDE_ACK, (WPARAM)win_->winId(),
+                          MAKELPARAM(appAtom_, systemTopicAtom_));
+        }
+        if (result) *result = 0;
+        return true;
+    }
+
+    bool ddeExecute(MSG* message, long* result) {
+        // unpack the DDE message
+        UINT_PTR unused;
+        HGLOBAL hData;
+        // IA64: Assume DDE LPARAMs are still 32-bit
+        Q_ASSERT(::UnpackDDElParam(WM_DDE_EXECUTE, message->lParam, &unused, (UINT_PTR*)&hData));
+
+        QString command = QString::fromWCharArray((LPCWSTR)::GlobalLock(hData));
+        ::GlobalUnlock(hData);
+
+        // acknowledge now - before attempting to execute
+        ::PostMessage((HWND)message->wParam, WM_DDE_ACK, (WPARAM)win_->winId(),
+                      // IA64: Assume DDE LPARAMs are still 32-bit
+                      ReuseDDElParam(message->lParam, WM_DDE_EXECUTE, WM_DDE_ACK, (UINT)0x8000,
+                                     (UINT_PTR)hData));
+
+        // don't execute the command when the window is disabled
+        if (!win_->isEnabled()) {
+            if (result) *result = 0;
+            return true;
+        }
+
+        QRegExp re("^\\[(\\w+)\\((.*)\\)\\]$");
+        if (re.exactMatch(command)) {
+            fa_.executeCommand(utilqt::fromQString(re.cap(1)), utilqt::fromQString(re.cap(2)));
+        }
+
+        if (result) *result = 0;
+        return true;
+    }
+
+    bool ddeTerminate(MSG* message, long* result) {
+        // The client or server application should respond by posting a WM_DDE_TERMINATE message.
+        ::PostMessageW((HWND)message->wParam, WM_DDE_TERMINATE, (WPARAM)win_->winId(),
+                       message->lParam);
+        return true;
+    }
+
+    /*
+     * Sets specified value in the registry under HKCU\Software\Classes, which is mapped to HKCR
+     * then.
+     */
+    bool SetHkcrUserRegKey(QString key, const QString& value,
+                           const QString& valueName = QString::null) {
+        HKEY hKey;
+        key.prepend("Software\\Classes\\");
+
+        LONG lRetVal = RegCreateKey(HKEY_CURRENT_USER, (const wchar_t*)key.utf16(), &hKey);
+
+        if (ERROR_SUCCESS == lRetVal) {
+            LONG lResult = ::RegSetValueExW(
+                hKey, valueName.isEmpty() ? 0 : (const wchar_t*)valueName.utf16(), 0, REG_SZ,
+                (CONST BYTE*)value.utf16(), (value.length() + 1) * sizeof(wchar_t));
+
+            if (::RegCloseKey(hKey) == ERROR_SUCCESS && lResult == ERROR_SUCCESS) return true;
+
+            LogError("Error in setting Registry values: ",
+                     << "registration database update failed for key '" << key << "'.");
+        } else {
+            wchar_t buffer[4096];
+            ::FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM, 0, lRetVal, 0, buffer, 4096, 0);
+            QString szText = QString::fromUtf16((const ushort*)buffer);
+            LogError("Error in setting Registry values: " << utilqt::fromQString(szText));
+        }
+        return false;
+    }
+
+    FileAssociations& fa_;
+    QMainWindow* win_;
+
+    // the name of the application, without file extension
+    QString appAtomName_ = "";
+    // the name of the system topic atom, typically "System"
+    QString systemTopicAtomName_ = "system";
+    ATOM appAtom_ = 0;          // The windows atom needed for DDE communication
+    ATOM systemTopicAtom_ = 0;  // The windows system topic atom needed for DDE communication
+};
+
+#else
+
+// Dummy implementation for mac / linux
+class FileAssociationData {
+public:
+    FileAssociationData(FileAssociations& fa, QMainWindow* win) : fa_{fa}, win_{win} {}
+
+    bool nativeEvent(void* message, long* result) {}
+    void registerFileType(const std::string& documentId, const std::string& fileTypeName,
+                          const std::string& fileExtension, int appIconIndex,
+                          const std::vector<FileAssociationCommand>& commands) {}
+
+private:
+    FileAssociations& fa_;
+    QMainWindow* win_;
+};
+
+#endif
+
+FileAssociations::FileAssociations(QMainWindow* win)
+    : data_{std::make_unique<FileAssociationData>(*this, win)} {}
+
+FileAssociations::~FileAssociations() = default;
+
+bool FileAssociations::nativeEventFilter(const QByteArray& eventType, void* message, long* result) {
+    /*
+     * The type of event eventType is specific to the platform plugin chosen at run-time, and can
+     * be used to cast message to the right type.
+     *
+     * On X11, eventType is set to "xcb_generic_event_t", and the message can be casted to a
+     * xcb_generic_event_t pointer.
+     *
+     * On Windows, eventType is set to "windows_generic_MSG" for
+     * messages sent to toplevel windows, and "windows_dispatcher_MSG" for system-wide messages
+     * such as messages from a registered hot key. In both cases, the message can be casted to a
+     * MSG pointer. The result pointer is only used on Windows, and corresponds to the LRESULT
+     * pointer.
+     *
+     * On macOS, eventType is set to "mac_generic_NSEvent", and the message can be casted to an
+     * NSEvent pointer.
+     *
+     * In your reimplementation of this function, if you want to filter the message
+     * out, i.e. stop it being handled further, return true; otherwise return false.
+     */
+    if (eventType == "windows_generic_MSG" || eventType == "windows_dispatcher_MSG") {
+        return data_->nativeEvent(message, result);
+    }
+    return false;
+}
+
+void FileAssociations::registerFileType(const std::string& documentId,
+                                        const std::string& fileTypeName,
+                                        const std::string& fileExtension, int appIconIndex,
+                                        std::vector<FileAssociationCommand> commands) {
+    data_->registerFileType(documentId, fileTypeName, fileExtension, appIconIndex, commands);
+
+    for (auto&& command : commands) {
+        commands_[command.ddeCommand_] = std::move(command.callback_);
+    }
+}
+
+void FileAssociations::executeCommand(const std::string& command, const std::string& param) {
+    auto it = commands_.find(command);
+    if (it != commands_.end()) {
+        it->second(filesystem::cleanupPath(param));
+    }
+}
+
+}  // namespace inviwo

--- a/src/qt/editor/networkeditor.cpp
+++ b/src/qt/editor/networkeditor.cpp
@@ -50,6 +50,7 @@
 #include <inviwo/core/processors/processorfactory.h>
 #include <inviwo/core/processors/processorwidgetfactory.h>
 #include <inviwo/core/properties/cameraproperty.h>
+#include <inviwo/core/processors/processorutils.h>
 #include <inviwo/core/util/factory.h>
 #include <inviwo/core/util/settings/linksettings.h>
 #include <inviwo/core/util/settings/systemsettings.h>
@@ -74,6 +75,8 @@
 #include <modules/qtwidgets/eventconverterqt.h>
 #include <modules/qtwidgets/inviwoqtutils.h>
 #include <modules/qtwidgets/propertylistwidget.h>
+
+#include <inviwo/core/rendering/datavisualizermanager.h>
 
 #include <warn/push>
 #include <warn/ignore/all>
@@ -279,20 +282,6 @@ void NetworkEditor::showLinkDialog(Processor* processor1, Processor* processor2)
 //////////////////////////////////////
 //   PORT INSPECTOR FUNCTIONALITY   //
 //////////////////////////////////////
-bool NetworkEditor::addPortInspector(Outport* outport, QPointF pos) {
-    auto pim = mainwindow_->getInviwoApplication()->getPortInspectorManager();
-    if (!pim->hasPortInspector(outport)) {
-        pim->addPortInspector(outport, ivec2(pos.x(), pos.y()));
-        return true;
-    } else {
-        return false;
-    }
-}
-
-void NetworkEditor::removePortInspector(Outport* outport) {
-    mainwindow_->getInviwoApplication()->getPortInspectorManager()->removePortInspector(outport);
-}
-
 std::shared_ptr<const Image> NetworkEditor::renderPortInspectorImage(Outport* outport) {
     auto pim = mainwindow_->getInviwoApplication()->getPortInspectorManager();
     return pim->renderPortInspectorImage(outport);
@@ -490,42 +479,84 @@ void NetworkEditor::keyReleaseEvent(QKeyEvent* keyEvent) {
 }
 
 void NetworkEditor::contextMenuEvent(QGraphicsSceneContextMenuEvent* e) {
+
+    auto addVisualizers = [this](QMenu& menu, ProcessorOutportGraphicsItem* ogi) {
+        auto outport = ogi->getPort();
+
+        auto app = mainwindow_->getInviwoApplication();
+        auto pim = app->getPortInspectorManager();
+
+        if (pim->isPortInspectorSupported(outport)) {
+            auto pos = ogi->mapPosToSceen(ogi->rect().center());
+            auto hasInspector = pim->hasPortInspector(outport);
+            auto showPortInsector =
+                menu.addAction(tr(hasInspector ? "Hide Port Inspector" : "Show Port &Inspector"));
+            showPortInsector->setCheckable(true);
+            showPortInsector->setChecked(hasInspector);
+            connect(showPortInsector, &QAction::triggered, [this, pim, outport, pos]() {
+                if (!pim->hasPortInspector(outport)) {
+                    pim->addPortInspector(outport, ivec2(pos.x(), pos.y()));
+                } else {
+                    pim->removePortInspector(outport);
+                }
+            });
+        }
+
+        auto dataVis = app->getDataVisualizerManager()->getDataVisualizersForOutport(outport);
+        if (!dataVis.empty()) {
+            auto subMenu = menu.addMenu("Add Visualizers");
+            for (auto vis : dataVis) {
+                auto action = subMenu->addAction(utilqt::toQString(vis->getName()));
+                connect(action, &QAction::triggered, [this, vis, outport]() {
+                    auto pos = util::getPosition(outport->getProcessor());
+                    auto oldPos = util::getPositions(network_);
+                    auto added = vis->addVisualizerNetwork(outport, network_);
+                    // add bellow pos
+                    const auto bounds = util::getBoundingBox(added);
+                    for (auto p : oldPos) {
+                        if ((p.x > pos.x - ProcessorGraphicsItem::size_.width() / 2) &&
+                            (p.x <
+                             pos.x + bounds.second.x + ProcessorGraphicsItem::size_.width() / 2)) {
+                            pos.y = std::max(p.y, pos.y);
+                        }
+                    }
+
+                    const auto offset = pos + ivec2{0, 25 + ProcessorGraphicsItem::size_.height()} -
+                                        ivec2{bounds.first.x, bounds.first.y};
+                    util::offsetPosition(added, offset);
+                });
+            }
+        }
+
+        if (auto imagePort = dynamic_cast<ImageOutport*>(outport)) {
+            if (auto image = imagePort->getData()) {
+                menu.addSeparator();
+                utilqt::addImageActions(menu, *image);
+            }
+        }
+    };
+
     QMenu menu;
     ProcessorGraphicsItem* clickedProcessor = nullptr;
-    auto pim = mainwindow_->getInviwoApplication()->getPortInspectorManager();
 
     for (auto& item : items(e->scenePos())) {
         if (auto outport = qgraphicsitem_cast<ProcessorOutportGraphicsItem*>(item)) {
-            QAction* showPortInsector = menu.addAction(tr("Port &Inspector"));
-            showPortInsector->setCheckable(true);
-            if (pim->hasPortInspector(outport->getPort())) {
-                showPortInsector->setChecked(true);
-            }
-            connect(showPortInsector, &QAction::triggered,
-                    [this, outport]() { contextMenuShowInspector(outport); });
-
-            if (auto imgPort = dynamic_cast<ImageOutport*>(outport->getPort())) {
-                if (auto img = imgPort->getData()) {
-                    menu.addSeparator();
-                    utilqt::addImageActions(menu, *img);
-                }
-            }
-
+            addVisualizers(menu, outport);
             break;
-        }
 
-        if (auto inport = qgraphicsitem_cast<ProcessorInportGraphicsItem*>(item)) {
-            QAction* showPortInsector = menu.addAction(tr("Port &Inspector"));
-            showPortInsector->setCheckable(true);
-            if (pim->hasPortInspector(inport->getPort()->getConnectedOutport())) {
-                showPortInsector->setChecked(true);
+        } else if (auto inport = qgraphicsitem_cast<ProcessorInportGraphicsItem*>(item)) {
+            if (inport->getPort()->isConnected()) {
+                auto port = inport->getConnections().front()->getOutportGraphicsItem();
+                addVisualizers(menu, port);
             }
-            connect(showPortInsector, &QAction::triggered,
-                    [this, inport]() { contextMenuShowInspector(inport); });
             break;
-        }
 
-        if (auto processor = qgraphicsitem_cast<ProcessorGraphicsItem*>(item)) {
+        } else if (auto connection = qgraphicsitem_cast<ConnectionGraphicsItem*>(item)) {
+            auto port = connection->getOutportGraphicsItem();
+            addVisualizers(menu, port);
+            break;
+
+        } else if (auto processor = qgraphicsitem_cast<ProcessorGraphicsItem*>(item)) {
             clickedProcessor = processor;
 
             auto editName = menu.addAction(tr("Edit Name"));
@@ -613,30 +644,8 @@ void NetworkEditor::contextMenuEvent(QGraphicsSceneContextMenuEvent* e) {
             });
 
             break;
-        }
 
-        if (auto connection = qgraphicsitem_cast<ConnectionGraphicsItem*>(item)) {
-            QAction* showPortInsector = menu.addAction(tr("Show Port Inspector"));
-            showPortInsector->setCheckable(true);
-            if (pim->hasPortInspector(connection->getOutportGraphicsItem()->getPort())) {
-                showPortInsector->setChecked(true);
-            }
-            connect(showPortInsector, &QAction::triggered, [this, connection]() {
-                contextMenuShowInspector(connection->getOutportGraphicsItem());
-            });
-
-            if (auto imgPort =
-                    dynamic_cast<ImageOutport*>(connection->getOutportGraphicsItem()->getPort())) {
-                if (auto img = imgPort->getData()) {
-                    menu.addSeparator();
-                    utilqt::addImageActions(menu, *img);
-                }
-            }
-
-            break;
-        }
-
-        if (auto link = qgraphicsitem_cast<LinkConnectionGraphicsItem*>(item)) {
+        } else if (auto link = qgraphicsitem_cast<LinkConnectionGraphicsItem*>(item)) {
             QAction* editLink = menu.addAction(tr("Edit Links"));
             connect(editLink, &QAction::triggered, [this, link]() {
                 showLinkDialog(link->getSrcProcessorGraphicsItem()->getProcessor(),
@@ -1082,7 +1091,7 @@ QByteArray NetworkEditor::cut() {
 void NetworkEditor::paste(QByteArray mimeData) {
     NetworkLock lock(network_);
     try {
-        auto orgBounds = util::getBoundingBox(network_->getProcessors());
+        auto orgBounds = util::getBoundingBox(network_);
 
         std::stringstream ss;
         for (auto d : mimeData) ss << d;
@@ -1134,7 +1143,7 @@ void NetworkEditor::paste(QByteArray mimeData) {
 void NetworkEditor::append(std::istream& is, const std::string& refPath) {
     NetworkLock lock(network_);
     try {
-        const auto orgBounds = util::getBoundingBox(network_->getProcessors());
+        const auto orgBounds = util::getBoundingBox(network_);
 
         RenderContext::getPtr()->activateDefaultRenderContext();
         const auto added =
@@ -1296,27 +1305,6 @@ void NetworkEditor::helpEvent(QGraphicsSceneHelpEvent* e) {
         };
     }
     QGraphicsScene::helpEvent(e);
-}
-
-void NetworkEditor::contextMenuShowInspector(EditorGraphicsItem* item) {
-    Outport* port = nullptr;
-    QPointF pos;
-    if (auto pin = qgraphicsitem_cast<ProcessorInportGraphicsItem*>(item)) {
-        pos = pin->mapPosToSceen(pin->rect().center());
-        port = pin->getPort()->getConnectedOutport();
-    } else if (auto pout = qgraphicsitem_cast<ProcessorOutportGraphicsItem*>(item)) {
-        pos = pout->mapPosToSceen(pout->rect().center());
-        port = pout->getPort();
-    } else {
-        return;
-    }
-
-    auto pim = mainwindow_->getInviwoApplication()->getPortInspectorManager();
-    if (!pim->hasPortInspector(port)) {
-        addPortInspector(port, pos);
-    } else {
-        removePortInspector(port);
-    }
 }
 
 void NetworkEditor::onProcessorNetworkDidAddProcessor(Processor* processor) {

--- a/src/qt/editor/networkeditorview.cpp
+++ b/src/qt/editor/networkeditorview.cpp
@@ -73,8 +73,6 @@ NetworkEditorView::NetworkEditorView(NetworkEditor* networkEditor, InviwoMainWin
 
     setTransformationAnchor(QGraphicsView::AnchorUnderMouse);
 
-    setAcceptDrops(true);
-
     loadHandle_ = mainwindow_->getInviwoApplication()->getWorkspaceManager()->onLoad(
         [this](Deserializer&) { fitNetwork(); });
 
@@ -323,30 +321,6 @@ void NetworkEditorView::exportViewToFile(const QString& filename, bool entireSce
     }
 
     networkEditor_->setBackgroundVisible(true);
-}
-
-void NetworkEditorView::dropEvent(QDropEvent* event) {
-    auto mimeData = event->mimeData();
-    if (mimeData->hasUrls()) {
-        QStringList pathList;
-        QList<QUrl> urlList = mimeData->urls();
-
-        // pick first url
-        auto filename = urlList.front().toLocalFile();
-        mainwindow_->openWorkspace(filename);
-        event->acceptProposedAction();
-    } else {
-        QGraphicsView::dropEvent(event);
-    }
-}
-
-void NetworkEditorView::dragEnterEvent(QDragEnterEvent* event) {
-    auto mimeData = event->mimeData();
-    if (mimeData->hasUrls()) {
-        event->acceptProposedAction();
-    } else {
-        QGraphicsView::dragEnterEvent(event);
-    }
 }
 
 }  // namespace inviwo

--- a/tests/integrationtests/network-test.cpp
+++ b/tests/integrationtests/network-test.cpp
@@ -44,7 +44,7 @@ public:
     NetworkTest() : network(InviwoApplication::getPtr()) {};
 protected:
     virtual void SetUp() {
-       Processor* p1 = new VolumeSource();
+       Processor* p1 = new VolumeSource(InviwoApplication::getPtr());
        p1->setIdentifier("volumeSource");
        network.addProcessor(p1);
 


### PR DESCRIPTION
Qt/Core: Added new concept of a DataVisualizer to be represent a standard network for a data type. Added visualizers for volume/mesh/image. Use the visualizers when droping files on the main window. Alos added file association for inviwo workspaces and .dat files on windows.

Open/Append workspaces from the explorer
![image](https://user-images.githubusercontent.com/3638222/40433169-a437e504-5eab-11e8-9109-d1355ffcde0d.png)

Open dat files form the explorer
![image](https://user-images.githubusercontent.com/3638222/40433277-ee01f2c4-5eab-11e8-83b5-61cd6767374c.png)
So far only dat-files are registered, (done in inviwomainwindow.cpp) not 100% if we want that one or other ones, could be discussed. Same behaviour is achieved by passing --data on the command line

Drag data file onto inviwo
![image](https://user-images.githubusercontent.com/3638222/40434480-c13dabb8-5eae-11e8-9696-5133a6a44023.png)

Visualiser selector show up
![image](https://user-images.githubusercontent.com/3638222/40434368-80a0d116-5eae-11e8-8c97-457a761796e1.png)

Network added
![image](https://user-images.githubusercontent.com/3638222/40434537-df195c72-5eae-11e8-9b83-cb555af48c30.png)

Visualizers also available on ports
![image](https://user-images.githubusercontent.com/3638222/40434600-fec68342-5eae-11e8-9176-09bab12980c8.png)


