### PR TITLE
Various: CLang-6.0 related warning and compile fixes (Ubuntu 18.04)

### DIFF
--- a/docs/namespaces.dox
+++ b/docs/namespaces.dox
@@ -8,6 +8,15 @@
  */
 
 /**
+ * \namespace inviwo::dispatching dispatching
+ */
+
+/**
+ * \namespace inviwo::dispatching::filter dispatching::filter
+ */
+
+
+/**
  * \namespace inviwo::util util
  */
 

--- a/ext/glm/CMakeLists.txt
+++ b/ext/glm/CMakeLists.txt
@@ -1,11 +1,17 @@
+
 add_subdirectory(glm)
 
 add_library(inviwo::glm ALIAS glm)
-target_compile_definitions(glm INTERFACE 
-	GLM_FORCE_RADIANS 
-	GLM_FORCE_SIZE_T_LENGTH
-	GLM_FORCE_UNRESTRICTED_GENTYPE
-	GLM_ENABLE_EXPERIMENTAL
+target_compile_definitions(glm INTERFACE
+    GLM_FORCE_RADIANS
+    GLM_FORCE_SIZE_T_LENGTH
+    GLM_FORCE_UNRESTRICTED_GENTYPE
+    GLM_ENABLE_EXPERIMENTAL
 )
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    target_compile_definitions(glm INTERFACE  GLM_LANG_STL11_FORCED)
+endif()
+
 set_target_properties(glm_dummy PROPERTIES VERSION 0.9.9)
 ivw_folder(glm_dummy ext)

--- a/ext/glm/CMakeLists.txt
+++ b/ext/glm/CMakeLists.txt
@@ -10,7 +10,9 @@ target_compile_definitions(glm INTERFACE
 )
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    target_compile_definitions(glm INTERFACE  GLM_LANG_STL11_FORCED)
+    # Needed when using clang since GLM fails to detect c++11/14 support
+    # https://github.com/g-truc/glm/issues/620
+    target_compile_definitions(glm INTERFACE GLM_FORCE_CXX14)
 endif()
 
 set_target_properties(glm_dummy PROPERTIES VERSION 0.9.9)

--- a/include/inviwo/core/io/rawvolumeramloader.h
+++ b/include/inviwo/core/io/rawvolumeramloader.h
@@ -55,9 +55,9 @@ public:
 
     using type = std::shared_ptr<VolumeRAM>;
 
-    template <class T>
-    std::shared_ptr<VolumeRAM> dispatch() const {
-        typedef typename T::type F;
+    template <typename Result, typename T>
+    std::shared_ptr<VolumeRAM> operator()() const {
+        using F = typename T::type;
 
         std::size_t size = dimensions_.x * dimensions_.y * dimensions_.z;
         auto data = util::make_unique<F[]>(size);
@@ -83,6 +83,6 @@ private:
     const DataFormatBase* format_;
 };
 
-}  // namespace
+}  // namespace inviwo
 
 #endif  // IVW_RAWVOLUMERAMLOADER_H

--- a/include/inviwo/core/util/formatdispatching.h
+++ b/include/inviwo/core/util/formatdispatching.h
@@ -140,10 +140,14 @@ struct DispatchHelper<Result, B, E, std::tuple<Formats...>> {
  *  * __Predicate__ A type that is used to filter the list of types to consider in the
  *    dispatching. The `dispatching::filter` namespace have a few standard ones predefined.
  *
+ * # Example
+ * \snippet src/core/datastructures/buffer/bufferram.cpp Format Dispatching Example
+ *
  * @param callable This should be a struct with a generic call operator taking two template 
  * arguments the result type and DataFormat type. The callable will be called with the supplied 
  * arguments (`args`).
  * @param args Any arguments that should be passed on to the lambda.
+ *
  *
  * @throws dispatching::DispatchException in the case that the format of the buffer is not in
  * the list of formats after the filtering.

--- a/modules/animation/datastructures/keyframesequence.h
+++ b/modules/animation/datastructures/keyframesequence.h
@@ -267,7 +267,7 @@ void KeyframeSequenceTyped<Key>::add(const Key& key) {
 template <typename Key>
 void KeyframeSequenceTyped<Key>::addKeyFrame(std::unique_ptr<Key> key) {
     auto it = keyframes_.insert(std::upper_bound(keyframes_.begin(), keyframes_.end(), key,
-                                                 [&key](const auto& a, const auto& b) {
+                                                 [](const auto& a, const auto& b) {
                                                      return a->getTime() < b->getTime();
                                                  }),
                                 std::move(key));

--- a/modules/base/algorithm/image/imagecontour.cpp
+++ b/modules/base/algorithm/image/imagecontour.cpp
@@ -38,7 +38,8 @@ std::shared_ptr<Mesh> ImageContour::apply(const LayerRepresentation *in, size_t 
     if (df->getNumericType() != NumericType::Float) {
         isoValue = df->getMin() + isoValue * (df->getMax() - df->getMin());
     }
-    return df->dispatch(disp, in, channel, isoValue, color);
+    return dispatching::dispatch<std::shared_ptr<Mesh>, dispatching::filter::All>(
+        df->getId(), disp, in, channel, isoValue, color);
 }
 
-}  // namespace
+}  // namespace inviwo

--- a/modules/base/algorithm/image/imagecontour.h
+++ b/modules/base/algorithm/image/imagecontour.h
@@ -51,13 +51,13 @@ public:
 namespace detail {
 struct IVW_MODULE_BASE_API ImageContourDispatcher {
     using type = std::shared_ptr<Mesh>;
-    template <class T>
-    std::shared_ptr<Mesh> dispatch(const LayerRepresentation* in, size_t channel, double isoValue,
+  template <typename Result, typename T>
+    std::shared_ptr<Mesh> operator()(const LayerRepresentation* in, size_t channel, double isoValue,
                                    vec4 color);
 };
 
-template <class DataType>
-std::shared_ptr<Mesh> ImageContourDispatcher::dispatch(const LayerRepresentation* in,
+template <typename Result, class DataType>
+std::shared_ptr<Mesh> ImageContourDispatcher::operator()(const LayerRepresentation* in,
                                                        size_t channel, double isoValue,
                                                        vec4 color) {
     static const std::vector<std::vector<int>> caseTable = {

--- a/modules/base/algorithm/meshutils.cpp
+++ b/modules/base/algorithm/meshutils.cpp
@@ -146,8 +146,6 @@ std::shared_ptr<BasicMesh> disk(const vec3& center, const vec3& normal, const ve
 std::shared_ptr<BasicMesh> cone(const vec3& start, const vec3& stop, const vec4& color,
                                 const float& radius, const size_t& segments) {
     const vec3 tc(0.5f, 0.5f, 0.0f);
-    const vec3 tn(0.0f, 0.0f, 1.0f);
-    const vec3 to(0.5f, 0.0f, 0.0f);
 
     auto mesh = std::make_shared<BasicMesh>();
     mesh->setModelMatrix(mat4(1.f));

--- a/modules/base/algorithm/volume/volumelaplacian.cpp
+++ b/modules/base/algorithm/volume/volumelaplacian.cpp
@@ -35,8 +35,8 @@ std::shared_ptr<Volume> util::volumeLaplacian(std::shared_ptr<const Volume> volu
                                               VolumeLaplacianPostProcessing postProcessing,
                                               double scale) {
     util::detail::VolumeLaplacianDispatcher disp;
-    return volume->getDataFormat()->dispatch(disp, volume, postProcessing, scale);
+    return dispatching::dispatch<std::shared_ptr<Volume>, dispatching::filter::All>(
+        volume->getDataFormat()->getId(), disp, volume, postProcessing, scale);
 }
 
-} // namespace
-
+}  // namespace inviwo

--- a/modules/base/algorithm/volume/volumelaplacian.h
+++ b/modules/base/algorithm/volume/volumelaplacian.h
@@ -51,13 +51,13 @@ namespace detail {
 
 struct VolumeLaplacianDispatcher {
     using type = std::shared_ptr<Volume>;
-    template <class DF>
-    std::shared_ptr<Volume> dispatch(std::shared_ptr<const Volume> volume,
-                                     VolumeLaplacianPostProcessing postProcessing, double scale);
+    template <typename Result, typename T>
+    std::shared_ptr<Volume> operator()(std::shared_ptr<const Volume> volume,
+                                       VolumeLaplacianPostProcessing postProcessing, double scale);
 };
 
-template <class DF>
-std::shared_ptr<Volume> inviwo::util::detail::VolumeLaplacianDispatcher::dispatch(
+template <typename Result, typename DF>
+std::shared_ptr<Volume> VolumeLaplacianDispatcher::operator()(
     std::shared_ptr<const Volume> volume, VolumeLaplacianPostProcessing postProcessing,
     double scale) {
     using T = typename DF::type;
@@ -149,11 +149,10 @@ std::shared_ptr<Volume> inviwo::util::detail::VolumeLaplacianDispatcher::dispatc
 
     return newVolume;
 }
-}
+}  // namespace detail
 
-}  // namespace
+}  // namespace util
 
-}  // namespace
+}  // namespace inviwo
 
-#endif // IVW_VOLUMELAPLACIANALGO_H
-
+#endif  // IVW_VOLUMELAPLACIANALGO_H

--- a/modules/base/algorithm/volume/volumeramsubset.cpp
+++ b/modules/base/algorithm/volume/volumeramsubset.cpp
@@ -36,7 +36,8 @@ std::shared_ptr<VolumeRAM> VolumeRAMSubSet::apply(const VolumeRepresentation* in
                                                   const VolumeBorders& border /*= VolumeBorders()*/,
                                                   bool clampBorderOutsideVolume /*= true*/) {
     detail::VolumeRAMSubSetDispatcher disp;
-    return in->getDataFormat()->dispatch(disp, in, dim, offset, border, clampBorderOutsideVolume);
+    return dispatching::dispatch<std::shared_ptr<VolumeRAM>, dispatching::filter::All>(
+        in->getDataFormat()->getId(), disp, in, dim, offset, border, clampBorderOutsideVolume);
 }
 
-}  // namespace
+}  // namespace inviwo

--- a/modules/base/algorithm/volume/volumeramsubset.h
+++ b/modules/base/algorithm/volume/volumeramsubset.h
@@ -48,16 +48,17 @@ namespace detail {
 
 struct IVW_MODULE_BASE_API VolumeRAMSubSetDispatcher {
     using type = std::shared_ptr<VolumeRAM>;
-    template <class T>
-    std::shared_ptr<VolumeRAM> dispatch(const VolumeRepresentation* in, size3_t dim, size3_t offset,
-                                        const VolumeBorders& border, bool clampBorderOutsideVolume);
+    template <typename Result, typename T>
+    std::shared_ptr<VolumeRAM> operator()(const VolumeRepresentation* in, size3_t dim,
+                                          size3_t offset, const VolumeBorders& border,
+                                          bool clampBorderOutsideVolume);
 };
 
-template <class DataType>
-std::shared_ptr<VolumeRAM> VolumeRAMSubSetDispatcher::dispatch(const VolumeRepresentation* in,
-                                                               size3_t dim, size3_t offset,
-                                                               const VolumeBorders& border,
-                                                               bool clampBorderOutsideVolume) {
+template <typename Result, typename DataType>
+std::shared_ptr<VolumeRAM> VolumeRAMSubSetDispatcher::operator()(const VolumeRepresentation* in,
+                                                                 size3_t dim, size3_t offset,
+                                                                 const VolumeBorders& border,
+                                                                 bool clampBorderOutsideVolume) {
     using T = typename DataType::type;
 
     const VolumeRAMPrecision<T>* volume = dynamic_cast<const VolumeRAMPrecision<T>*>(in);
@@ -122,8 +123,8 @@ std::shared_ptr<VolumeRAM> VolumeRAMSubSetDispatcher::dispatch(const VolumeRepre
     return newVolume;
 }
 
-}  // namespace
+}  // namespace detail
 
-}  // namespace
+}  // namespace inviwo
 
 #endif  // IVW_VOLUMERAMSUBSET_H

