### PR TITLE
Core: ForEach: Change order of template arugment to support iterating over containers where value_type is not defined

### DIFF
--- a/include/inviwo/core/util/foreach.h
+++ b/include/inviwo/core/util/foreach.h
@@ -72,10 +72,10 @@ std::vector<std::future<void>> forEachParallelAsync(const Iterable& iterable, Ca
                                                     size_t jobs = 0) {
     auto settings = InviwoApplication::getPtr()->getSettingsByType<SystemSettings>();
     auto poolSize = settings->poolSize_.get();
-    auto includeIndex = typename std::conditional<util::is_callable_with<T, size_t>(callback),
-                                                  std::true_type, std::false_type>::type();
+    using IncludeIndexType = typename std::conditional<util::is_callable_with<T, size_t>(callback),
+                                                       std::true_type, std::false_type>::type;
     if (poolSize == 0) {
-        detail::foreach_helper(includeIndex, iterable.begin(), iterable.end(), callback);
+        detail::foreach_helper(IncludeIndexType(), iterable.begin(), iterable.end(), callback);
         return {};
     }
 
@@ -88,8 +88,8 @@ std::vector<std::future<void>> forEachParallelAsync(const Iterable& iterable, Ca
     for (size_t job = 0; job < jobs; ++job) {
         auto start = (s * job) / jobs;
         auto end = (s * (job + 1)) / jobs;
-        futures.push_back(dispatchPool([&callback, &iterable, start, end, &includeIndex]() {
-            detail::foreach_helper(includeIndex, iterable.begin() + start,
+        futures.push_back(dispatchPool([callback, &iterable, start, end]() {
+            detail::foreach_helper(IncludeIndexType(), iterable.begin() + start,
                                    iterable.begin() + static_cast<size_t>(end), callback, start);
         }));
     }

--- a/include/inviwo/core/util/foreach.h
+++ b/include/inviwo/core/util/foreach.h
@@ -40,19 +40,18 @@
 namespace inviwo {
 
 namespace util {
-    namespace detail{
-        template <typename Callback, typename IT>
-        void foreach_helper(std::false_type, IT a, IT b, Callback callback, size_t = 0) {
-            std::for_each(a, b, callback);
-        }
+namespace detail {
+template <typename Callback, typename IT>
+void foreach_helper(std::false_type, IT a, IT b, Callback callback, size_t = 0) {
+    std::for_each(a, b, callback);
+}
 
-        template <typename Callback, typename IT>
-        void foreach_helper(std::true_type, IT a, IT b, Callback callback, size_t start = 0) {
-            std::for_each(a, b, [&](auto v) { callback(v, start++); });
-        }
+template <typename Callback, typename IT>
+void foreach_helper(std::true_type, IT a, IT b, Callback callback, size_t start = 0) {
+    std::for_each(a, b, [&](auto v) { callback(v, start++); });
+}
 
-    }
-
+}  // namespace detail
 
 /**
  * Use multiple threads to iterate over all elements in an iterable data structure (such as
@@ -68,7 +67,7 @@ namespace util {
  * create pool size * 4 jobs
  * @return a vector of futures, one for each job created.
  */
-template <typename Iterable, typename Callback, typename T = typename Iterable::value_type>
+template <typename Iterable, typename T = typename Iterable::value_type, typename Callback>
 std::vector<std::future<void>> forEachParallelAsync(const Iterable& iterable, Callback callback,
                                                     size_t jobs = 0) {
     auto settings = InviwoApplication::getPtr()->getSettingsByType<SystemSettings>();
@@ -110,9 +109,9 @@ std::vector<std::future<void>> forEachParallelAsync(const Iterable& iterable, Ca
  * @param jobs optional parameter specifying how many jobs to create, if jobs==0 (default) it will
  * create pool size * 4 jobs
  */
-template <typename Iterable, typename Callback, typename T = typename Iterable::value_type>
+template <typename Iterable, typename T = typename Iterable::value_type, typename Callback>
 void forEachParallel(const Iterable& iterable, Callback callback, size_t jobs = 0) {
-    auto futures = forEachParallelAsync<Iterable,Callback,T>(iterable, callback, jobs);
+    auto futures = forEachParallelAsync<Iterable, T, Callback>(iterable, callback, jobs);
 
     for (const auto& e : futures) {
         e.wait();


### PR DESCRIPTION
Core: ForEach: Change order of template arugment to support iterating over containers where value_type is not defined