### PR TITLE
Core: refactored Clock, ClockGL, closes #48 #49

### DIFF
--- a/include/inviwo/core/util/clock.h
+++ b/include/inviwo/core/util/clock.h
@@ -24,13 +24,17 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  *********************************************************************************/
 
 #ifndef IVW_CLOCK_H
 #define IVW_CLOCK_H
 
 #include <inviwo/core/common/inviwocoredefine.h>
+#include <inviwo/core/util/stringconversion.h>
+#include <inviwo/core/util/logcentral.h>
+
+#include <sstream>
 #include <string>
 #include <chrono>
 
@@ -38,118 +42,236 @@ namespace inviwo {
 
 /** \class Clock
  *
- * Class for measure time.
+ * Clock for measuring elapsed time between a start and stop point. The clock accumulates the
+ * elapsed times when start and stop are called multiple times.
  */
 class IVW_CORE_API Clock {
 public:
-    Clock();
-    virtual ~Clock() {}
+    using clock = std::chrono::high_resolution_clock;
+    using duration = std::chrono::high_resolution_clock::duration;
+    using time_point = std::chrono::high_resolution_clock::time_point;
 
     /**
-     * Start the Clock.
+     * creates a clock and starts it
+     */
+    Clock();
+
+    /**
+     * query whether the clock has been started
      *
+     * @return true if the clock is running
+     */
+    bool isRunning() const;
+
+    /**
+     * starts the clock
      */
     void start();
 
     /**
-     * Set new reference time.
-     *
+     * stops the clock and accumulates the elapsed time since start() was called
      */
-    void tick();
+    void stop();
 
     /**
-    * Returns the amount of milliseconds between start and tick call.
-    * If neither start or tick has been called, the return value is undefined.
-    */
-    float getElapsedMiliseconds() const;
+     * resets the accumulated time to 0
+     */
+    void reset();
 
     /**
-    * Returns the amount of seconds between start and tick call.
-    * If neither start or tick has been called, the return value is undefined.
-    */
-    float getElapsedSeconds() const;
+     * returns the accumulated time. If the clock is running the result is accumulated
+     * time plus the current elapsed time.
+     *
+     * @return accumulated time
+     */
+    duration getElapsedTime() const;
+
+    /**
+     * returns the accumulated time. If the clock is running the result is accumulated
+     * time plus the current elapsed time.
+     *
+     * @return accumulated time in milliseconds
+     * \see getElapsedTime
+     */
+    double getElapsedMiliseconds() const;
+
+    /**
+     * returns the accumulated time. If the clock is running the result is accumulated
+     * time plus the current elapsed time.
+     *
+     * @return accumulated time in seconds
+     * \see getElapsedTime
+     */
+    double getElapsedSeconds() const;
 
 protected:
-    std::chrono::high_resolution_clock::time_point startTime_;
-    std::chrono::high_resolution_clock::time_point tickTime_;
+    bool isRunning_ = false;
+
+    time_point startTime_;
+    duration accumulatedTime_;
 };
 
-/** \class ScopedClockCPU
+/** \class ScopedClock
  *
- * Scoped timer for CPU that prints elapsed time in destructor.
- * Usage is simplified by the macros (does nothing unless IVW_PROFILING is defined)
- * IVW_CPU_PROFILING("My message")
+ * Scoped clock which prints the elapsed time when the instance is destroyed, i.e. print() is called
+ * by the destructor.
  *
+ * \see ScopedClockCPU, ScopedClockGL
  */
-class IVW_CORE_API ScopedClockCPU {
+template <typename Clock>
+class ScopedClock : public Clock {
 public:
-    ScopedClockCPU(const std::string& logSource, const std::string& message,
-                   float logIfAtLeastMilliSec = 0.0f)
-        : logSource_(logSource), logMessage_(message), logIfAtLeastMilliSec_(logIfAtLeastMilliSec) {
-        clock_.start();
-    }
+    ScopedClock() = delete;
 
+    ScopedClock(const std::string& logSource, const std::string& message,
+                typename Clock::duration logIfAtLeast = typename Clock::duration{},
+                LogLevel logLevel = LogLevel::Info);
+
+    ScopedClock(const std::string& logSource, const std::string& message,
+                double logIfAtLeastMilliSec, LogLevel logLevel = LogLevel::Info);
+
+    ~ScopedClock() { print(); }
+
+    /**
+     * log the accumulated time but only if it is larger than the duration threshold (logIfAtLeast)
+     * given in the constructor.
+     */
     void print();
-    void reset();
+
+    /**
+     * log the accumulated time but only if it is larger than the duration threshold (logIfAtLeast)
+     * given in the constructor. Also resets the clock and restarts it.
+     */
     void printAndReset();
 
-    virtual ~ScopedClockCPU();
-
 private:
-    // Default constructor not allowed
-    // ScopedClockCPU() {};
-    Clock clock_;
+    const std::string logSource_;
+    const std::string logMessage_;
 
-    std::string logSource_;
-    std::string logMessage_;
-
-    float logIfAtLeastMilliSec_;
+    const typename Clock::duration logIfAtLeast_;
+    const LogLevel logLevel_ = LogLevel::Info;
 };
 
-#define ADDLINE_PART1(x, y) x##y
-#define ADDLINE_PART2(x, y) ADDLINE_PART1(x, y)
-#define ADDLINE(x) ADDLINE_PART2(x, __LINE__)
+template <typename Clock>
+ScopedClock<Clock>::ScopedClock(const std::string& logSource, const std::string& message,
+                                typename Clock::duration logIfAtLeast, LogLevel logLevel)
+    : logSource_{logSource}
+    , logMessage_{message}
+    , logIfAtLeast_{logIfAtLeast}
+    , logLevel_(logLevel) {}
+
+template <typename Clock>
+ScopedClock<Clock>::ScopedClock(const std::string& logSource, const std::string& message,
+                                double logIfAtLeastMilliSec, LogLevel logLevel)
+    : ScopedClock(logSource, message,
+                  std::chrono::duration_cast<Clock::duration>(
+                      std::chrono::duration<double, std::chrono::milliseconds::period>(
+                          logIfAtLeastMilliSec)),
+                  logLevel) {}
+
+template <typename Clock>
+void ScopedClock<Clock>::print() {
+    if (getElapsedTime() > logIfAtLeast_) {
+        std::stringstream message;
+        message << logMessage_ << ": " << msToString(getElapsedMiliseconds());
+        LogCentral::getPtr()->log(logSource_, logLevel_, LogAudience::Developer, __FILE__,
+                                  __FUNCTION__, __LINE__, message.str());
+    }
+}
+
+template <typename Clock>
+void ScopedClock<Clock>::printAndReset() {
+    print();
+    reset();
+    start();
+}
+
+/**
+ * \class ScopedClockCPU
+ * scoped clock for CPU time measurements
+ *
+ * \see IVW_CPU_PROFILING(message), IVW_CPU_PROFILING_CUSTOM(src, message)
+ * \see IVW_CPU_PROFILING_IF(time, message), IVW_CPU_PROFILING_IF(time, src, message)
+ */
+using ScopedClockCPU = ScopedClock<Clock>;
+
+#define IVW_ADDLINE_PART1(x, y) x##y
+#define IVW_ADDLINE_PART2(x, y) IVW_ADDLINE_PART1(x, y)
+#define IVW_ADDLINE(x) IVW_ADDLINE_PART2(x, __LINE__)
+
+/**
+ * \def IVW_CPU_PROFILING(message)
+ * creates a scoped CPU clock with the given message.
+ *
+ * @param src      source of the log message
+ */
+
+/**
+ * \def IVW_CPU_PROFILING_CUSTOM(src, message)
+ * creates a scoped CPU clock with the given source and message.
+ * Does nothing unless IVW_PROFILING is defined.
+ *
+ * @param src      source of the log message
+ * @param message  log message
+ */
+
+/**
+ * \def IVW_CPU_PROFILING_IF(time, message)
+ * creates a scoped CPU clock with the given message and minimum duration.
+ * Does nothing unless IVW_PROFILING is defined.
+ *
+ * @param time     either a std::chrono::duration or a double value (milliseconds)
+ * @param message  log message
+ */
+
+/**
+ * \def IVW_CPU_PROFILING_IF_CUSTOM(time, src, message)
+ * creates a scoped CPU clock with the given source, message, and minimum duration.
+ * Does nothing unless IVW_PROFILING is defined.
+ *
+ * @param time     either a std::chrono::duration or a double value (milliseconds)
+ * @param src      source of the log message
+ * @param message  log message
+ */
 
 #if IVW_PROFILING
-#define IVW_CPU_PROFILING(message)                                                     \
-    std::ostringstream ADDLINE(__stream);                                              \
-    ADDLINE(__stream) << message;                                                      \
-    ScopedClockCPU ADDLINE(__clock)(parseTypeIdName(std::string(typeid(this).name())), \
-                                    ADDLINE(__stream).str());
+#define IVW_CPU_PROFILING(message)                                                         \
+    std::ostringstream IVW_ADDLINE(__stream);                                              \
+    IVW_ADDLINE(__stream) << message;                                                      \
+    ScopedClockCPU IVW_ADDLINE(__clock)(parseTypeIdName(std::string(typeid(this).name())), \
+                                        IVW_ADDLINE(__stream).str());
 #else
 #define IVW_CPU_PROFILING(message)
 #endif
 
 #if IVW_PROFILING
-#define IVW_CPU_PROFILING_CUSTOM(src,message)                                                     \
-    std::ostringstream ADDLINE(__stream);                                              \
-    ADDLINE(__stream) << message;                                                      \
-    ScopedClockCPU ADDLINE(__clock)(src, \
-                                    ADDLINE(__stream).str());
+#define IVW_CPU_PROFILING_CUSTOM(src, message) \
+    std::ostringstream IVW_ADDLINE(__stream);  \
+    IVW_ADDLINE(__stream) << message;          \
+    ScopedClockCPU IVW_ADDLINE(__clock)(src, IVW_ADDLINE(__stream).str());
 #else
-#define IVW_CPU_PROFILING_CUSTOM(src,message)
+#define IVW_CPU_PROFILING_CUSTOM(src, message)
 #endif
 
 #if IVW_PROFILING
-#define IVW_CPU_PROFILING_IF(time, message)                                            \
-    std::ostringstream ADDLINE(__stream);                                              \
-    ADDLINE(__stream) << message;                                                      \
-    ScopedClockCPU ADDLINE(__clock)(parseTypeIdName(std::string(typeid(this).name())), \
-                                    ADDLINE(__stream).str(), time);
+#define IVW_CPU_PROFILING_IF(time, message)                                                \
+    std::ostringstream IVW_ADDLINE(__stream);                                              \
+    IVW_ADDLINE(__stream) << message;                                                      \
+    ScopedClockCPU IVW_ADDLINE(__clock)(parseTypeIdName(std::string(typeid(this).name())), \
+                                        IVW_ADDLINE(__stream).str(), time);
 #else
 #define IVW_CPU_PROFILING_IF(time, message)
 #endif
 
 #if IVW_PROFILING
-#define IVW_CPU_PROFILING_IF_CUSTOM(time, src, message)                                            \
-    std::ostringstream ADDLINE(__stream);                                              \
-    ADDLINE(__stream) << message;                                                      \
-    ScopedClockCPU ADDLINE(__clock)(src, \
-                                    ADDLINE(__stream).str(), time);
+#define IVW_CPU_PROFILING_IF_CUSTOM(time, src, message) \
+    std::ostringstream IVW_ADDLINE(__stream);           \
+    IVW_ADDLINE(__stream) << message;                   \
+    ScopedClockCPU IVW_ADDLINE(__clock)(src, IVW_ADDLINE(__stream).str(), time);
 #else
 #define IVW_CPU_PROFILING_IF_CUSTOM(time, src, message)
 #endif
 
 }  // namespace inviwo
 
-#endif  // IVW_TIMER_H
+#endif  // IVW_CLOCK_H

--- a/include/inviwo/core/util/clock.h
+++ b/include/inviwo/core/util/clock.h
@@ -171,9 +171,9 @@ ScopedClock<Clock>::ScopedClock(const std::string& logSource, const std::string&
 
 template <typename Clock>
 void ScopedClock<Clock>::print() {
-    if (getElapsedTime() > logIfAtLeast_) {
+    if (Clock::getElapsedTime() > logIfAtLeast_) {
         std::stringstream message;
-        message << logMessage_ << ": " << msToString(getElapsedMiliseconds());
+        message << logMessage_ << ": " << msToString(Clock::getElapsedMiliseconds());
         LogCentral::getPtr()->log(logSource_, logLevel_, LogAudience::Developer, __FILE__,
                                   __FUNCTION__, __LINE__, message.str());
     }
@@ -182,8 +182,8 @@ void ScopedClock<Clock>::print() {
 template <typename Clock>
 void ScopedClock<Clock>::printAndReset() {
     print();
-    reset();
-    start();
+    Clock::reset();
+    Clock::start();
 }
 
 /**

--- a/modules/opengl/clockgl.cpp
+++ b/modules/opengl/clockgl.cpp
@@ -24,60 +24,125 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  *********************************************************************************/
 
 #include <modules/opengl/clockgl.h>
 
+#include <inviwo/core/util/logcentral.h>
 
 namespace inviwo {
 
-#if GL_VERSION_3_3 && GL_ARB_timer_query
-ClockGL::ClockGL() {
-    // Note that this can take
-    // Generate start and end queries
-    glGenQueries(2, queries_);
-}
+ClockGL::ClockGL() { start(); }
 
 ClockGL::~ClockGL() {
-    // Release generated queries
-    glDeleteQueries(2, queries_);
+    for (auto& query : queries_) {
+        glDeleteQueries(2, query.ids.data());
+    }
+}
+
+bool ClockGL::isRunning() const {
+    return !queries_.empty() && queries_.back().state == State::Started;
 }
 
 void ClockGL::start() {
-    // Start query
-    glQueryCounter(queries_[0], GL_TIMESTAMP);
-}
+    collectTiming();
 
-void ClockGL::stop() {
-    // Set end query
-    glQueryCounter(queries_[1], GL_TIMESTAMP);
-}
-
-float ClockGL::getElapsedTime() const {
-    int done = 0;
-    // Wait for results to be available
-    while (!done) {
-        glGetQueryObjectiv(queries_[1], GL_QUERY_RESULT_AVAILABLE, &done);
+    if (!queries_.empty() && queries_.back().state == State::Started) {
+        glQueryCounter(queries_.back().startId(), GL_TIMESTAMP);
+    } else if (queries_.empty() && queries_.front().state == State::Unused) {
+        std::rotate(queries_.begin(), queries_.begin() + 1, queries_.end());
+        glQueryCounter(queries_.back().startId(), GL_TIMESTAMP);
+    } else {
+        queries_.push_back({{0, 0}, State::Started});
+        glGenQueries(2, queries_.back().ids.data());
+        glQueryCounter(queries_.back().startId(), GL_TIMESTAMP);
     }
-    GLuint64 start;
-    GLuint64 stop;
-    glGetQueryObjectui64v(queries_[0], GL_QUERY_RESULT, &start);
-    glGetQueryObjectui64v(queries_[1], GL_QUERY_RESULT, &stop);
-    return 1e-6f * static_cast<float>(stop-start);
 }
-#else
-// OpenGL 3.3 is not supported, use CPU clock as fallback
-ClockGL::ClockGL() {}
-ClockGL::~ClockGL() {}
-void ClockGL::start() { clock_.start(); }
+
 void ClockGL::stop() {
-    glFinish(); 
-    clock_.stop();
+    if (isRunning()) {
+        glQueryCounter(queries_.back().stopId(), GL_TIMESTAMP);
+        queries_.back().state = State::Stopped;
+    }
 }
-float ClockGL::getElapsedTime() const { return clock_.getElapsedMiliseconds(); }
 
-#endif
+void ClockGL::reset() {
+    for (auto& query : queries_) {
+        query.state = State::Unused;
+    }
+    accumulatedTime_ = static_cast<duration>(0);
+}
 
+auto ClockGL::getElapsedTime(std::chrono::seconds timeout) -> duration {
+    auto startWaitingTime = std::chrono::high_resolution_clock::now();
 
-} // namespace
+    if (isRunning()) {
+        // add query end marker to get time elapsed since start without affecting ongoing
+        // measurement
+        glQueryCounter(queries_.back().stopId(), GL_TIMESTAMP);
+    }
+
+    // ensure that query results are available. Abort after timeOut, which might be caused by
+    // using the same ClockGL in different contexts or a GL computation taking too long.
+    int done = 0;
+    while (!done && std::chrono::high_resolution_clock::now() - startWaitingTime < timeout) {
+        glGetQueryObjectiv(queries_.back().stopId(), GL_QUERY_RESULT_AVAILABLE, &done);
+    }
+
+    collectTiming();
+    if (done) {
+        if (isRunning()) {
+            // special case if last query is still ongoing, i.e. this query is
+            // not considered by collectTiming()
+            GLuint64 start;
+            GLuint64 stop;
+            glGetQueryObjectui64v(queries_.back().startId(), GL_QUERY_RESULT, &start);
+            glGetQueryObjectui64v(queries_.back().stopId(), GL_QUERY_RESULT, &stop);
+            return accumulatedTime_ + std::chrono::nanoseconds{stop - start};
+        } else {
+            return accumulatedTime_;
+        }
+    } else {  // timeout
+        std::string msg =
+            "ClockGL timeout: ClockGL waited " +
+            std::to_string(std::chrono::duration_cast<std::chrono::seconds>(timeout).count()) +
+            "s for OpenGL to finish. Elapsed time will be incorrect.\n"
+            "This can be caused by compute-intensive operations or using "
+            "ClockGL in different GL contexts.";
+        LogCentral::getPtr()->log("ClockGL", LogLevel::Error, LogAudience::User, __FILE__,
+                                  __FUNCTION__, __LINE__, msg);
+        return accumulatedTime_;
+    }
+}
+
+void ClockGL::collectTiming() {
+    for (auto& query : queries_) {
+        if (query.state == State::Stopped) {
+            int done = 0;
+            glGetQueryObjectiv(query.stopId(), GL_QUERY_RESULT_AVAILABLE, &done);
+            if (done) {
+                GLuint64 start;
+                GLuint64 stop;
+                glGetQueryObjectui64v(query.startId(), GL_QUERY_RESULT, &start);
+                glGetQueryObjectui64v(query.stopId(), GL_QUERY_RESULT, &stop);
+                accumulatedTime_ += std::chrono::nanoseconds{stop - start};
+                query.state = State::Unused;
+            }
+        }
+    }
+    std::stable_partition(queries_.begin(), queries_.end(),
+                          [](auto& query) { return query.state == State::Unused; });
+}
+
+double ClockGL::getElapsedMiliseconds(std::chrono::seconds timeout) {
+    using duration_double = std::chrono::duration<double, std::chrono::milliseconds::period>;
+    return std::chrono::duration_cast<duration_double>(getElapsedTime(timeout)).count();
+}
+
+double ClockGL::getElapsedSeconds(std::chrono::seconds timeout) {
+    using duration_double = std::chrono::duration<double, std::chrono::seconds::period>;
+    return std::chrono::duration_cast<duration_double>(getElapsedTime(timeout)).count();
+}
+
+}  // namespace inviwo

--- a/modules/opengl/clockgl.h
+++ b/modules/opengl/clockgl.h
@@ -24,7 +24,7 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  *********************************************************************************/
 
 #ifndef IVW_CLOCK_GL_H
@@ -32,85 +32,152 @@
 
 #include <modules/opengl/openglmoduledefine.h>
 #include <modules/opengl/inviwoopengl.h>
-#include <inviwo/core/util/logcentral.h>
 #include <inviwo/core/util/clock.h>
-#include <inviwo/core/util/stringconversion.h>
+
+#include <chrono>
+#include <vector>
+#include <array>
 
 namespace inviwo {
 
 /** \class ClockGL
  *
- * Simple timer for OpenGL.
- * Uses OpenGL queries if OpenGL 3.3 or higher is supported,
- * otherwise uses CPU which calls glFinish before stopping time.
- * Usage is simplified by the macros (does nothing unless IVW_PROFILING is defined)
- * IVW_OPENGL_PROFILING("My message")
+ * Clock for measuring elapsed time between a start and stop points on the GPU using OpenGL
+ * performance timer queries. The clock accumulates the elapsed times when start and stop are called
+ * multiple times.
+ *
+ * Note: The render context of the current thread needs to be activated. Using the same ClockGL
+ *       instance in different render contexts results in undefined behavior and getElapsedTime() 
+ *       will most likely time out.
+ *
+ * \see RenderContext::activateDefaultRenderContext, RenderContext::activateLocalRenderContext
  */
 class IVW_MODULE_OPENGL_API ClockGL {
 public:
-    ClockGL();
-    virtual ~ClockGL();
+    using duration = std::chrono::nanoseconds;
 
-    /** \brief Start OpenGL timing.
+    /**
+     * creates a clock and starts it
+     */
+    ClockGL();
+
+    ~ClockGL();
+
+    /**
+     * query whether the clock has been started
+     *
+     * @return true if the clock is running
+     */
+    bool isRunning() const;
+
+    /**
+     * starts the clock
      */
     void start();
 
-    /** \brief Stop OpenGL timing.
+    /**
+     * stops the clock and accumulates the elapsed time since start() was called
      */
     void stop();
 
-    /** \brief Returns time taken for command execution in milliseconds.
-     * @note Requires that stop has been called before.
-     * @return float Time in milliseconds
+    /**
+     * resets the queries and sets the accumulated time to 0
      */
-    float getElapsedTime() const;
+    void reset();
 
-private:
-#ifdef GL_VERSION_3_3
-    GLuint queries_[2];
-#else
-    Clock clock_;
-#endif
+    /**
+     * returns the accumulated time. If the clock is running the result is accumulated
+     * time plus the current elapsed time. This function will wait at most \p timeout seconds
+     * for the performance queries to be completed. In case of a time out, the results are
+     * incorrect.
+     *
+     * @param timeout    time out in seconds when querying the OpenGL performance counters
+     * @return accumulated time
+     */
+    duration getElapsedTime(std::chrono::seconds timeout = std::chrono::seconds{30});
+
+    /**
+     * returns the accumulated time. If the clock is running the result is accumulated
+     * time plus the current elapsed time. This function will wait at most \p timeout seconds
+     * for the performance queries to be completed. In case of a time out, the results are
+     * incorrect.
+     *
+     * @param timeout    time out in seconds when querying the OpenGL performance counters
+     * @return accumulated time in milliseconds
+     * \see getElapsedTime
+     */
+    double getElapsedMiliseconds(std::chrono::seconds timeout = std::chrono::seconds{30});
+
+    /**
+     * returns the accumulated time. If the clock is running the result is accumulated
+     * time plus the current elapsed time. This function will wait at most \p timeout seconds
+     * for the performance queries to be completed. In case of a time out, the results are
+     * incorrect.
+     *
+     * @param timeout    time out in seconds when querying the OpenGL performance counters
+     * @return accumulated time in seconds
+     * \see getElapsedTime
+     */
+    double getElapsedSeconds(std::chrono::seconds timeout = std::chrono::seconds{30});
+
+protected:
+    void collectTiming();
+
+    enum class State { Unused, Started, Stopped };
+    struct Query {
+        std::array<GLuint, 2> ids;
+        State state;
+        GLuint startId() const { return ids[0]; }
+        GLuint stopId() const { return ids[1]; }
+    };
+    duration accumulatedTime_;
+    std::vector<Query> queries_;
 };
 
-/** \class ScopedClockGL
+/**
+ * \class ScopedClockGL
+ * scoped clock for OpenGL time measurements
  *
- * Scoped timer for OpenGL that prints elapsed time in destructor.
- * Usage is simplified by the macros (does nothing unless IVW_PROFILING is defined)
- * IVW_OPENGL_PROFILING("My message")
- *
- * Note: The render context of the current thread needs to be active when using this clock!
- *       Otherwise there is a high likelyhood that the ScopedClock will wait forever.
- * \see RenderContext::activateDefaultRenderContext, RenderContext::activateLocalRenderContext
+ * \see IVW_OPENGL_PROFILING(message), IVW_OPENGL_PROFILING_CUSTOM(src, message)
+ * \see IVW_OPENGL_PROFILING_IF(time, message), IVW_OPENGL_PROFILING_IF(time, src, message)
  */
-class ScopedClockGL {
-public:
-    ScopedClockGL(const std::string& logSource, const std::string& message,
-                  float logIfAtLeastMilliSec = 0.0f)
-        : logSource_(logSource), logMessage_(message), logIfAtLeastMilliSec_(logIfAtLeastMilliSec) {
-        clock_.start();
-    }
-    virtual ~ScopedClockGL() {
-        clock_.stop();
-        if (clock_.getElapsedTime() > logIfAtLeastMilliSec_) {
-            std::stringstream message;
-            message << logMessage_ << ": " << clock_.getElapsedTime() << "ms";
-            LogCentral::getPtr()->log(logSource_, LogLevel::Info, LogAudience::Developer, __FILE__,
-                                      __FUNCTION__, __LINE__, message.str());
-        }
-    }
+using ScopedClockGL = ScopedClock<ClockGL>;
 
-private:
-    // Default constructor not allowed
-    ScopedClockGL(){};
-    ClockGL clock_;
-    std::string logSource_;
-    std::string logMessage_;
-    float logIfAtLeastMilliSec_;
-};
+/**
+ * \def IVW_OPENGL_PROFILING(message)
+ * creates a scoped ClockGL clock with the given message.
+ *
+ * @param src      source of the log message
+ */
 
+/**
+ * \def IVW_OPENGL_PROFILING_CUSTOM(src, message)
+ * creates a scoped ClockGL clock with the given source and message.
+ * Does nothing unless IVW_PROFILING is defined.
+ *
+ * @param src      source of the log message
+ * @param message  log message
+ */
 
-    
+/**
+ * \def IVW_OPENGL_PROFILING_IF(time, message)
+ * creates a scoped ClockGL clock with the given message and minimum duration.
+ * Does nothing unless IVW_PROFILING is defined.
+ *
+ * @param time     either a std::chrono::duration or a double value (milliseconds)
+ * @param message  log message
+ */
+
+/**
+ * \def IVW_OPENGL_PROFILING_IF_CUSTOM(time, src, message)
+ * creates a scoped ClockGL clock with the given source, message, and minimum duration.
+ * Does nothing unless IVW_PROFILING is defined.
+ *
+ * @param time     either a std::chrono::duration or a double value (milliseconds)
+ * @param src      source of the log message
+ * @param message  log message
+ */
+
 #if IVW_PROFILING
 #define IVW_OPENGL_PROFILING(message)                                                 \
     std::ostringstream ADDLINE(__stream);                                             \
@@ -119,6 +186,15 @@ private:
                                    ADDLINE(__stream).str());
 #else
 #define IVW_OPENGL_PROFILING(message)
+#endif
+
+#if IVW_PROFILING
+#define IVW_OPENGL_PROFILING_CUSTOM(src, message) \
+    std::ostringstream IVW_ADDLINE(__stream);     \
+    IVW_ADDLINE(__stream) << message;             \
+    ScopedClockGL IVW_ADDLINE(__clock)(src, IVW_ADDLINE(__stream).str());
+#else
+#define IVW_OPENGL_PROFILING_CUSTOM(src, message)
 #endif
 
 #if IVW_PROFILING
@@ -131,6 +207,15 @@ private:
 #define IVW_OPENGL_PROFILING_IF(time, message)
 #endif
 
-}  // namespace
+#if IVW_PROFILING
+#define IVW_OPENGL_PROFILING_IF_CUSTOM(time, src, message) \
+    std::ostringstream IVW_ADDLINE(__stream);              \
+    IVW_ADDLINE(__stream) << message;                      \
+    ScopedClockGL IVW_ADDLINE(__clock)(src, IVW_ADDLINE(__stream).str(), time);
+#else
+#define IVW_OPENGL_PROFILING_IF_CUSTOM(time, src, message)
+#endif
+
+}  // namespace inviwo
 
 #endif  // IVW_CLOCK_GL_H

--- a/modules/python3qt/pythoneditorwidget.cpp
+++ b/modules/python3qt/pythoneditorwidget.cpp
@@ -405,7 +405,7 @@ void PythonEditorWidget::run() {
     Clock c;
     c.start();
     bool ok = script_.run();
-    c.tick();
+    c.stop();
 
     std::stringstream ss;
     ss << (ok ? "Executed Successfully" : "Failed");

--- a/src/qt/editor/processorgraphicsitem.cpp
+++ b/src/qt/editor/processorgraphicsitem.cpp
@@ -443,7 +443,7 @@ void ProcessorGraphicsItem::onProcessorAboutToProcess(Processor*) {
 }
 
 void ProcessorGraphicsItem::onProcessorFinishedProcess(Processor*) {
-    clock_.tick();
+    clock_.stop();
     evalTime_ = clock_.getElapsedMiliseconds();
     maxEvalTime_ = maxEvalTime_ < evalTime_ ? evalTime_ : maxEvalTime_;
     totEvalTime_ += evalTime_;


### PR DESCRIPTION
* common interface for Clock and ClockGL based on std::chrono
* renamed Clock::tick() to Clock::stop()
* timeout for ClockGL queries (e.g. to avoid deadlocks in case when used in different context)
