### PR TITLE
BrushingAndLinking: Prevent sending an event on first evaluation

### DIFF
--- a/modules/brushingandlinking/ports/brushingandlinkingports.cpp
+++ b/modules/brushingandlinking/ports/brushingandlinkingports.cpp
@@ -37,7 +37,7 @@ BrushingAndLinkingInport::BrushingAndLinkingInport(std::string identifier)
 
     onConnect([&]() {
         sendFilterEvent(filterCache_);
-        sendSelectionEvent(selctionCache_);
+        sendSelectionEvent(selectionCache_);
     });
 }
 
@@ -49,9 +49,9 @@ void BrushingAndLinkingInport::sendFilterEvent(const std::unordered_set<size_t> 
 }
 
 void BrushingAndLinkingInport::sendSelectionEvent(const std::unordered_set<size_t> &indices) {
-    if (selctionCache_.size() == 0 && indices.size() == 0) return;
-    selctionCache_ = indices;
-    SelectionEvent event(this, selctionCache_);
+    if (selectionCache_.size() == 0 && indices.size() == 0) return;
+    selectionCache_ = indices;
+    SelectionEvent event(this, selectionCache_);
     getProcessor()->propagateEvent(&event, nullptr);
 }
 
@@ -67,7 +67,7 @@ bool BrushingAndLinkingInport::isSelected(size_t idx) const {
     if (isConnected()) {
         return getData()->isSelected(idx);
     } else {
-        return selctionCache_.find(idx) != selctionCache_.end();
+        return selectionCache_.find(idx) != selectionCache_.end();
     }
 }
 
@@ -75,7 +75,7 @@ const std::unordered_set<size_t> &BrushingAndLinkingInport::getSelectedIndices()
     if (isConnected()) {
         return getData()->getSelectedIndices();
     } else {
-        return selctionCache_;
+        return selectionCache_;
     }
 }
 

--- a/modules/brushingandlinking/ports/brushingandlinkingports.cpp
+++ b/modules/brushingandlinking/ports/brushingandlinkingports.cpp
@@ -29,7 +29,7 @@
 
 #include <modules/brushingandlinking/ports/brushingandlinkingports.h>
 
-namespace inviwo{
+namespace inviwo {
 
 BrushingAndLinkingInport::BrushingAndLinkingInport(std::string identifier)
     : DataInport<BrushingAndLinkingManager>(identifier) {
@@ -42,12 +42,14 @@ BrushingAndLinkingInport::BrushingAndLinkingInport(std::string identifier)
 }
 
 void BrushingAndLinkingInport::sendFilterEvent(const std::unordered_set<size_t> &indices) {
+    if (filterCache_.size() == 0 && indices.size() == 0) return;
     filterCache_ = indices;
     FilteringEvent event(this, filterCache_);
     getProcessor()->propagateEvent(&event, nullptr);
 }
 
 void BrushingAndLinkingInport::sendSelectionEvent(const std::unordered_set<size_t> &indices) {
+    if (selctionCache_.size() == 0 && indices.size() == 0) return;
     selctionCache_ = indices;
     SelectionEvent event(this, selctionCache_);
     getProcessor()->propagateEvent(&event, nullptr);
@@ -72,18 +74,15 @@ bool BrushingAndLinkingInport::isSelected(size_t idx) const {
 const std::unordered_set<size_t> &BrushingAndLinkingInport::getSelectedIndices() const {
     if (isConnected()) {
         return getData()->getSelectedIndices();
-    }
-    else {
+    } else {
         return selctionCache_;
     }
 }
 
-
 const std::unordered_set<size_t> &BrushingAndLinkingInport::getFilteredIndices() const {
     if (isConnected()) {
         return getData()->getFilteredIndices();
-    }
-    else {
+    } else {
         return filterCache_;
     }
 }
@@ -99,4 +98,4 @@ std::string BrushingAndLinkingOutport::getClassIdentifier() const {
     return PortTraits<BrushingAndLinkingOutport>::classIdentifier();
 }
 
-}  // namespace
+}  // namespace inviwo

--- a/modules/brushingandlinking/ports/brushingandlinkingports.h
+++ b/modules/brushingandlinking/ports/brushingandlinkingports.h
@@ -61,7 +61,7 @@ public:
     virtual std::string getClassIdentifier() const override;
 
     std::unordered_set<size_t> filterCache_;
-    std::unordered_set<size_t> selctionCache_;
+    std::unordered_set<size_t> selectionCache_;
 };
 
 class IVW_MODULE_BRUSHINGANDLINKING_API BrushingAndLinkingOutport


### PR DESCRIPTION
This avoids sending events twice when nothing is filtered upon start up. 