--- a/modules/base/io/binarystlwriter.cpp
+++ b/modules/base/io/binarystlwriter.cpp
@@ -125,7 +125,7 @@ void BinarySTLWriter::writeData(const Mesh* data, std::ostream& f) const {
             }
         }
         return std::function<void(std::vector<vec3>&, size_t, size_t, size_t)>(
-            [&f](std::vector<vec3>& normals, size_t, size_t, size_t) -> void {
+            [](std::vector<vec3>& normals, size_t, size_t, size_t) -> void {
                 normals.emplace_back(0.0f);
             });
     }();

--- a/modules/base/io/stlwriter.cpp
+++ b/modules/base/io/stlwriter.cpp
@@ -126,7 +126,7 @@ void StlWriter::writeData(const Mesh* data, std::ostream& f) const {
             }
         }
         return std::function<void(std::ostream&, size_t, size_t, size_t)>(
-            [&f](std::ostream& fs, size_t, size_t, size_t) -> void {
+            [](std::ostream& fs, size_t, size_t, size_t) -> void {
                 fs << "0.0 0.0 0.0\n";
             });
     }();

--- a/modules/base/processors/imagesourceseries.h
+++ b/modules/base/processors/imagesourceseries.h
@@ -85,8 +85,6 @@ private:
 
     std::vector<FileExtension> validExtensions_;
     std::vector<std::string> fileList_;
-    
-    bool ready_; //!< flag for isReady state depending on existing file matching the pattern
 };
 
 } // namespace

--- a/modules/base/processors/volumesequencesingletimestepsampler.h
+++ b/modules/base/processors/volumesequencesingletimestepsampler.h
@@ -49,7 +49,7 @@ public:
         : SpatialSampler(*v0,space), t_(t), v0_(v0, space), v1_(v1, space) {}
 
 protected:
