### PR TITLE
Feature/doxygen warnings

### DIFF
--- a/include/inviwo/core/common/version.h
+++ b/include/inviwo/core/common/version.h
@@ -63,7 +63,7 @@ public:
     /**
      * \brief Parses the version. Defaults to version 1.0.0.0
      *
-     * @param std::string versionString Dot separated version string "Major.Minor.Patch.Build"
+     * @param versionString Dot separated version string "Major.Minor.Patch.Build"
      */
     Version(std::string versionString);
     Version(const char* versionString);

--- a/include/inviwo/core/datastructures/camera.h
+++ b/include/inviwo/core/datastructures/camera.h
@@ -55,6 +55,8 @@ public:
      * @param lookFrom Camera position (eye)
      * @param lookTo Camera focus point (center)
      * @param lookUp Camera up direction
+     * @param nearPlane Camera near clip-plane
+     * @param farPlane Camera far clip-plane
      */
     Camera(vec3 lookFrom = vec3(0.0f, 0.0f, 2.0f), vec3 lookTo = vec3(0.0f),
            vec3 lookUp = vec3(0.0f, 1.0f, 0.0f), float nearPlane = 0.01f,

--- a/include/inviwo/core/datastructures/geometry/plane.h
+++ b/include/inviwo/core/datastructures/geometry/plane.h
@@ -83,17 +83,19 @@ public:
     vec3 projectPoint(const vec3& x) const;
 
     /**
-     * Check if point is on positive side of plane. 
-     *         Plane
-     *           |
-     *           |-> normal
-     * (outside) |  (inside)
-     *
+     * Check if point is on positive side of plane.
+     * \verbatim
+              Plane
+                |
+                |-> normal
+      (outside) |  (inside)
+     \endverbatim
+     * 
      * @see Plane::distance
-     * @param Point to check
-     * @return True if on positive side of normal or on the plane, otherwise false
+     * @param point to check
+     * @return true if on positive side of normal or on the plane, otherwise false
      */
-    bool isInside(const vec3&) const;
+    bool isInside(const vec3 &point) const;
 
     bool perpendicularToPlane(const vec3&) const;
 

--- a/include/inviwo/core/datastructures/image/image.h
+++ b/include/inviwo/core/datastructures/image/image.h
@@ -80,7 +80,9 @@ public:
 
     /**
      * \brief encode the requested layer contents to a buffer considering the given image extension
+     * @param layerType Indicate which type of layer to return. see LayerType
      * @param fileExtension file extension of the requested image format
+     * @param idx In case of layerType beging LayerType::ColorLayer, than return color layer at index idx
      * @return encoded layer contents as std::vector
      */
     DataBuffer getLayerAsCodedBuffer(LayerType layerType, const std::string& fileExtension,

--- a/include/inviwo/core/datastructures/image/layerramprecision.h
+++ b/include/inviwo/core/datastructures/image/layerramprecision.h
@@ -106,6 +106,7 @@ private:
  * @param dimensions of layer to create.
  * @param type of layer to create.
  * @param format of layer to create.
+ * @param swizzleMask used in for the layer, defaults to RGB-alpha
  * @return nullptr if no valid format was specified.
  */
 IVW_CORE_API std::shared_ptr<LayerRAM> createLayerRAM(

--- a/include/inviwo/core/datastructures/tfprimitiveset.h
+++ b/include/inviwo/core/datastructures/tfprimitiveset.h
@@ -133,7 +133,7 @@ public:
     /**
      * Add a TFPrimitive
      *
-     * @param value   TFPrimitive to be added
+     * @param primitive   TFPrimitive to be added
      * @throws RangeException if TF type is relative and the primitive position is outside [0,1]
      */
     void add(const TFPrimitive& primitive);
@@ -160,7 +160,7 @@ public:
     /**
      * Add a TFPrimitive
      *
-     * @param value   TFPrimitive to be added
+     * @param data   Primitive to be added
      * @throws RangeException if TF type is relative and position of point is outside [0,1]
      */
     void add(const TFPrimitiveData& data);
@@ -168,7 +168,7 @@ public:
     /**
      * Add multiple TFPrimitives
      *
-     * @param values  TFPrimitives to be added
+     * @param primitives  vector of primitives to be added
      * @throws RangeException if TF type is relative and any of the given points is outside [0,1]
      */
     void add(const std::vector<TFPrimitiveData>& primitives);

--- a/include/inviwo/core/interaction/events/touchevent.h
+++ b/include/inviwo/core/interaction/events/touchevent.h
@@ -49,11 +49,12 @@ public:
     TouchPoint() = default;
     /**
      * @param id Touch point id that distinguishes a particular touch point
-     * @param pos Position in screen coordinates [0 dim-1]^2.
-     * @param posNormalized Position normalized to the size of the screen [0 1]^2.
-     * @param prevPos Previous position in screen coordinates [0 dim-1]^2.
-     * @param  prevPosNormalized Previous position normalized to the size of the screen [0 1]^2.
      * @param touchState State of the touch point.
+     * @param posNormalized Position normalized to the size of the screen [0 1]^2.
+     * @param prevPosNormalized Previous position normalized to the size of the screen [0 1]^2.
+     * @param pressedPosNormalized Position that was pressed normalized to the size of the screen [0 1]^2.
+     * @param canvasSize size of the canvas from where the event originates
+     * @param pressure the pressure of the touch 
      * @param depth Depth value in normalized device coordinates ([-1 1]) at touch point, 1
      * if no depth is available.
      */

--- a/include/inviwo/core/io/serialization/deserializer.h
+++ b/include/inviwo/core/io/serialization/deserializer.h
@@ -68,7 +68,7 @@ public:
      * @param stream Stream with content that is to be deserialized.
      * @param refPath A path that will be used to decode the location of data during
      * deserialization.
-     * @param bool allowReference flag to manage references to avoid multiple object creation.
+     * @param allowReference flag to manage references to avoid multiple object creation.
      */
     Deserializer(std::istream& stream, const std::string& refPath, bool allowReference = true);
 
@@ -132,7 +132,7 @@ public:
      * eg., std::map<std::string, Property*>
      *
      * eg. xml tree
-     *
+     *\code{.xml}
      *     <Properties>
      *          <Property identifier="enableMIP" displayName="MIP">
      *              <value content="0" />
@@ -141,14 +141,14 @@ public:
      *              <value content="0" />
      *          </Property>
      *     <Properties>
-     *
+     *\endcode
      * In the above xml tree,
      *
      * key                   = "Properties"
      * itemKey               = "Property"
      * param comparisionAttribute  = "identifier"
      * param sMap["enableMIP"]     = address of a property
-     *         sMap["enableShading"] = address of a property
+     *       sMap["enableShading"] = address of a property
      *         where, "enableMIP" & "enableShading" are keys.
      *         address of a property is a value
      *

--- a/include/inviwo/core/io/serialization/serializebase.h
+++ b/include/inviwo/core/io/serialization/serializebase.h
@@ -180,6 +180,7 @@ public:
      *
      * @param serializer reference to serializer or deserializer
      * @param node //Parent (Ticpp Node) element.
+     * @param retrieveChild whether to retrieve child node or not.
      */
     NodeSwitch(SerializeBase& serializer, TxElement* node, bool retrieveChild = true);
 
@@ -188,6 +189,7 @@ public:
      *
      * @param serializer reference to serializer or deserializer
      * @param key the child to switch to.
+     * @param retrieveChild whether to retrieve child node or not.
      */
     NodeSwitch(SerializeBase& serializer, const std::string& key, bool retrieveChild = true);
 

--- a/include/inviwo/core/ports/inport.h
+++ b/include/inviwo/core/ports/inport.h
@@ -70,7 +70,7 @@ public:
     /**
      * An inport can be set optional, in which case the processor will by default be ready even if
      * no outport is connected. This means that an optional inport may not have any connected
-     * outports when evaluating the @ProcessorNetwork, i.e. when Processor::process() is called.
+     * outports when evaluating the ProcessorNetwork, i.e. when Processor::process() is called.
      * Hence one needs to check manually that the port isReady before using it.
      * @see isReady
      */

--- a/include/inviwo/core/ports/porttraits.h
+++ b/include/inviwo/core/ports/porttraits.h
@@ -42,14 +42,14 @@ namespace inviwo {
  * \brief A traits class for getting the class identifier from a Port.
  * This provides a customization point if one wants to generate the class identifier dynamically,
  * by specializing the traits for your kind of Port:
- *
+ * \code{.cpp}
  *     template <typename T>
  *     struct PortTraits<MyPort<T>> {
  *        static std::string classIdentifier() {
  *           return generateMyPortClassIdentifier<T>();
  *        }
  *     };
- *
+ * \endcode
  * The default behavior returns the static member "classIdentifier";
  */
 template <typename T, typename = void>

--- a/include/inviwo/core/processors/processortraits.h
+++ b/include/inviwo/core/processors/processortraits.h
@@ -65,14 +65,14 @@ ProcessorInfo processorInfo() {
  * \brief A traits class for getting the Processor info from a processor.
  * This provides a customization point if one wants to generate the processor info dynamically,
  * by specializing the traits for your kind of processor:
- *
+ *\code{.cpp}
  *     template <typename T>
  *     struct ProcessorTraits<MyProcessor<T>> {
  *        static ProcessorInfo getProcessorInfo() {
  *           return generateMyProcessorInfo<T>();
  *        } 
  *     };
- *
+ *\endcode
  * The default behaviour returns the static member processorInfo_;
  *
  */

--- a/include/inviwo/core/util/fileobserver.h
+++ b/include/inviwo/core/util/fileobserver.h
@@ -78,7 +78,7 @@ public:
      * \brief Stops observing the file if being observed.
      * @param filePath Full path to file
      */
-    bool stopFileObservation(const std::string& fileName);
+    bool stopFileObservation(const std::string& filePath);
     
     /**
      * Stop observation of all observed files

--- a/include/inviwo/core/util/filesystem.h
+++ b/include/inviwo/core/util/filesystem.h
@@ -54,7 +54,8 @@ namespace filesystem {
  * On Windows, the file name is first converted from a utf-8 string to std::wstring and then the
  * stream is created using the std::wstring as std::fstream(std::string) does not support utf-8.
  *
- * @param filename   utf-8 encoded string
+ * @param filename  utf-8 encoded string
+ * @param mode      mode to open the file (input or output)
  * @return stream for the given file, i.e. `std::fstream(filename, mode);`
  *
  * \see std::fstream
@@ -77,6 +78,7 @@ IVW_CORE_API std::fstream fstream(const std::string& filename,
  * stream is created using the std::wstring as std::ifstream(std::string) does not support utf-8.
  *
  * @param filename   utf-8 encoded string
+ * @param mode       mode to open the file (input or output)
  * @return stream for the given file, i.e. `std::ifstream(filename, mode);`
  *
  * \see std::ifstream
@@ -98,6 +100,7 @@ IVW_CORE_API std::ifstream ifstream(const std::string& filename,
  * stream is created using the std::wstring as std::ofstream(std::string) does not support utf-8.
  *
  * @param filename   utf-8 encoded string
+ * @param mode       mode to open the file (input or output)
  * @return stream for the given file, i.e. `std::ofstream(filename, mode);`
  *
  * \see std::ofstream
@@ -135,8 +138,8 @@ IVW_CORE_API std::string getInviwoUserSettingsPath();
 /**
  * \brief Check if a file exists.
  * @see directoryExists for directories
- * @param fileName The path to the file
- * @return True if file exists, false otherwise
+ * @param filePath The path to the file
+ * @return true if file exists, false otherwise
  */
 IVW_CORE_API bool fileExists(const std::string& filePath);
 
@@ -174,6 +177,7 @@ enum class ListMode {
  * Returns the file listing of a directory
  *
  * @param path Files are listed for this directory
+ * @param mode What types of contents to return see ListMode
  * @return List of files residing in the given path
  */
 IVW_CORE_API std::vector<std::string> getDirectoryContents(const std::string& path,
@@ -183,6 +187,7 @@ IVW_CORE_API std::vector<std::string> getDirectoryContents(const std::string& pa
  * Recursively searches and returns full path to files/directories in specified directory and its
  * subdirectories.
  * @param path Files are listed for this directory and its subdirectories
+ * @param mode What types of contents to return see ListMode
  * @return List of files residing in the given path and its subdirectories
  */
 IVW_CORE_API std::vector<std::string> getDirectoryContentsRecursively(
@@ -195,7 +200,7 @@ IVW_CORE_API std::vector<std::string> getDirectoryContentsRecursively(
  *
  * @param pattern  The pattern used for matching, might contain '*' and '?'
  * @param str      String which needs to be checked
- * @return True if the given string matches the pattern, false otherwise.
+ * @return true if the given string matches the pattern, false otherwise.
  */
 IVW_CORE_API bool wildcardStringMatch(const std::string& pattern, const std::string& str);
 
@@ -254,6 +259,7 @@ IVW_CORE_API std::string findBasePath();
  * @see PathType
  * @param pathType Enum for type of path
  * @param suffix Path extension
+ * @param createFolder if true, will create the folder on disk if it does not exists.
  * @return basePath +  pathType + suffix
  */
 IVW_CORE_API std::string getPath(PathType pathType, const std::string& suffix = "",

--- a/include/inviwo/core/util/foreach.h
+++ b/include/inviwo/core/util/foreach.h
@@ -60,7 +60,7 @@ void foreach_helper(std::true_type, IT a, IT b, Callback callback, size_t start 
  * The function will return once all jobs as has been created and queued.
  *
  * @param iterable the data structure to iterate over
- * @param the callback to call for each element, can be either `[](auto &a){}` or `[](auto &a,
+ * @param callback to call for each element, can be either `[](auto &a){}` or `[](auto &a,
  * size_t id){}` where `a` is an data item from the iterable data structure and `id` is the index in
  * the data structure
  * @param jobs optional parameter specifying how many jobs to create, if jobs==0 (default) it will
@@ -103,7 +103,7 @@ std::vector<std::future<void>> forEachParallelAsync(const Iterable& iterable, Ca
  * The function will return once all jobs as has finished processing.
  *
  * @param iterable the data structure to iterate over
- * @param the callback to call for each element, can be either `[](auto &a){}` or `[](auto &a,
+ * @param callback to call for each element, can be either `[](auto &a){}` or `[](auto &a,
  * size_t id){}` where `a` is an data item from the iterable data structure and `id` is the index in
  * the data structure
  * @param jobs optional parameter specifying how many jobs to create, if jobs==0 (default) it will

--- a/include/inviwo/core/util/sharedlibrary.h
+++ b/include/inviwo/core/util/sharedlibrary.h
@@ -100,11 +100,11 @@ public:
      * \brief Get function address from library.
      *
      * Example usage:
-     * @code
+     * \code{.cpp}
      *      using f_getModule = InviwoModuleFactoryObject* (__stdcall *)();
      *      auto moduleFunc = reinterpret_cast<f_getModule>(sharedLib->findSymbol("createModule"));
-     * @endcode
-     * @param std::string name Function name
+     * \endcode
+     * @param name Function name
      * @return Address to function if found, otherwise nullptr
      */
     void* findSymbol(const std::string& name);
@@ -113,11 +113,11 @@ public:
      * \brief Get typed function address from library.
      *
      * Example usage:
-     * @code
+     * \code{.cpp}
      *      using f_getModule = InviwoModuleFactoryObject* (__stdcall *)();
      *      auto moduleFunc = sharedLib->findSymbolTyped<f_getModule>("createModule"));
-     * @endcode
-     * @param std::string name Function name
+     * \endcode
+     * @param name Function name
      * @return Address to function if found, otherwise nullptr
      */
     template <typename T>

--- a/include/inviwo/core/util/stdextensions.h
+++ b/include/inviwo/core/util/stdextensions.h
@@ -178,6 +178,7 @@ void for_each_in_tuple(F&& f, TupleType1&& t1, TupleType2&& t2) {
 /**
  * A utility for iterating over types in a list.
  * Example:
+ * \code{.cpp}
  *     struct Functor {
  *         template <typename T>
  *         auto operator()(std::vector<Property*>& properties) {
@@ -187,6 +188,7 @@ void for_each_in_tuple(F&& f, TupleType1&& t1, TupleType2&& t2) {
  *     std::vector<Property*>& properties;
  *     using Vec4s = std::tuple<vec4, dvec4, ivec4, size4_t>;
  *     util::for_each_type<Vec4s>{}(Functor{}, properties);
+ * \endcode
  */
 template <class... Types>
 struct for_each_type;

--- a/include/inviwo/core/util/stringconversion.h
+++ b/include/inviwo/core/util/stringconversion.h
@@ -78,9 +78,9 @@ std::wstring toWstring(const std::string& str);
  * Using delimiter ';' on string "aa;bb" will result in a vector contaning aa and bb.
  * 
  * @note Empty substrings are not skipped, ";;" will generate an element.
- * @param toSplit Delimiter separated string
- * @param delimiter The character use for splitting
- * @return Substrings
+ * @param str The string to split
+ * @param delimeter The character use for splitting (default to space)
+ * @return a vector containing the substrings 
  */
 IVW_CORE_API std::vector<std::string> splitString(const std::string& str, char delimeter = ' ');
 
@@ -130,7 +130,7 @@ IVW_CORE_API std::string camelCaseToHeader(const std::string& s);
 /**
  * \brief Case insensitive equal comparison of two strings.
  * @return true if all the elements in the two containers are the same. 
- * @seealso CaseInsensitiveCompare
+ * @see CaseInsensitiveCompare
  */
 IVW_CORE_API bool iCaseCmp(const std::string& l, const std::string& r);
 /**

--- a/include/inviwo/core/util/utilities.h
+++ b/include/inviwo/core/util/utilities.h
@@ -77,8 +77,8 @@ IVW_CORE_API std::string cleanIdentifier(const std::string& identifier,
  * Turns "/path/to/inviwo-module-yourmodule.dll" into "yourmodule".
  * Returns filename without extension if inviwo-module was not found.
  *
- * @param std::string filePath Path to module file
- * @return IVW_CORE_API std::string Module name
+ * @param  filePath Path to module file
+ * @return name of the module 
  */
 IVW_CORE_API std::string stripModuleFileNameDecoration(std::string filePath);
 

--- a/include/inviwo/qt/editor/editorgrapicsitem.h
+++ b/include/inviwo/qt/editor/editorgrapicsitem.h
@@ -44,7 +44,7 @@ namespace inviwo {
 
 class NetworkEditor;
 
-enum IVW_QTEDITOR_API InviwoUserGraphicsItemType {
+enum InviwoUserGraphicsItemType {
     ProcessorGraphicsType = 1,
     CurveGraphicsType,
     ConnectionDragGraphicsType,

--- a/include/inviwo/qt/editor/linkdialog/linkdialoggraphicsitems.h
+++ b/include/inviwo/qt/editor/linkdialog/linkdialoggraphicsitems.h
@@ -73,7 +73,7 @@ static const int arrowWidth = propertyWidth / 15;
 static const int arrowHeight = arrowWidth / 2;
 }
 
-enum IVW_QTEDITOR_API InviwoLinkUserGraphicsItemType {
+enum InviwoLinkUserGraphicsItemType {
     LinkDialogCurveGraphicsItemType = 3,
     LinkDialogProcessorGraphicsItemType = 4,
     LinkDialogPropertyGraphicsItemType = 5,

--- a/include/inviwo/qt/editor/processorpreview.h
+++ b/include/inviwo/qt/editor/processorpreview.h
@@ -51,6 +51,7 @@ IVW_QTEDITOR_API QImage generatePreview(const QString& classIdentifier);
 /**
 * Generate an image of a processor
 *
+* @param classIdentifier class Identifier of the processor to generate the preview for. 
 * @param opacity   if opacity is less than one, the output image will be semitransparent, range [0,1]
 */
 IVW_QTEDITOR_API QImage generateProcessorPreview(const QString& classIdentifier, double opacity = 1.0);

--- a/modules/base/algorithm/convexhull.h
+++ b/modules/base/algorithm/convexhull.h
@@ -45,7 +45,7 @@ namespace util {
 /**
 * \brief check whether the given polygon is convex
 *
-* @param hull   polygon consisting of points
+* @param polygon   polygon consisting of points
 * @return true if the polygon is convex, false otherwise
 */
 template <class T, typename std::enable_if<util::rank<T>::value == 1 && util::extent<T>::value == 2,
@@ -114,10 +114,10 @@ template <class T, typename std::enable_if<util::rank<T>::value == 1 && util::ex
 /**
 * \brief compute the complex hull from a given set of 2D points using
 * the Monotone Chain algorithm, i.e. Andrew's convex hull algorithm
-*
+* \see https://en.wikipedia.org/wiki/Convex_hull_algorithms#Algorithms
+* 
 * @param points   set of 2D points
 * @return complex hull of input points
-* \see <a href="https://en.wikipedia.org/wiki/Convex_hull_algorithms#Algorithms"/>
 */
 template <class T, typename std::enable_if<util::rank<T>::value == 1 && util::extent<T>::value == 2,
                                            int>::type = 0>

--- a/modules/base/algorithm/mesh/meshcameraalgorithms.h
+++ b/modules/base/algorithm/mesh/meshcameraalgorithms.h
@@ -55,7 +55,7 @@ IVW_MODULE_BASE_API void centerViewOnMeshes(const std::vector<std::shared_ptr<co
  * plane (increased by 1% to make sure that mesh is not clipped). The view directions considered are
  * lookFrom min/max -> lookTo. Near plane is computed as max(1e^-6, farPlaneDistance * farNearRatio)
  *
- * @param meshes worldSpaceBoundingBox Min and max points of geometry
+ * @param worldSpaceBoundingBox Min and max points of geometry
  * @param camera Camera used as basis for computation
  * @param farNearRatio Ratio between near and far plane. 1:10000 is commonly used by game engines.
  * @return Near and far plane distances.

--- a/modules/base/algorithm/randomutils.h
+++ b/modules/base/algorithm/randomutils.h
@@ -68,6 +68,7 @@ static inline glm::u64 nextPow2(glm::u64 x) {
  * Generate a sequence of length numberOfPoints of pseduo-random numbers on the open range (0 1).
  * @see https://en.wikipedia.org/wiki/Halton_sequence
  * @param base what base to use to generate fractions
+ * @param numberOfPoints amount of points to generate
  */
 template <typename T>
 std::vector<T> haltonSequence(size_t base, size_t numberOfPoints) {
@@ -226,9 +227,10 @@ std::shared_ptr<Volume> randomVolume(size3_t dims, Rand &randomNumberGenerator =
  * Generate an Image with perlin noise, a cloud like noise using the sum of several white noise
  * images with different frequencies
  * @param dims Size of the output image
- * @param persistence controlls the amplitude used in the different frequencies
- * @param levels controlls the min and max level used. The level is determining the frequency to use
+ * @param persistence controls the amplitude used in the different frequencies
+ * @param startLevel controls the min level used. The level is determining the frequency to use
  * in each white noise image as 2^level
+ * @param endLevel controlsthe max level used. 
  * @param randomNumberGenerator the Random number generator to use, defaults to the Mersenne Twister
  * engine (std::mt19937)
  */

--- a/modules/base/io/ivfsequencevolumewriter.h
+++ b/modules/base/io/ivfsequencevolumewriter.h
@@ -87,7 +87,7 @@ public:
      * @param name the name of the dataset, will be used for to name the output files [name].ivfs
      * and [name]xx.ivf
      * @param path path to the folder to put the main file
-     * @param reltivePathToElements relative path (from the path to the main file) to where the
+     * @param reltivePathToTimesteps relative path (from the path to the main file) to where the
      * sequence elements will be written.
      */
     void writeData(const VolumeSequence* volumes, std::string name, std::string path,

--- a/modules/base/processors/meshclipping.h
+++ b/modules/base/processors/meshclipping.h
@@ -84,12 +84,12 @@ protected:
     virtual void process() override;
 
     /**
-     * Clip mesh againts plane. Replaces removed parts with triangles aligned with the plane.
-     * @thows Exception if mesh is not a SimpleMesh or BasicMesh
-     * @param Mesh to clip
-     * @param Plane in world space coordinate system.
+     * Clip mesh against plane. Replaces removed parts with triangles aligned with the plane.
+     * @throws Exception if mesh is not a SimpleMesh or BasicMesh
+     * @param mesh to clip
+     * @param plane in world space coordinate system.
      */
-    std::shared_ptr<Mesh> clipGeometryAgainstPlane(const Mesh*, const Plane&);
+    std::shared_ptr<Mesh> clipGeometryAgainstPlane(const Mesh *mesh, const Plane &plane);
 
 private:
     void onAlignPlaneNormalToCameraNormalPressed();

--- a/modules/basegl/viewmanager.h
+++ b/modules/basegl/viewmanager.h
@@ -121,13 +121,15 @@ public:
     /**
     * \brief replace a previously defined viewport at index ind with a new viewport using the
     * following coordinate system:
-    * y ^
-    *   |
-    *   |
-    *   ------> x
-    *
+    \verbatim 
+     y ^
+       |
+       |
+       ------> x
+    \endverbatim 
     * @see ViewManager
     * @param ind Viewport index [0 size()-1]
+    * @param view the view to replace with
     */
     void replace(ViewId ind, View view);
 

--- a/modules/cimg/cimgutils.h
+++ b/modules/cimg/cimgutils.h
@@ -79,18 +79,18 @@ namespace cimgutil {
     /**
      * \brief Rescales Layer of given image data
      *
-     * @param Layer * inputImage image data that needs to be rescaled
-     * @param uvec2 dst_dim is destination dimensions
-     * @param void* rescaled raw data
+     * @param inputLayer image data that needs to be rescaled
+     * @param dst_dim is destination dimensions
+     * @return rescaled raw data
      */
     IVW_MODULE_CIMG_API void* rescaleLayer(const Layer* inputLayer, uvec2 dst_dim);
 
     /**
      * \brief Rescales LayerRAM representation uses FILTER_BILINEAR by default.
      *
-     * @param LayerRAM * imageRam representation that needs rescaling
-     * @param uvec2 dst_dim is destination dimensions
-     * @param void* rescaled raw data
+     * @param layerRam representation that needs rescaling
+     * @param dst_dim is destination dimensions
+     * @return rescaled raw data
      */
     IVW_MODULE_CIMG_API void* rescaleLayerRAM(const LayerRAM* layerRam, uvec2 dst_dim);
 

--- a/modules/fontrendering/textrenderer.h
+++ b/modules/fontrendering/textrenderer.h
@@ -179,11 +179,11 @@ public:
     /**
      * \brief renders the given string with the specified color into a subregion of the texture.
      *
-     * @param texture   the text will be rendered into this texture
-     * @param origin    origin of sub region within the texture (lower left corner, in pixel)
-     * @param extent    extent of sub region (in pixel)
-     * @param str    input string
-     * @param color  color of rendered text
+     * @param texObject      the text will be rendered into this texture
+     * @param origin         origin of sub region within the texture (lower left corner, in pixel)
+     * @param size           extent of sub region (in pixel)
+     * @param str            input string
+     * @param color          color of rendered text
      * @param clearTexture   if true, the texture is cleared before rendering the text
      */
     void renderToTexture(const TextTextureObject &texObject, const size2_t &origin,

--- a/modules/opengl/buffer/buffergl.h
+++ b/modules/opengl/buffer/buffergl.h
@@ -49,9 +49,8 @@ public:
      *
      * @param size Size in bytes.
      * @param format Data format
-     * @param type What kind of data is stored (positions, normals...) ? Will determine
-     *location in shader.
-     * @param usage STATIC if not changing all the time, else DYNAMIC.
+     * @param usage BufferUsage::Static if not changing all the time, else BufferUsage::Dynamic.
+     * @param target BufferTarget::Data for vertex buffers and BufferTarget::Index for index buffers
      * @param data Will be created if nullptr.
      * @return
      */

--- a/modules/opengl/rendering/texturequadrenderer.h
+++ b/modules/opengl/rendering/texturequadrenderer.h
@@ -105,7 +105,7 @@ public:
      * dimensions determine the covered area in pixel. The anchor point of the
      * image is in the lower left corner.
      *
-     * @param layer   layer which is to be rendered onto the current render target
+     * @param image   layer which is to be rendered onto the current render target
      * @param pos     position of lower left corner in screen space coordinates
      * @param canvasSize   dimensions of the current render target
      * @param transformation  additional transformation matrix to be applied before rendering. (For
@@ -193,7 +193,7 @@ public:
      * extent. The covered area is defined by the extent (in pixel). The anchor point
      * of the layer is in the lower left corner.
      *
-     * @param layer   layer which is to be rendered onto the current render target
+     * @param image   layer which is to be rendered onto the current render target
      * @param pos     position of lower left corner in screen space coordinates
      * @param extent      extent covered by the rendered texture in screen space coordinates
      * @param canvasSize   dimensions of the current render target

--- a/modules/plotting/utils/axisutils.h
+++ b/modules/plotting/utils/axisutils.h
@@ -71,7 +71,6 @@ getLabelPositions3D(const AxisProperty& property, const vec3& startPos, const ve
  * end position
  *
  * @param property    axis property used for tick settings
- * @param outputDim   dimensions of the canvas
  * @param startPos  start position of axis
  * @param endPos    end position of axis
  * @return mesh containing of ticks, each tick is represented by two positions and matching colors
@@ -110,6 +109,7 @@ std::shared_ptr<Mesh> IVW_MODULE_PLOTTING_API generateAxisMesh3D(const AxisPrope
  * @param startPos  start position of axis (spatial coordinates)
  * @param endPos    end position of axis  (spatial coordinates)
  * @param tickDirection   direction of ticks pointing outwards (spatial coordinates)
+ * @param tickLength length of the ticks
  * @param style     tick style (none, inside, outside, both)
  * @param color     tick color
  * @param flip      if true, the orientation of ticks is flipped (only affects inside/outside

--- a/modules/plotting/utils/statsutils.h
+++ b/modules/plotting/utils/statsutils.h
@@ -62,8 +62,9 @@ std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& o
  *
  * NaNs (Not a Numbers) are excluded from the computation.
  * The following example will return {1,2}
- * @code auto percentiles = utilstats::percentiles({1, 0, 3, 2}, {0.25, 0.75});
- *
+ * \code{.cpp} 
+ *    auto percentiles = utilstats::percentiles({1, 0, 3, 2}, {0.25, 0.75});
+ * \endcode
  * See also https://en.wikipedia.org/wiki/Percentile
  *
  * @param data to compute percentiles on

--- a/modules/qtwidgets/eventconverterqt.h
+++ b/modules/qtwidgets/eventconverterqt.h
@@ -51,24 +51,19 @@ namespace utilqt {
      * to an inviwo button.
      *
      * Converts QMouseEvent::getButtons().
-     *
-     * @param QMouseEvent * e 
-     * @return MouseEvent::MouseButton 
      */
     IVW_MODULE_QTWIDGETS_API MouseButtons getMouseButtons(const QMouseEvent* e);
-    /** 
-     * \brief Convert the button originally 
+
+    /**
+     * \brief Convert the button originally
      * causing the event to an inviwo button.
      *
      * Converts QMouseEvent::getButton().
-     * 
-     * @note Qt does not include the button 
-     * that caused a release event in the regular 
-     * QMouseEvent::getButtons function, which is 
-     * why a separate conversion function
-     * is necessary 
-     * @param QMouseEvent * e 
-     * @return MouseEvent::MouseButton 
+     *
+     * @note Qt does not include the button that caused a release event in the regular
+     * QMouseEvent::getButtons function, which is why a separate conversion function is necessary
+     * @param e the QT Mouse Event
+     * @return MouseEvent::MouseButton
      */
     IVW_MODULE_QTWIDGETS_API MouseButton getMouseButtonCausingEvent(const QMouseEvent* e);
     IVW_MODULE_QTWIDGETS_API MouseButtons getMouseWheelButtons(const QWheelEvent* e);

--- a/modules/qtwidgets/inviwoqtutils.h
+++ b/modules/qtwidgets/inviwoqtutils.h
@@ -147,7 +147,7 @@ IVW_MODULE_QTWIDGETS_API QMainWindow* getApplicationMainWindow();
  * @see CanvasProcessorWidgetQt
  * @param point The previous screen position of the widget
  * @param size The size of the widget
- * @param bool decorationOffset Offset widget below top horizontal window bar
+ * @param decorationOffset Offset widget below top horizontal window bar
  * @return The adapted point on the screen, same as input point if no adjustment was necessary
  */
 IVW_MODULE_QTWIDGETS_API QPoint movePointOntoDesktop(const QPoint& point, const QSize& size,

--- a/modules/qtwidgets/tf/tfcoloredit.h
+++ b/modules/qtwidgets/tf/tfcoloredit.h
@@ -62,6 +62,7 @@ public:
      * "#f9a033".
      *
      * @param color   rgb components are converted into a hexadecimal color code
+     * @param ambiguous     whether the color has a name or not
      */
     void setColor(const QColor& color, bool ambiguous);
 

--- a/modules/qtwidgets/tf/tfeditorprimitive.h
+++ b/modules/qtwidgets/tf/tfeditorprimitive.h
@@ -74,6 +74,7 @@ public:
      * The graphical representation should thus be centered around (0,0) in local
      * coordinates.
      *
+     * @param primitive pointer to the primitive
      * @param scene    item will be added to this QGraphicsScene
      * @param pos      normalized position of primitive (scalar value and opacity)
      * @param size     base size of primitive

--- a/modules/qtwidgets/tf/tfselectionwatcher.h
+++ b/modules/qtwidgets/tf/tfselectionwatcher.h
@@ -82,7 +82,7 @@ public slots:
     /**
      * set the color of all currently selected TF primitives
      *
-     * @param color  new color
+     * @param c  the new color
      */
     void setColor(const QColor &c);
 
@@ -90,8 +90,6 @@ public slots:
      * updates the selection state and sends out signals for position, alpha, and color.
      * In case, multiple primitives are selected, the values are considered ambiguous unless
      * they all have the same value. The position, alpha, and color are considered separately.
-     *
-     * @param pos  new position
      */
     void updateSelection(const std::vector<TFPrimitive *> selection);
 

--- a/tools/doxygen/doxygen.cmake
+++ b/tools/doxygen/doxygen.cmake
@@ -123,6 +123,8 @@ SEARCH_INCLUDES        = NO
 
 IMAGE_PATH             = ${image_paths}
 
+INCLUDE_PATH           = ${IVW_ROOT_DIR}/ext
+
 EXTENSION_MAPPING      = no_extension=C++ frag=C++ vert=C++ geom=C++ glsl=C++
 
 FILE_PATTERNS          = *.c \\
@@ -140,7 +142,7 @@ RECURSIVE              = YES
 EXCLUDE                =
 EXCLUDE_PATTERNS       = */moc_* \\
                          */qrc_* \\
-                         */ext/* \\
+                         */modules/*/ext/* \\
                          */clogs/* \\
                          *-test.cpp \\
                          *sqlite3* \\


### PR DESCRIPTION
By adding `INCLUDE_PATH           = ${IVW_ROOT_DIR}/ext` to doxygen.cmake and modifying  `EXCLUDE_PATTERNS` to exclude `*/modules/*/ext/*` rather than `*/ext/*` we will get rid of a few hundred doxygen warnings related to `#include <warn/push>` etc. 
Furthermore, This PR addresses various doxygen warnings that we had in many places in our code. 