### PR TITLE
Indirect iterator

### DIFF
--- a/include/inviwo/core/ports/inportiterable.h
+++ b/include/inviwo/core/ports/inportiterable.h
@@ -82,8 +82,8 @@ public:
             return i;
         }
 
-        std::shared_ptr<const T> operator*() { return *dIter_; }
-        std::shared_ptr<const T> operator->() { return *dIter_; }
+        std::shared_ptr<const T> operator*() const { return *dIter_; }
+        std::shared_ptr<const T> operator->() const { return *dIter_; }
 
         bool operator==(const self& rhs) const {
             return pIter_ == rhs.pIter_ && dIter_ == rhs.dIter_;
@@ -150,10 +150,10 @@ public:
             pIter_++;
             return i;
         }
-        std::shared_ptr<const T> operator*() {
+        std::shared_ptr<const T> operator*() const {
             return static_cast<DataOutport<T>*>(*pIter_)->getData();
         }
-        std::shared_ptr<const T> operator->() {
+        std::shared_ptr<const T> operator->() const {
             return static_cast<DataOutport<T>*>(*pIter_)->getData();
         }
         bool operator==(const self& rhs) const { return pIter_ == rhs.pIter_; }

--- a/include/inviwo/core/ports/outportiterable.h
+++ b/include/inviwo/core/ports/outportiterable.h
@@ -76,8 +76,8 @@ struct OutportIterable {
             return i;
         }
 
-        std::shared_ptr<const T> operator*() { return self_->getref(); }
-        std::shared_ptr<const T> operator->() { return self_->getptr(); }
+        std::shared_ptr<const T> operator*() const { return self_->getref(); }
+        std::shared_ptr<const T> operator->() const { return self_->getptr(); }
 
         bool operator==(const const_iterator& rhs) const {
             if (!self_ && !(rhs.self_))

--- a/include/inviwo/core/util/indirectiterator.h
+++ b/include/inviwo/core/util/indirectiterator.h
@@ -172,15 +172,15 @@ struct IndirectIterator {
     }
 
     template <typename I = Iter, typename = require_t<std::random_access_iterator_tag, I>>
-    reference operator[](difference_type i) {
+    reference operator[](difference_type i) const {
         return *iterator_[i];
     }
 
-    reference operator*() { 
+    reference operator*() const { 
         return **iterator_; 
     }
 
-    pointer operator->() { return detail_indirect::asPointer<is_const>::get(*(iterator_.operator->())); }
+    pointer operator->() const { return detail_indirect::asPointer<is_const>::get(*(iterator_.operator->())); }
 
     const Iter& base() const {return iterator_;}
     Iter& base() {return iterator_;}

--- a/include/inviwo/core/util/indirectiterator.h
+++ b/include/inviwo/core/util/indirectiterator.h
@@ -32,6 +32,7 @@
 
 #include <iterator>
 #include <type_traits>
+#include <memory>
 
 namespace inviwo {
 
@@ -67,6 +68,7 @@ struct add_const_to_reference<T&&> {
 template <typename T>
 using add_const_to_reference_t = typename add_const_to_reference<T>::type;
 
+// a utility to get a raw pointer as a const or mutable
 template <bool asConst>
 struct asPointer {};
 

--- a/include/inviwo/core/util/indirectiterator.h
+++ b/include/inviwo/core/util/indirectiterator.h
@@ -1,0 +1,225 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2018 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#ifndef IVW_INDIRECTITERATOR_H
+#define IVW_INDIRECTITERATOR_H
+
+#include <iterator>
+#include <type_traits>
+
+namespace inviwo {
+
+namespace util {
+
+namespace detail_indirect {
+template <typename Tag, typename Iter>
+struct require : std::enable_if<std::is_base_of<Tag, typename Iter::iterator_category>::value> {};
+template <typename Tag, typename Iter>
+using require_t = typename require<Tag, Iter>::type;
+
+template <typename Iterator>
+struct is_const_iterator {
+    typedef typename std::iterator_traits<Iterator>::pointer pointer;
+    static constexpr bool value = std::is_const<typename std::remove_pointer<pointer>::type>::value;
+};
+
+template <typename T>
+struct add_const_to_reference {
+    using type = const T;
+};
+
+template <typename T>
+struct add_const_to_reference<T&> {
+    using type = const T&;
+};
+
+template <typename T>
+struct add_const_to_reference<T&&> {
+    using type = const T&&;
+};
+
+template <typename T>
+using add_const_to_reference_t = typename add_const_to_reference<T>::type;
+
+template <bool asConst>
+struct asPointer {};
+
+template <>
+struct asPointer<true> {
+    template <typename T>
+    static constexpr const T* get(const T* p) {
+        return p;
+    }
+    template <typename T, typename D>
+    static constexpr const T* get(const std::unique_ptr<T, D>& p) {
+        return p.get();
+    }
+    template <typename T>
+    static constexpr const T* get(const std::shared_ptr<T>& p) {
+        return p.get();
+    }
+};
+template <>
+struct asPointer<false> {
+    template <typename T>
+    static constexpr T* get(const T* p) {
+        return p;
+    }
+    template <typename T, typename D>
+    static constexpr T* get(const std::unique_ptr<T, D>& p) {
+        return p.get();
+    }
+    template <typename T>
+    static constexpr T* get(const std::shared_ptr<T>& p) {
+        return p.get();
+    }
+};
+
+}  // namespace detail_indirect
+
+template <typename Iter, bool PropagateConst = true>
+struct IndirectIterator {
+    using difference_type = typename std::iterator_traits<Iter>::difference_type;
+    using iterator_category = typename std::iterator_traits<Iter>::iterator_category;
+    
+    using base_value = typename std::iterator_traits<Iter>::value_type;
+    using value_type = decltype(*std::declval<base_value>());
+    
+    static constexpr bool is_const = std::conditional_t<PropagateConst, detail_indirect::is_const_iterator<Iter>, std::false_type>::value;
+    
+    using base_pointer = typename std::iterator_traits<Iter>::pointer;
+    using pointer = decltype(detail_indirect::asPointer<is_const>::get(*std::declval<base_pointer>()));
+    
+    using base_reference = typename std::iterator_traits<Iter>::reference;
+    using reference = std::conditional_t<is_const, 
+        detail_indirect::add_const_to_reference_t<decltype(*std::declval<base_reference>())>, 
+        decltype(*std::declval<base_reference>())>;
+
+    template <typename Tag, typename Iterables>
+    using require_t = detail_indirect::require_t<Tag, Iter>;
+    
+    IndirectIterator() = default;
+    IndirectIterator(Iter iterator) : iterator_(iterator) {}
+
+    IndirectIterator& operator++() {
+        ++iterator_;
+        return *this;
+    }
+    IndirectIterator operator++(int) {
+        return {iterator_++};
+    }
+
+    template <typename I = Iter, typename = require_t<std::bidirectional_iterator_tag, I>>
+    IndirectIterator& operator--() {
+        --iterator_;
+        return *this;
+    }
+    template <typename I = Iter, typename = require_t<std::bidirectional_iterator_tag, I>>
+    IndirectIterator operator--(int) {
+        return {iterator_--};
+    }
+
+    template <typename I = Iter, typename = require_t<std::random_access_iterator_tag, I>>
+    IndirectIterator& operator+=(difference_type rhs) {
+        iterator_ += rhs;
+        return *this;
+    }
+    template <typename I = Iter, typename = require_t<std::random_access_iterator_tag, I>>
+    IndirectIterator& operator-=(difference_type rhs) {
+        iterator_-=rhs;
+        return *this;
+    }
+
+    template <typename I = Iter, typename = require_t<std::random_access_iterator_tag, I>>
+    difference_type operator-(const IndirectIterator& rhs) const {
+        return iterator_ - rhs.iterator_;
+    }
+    template <typename I = Iter, typename = require_t<std::random_access_iterator_tag, I>>
+    IndirectIterator operator+(difference_type i) const {
+        auto iter = *this;
+        return iter += i;
+    }
+    template <typename I = Iter, typename = require_t<std::random_access_iterator_tag, I>>
+    IndirectIterator operator-(difference_type i) const {
+        auto iter = *this;
+        return iter -= i;
+    }
+
+    template <typename I = Iter, typename = require_t<std::random_access_iterator_tag, I>>
+    reference operator[](difference_type i) {
+        return *iterator_[i];
+    }
+
+    reference operator*() { 
+        return **iterator_; 
+    }
+
+    pointer operator->() { return detail_indirect::asPointer<is_const>::get(*(iterator_.operator->())); }
+
+    const Iter& base() const {return iterator_;}
+    Iter& base() {return iterator_;}
+
+    bool operator==(const IndirectIterator& rhs) const { return iterator_ == rhs.iterator_; }
+
+    bool operator!=(const IndirectIterator& rhs) const {
+        return iterator_ != rhs.iterator_;
+    }
+
+    template <typename I = Iter, typename = require_t<std::random_access_iterator_tag, I>>
+    bool operator>(const IndirectIterator& rhs) const {
+        return iterator_ > rhs.iterator_;
+    }
+    template <typename I = Iter, typename = require_t<std::random_access_iterator_tag, I>>
+    bool operator<(const IndirectIterator& rhs) const {
+        return iterator_ < rhs.iterator_;
+    }
+    template <typename I = Iter, typename = require_t<std::random_access_iterator_tag, I>>
+    bool operator>=(const IndirectIterator& rhs) const {
+        return iterator_ >= rhs.iterator_;
+    }
+    template <typename I = Iter, typename = require_t<std::random_access_iterator_tag, I>>
+    bool operator<=(const IndirectIterator& rhs) const {
+        return iterator_ <= rhs.iterator_;
+    }
+
+private:
+    Iter iterator_;
+};
+
+template <bool PropagateConst = true, typename Iter>
+IndirectIterator<Iter, PropagateConst> makeIndirectIterator(Iter&& iter) {
+    return IndirectIterator<Iter, PropagateConst>(std::forward<Iter>(iter));
+}
+
+
+}  // namespace util
+
+}  // namespace inviwo
+
+#endif  // IVW_INDIRECTITERATOR_H

--- a/include/inviwo/core/util/stdextensions.h
+++ b/include/inviwo/core/util/stdextensions.h
@@ -375,17 +375,17 @@ inline iter_range<Iter> as_range(std::pair<Iter, Iter> const& x) {
     return iter_range<Iter>(x);
 }
 
-template <class Cont>
-inline iter_range<typename Cont::iterator> as_range(Cont& c) {
+template <class Container>
+inline iter_range<typename Container::iterator> as_range(Container& c) {
     using std::begin;
     using std::end;
-    return iter_range<typename Cont::iterator>(std::make_pair(begin(c), end(c)));
+    return iter_range<typename Container::iterator>(std::make_pair(begin(c), end(c)));
 }
-template <class Cont>
-inline iter_range<typename Cont::const_iterator> as_range(const Cont& c) {
+template <class Container>
+inline iter_range<typename Container::const_iterator> as_range(const Container& c) {
     using std::begin;
     using std::end;
-    return iter_range<typename Cont::const_iterator>(std::make_pair(begin(c), end(c)));
+    return iter_range<typename Container::const_iterator>(std::make_pair(begin(c), end(c)));
 }
 
 template <typename T, typename OutIt, typename P>

--- a/include/inviwo/core/util/stdextensions.h
+++ b/include/inviwo/core/util/stdextensions.h
@@ -375,6 +375,19 @@ inline iter_range<Iter> as_range(std::pair<Iter, Iter> const& x) {
     return iter_range<Iter>(x);
 }
 
+template <class Cont>
+inline iter_range<typename Cont::iterator> as_range(Cont& c) {
+    using std::begin;
+    using std::end;
+    return iter_range<typename Cont::iterator>(std::make_pair(begin(c), end(c)));
+}
+template <class Cont>
+inline iter_range<typename Cont::const_iterator> as_range(const Cont& c) {
+    using std::begin;
+    using std::end;
+    return iter_range<typename Cont::const_iterator>(std::make_pair(begin(c), end(c)));
+}
+
 template <typename T, typename OutIt, typename P>
 OutIt copy_if(const T& cont, OutIt out, P pred) {
     using std::begin;

--- a/include/inviwo/core/util/zip.h
+++ b/include/inviwo/core/util/zip.h
@@ -172,32 +172,32 @@ auto getEnd(std::tuple<T...>& t) {
 }
 
 template <typename T, std::size_t... I>
-auto refImpl(T& t, std::index_sequence<I...>) -> proxy<decltype(*(std::get<I>(t)))...> {
+auto refImpl(const T& t, std::index_sequence<I...>) -> proxy<decltype(*(std::get<I>(t)))...> {
     return proxy<decltype(*(std::get<I>(t)))...>{*(std::get<I>(t))...};
 }
 template <typename... T>
-auto ref(std::tuple<T...>& t) -> proxy<decltype(*(std::declval<T>()))...> {
+auto ref(const std::tuple<T...>& t) -> proxy<decltype(*(std::declval<T>()))...> {
     return refImpl(t, std::index_sequence_for<T...>{});
 }
 
 template <typename T, typename ptrdiff_t, std::size_t... I>
-auto indexImpl(T& t, ptrdiff_t i, std::index_sequence<I...>)
+auto indexImpl(const T& t, ptrdiff_t i, std::index_sequence<I...>)
     -> proxy<decltype(std::get<I>(t)[std::declval<ptrdiff_t>()])...> {
     return proxy<decltype(std::get<I>(t)[std::declval<ptrdiff_t>()])...>{std::get<I>(t)[i]...};
 }
 template <typename... T, typename ptrdiff_t>
-auto index(std::tuple<T...>& t, ptrdiff_t i)
+auto index(const std::tuple<T...>& t, ptrdiff_t i)
     -> proxy<decltype(std::declval<T>()[std::declval<ptrdiff_t>()])...> {
     return indexImpl(t, i, std::index_sequence_for<T...>{});
 }
 
 template <typename T, std::size_t... I>
-auto pointerImpl(T& t, std::index_sequence<I...>)
+auto pointerImpl(const T& t, std::index_sequence<I...>)
     -> std::tuple<decltype((std::get<I>(t)).operator->())...> {
     return std::tuple<decltype((std::get<I>(t)).operator->())...>{(std::get<I>(t)).operator->()...};
 }
 template <typename... T>
-auto pointer(std::tuple<T...>& t) -> std::tuple<decltype((std::declval<T>()).operator->())...> {
+auto pointer(const std::tuple<T...>& t) -> std::tuple<decltype((std::declval<T>()).operator->())...> {
     return pointerImpl(t, std::index_sequence_for<T...>{});
 }
 
@@ -296,13 +296,13 @@ struct zipIterator {
     }
 
     template <typename I = Iterables, typename = require_t<std::random_access_iterator_tag, I>>
-    reference operator[](difference_type rhs) {
+    reference operator[](difference_type rhs) const {
         return detailzip::index(iterators_, rhs);
     }
 
-    reference operator*() { return detailzip::ref(iterators_); }
+    reference operator*() const { return detailzip::ref(iterators_); }
 
-    pointer operator->() { return detailzip::pointer(iterators_); }
+    pointer operator->() const { return detailzip::pointer(iterators_); }
 
     template <size_t N>
     typename std::tuple_element<N, Iterators>::type& get() {
@@ -449,7 +449,7 @@ struct sequence {
 
         reference operator*() const { return val_; }
 
-        pointer operator->() { return &val_; }
+        pointer operator->() const { return &val_; }
 
         bool operator==(const iterator& rhs) const { return val_ == rhs.val_; }
         bool operator!=(const iterator& rhs) const { return val_ != rhs.val_; }

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -280,6 +280,7 @@ set(HEADER_FILES
     ${IVW_INCLUDE_DIR}/inviwo/core/util/imageramutils.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/imagesampler.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/indexmapper.h
+    ${IVW_INCLUDE_DIR}/inviwo/core/util/indirectiterator.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/interpolation.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/intersection/rayplaneintersection.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/intersection/raysphereintersection.h
@@ -533,6 +534,7 @@ set(SOURCE_FILES
     util/imagecache.cpp
     util/imageramutils.cpp
     util/imagesampler.cpp
+    util/indirectiterator.cpp
     util/inviwosetupinfo.cpp
     util/licenseinfo.cpp
     util/logcentral.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -585,6 +585,7 @@ set(TEST_FILES
     tests/unittests/document-test.cpp
     tests/unittests/filesystem-test.cpp
     tests/unittests/glm-test.cpp
+    tests/unittests/indirectiterator-tests.cpp
     tests/unittests/metadata-test.cpp
     tests/unittests/picking-test.cpp
     tests/unittests/serialize-container-test.cpp

--- a/src/core/tests/unittests/indirectiterator-tests.cpp
+++ b/src/core/tests/unittests/indirectiterator-tests.cpp
@@ -1,0 +1,138 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2014-2018 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <gtest/gtest.h>
+#include <warn/pop>
+
+#include <vector>
+#include <memory>
+#include <type_traits>
+
+#include <inviwo/core/util/indirectiterator.h>
+
+namespace inviwo {
+
+TEST(IndirectIteratorTest, Pair) {
+    std::vector<int> ref;
+    std::vector<std::unique_ptr<int>> vec;
+    for (int i = 0; i < 5; ++i) {
+        ref.push_back(i);
+        vec.push_back(std::make_unique<int>(i));
+    }
+
+    const auto& cvec = vec;
+
+    {
+        auto b = util::makeIndirectIterator(vec.begin());
+        auto e = util::makeIndirectIterator(vec.end());
+        auto rb = ref.begin();
+        for (; b != e; ++b, ++rb) {
+            EXPECT_EQ(*b, *rb);
+        }
+    }
+
+    {
+        auto b = util::makeIndirectIterator(vec.begin());
+        auto e = util::makeIndirectIterator(vec.end());
+        for (; b != e; ++b) {
+            *b += 10;
+        }
+    }
+    {
+        auto b = util::makeIndirectIterator(vec.begin());
+        auto e = util::makeIndirectIterator(vec.end());
+        auto rb = ref.begin();
+        for (; b != e; ++b, ++rb) {
+            EXPECT_EQ(*b, *rb + 10);
+        }
+    }
+
+    {
+        auto b = util::makeIndirectIterator(cvec.begin());
+        auto e = util::makeIndirectIterator(cvec.end());
+        auto rb = ref.begin();
+        for (; b != e; ++b, ++rb) {
+            EXPECT_EQ(*b, *rb + 10);
+        }
+    }
+
+    {
+        auto b = util::makeIndirectIterator<false>(cvec.begin());
+        auto e = util::makeIndirectIterator<false>(cvec.end());
+        for (; b != e; ++b) {
+            *b += 10;
+        }
+    }
+
+    {
+        auto b = util::makeIndirectIterator(cvec.begin());
+        auto e = util::makeIndirectIterator(cvec.end());
+        auto rb = ref.begin();
+        for (; b != e; ++b, ++rb) {
+            EXPECT_EQ(*b, *rb + 20);
+        }
+    }
+
+    {
+        auto b = util::makeIndirectIterator(vec.begin());
+        static_assert(std::is_assignable<decltype(*b), int>::value, "");
+    }
+    {
+        auto b = util::makeIndirectIterator(cvec.begin());
+        static_assert(!std::is_assignable<decltype(*b), int>::value, "");
+    }
+    {
+        auto b = util::makeIndirectIterator(vec.cbegin());
+        static_assert(!std::is_assignable<decltype(*b), int>::value, "");
+    }
+    {
+        auto b = util::makeIndirectIterator(cvec.cbegin());
+        static_assert(!std::is_assignable<decltype(*b), int>::value, "");
+    }
+    {
+        auto b = util::makeIndirectIterator<false>(vec.begin());
+        static_assert(std::is_assignable<decltype(*b), int>::value, "");
+    }
+    {
+        auto b = util::makeIndirectIterator<false>(cvec.begin());
+        static_assert(std::is_assignable<decltype(*b), int>::value, "");
+    }
+    {
+        auto b = util::makeIndirectIterator<false>(vec.cbegin());
+        static_assert(std::is_assignable<decltype(*b), int>::value, "");
+    }
+    {
+        auto b = util::makeIndirectIterator<false>(cvec.cbegin());
+        static_assert(std::is_assignable<decltype(*b), int>::value, "");
+    }
+}
+
+}  // namespace inviwo

--- a/src/core/util/indirectiterator.cpp
+++ b/src/core/util/indirectiterator.cpp
@@ -1,0 +1,34 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2018 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/core/util/indirectiterator.h>
+
+namespace inviwo {
+
+}  // namespace inviwo


### PR DESCRIPTION
Example:
```
std::vector<std::unique_ptr<int>> vec;
for (int i = 0; i < 5; ++i) {
    vec.push_back(std::make_unique<int>(i));
}

auto b = util::makeIndirectIterator(vec.begin());
auto e = util::makeIndirectIterator(vec.end());
for (; b != e; ++b) {
    std::cout << *b << " ";
}
```
Note no need to do the extra deref of the unique_ptr since that is handled by the indirect Iterator
*b will be a reference to int.

The use case if to container types that stores items using a vector of pointers, but want to expose an iterator directly to the item not to the pointer...

Also some bug fixes for other iterators, operator* has to be const for an iterator to be standard conforming...