-    virtual dvec3 sampleDataSpace(const dvec3 &pos) const {
+    virtual dvec3 sampleDataSpace(const dvec3 &pos) const override {
         auto a = v0_.sampleDataSpace(pos);
         auto b = v1_.sampleDataSpace(pos);
         return a + t_ * (b - a);

--- a/modules/basegl/algorithm/imageconvolution.cpp
+++ b/modules/basegl/algorithm/imageconvolution.cpp
@@ -69,8 +69,8 @@ std::shared_ptr<Image> ImageConvolution::gaussianLowpass(const Layer &layer, int
 }
 
 std::shared_ptr<Image> ImageConvolution::lowpass(const Layer &layer, int kernelSize) {
-    return convolution_separable(layer, [kernelSize](float /*p*/) { return 1.f; }, kernelSize,
-                                static_cast<float>(kernelSize));
+    return convolution_separable(layer, [](float /*p*/) { return 1.f; }, kernelSize,
+                                 static_cast<float>(kernelSize));
 }
 
 std::shared_ptr<Image> ImageConvolution::convolution(const Layer &layer,
@@ -145,4 +145,4 @@ std::shared_ptr<Image> ImageConvolution::convolution_internal(const Layer &layer
     return outImage;
 }
 
-}  // namespace
+}  // namespace inviwo

--- a/modules/cimg/cimglayerreader.cpp
+++ b/modules/cimg/cimglayerreader.cpp
@@ -102,7 +102,8 @@ std::shared_ptr<LayerRepresentation> CImgLayerRAMLoader::createRepresentation() 
     layerDisk_->updateDataFormat(DataFormatBase::get(formatId));
     updateSwizzleMask(layerDisk_);
 
-    return layerDisk_->getDataFormat()->dispatch(*this, data);
+    return dispatching::dispatch<std::shared_ptr<LayerRepresentation>, dispatching::filter::All>(
+        formatId, *this, data);
 }
 
 void CImgLayerRAMLoader::updateRepresentation(std::shared_ptr<LayerRepresentation> dest) const {

--- a/modules/cimg/cimglayerreader.h
+++ b/modules/cimg/cimglayerreader.h
@@ -66,9 +66,9 @@ public:
 
     using type = std::shared_ptr<LayerRAM>;
 
-    template <class T>
-    std::shared_ptr<LayerRAM> dispatch(void* data) const {
-        typedef typename T::type F;
+    template <typename Result, typename T>
+    std::shared_ptr<LayerRAM> operator()(void* data) const {
+        using F = typename T::type;
         auto layerRAM = std::make_shared<LayerRAMPrecision<F>>(
             static_cast<F*>(data), layerDisk_->getDimensions(), layerDisk_->getLayerType(),
             layerDisk_->getSwizzleMask());

--- a/modules/cimg/cimgutils.cpp
+++ b/modules/cimg/cimgutils.cpp
@@ -224,10 +224,12 @@ struct CImgNormalizedLayerDispatcher {
 
 struct CImgLoadLayerDispatcher {
     using type = void*;
-    template <typename T>
-    void* dispatch(void* dst, const std::string& filePath, uvec2& dimensions,
-                   DataFormatId& formatId, const DataFormatBase* dataFormat, bool rescaleToDim) {
-        using P = typename T::primitive;
+    template <typename Result, typename DF>
+    void* operator()(void* dst, const std::string& filePath, uvec2& dimensions,
+                     DataFormatId& formatId, bool rescaleToDim) {
+        using P = typename DF::primitive;
+
+      const DataFormatBase* dataFormat = DF::get();
 
         try {
             cimg_library::CImg<P> img(filePath.c_str());
@@ -260,8 +262,8 @@ struct CImgLoadLayerDispatcher {
 
 struct CImgSaveLayerDispatcher {
     using type = void;
-    template <typename T>
-    void dispatch(const std::string& filePath, const LayerRAM* inputLayer) {
+    template <typename Result, typename T>
+    void operator()(const std::string& filePath, const LayerRAM* inputLayer) {
         auto img = LayerToCImg<typename T::type>::convert(inputLayer);
 
         // Should rescale values based on output format i.e. PNG/JPG is 0-255, HDR different.
@@ -315,8 +317,8 @@ struct CImgSaveLayerDispatcher {
 
 struct CImgSaveLayerToBufferDispatcher {
     using type = std::unique_ptr<std::vector<unsigned char>>;
-    template <typename T>
-    type dispatch(const LayerRAM* inputLayer, const std::string& extension) {
+    template <typename Result, typename T>
+    type operator()(const LayerRAM* inputLayer, const std::string& extension) {
         auto img = LayerToCImg<typename T::type>::convert(inputLayer);
 
         // Should rescale values based on output format i.e. PNG/JPG is 0-255, HDR different.
@@ -370,8 +372,8 @@ struct CImgSaveLayerToBufferDispatcher {
 
 struct CImgRescaleLayerDispatcher {
     using type = void*;
-    template <typename T>
-    void* dispatch(const LayerRAM* inputLayerRAM, uvec2 dst_dim) {
+    template <typename Result, typename T>
+    void* operator()(const LayerRAM* inputLayerRAM, uvec2 dst_dim) {
         auto img = LayerToCImg<typename T::type>::convert(inputLayerRAM);
 
         img->resize(dst_dim.x, dst_dim.y, -100, -100, 3);
@@ -382,16 +384,20 @@ struct CImgRescaleLayerDispatcher {
 
 struct CImgLoadVolumeDispatcher {
     using type = void*;
-    template <typename T>
-    void* dispatch(void* dst, const std::string& filePath, size3_t& dimensions,
-                   DataFormatId& formatId, const DataFormatBase* dataFormat) {
-        cimg_library::CImg<typename T::primitive> img(filePath.c_str());
+    template <typename Result, typename DF>
+    void* operator()(void* dst, const std::string& filePath, size3_t& dimensions,
+                     DataFormatId& formatId) {
+        const DataFormatBase* dataFormat = DF::get();
+
+
+        cimg_library::CImg<typename DF::primitive> img(filePath.c_str());
+
 
         size_t components = static_cast<size_t>(img.spectrum());
         dimensions = size3_t(img.width(), img.height(), img.depth());
 
         const DataFormatBase* loadedDataFormat = DataFormatBase::get(
-            dataFormat->getNumericType(), components, sizeof(typename T::primitive) * 8);
+            dataFormat->getNumericType(), components, sizeof(typename DF::primitive) * 8);
         if (loadedDataFormat)
             formatId = loadedDataFormat->getId();
         else
@@ -400,7 +406,7 @@ struct CImgLoadVolumeDispatcher {
         // Image is up-side-down
         img.mirror('y');
 
-        return CImgToVoidConvert<typename T::primitive>::convert(dst, &img);
+        return CImgToVoidConvert<typename DF::primitive>::convert(dst, &img);
     }
 };
 
@@ -414,11 +420,10 @@ void* loadLayerData(void* dst, const std::string& filePath, uvec2& dimensions,
     } else {
         formatId = DataFormatId::Float32;
     }
-    const DataFormatBase* dataFormat = DataFormatBase::get(formatId);
 
     CImgLoadLayerDispatcher disp;
-    return dataFormat->dispatch(disp, dst, filePath, dimensions, formatId, dataFormat,
-                                rescaleToDim);
+    return dispatching::dispatch<void*, dispatching::filter::All>(
+        formatId, disp, dst, filePath, dimensions, formatId, rescaleToDim);
 }
 
 void* loadVolumeData(void* dst, const std::string& filePath, size3_t& dimensions,
@@ -429,23 +434,27 @@ void* loadVolumeData(void* dst, const std::string& filePath, size3_t& dimensions
     } else {
         formatId = DataFormatId::Float32;
     }
-    const DataFormatBase* dataFormat = DataFormatBase::get(formatId);
 
     CImgLoadVolumeDispatcher disp;
-    return dataFormat->dispatch(disp, dst, filePath, dimensions, formatId, dataFormat);
+    return dispatching::dispatch<void*, dispatching::filter::All>(formatId, disp, dst, filePath,
+                                                                  dimensions, formatId);
 }
 
 void saveLayer(const std::string& filePath, const Layer* inputLayer) {
     CImgSaveLayerDispatcher disp;
     const LayerRAM* inputLayerRam = inputLayer->getRepresentation<LayerRAM>();
-    inputLayerRam->getDataFormat()->dispatch(disp, filePath, inputLayerRam);
+
+    return dispatching::dispatch<void, dispatching::filter::All>(
+        inputLayerRam->getDataFormat()->getId(), disp, filePath, inputLayerRam);
 }
 
 std::unique_ptr<std::vector<unsigned char>> saveLayerToBuffer(const std::string& extension,
                                                               const Layer* inputLayer) {
     CImgSaveLayerToBufferDispatcher disp;
     const LayerRAM* inputLayerRam = inputLayer->getRepresentation<LayerRAM>();
-    return inputLayerRam->getDataFormat()->dispatch(disp, inputLayerRam, extension);
+    return dispatching::dispatch<std::unique_ptr<std::vector<unsigned char>>,
+                                 dispatching::filter::All>(inputLayerRam->getDataFormat()->getId(),
+                                                           disp, inputLayerRam, extension);
 }
 
 void* rescaleLayer(const Layer* inputLayer, uvec2 dst_dim) {
@@ -455,13 +464,14 @@ void* rescaleLayer(const Layer* inputLayer, uvec2 dst_dim) {
 
 void* rescaleLayerRAM(const LayerRAM* srcLayerRam, uvec2 dst_dim) {
     CImgRescaleLayerDispatcher disp;
-    return srcLayerRam->getDataFormat()->dispatch(disp, srcLayerRam, dst_dim);
+    return dispatching::dispatch<void*, dispatching::filter::All>(
+        srcLayerRam->getDataFormat()->getId(), disp, srcLayerRam, dst_dim);
 }
 
 struct CImgRescaleLayerRamToLayerRamDispatcher {
     using type = bool;
-    template <typename T>
-    bool dispatch(const LayerRAM* source, LayerRAM* target) {
+    template <typename Result, typename T>
+    bool operator()(const LayerRAM* source, LayerRAM* target) {
         using E = typename T::type;       // elem type i.e. vec3
         using P = typename T::primitive;  // comp type i.e float
         const size_t rank = util::rank<E>::value;
@@ -522,7 +532,8 @@ bool rescaleLayerRamToLayerRam(const LayerRAM* source, LayerRAM* target) {
     if (source->getDataFormatId() != target->getDataFormatId()) return false;
 
     CImgRescaleLayerRamToLayerRamDispatcher disp;
-    return source->getDataFormat()->dispatch(disp, source, target);
+    return dispatching::dispatch<bool, dispatching::filter::All>(source->getDataFormat()->getId(),
+                                                                 disp, source, target);
 }
 
 std::string getLibPNGVesrion() {

--- a/modules/cimg/cimgutils.cpp
+++ b/modules/cimg/cimgutils.cpp
@@ -229,7 +229,7 @@ struct CImgLoadLayerDispatcher {
                      DataFormatId& formatId, bool rescaleToDim) {
         using P = typename DF::primitive;
 
-      const DataFormatBase* dataFormat = DF::get();
+        const DataFormatBase* dataFormat = DF::get();
 
         try {
             cimg_library::CImg<P> img(filePath.c_str());
@@ -389,19 +389,18 @@ struct CImgLoadVolumeDispatcher {
                      DataFormatId& formatId) {
         const DataFormatBase* dataFormat = DF::get();
 
-
         cimg_library::CImg<typename DF::primitive> img(filePath.c_str());
-
 
         size_t components = static_cast<size_t>(img.spectrum());
         dimensions = size3_t(img.width(), img.height(), img.depth());
 
         const DataFormatBase* loadedDataFormat = DataFormatBase::get(
             dataFormat->getNumericType(), components, sizeof(typename DF::primitive) * 8);
-        if (loadedDataFormat)
+        if (loadedDataFormat) {
             formatId = loadedDataFormat->getId();
-        else
+        } else {
             throw Exception("CImgLoadVolumeDispatcher, could not find proper data type");
+        }
 
         // Image is up-side-down
         img.mirror('y');

--- a/modules/cimg/cimgvolumereader.cpp
+++ b/modules/cimg/cimgvolumereader.cpp
@@ -31,6 +31,7 @@
 #include <modules/cimg/cimgutils.h>
 #include <inviwo/core/datastructures/volume/volumeramprecision.h>
 #include <inviwo/core/datastructures/volume/volumedisk.h>
+#include <inviwo/core/util/formatdispatching.h>
 #include <inviwo/core/util/filesystem.h>
 #include <inviwo/core/io/datareaderexception.h>
 
@@ -88,7 +89,8 @@ std::shared_ptr<VolumeRepresentation> CImgVolumeRAMLoader::createRepresentation(
     data = cimgutil::loadVolumeData(nullptr, fileName, dimensions, formatId);
     volumeDisk_->setDimensions(dimensions);
 
-    return volumeDisk_->getDataFormat()->dispatch(*this, data);
+    return dispatching::dispatch<std::shared_ptr<VolumeRepresentation>, dispatching::filter::All>(
+        volumeDisk_->getDataFormat()->getId(), *this, data);
 }
 
 void CImgVolumeRAMLoader::updateRepresentation(std::shared_ptr<VolumeRepresentation> dest) const {

--- a/modules/cimg/cimgvolumereader.h
+++ b/modules/cimg/cimgvolumereader.h
@@ -24,7 +24,7 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  *********************************************************************************/
 
 #ifndef IVW_CIMGVOLUMEREADER_H
@@ -52,12 +52,12 @@ public:
 
     virtual std::shared_ptr<Volume> readData(const std::string& filePath) override;
 
- protected:
-     void printMetaInfo(const MetaDataOwner&, std::string) const;
-
+protected:
+    void printMetaInfo(const MetaDataOwner&, std::string) const;
 };
 
-class IVW_MODULE_CIMG_API CImgVolumeRAMLoader : public DiskRepresentationLoader<VolumeRepresentation> {
+class IVW_MODULE_CIMG_API CImgVolumeRAMLoader
+    : public DiskRepresentationLoader<VolumeRepresentation> {
 public:
     CImgVolumeRAMLoader(VolumeDisk* volumeDisk);
     virtual CImgVolumeRAMLoader* clone() const override;
@@ -66,9 +66,9 @@ public:
     virtual void updateRepresentation(std::shared_ptr<VolumeRepresentation> dest) const override;
 
     using type = std::shared_ptr<VolumeRAM>;
-    template <class T>
-    std::shared_ptr<VolumeRAM> dispatch(void* data) const {
-        typedef typename T::type F;
+    template <typename ReturnType, typename T>
+    std::shared_ptr<VolumeRAM> operator()(void* data) const {
+        using F = typename T::type;
         return std::make_shared<VolumeRAMPrecision<F>>(static_cast<F*>(data),
                                                        volumeDisk_->getDimensions());
     }
@@ -77,6 +77,6 @@ private:
     VolumeDisk* volumeDisk_;
 };
 
-}  // namespace
+}  // namespace inviwo
 
 #endif  // IVW_CIMGVOLUMEREADER_H

--- a/modules/nifti/niftireader.cpp
+++ b/modules/nifti/niftireader.cpp
@@ -53,46 +53,30 @@ NiftiReader::NiftiReader() : DataReaderType<VolumeSequence>() {
 NiftiReader* NiftiReader::clone() const { return new NiftiReader(*this); }
 
 const DataFormatBase* NiftiReader::niftiDataTypeToInviwoDataFormat(int niftiDataType) {
-    switch (niftiDataType) {
-        case DT_UNKNOWN:
-            return nullptr;
-        case DT_BINARY:
-            return nullptr;
-        case DT_INT8:
-            return DataInt8::get();
-        case DT_UINT8:
-            return DataUInt8::get();
-        case DT_INT16:
-            return DataInt16::get();
-        case DT_UINT16:
-            return DataUInt16::get();
-        case DT_INT32:
-            return DataInt32::get();
-        case DT_UINT32:
-            return DataUInt32::get();
-        case DT_INT64:
-            return DataInt64::get();
-        case DT_UINT64:
-            return DataUInt64::get();
-        case DT_FLOAT32:
-            return DataFloat32::get();
-        case DT_FLOAT64:
-            return DataFloat64::get();
-        case DT_FLOAT128:
-            return nullptr;
-        case DT_COMPLEX64:
-            return nullptr;
-        case DT_COMPLEX128:
-            return nullptr;
-        case DT_COMPLEX256:
-            return nullptr;
-        case DT_RGB24:
-            return DataVec3UInt8::get();
-        case DT_RGBA32:
-            return DataVec4UInt8::get();
+    // clang-format off
+    switch (niftiDataType){
+        case DT_UNKNOWN:    return nullptr;
+        case DT_BINARY:     return nullptr;
+        case DT_INT8:       return DataInt8::get();
+        case DT_UINT8:      return DataUInt8::get();
+        case DT_INT16:      return DataInt16::get();
+        case DT_UINT16:     return DataUInt16::get();
+        case DT_INT32:      return DataInt32::get();
+        case DT_UINT32:     return DataUInt32::get();
+        case DT_INT64:      return DataInt64::get();
+        case DT_UINT64:     return DataUInt64::get();
+        case DT_FLOAT32:    return DataFloat32::get();
+        case DT_FLOAT64:    return DataFloat64::get();
+        case DT_FLOAT128:   return nullptr;
+        case DT_COMPLEX64:  return nullptr;
+        case DT_COMPLEX128: return nullptr;
+        case DT_COMPLEX256: return nullptr;
+        case DT_RGB24:      return DataVec3UInt8::get();
+        case DT_RGBA32:     return DataVec4UInt8::get();
         default:
             return nullptr;
     }
+    // clang-format on
 }
 
 std::shared_ptr<NiftiReader::VolumeSequence> NiftiReader::readData(const std::string& filePath) {
@@ -288,8 +272,8 @@ std::shared_ptr<NiftiReader::VolumeSequence> NiftiReader::readData(const std::st
                     dataRange = dvec2(0., 4095.);
                     LogInfo(
                         "Guessing 12-bit data range in 16-bit data since all values are below "
-                        "4096. "
-                        "Change data range in VolumeSource to [0 65535] if this is incorrect.");
+                        "4096. Change data range in VolumeSource to [0 65535] if this is "
+                        "incorrect.");
                 } else {
                     // This was probably a 16-bit data set after all
                     dataRange = dvec2(0., format->getMax());

--- a/modules/nifti/niftireader.cpp
+++ b/modules/nifti/niftireader.cpp
@@ -32,6 +32,7 @@
 #include <inviwo/core/datastructures/volume/volumedisk.h>
 #include <inviwo/core/util/filesystem.h>
 #include <inviwo/core/util/formatconversion.h>
+#include <inviwo/core/util/formatdispatching.h>
 #include <inviwo/core/util/stringconversion.h>
 #include <inviwo/core/io/datareaderexception.h>
 
@@ -52,27 +53,45 @@ NiftiReader::NiftiReader() : DataReaderType<VolumeSequence>() {
 NiftiReader* NiftiReader::clone() const { return new NiftiReader(*this); }
 
 const DataFormatBase* NiftiReader::niftiDataTypeToInviwoDataFormat(int niftiDataType) {
-    switch (niftiDataType){
-    case DT_UNKNOWN:    return nullptr;
-    case DT_BINARY:     return nullptr;
-    case DT_INT8:       return DataInt8::get();
-    case DT_UINT8:      return DataUInt8::get();
-    case DT_INT16:      return DataInt16::get();
-    case DT_UINT16:     return DataUInt16::get();
-    case DT_INT32:      return DataInt32::get();
-    case DT_UINT32:     return DataUInt32::get();
-    case DT_INT64:      return DataInt64::get(); 
-    case DT_UINT64:     return DataUInt64::get(); 
-    case DT_FLOAT32:    return DataFloat32::get();
-    case DT_FLOAT64:    return DataFloat64::get();
-    case DT_FLOAT128:   return nullptr;
-    case DT_COMPLEX64:  return nullptr;
-    case DT_COMPLEX128: return nullptr;
-    case DT_COMPLEX256: return nullptr;
-    case DT_RGB24:      return DataVec3UInt8::get();
-    case DT_RGBA32:     return DataVec4UInt8::get();
-    default:
-        return nullptr;
+    switch (niftiDataType) {
+        case DT_UNKNOWN:
+            return nullptr;
+        case DT_BINARY:
+            return nullptr;
+        case DT_INT8:
+            return DataInt8::get();
+        case DT_UINT8:
+            return DataUInt8::get();
+        case DT_INT16:
+            return DataInt16::get();
+        case DT_UINT16:
+            return DataUInt16::get();
+        case DT_INT32:
+            return DataInt32::get();
+        case DT_UINT32:
+            return DataUInt32::get();
+        case DT_INT64:
+            return DataInt64::get();
+        case DT_UINT64:
+            return DataUInt64::get();
+        case DT_FLOAT32:
+            return DataFloat32::get();
+        case DT_FLOAT64:
+            return DataFloat64::get();
+        case DT_FLOAT128:
+            return nullptr;
+        case DT_COMPLEX64:
+            return nullptr;
+        case DT_COMPLEX128:
+            return nullptr;
+        case DT_COMPLEX256:
+            return nullptr;
+        case DT_RGB24:
+            return DataVec3UInt8::get();
+        case DT_RGBA32:
+            return DataVec4UInt8::get();
+        default:
+            return nullptr;
     }
 }
 
@@ -267,8 +286,10 @@ std::shared_ptr<NiftiReader::VolumeSequence> NiftiReader::readData(const std::st
                 if (dataRange.y < 4096.) {
                     // All values within 12-bit range so we guess that this is a 12-bit data set
                     dataRange = dvec2(0., 4095.);
-                    LogInfo("Guessing 12-bit data range in 16-bit data since all values are below 4096. "
-                            "Change data range in VolumeSource to [0 65535] if this is incorrect.");
+                    LogInfo(
+                        "Guessing 12-bit data range in 16-bit data since all values are below "
+                        "4096. "
+                        "Change data range in VolumeSource to [0 65535] if this is incorrect.");
                 } else {
                     // This was probably a 16-bit data set after all
                     dataRange = dvec2(0., format->getMax());
@@ -325,7 +346,8 @@ NiftiVolumeRAMLoader* NiftiVolumeRAMLoader::clone() const {
 }
 
 std::shared_ptr<VolumeRepresentation> NiftiVolumeRAMLoader::createRepresentation() const {
-    return NiftiReader::niftiDataTypeToInviwoDataFormat(nim->datatype)->dispatch(*this);
+    return dispatching::dispatch<std::shared_ptr<VolumeRepresentation>, dispatching::filter::All>(
+        NiftiReader::niftiDataTypeToInviwoDataFormat(nim->datatype)->getId(), *this);
 }
 
 void NiftiVolumeRAMLoader::updateRepresentation(std::shared_ptr<VolumeRepresentation> dest) const {

--- a/modules/nifti/niftireader.h
+++ b/modules/nifti/niftireader.h
@@ -90,9 +90,9 @@ public:
 
     using type = std::shared_ptr<VolumeRAM>;
 
-    template <class T>
-    std::shared_ptr<VolumeRAM> dispatch() const {
-        typedef typename T::type F;
+  template <typename Result, typename T>
+    std::shared_ptr<VolumeRAM> operator()() const {
+        using F = typename T::type;
 
         const std::size_t size = region_size[0] * region_size[1] * region_size[2] * region_size[3] *
                                  region_size[4] * region_size[5] * region_size[6];

--- a/modules/opengl/CMakeLists.txt
+++ b/modules/opengl/CMakeLists.txt
@@ -1,4 +1,7 @@
 
+# Set CMake to prefere Vendor gl libraries rather than legacy, fixes warning on some unix systems
+set(OpenGL_GL_PREFERENCE GLVND) 
+
 add_subdirectory(ext/glew)
 
 #--------------------------------------------------------------------

--- a/modules/plotting/properties/dataframeproperty.cpp
+++ b/modules/plotting/properties/dataframeproperty.cpp
@@ -39,8 +39,7 @@ DataFrameColumnProperty::DataFrameColumnProperty(std::string identifier, std::st
                                                  bool allowNone, size_t firstIndex)
     : OptionPropertyInt(identifier, displayName)
     , dataframe_(nullptr)
-    , allowNone_(allowNone)
-    , firstIndex_(firstIndex) {
+    , allowNone_(allowNone) {
     setSerializationMode(PropertySerializationMode::All);
 }
 
@@ -65,6 +64,8 @@ void DataFrameColumnProperty::setOptions(std::shared_ptr<const DataFrame> datafr
     if (!dataframe || dataframe->getNumberOfColumns() <= 1) return;
     dataframe_ = dataframe;
 
+    bool wasEmpty = options_.empty();
+
     std::vector<OptionPropertyIntOption> options;
     if (allowNone_) {
         options.emplace_back("none", "None", -1);
@@ -82,6 +83,9 @@ void DataFrameColumnProperty::setOptions(std::shared_ptr<const DataFrame> datafr
     }
 
     replaceOptions(std::move(options));
+    if(wasEmpty){
+        setSelectedIndex(firstIndex_);
+    }
     setCurrentStateAsDefault();
 }
 

--- a/modules/plotting/properties/dataframeproperty.cpp
+++ b/modules/plotting/properties/dataframeproperty.cpp
@@ -39,7 +39,8 @@ DataFrameColumnProperty::DataFrameColumnProperty(std::string identifier, std::st
                                                  bool allowNone, size_t firstIndex)
     : OptionPropertyInt(identifier, displayName)
     , dataframe_(nullptr)
-    , allowNone_(allowNone) {
+    , allowNone_(allowNone)
+    , firstIndex_(firstIndex) {
     setSerializationMode(PropertySerializationMode::All);
 }
 
@@ -83,7 +84,7 @@ void DataFrameColumnProperty::setOptions(std::shared_ptr<const DataFrame> datafr
     }
 
     replaceOptions(std::move(options));
-    if(wasEmpty){
+    if (wasEmpty) {
         setSelectedIndex(firstIndex_);
     }
     setCurrentStateAsDefault();

--- a/modules/python3/processors/pythonscriptprocessor.cpp
+++ b/modules/python3/processors/pythonscriptprocessor.cpp
@@ -73,7 +73,7 @@ PythonScriptProcessor::PythonScriptProcessor(InviwoApplication* app)
         runscript();
     });
 
-    script_.onChange([this, runscript]() { runscript(); });
+    script_.onChange([runscript]() { runscript(); });
 
     runscript();
 }

--- a/modules/python3qt/pythoneditorwidget.cpp
+++ b/modules/python3qt/pythoneditorwidget.cpp
@@ -36,7 +36,6 @@
 #include <inviwo/core/util/clock.h>
 #include <inviwo/core/util/stringconversion.h>
 
-#include <modules/qtwidgets/properties/syntaxhighlighter.h>
 #include <modules/qtwidgets/inviwoqtutils.h>
 #include <modules/qtwidgets/inviwofiledialog.h>
 #include <modules/qtwidgets/qtwidgetssettings.h>
@@ -450,7 +449,7 @@ void PythonEditorWidget::onTextChange() {
     updateTitleBar();
 }
 
-void PythonEditorWidget::setFileName(const std::string filename) {
+void PythonEditorWidget::setFileName(const std::string &filename) {
     scriptFileName_ = filename;
     script_.setFilename(filename);
     updateTitleBar();

--- a/modules/python3qt/pythoneditorwidget.h
+++ b/modules/python3qt/pythoneditorwidget.h
@@ -92,12 +92,12 @@ protected:
     virtual void focusInEvent(QFocusEvent *event) override;
 
 private:
-    void setFileName(const std::string filename);
+    void setFileName(const std::string &filename);
     void updateTitleBar();
     void queryReloadFile();
 
 
-    void saveState();
+    virtual void saveState() override;
 
     QMainWindow* mainWindow_;
     CodeEdit* pythonCode_;
@@ -116,7 +116,6 @@ private:
     bool reloadQueryInProgress_ = false;
     void readFile();
 
-    SyntaxHighligther* syntaxHighligther_;
     std::shared_ptr<std::function<void()>> syntaxCallback_;
 
     static PythonEditorWidget* instance_;

--- a/modules/qtwidgets/properties/stringpropertywidgetqt.h
+++ b/modules/qtwidgets/properties/stringpropertywidgetqt.h
@@ -48,7 +48,7 @@ class IVW_MODULE_QTWIDGETS_API StringPropertyWidgetQt : public PropertyWidgetQt 
 public:
     StringPropertyWidgetQt(StringProperty* property);
 
-    void updateFromProperty();
+    virtual void updateFromProperty() override;
     void setPropertyValue();
 
     virtual PropertyEditorWidget* getEditorWidget() const override;
@@ -57,10 +57,9 @@ public:
 private:
     StringProperty* property_;
     LineEditQt* lineEdit_;
-    EditableLabelQt* label_;
     std::unique_ptr<TextEditorDockWidget> editor_;
 };
 
-}  // namespace
+}  // namespace inviwo
 
 #endif  // IVW_STRINGPROPERTYWIDGETQT_H

--- a/modules/qtwidgets/tf/tfeditor.cpp
+++ b/modules/qtwidgets/tf/tfeditor.cpp
@@ -472,7 +472,7 @@ void TFEditor::contextMenuEvent(QGraphicsSceneContextMenuEvent* e) {
         connect(editColor, &QAction::triggered, this, &TFEditor::showColorDialog);
 
         duplicatePrimitive->setEnabled(!selectionEmpty);
-        connect(duplicatePrimitive, &QAction::triggered, this, [this, pos]() {
+        connect(duplicatePrimitive, &QAction::triggered, this, [this]() {
             NetworkLock lock(tfPropertyPtr_->getProperty());
             util::KeepTrueWhileInScope k(&selectNewPrimitives_);
             auto selection = getSelectedPrimitiveItems();
@@ -485,7 +485,7 @@ void TFEditor::contextMenuEvent(QGraphicsSceneContextMenuEvent* e) {
         });
 
         deletePrimitive->setEnabled(!selectionEmpty);
-        connect(deletePrimitive, &QAction::triggered, this, [this, pos]() {
+        connect(deletePrimitive, &QAction::triggered, this, [this]() {
             NetworkLock lock(tfPropertyPtr_->getProperty());
             auto selection = getSelectedPrimitiveItems();
             clearSelection();

--- a/modules/qtwidgets/tf/tfeditorcontrolpoint.h
+++ b/modules/qtwidgets/tf/tfeditorcontrolpoint.h
@@ -47,7 +47,7 @@ public:
 
     // override for qgraphicsitem_cast (refer qt documentation)
     enum { Type = UserType + TFEditorPrimitive::TFEditorControlPointType };
-    int type() const { return Type; }
+    int type() const override { return Type; }
 
     virtual void onTFPrimitiveChange(const TFPrimitive* p) override;
 

--- a/modules/qtwidgets/tf/tfeditorisovalue.h
+++ b/modules/qtwidgets/tf/tfeditorisovalue.h
@@ -45,7 +45,7 @@ public:
 
     // override for qgraphicsitem_cast (refer qt documentation)
     enum { Type = UserType + TFEditorPrimitive::TFEditorIsovalueType };
-    int type() const { return Type; }
+    int type() const override { return Type; }
 
     virtual void onTFPrimitiveChange(const TFPrimitive* p) override;
 

--- a/modules/qtwidgets/tf/tfpropertydialog.cpp
+++ b/modules/qtwidgets/tf/tfpropertydialog.cpp
@@ -129,7 +129,7 @@ void TFPropertyDialog::initializeDialog() {
 
             auto module = util::getInviwoApplication(property_)->getModuleByType<QtWidgetsModule>();
             QObject::connect(helpBtn, &QToolButton::clicked, this,
-                             [this, module]() { module->showTFHelpWindow(); });
+                             [module]() { module->showTFHelpWindow(); });
         }
     }
 

--- a/modules/userinterfacegl/processors/cropwidget.cpp
+++ b/modules/userinterfacegl/processors/cropwidget.cpp
@@ -484,8 +484,6 @@ void CropWidget::objectPicked(PickingEvent *p) {
             } else if (touchPoint.state() == TouchState::Finished) {
                 lastState_ = ivec2(-1);
             } else if (touchPoint.state() == TouchState::Updated) {
-                const auto delta = touchPoint.pos() - touchPoint.pressedPos();
-
                 InteractionElement element =
                     static_cast<InteractionElement>(p->getPickedId() % numInteractionWidgets);
                 rangePositionHandlePicked(cropAxes_[axisID], p, element);

--- a/modules/vectorfieldvisualization/processors/integrallinevectortomesh.cpp
+++ b/modules/vectorfieldvisualization/processors/integrallinevectortomesh.cpp
@@ -196,7 +196,8 @@ void IntegralLineVectorToMesh::updateOptions() {
             prop->setVisible(selectedIndex == i);
             prop->setSerializationMode(PropertySerializationMode::All);
             addProperty(prop.release());
-            colorBy_.onChange([=]() { propPtr->setVisible(i == colorBy_.getSelectedIndex()); });
+            colorBy_.onChange(
+                [=]() { propPtr->setVisible(i == static_cast<int>(colorBy_.getSelectedIndex())); });
         }
 
         i++;

--- a/src/core/datastructures/buffer/bufferram.cpp
+++ b/src/core/datastructures/buffer/bufferram.cpp
@@ -41,11 +41,12 @@ BufferRAM::BufferRAM(const DataFormatBase *format, BufferUsage usage, BufferTarg
 
 std::type_index BufferRAM::getTypeIndex() const { return std::type_index(typeid(BufferRAM)); }
 
+//! [Format Dispatching Example]
 struct BufferRamCreationDispatcher {
-    using type = std::shared_ptr<BufferRAM>;
-    template <class T>
-    std::shared_ptr<BufferRAM> dispatch(size_t size, BufferUsage usage, BufferTarget target) {
-        typedef typename T::type F;
+
+    template <typename Result, typename T>
+    Result operator()(size_t size, BufferUsage usage, BufferTarget target) {
+        using F = typename T::type;
         switch (target) {
             case BufferTarget::Index:
                 return std::make_shared<BufferRAMPrecision<F, BufferTarget::Index>>(size, usage);
@@ -60,8 +61,10 @@ std::shared_ptr<BufferRAM> createBufferRAM(size_t size, const DataFormatBase *fo
                                            BufferUsage usage, BufferTarget target) {
 
     BufferRamCreationDispatcher disp;
-    return format->dispatch(disp, size, usage, target);
+    return dispatching::dispatch<std::shared_ptr<BufferRAM>, dispatching::filter::All>(
+        format->getId(), disp, size, usage, target);
 }
+//! [Format Dispatching Example]
 
 bool operator==(const BufferBase &bufA, const BufferBase &bufB) {
     if (&bufA == &bufB) {

--- a/src/core/datastructures/image/layerramprecision.cpp
+++ b/src/core/datastructures/image/layerramprecision.cpp
@@ -33,18 +33,20 @@ namespace inviwo {
 
 struct LayerRAMCreationDispatcher {
     using type = std::shared_ptr<LayerRAM>;
-    template <class T>
-    std::shared_ptr<LayerRAM> dispatch(const size2_t& dimensions, LayerType type,
-                                       const SwizzleMask& swizzleMask) {
+    template <typename Result, typename T>
+    std::shared_ptr<LayerRAM> operator()(const size2_t& dimensions, LayerType type,
+                                         const SwizzleMask& swizzleMask) {
         using F = typename T::type;
         return std::make_shared<LayerRAMPrecision<F>>(dimensions, type, swizzleMask);
     }
 };
 
 std::shared_ptr<LayerRAM> createLayerRAM(const size2_t& dimensions, LayerType type,
-                                         const DataFormatBase* format, const SwizzleMask &swizzleMask) {
+                                         const DataFormatBase* format,
+                                         const SwizzleMask& swizzleMask) {
     LayerRAMCreationDispatcher disp;
-    return format->dispatch(disp, dimensions, type, swizzleMask);
+    return dispatching::dispatch<std::shared_ptr<LayerRAM>, dispatching::filter::All>(
+        format->getId(), disp, dimensions, type, swizzleMask);
 }
 
-}  // namespace
+}  // namespace inviwo

--- a/src/core/datastructures/volume/volumeramprecision.cpp
+++ b/src/core/datastructures/volume/volumeramprecision.cpp
@@ -33,9 +33,9 @@ namespace inviwo {
 
 struct VolumeRamCreationDispatcher {
     using type = std::shared_ptr<VolumeRAM>;
-    template <class T>
-    std::shared_ptr<VolumeRAM> dispatch(void* dataPtr, const size3_t& dimensions) {
-        typedef typename T::type F;
+    template <typename Result, typename T>
+    std::shared_ptr<VolumeRAM> operator()(void* dataPtr, const size3_t& dimensions) {
+        using F = typename T::type;
         return std::make_shared<VolumeRAMPrecision<F>>(static_cast<F*>(dataPtr), dimensions);
     }
 };
@@ -43,7 +43,8 @@ struct VolumeRamCreationDispatcher {
 std::shared_ptr<VolumeRAM> createVolumeRAM(const size3_t& dimensions, const DataFormatBase* format,
                                            void* dataPtr) {
     VolumeRamCreationDispatcher disp;
-    return format->dispatch(disp, dataPtr, dimensions);
+    return dispatching::dispatch<std::shared_ptr<VolumeRAM>, dispatching::filter::All>(
+        format->getId(), disp, dataPtr, dimensions);
 }
 
-}  // namespace
+}  // namespace inviwo

--- a/src/core/io/rawvolumeramloader.cpp
+++ b/src/core/io/rawvolumeramloader.cpp
@@ -43,7 +43,8 @@ RawVolumeRAMLoader::RawVolumeRAMLoader(const std::string& rawFile, size_t offset
 RawVolumeRAMLoader* RawVolumeRAMLoader::clone() const { return new RawVolumeRAMLoader(*this); }
 
 std::shared_ptr<VolumeRepresentation> RawVolumeRAMLoader::createRepresentation() const {
-    return format_->dispatch(*this);
+    return dispatching::dispatch<std::shared_ptr<VolumeRepresentation>, dispatching::filter::All>(
+        format_->getId(), *this);
 }
 
 void RawVolumeRAMLoader::updateRepresentation(std::shared_ptr<VolumeRepresentation> dest) const {
@@ -57,4 +58,4 @@ void RawVolumeRAMLoader::updateRepresentation(std::shared_ptr<VolumeRepresentati
     util::readBytesIntoBuffer(rawFile_, offset_, size * format_->getSize(), littleEndian_,
                               format_->getSize(), volumeDst->getData());
 }
-}  // namespace
+}  // namespace inviwo

--- a/src/core/network/processornetworkconverter.cpp
+++ b/src/core/network/processornetworkconverter.cpp
@@ -34,6 +34,8 @@ namespace inviwo {
 
 ProcessorNetworkConverter::ProcessorNetworkConverter(int from) : VersionConverter(), from_(from) {}
 
+#include <warn/push>
+#include <warn/ignore/implicit-fallthrough>
 bool ProcessorNetworkConverter::convert(TxElement* root) {
     switch (from_) {
         case 0:
@@ -75,6 +77,8 @@ bool ProcessorNetworkConverter::convert(TxElement* root) {
             return false;  // No changes
     }
 }
+
+#include <warn/pop>
 
 void ProcessorNetworkConverter::traverseNodes(TxElement* node, updateType update) {
     (this->*update)(node);
@@ -253,10 +257,7 @@ void ProcessorNetworkConverter::updateCameraToComposite(TxElement* node) {
 
     if (key == "Property") {
         std::string type = node->GetAttributeOrDefault("type", "");
-        std::string identifier = node->GetAttributeOrDefault("identifier", "");
         if (type == "org.inviwo.CameraProperty") {
-            std::vector<TxElement> subNodeVector;
-
             // create
             TxElement newNode;
             newNode.SetValue("Properties");
@@ -333,10 +334,6 @@ void ProcessorNetworkConverter::updatePropertyLinks(TxElement* node) {
             node->InsertEndChild(*dest);
 
             node->RemoveChild(properties);
-
-            std::stringstream ss;
-            ss << *node;
-            std::string txt = ss.str();
         }
     }
 }

--- a/src/core/ports/inport.cpp
+++ b/src/core/ports/inport.cpp
@@ -36,12 +36,12 @@ namespace inviwo {
 
 Inport::Inport(std::string identifier)
     : Port(identifier)
-    , isReady_{false, [this](const bool& /*isReady*/) {},
+    , isReady_{false, [](const bool& /*isReady*/) {},
                [this]() {
                    return (isConnected() && util::all_of(connectedOutports_,
                                                          [](Outport* p) { return p->isReady(); }));
                }}
-    , isOptional_(false, [this](const bool& /*isOptional*/) {}, []() { return false; })
+    , isOptional_(false, [](const bool& /*isOptional*/) {}, []() { return false; })
     , changed_(false)
     , lastInvalidationLevel_(InvalidationLevel::Valid) {}
 

--- a/src/core/ports/outport.cpp
+++ b/src/core/ports/outport.cpp
@@ -40,7 +40,7 @@ Outport::Outport(std::string identifier)
                        inport->readyUpdate();
                    }
                },
-               [this]() { return false; }}
+               []() { return false; }}
     , invalidationLevel_(InvalidationLevel::Valid) {}
 
 Outport::~Outport() = default;

--- a/src/core/tests/unittests/typedmesh-test.cpp
+++ b/src/core/tests/unittests/typedmesh-test.cpp
@@ -190,11 +190,11 @@ TEST(typedmesh, compilationChecks) {
 
     using TestMesh = TypedMesh<FloatBuffer, buffertraits::ColorsBuffer>;
     TestMesh t;
-    t.addVertex(1.0, vec4(1.0f));
-    t.setVertex(0, 1.5, vec4(1.0f));
+    t.addVertex(1.0f, vec4(1.0f));
+    t.setVertex(0, 1.5f, vec4(1.0f));
 
     t.addVertex(TestMesh::Vertex{2.0, vec4(0.5f)});
-    t.setVertex(1, {2.5, vec4(0.5f)});
+    t.setVertex(1, {2.5f, vec4(0.5f)});
 }
 
 TEST(typedmesh, copyconstructor) {

--- a/src/core/util/threadpool.cpp
+++ b/src/core/util/threadpool.cpp
@@ -61,7 +61,7 @@ size_t ThreadPool::trySetSize(size_t size) {
 
         condition.notify_all();
 
-        util::erase_remove_if(workers, [this](std::unique_ptr<Worker>& worker) {
+        util::erase_remove_if(workers, [](std::unique_ptr<Worker>& worker) {
             return worker->state == State::Done;
         });
     }

--- a/src/qt/editor/fileassociations.cpp
+++ b/src/qt/editor/fileassociations.cpp
@@ -318,16 +318,13 @@ private:
 // Dummy implementation for mac / linux
 class FileAssociationData {
 public:
-    FileAssociationData(FileAssociations& fa, QMainWindow* win) : fa_{fa}, win_{win} {}
+    FileAssociationData(FileAssociations& fa, QMainWindow* win) {}
 
     bool nativeEvent(void* message, long* result) { return false; }
     void registerFileType(const std::string& documentId, const std::string& fileTypeName,
                           const std::string& fileExtension, int appIconIndex,
                           const std::vector<FileAssociationCommand>& commands) {}
 
-private:
-    FileAssociations& fa_;
-    QMainWindow* win_;
 };
 
 #endif

--- a/src/qt/editor/linkdialog/linkdialogpropertygraphicsitems.cpp
+++ b/src/qt/editor/linkdialog/linkdialogpropertygraphicsitems.cpp
@@ -270,9 +270,8 @@ void LinkDialogPropertyGraphicsItem::paint(QPainter* p, const QStyleOptionGraphi
 
     p->restore();
     p->save();
-    QPoint arrowDim(linkdialog::arrowWidth, linkdialog::arrowHeight);
 
-    auto isBidirectional = [this](DialogConnectionGraphicsItem* item) {
+    auto isBidirectional = [](DialogConnectionGraphicsItem* item) {
         auto net = item->getPropertyLink().getSource()->getOwner()->getProcessor()->getNetwork();
 
         return net->isLinkedBidirectional(item->getPropertyLink().getSource(),

--- a/src/qt/editor/networkeditor.cpp
+++ b/src/qt/editor/networkeditor.cpp
@@ -493,7 +493,7 @@ void NetworkEditor::contextMenuEvent(QGraphicsSceneContextMenuEvent* e) {
                 menu.addAction(tr(hasInspector ? "Hide Port Inspector" : "Show Port &Inspector"));
             showPortInsector->setCheckable(true);
             showPortInsector->setChecked(hasInspector);
-            connect(showPortInsector, &QAction::triggered, [this, pim, outport, pos]() {
+            connect(showPortInsector, &QAction::triggered, [pim, outport, pos]() {
                 if (!pim->hasPortInspector(outport)) {
                     pim->addPortInspector(outport, ivec2(pos.x(), pos.y()));
                 } else {
@@ -628,12 +628,12 @@ void NetworkEditor::contextMenuEvent(QGraphicsSceneContextMenuEvent* e) {
 
             menu.addSeparator();
             QAction* invalidateOutputAction = menu.addAction(tr("Invalidate &Output"));
-            connect(invalidateOutputAction, &QAction::triggered, [this, processor]() {
+            connect(invalidateOutputAction, &QAction::triggered, [ processor]() {
                 processor->getProcessor()->invalidate(InvalidationLevel::InvalidOutput);
             });
 
             QAction* invalidateResourcesAction = menu.addAction(tr("Invalidate &Resources"));
-            connect(invalidateResourcesAction, &QAction::triggered, [this, processor]() {
+            connect(invalidateResourcesAction, &QAction::triggered, [ processor]() {
                 processor->getProcessor()->invalidate(InvalidationLevel::InvalidResources);
             });
             menu.addSeparator();


### PR DESCRIPTION
Fixes various compile warnings and compile errors when compiling with clang-6.0 on Ubuntu. 

The changes in  `ext/glm/CMakeLists.txt` and  ` src/core/tests/unittests/typedmesh-test.cpp` should also fix the daily clang build on jenkins 