### PR TITLE
Jenkinsfile: Fix for submodules when they have new url

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,6 +55,7 @@ node {
             echo "Building inviwo Running ${env.BUILD_ID} on ${env.JENKINS_URL}"
             dir('inviwo') {
                 checkout scm
+                sh 'git submodule sync' // needed when a submodule has a new url  
                 sh 'git submodule update --init'
             }
         }


### PR DESCRIPTION
A few days ago a few URLs was changed in the .gitmodules files, this breaks old Jenkins builds (e.g. master). 
After a URL has changed one has to run `git submoudle sync`. 

http://jenkins.inviwo.org:8080/job/inviwo-pub/job/master/