### PR TITLE
Base: Made information and basis properties read-only in VolumeSequenceSource

### DIFF
--- a/modules/base/processors/volumesequencesource.cpp
+++ b/modules/base/processors/volumesequencesource.cpp
@@ -75,6 +75,10 @@ VolumeSequenceSource::VolumeSequenceSource()
     addProperty(information_);
     addProperty(basis_);
 
+	// It does not make sense to change these for an entire sequence
+	information_.setReadOnly(true);
+	basis_.setReadOnly(true);
+
     auto updateVisible = [&]() {
         file_.setVisible(inputType_.get() == InputType::SingleFile);
         folder_.setVisible(inputType_.get() == InputType::Folder);
@@ -180,10 +184,6 @@ void VolumeSequenceSource::process() {
     }
 
     if (volumes_ && !volumes_->empty()) {
-        for (auto& vol : *volumes_) {
-            basis_.updateEntity(*vol);
-            information_.updateVolume(*vol);
-        }
         outport_.setData(volumes_);
     }
 }
@@ -191,6 +191,9 @@ void VolumeSequenceSource::process() {
 void VolumeSequenceSource::deserialize(Deserializer& d) {
     Processor::deserialize(d);
     addFileNameFilters();
+	// It does not make sense to change these for an entire sequence
+	information_.setReadOnly(true);
+	basis_.setReadOnly(true);
     deserialized_ = true;
 }
 }  // namespace inviwo


### PR DESCRIPTION
Made information and basis properties read-only in VolumeSequenceSource and disabled their usage since they where applied to all values no matter if you had changed them or not. it did not make sense to override these settings for all volumes. Still kept for information purposes.

