### PR TITLE
Exception stack trace

### DIFF
--- a/apps/inviwo/inviwo.cpp
+++ b/apps/inviwo/inviwo.cpp
@@ -35,11 +35,14 @@
 #include <inviwo/core/util/logerrorcounter.h>
 #include <inviwo/core/util/raiiutils.h>
 #include <inviwo/core/network/processornetwork.h>
-#include <inviwo/core/util/raiiutils.h>
+#include <inviwo/core/util/ostreamjoiner.h>
 #include <inviwo/qt/editor/inviwomainwindow.h>
 #include <inviwo/core/util/filelogger.h>
 #include "inviwosplashscreen.h"
 #include <moduleregistration.h>
+
+#include <sstream>
+#include <algorithm>
 
 #include <warn/push>
 #include <warn/ignore/all>
@@ -107,21 +110,51 @@ int main(int argc, char** argv) {
     logCounter.reset();
 
     // process last arguments
-    if (!clp.getQuitApplicationAfterStartup()) {
+    if (clp.getQuitApplicationAfterStartup()) {
+        mainWin.exitInviwo(false);
+        return 0;
+    }
+
+    while (true) {
         try {
             return inviwoApp.exec();
         } catch (const inviwo::Exception& e) {
-            inviwo::util::log(e.getContext(), e.getMessage());
-            QMessageBox::critical(nullptr, "Fatal Error", QString::fromStdString(e.getMessage()));
+            {
+                inviwo::util::log(e.getContext(), e.getMessage());
+                std::stringstream ss;
+                auto j = inviwo::util::make_ostream_joiner(ss, "\n");
+                std::copy(e.getStack().begin(), e.getStack().end(), j);
+                LogErrorCustom("inviwo.app", ss.str());
+            }
+            {
+                std::stringstream ss;
+                ss << e.getMessage() + "\n Stack Trace:\n";
+                auto j = inviwo::util::make_ostream_joiner(ss, "\n");
+                if (std::distance(e.getStack().begin(), e.getStack().end()) > 10) {
+                    std::copy(e.getStack().begin(), e.getStack().begin() + 10, j);
+                    ss << "\n...";
+                } else {
+                    std::copy(e.getStack().begin(), e.getStack().end(), j);
+                }
+                ss << "\nApplication state might be corrupted, be warned.";
+
+                auto res = QMessageBox::critical(
+                    &mainWin, "Fatal Error", QString::fromStdString(ss.str()),
+                    QMessageBox::Ignore | QMessageBox::Close, QMessageBox::Close);
+                if (res == QMessageBox::Close) {
+                    mainWin.askToSaveWorkspaceChanges();
+                    return 1;
+                }
+            }
+
         } catch (const std::exception& e) {
             LogErrorCustom("inviwo.cpp", e.what());
             QMessageBox::critical(nullptr, "Fatal Error", e.what());
+            return 1;
         } catch (...) {
             LogErrorCustom("inviwo.cpp", "Uncaught exception, terminating");
             QMessageBox::critical(nullptr, "Fatal Error", "Uncaught exception, terminating");
+            return 1;
         }
-    } else {
-        mainWin.exitInviwo(false);
-        return 0;
     }
 }

--- a/include/inviwo/core/util/exception.h
+++ b/include/inviwo/core/util/exception.h
@@ -47,11 +47,10 @@ namespace inviwo {
 struct IVW_CORE_API ExceptionContext {
     ExceptionContext(std::string caller = "", std::string file = "", std::string function = "",
                      int line = 0);
-
-    const std::string& getCaller();
-    const std::string& getFile();
-    const std::string& getFunction();
-    const int& getLine();
+    const std::string& getCaller() const;
+    const std::string& getFile() const;
+    const std::string& getFunction() const;
+    const int& getLine() const;
 
 private:
     std::string caller_;
@@ -76,10 +75,12 @@ public:
     virtual std::string getMessage() const noexcept;
     virtual const char* what() const noexcept override;
     virtual const ExceptionContext& getContext() const;
+    const std::vector<std::string>& getStack() const;
 
 private:
     std::string message_;
     ExceptionContext context_;
+    std::vector<std::string> stack_;
 };
 
 class IVW_CORE_API RangeException : public Exception {

--- a/include/inviwo/qt/editor/inviwomainwindow.h
+++ b/include/inviwo/qt/editor/inviwomainwindow.h
@@ -107,6 +107,7 @@ public:
     * leaves the current workspace file as current workspace
     */
     void saveWorkspaceAsCopy();
+    bool askToSaveWorkspaceChanges();
     void exitInviwo(bool saveIfModified = true);
     void showAboutBox();
 
@@ -134,8 +135,6 @@ private:
 
     void saveCanvases(std::string path, std::string fileName);
     void getScreenGrab(std::string path, std::string fileName);
-
-    bool askToSaveWorkspaceChanges();
 
     void addToRecentWorkspaces(QString workspaceFileName);
 

--- a/src/core/util/exception.cpp
+++ b/src/core/util/exception.cpp
@@ -29,11 +29,14 @@
 
 #include <inviwo/core/util/exception.h>
 #include <inviwo/core/util/logcentral.h>
+#include <inviwo/core/util/stacktrace.h>
 
 namespace inviwo {
 
 Exception::Exception(const std::string& message, ExceptionContext context)
-    : std::exception(), message_(message), context_(context) {}
+    : std::exception(), message_(message), context_(std::move(context)), stack_{getStackTrace()} {
+    stack_.erase(stack_.begin(), stack_.begin() + 3);
+}
 
 Exception::~Exception() noexcept = default;
 
@@ -41,6 +44,8 @@ std::string Exception::getMessage() const noexcept { return message_; }
 const char* Exception::what() const noexcept { return message_.c_str(); }
 
 const ExceptionContext& Exception::getContext() const { return context_; }
+
+const std::vector<std::string>& Exception::getStack() const { return stack_; }
 
 RangeException::RangeException(const std::string& message, ExceptionContext context)
     : Exception(message, context) {}
@@ -84,12 +89,12 @@ ExceptionContext::ExceptionContext(std::string caller, std::string file, std::st
                                    int line)
     : caller_(caller), file_(file), function_(function), line_(line) {}
 
-const std::string& ExceptionContext::getCaller() { return caller_; }
+const std::string& ExceptionContext::getCaller() const { return caller_; }
 
-const std::string& ExceptionContext::getFile() { return file_; }
+const std::string& ExceptionContext::getFile() const { return file_; }
 
-const std::string& ExceptionContext::getFunction() { return function_; }
+const std::string& ExceptionContext::getFunction() const { return function_; }
 
-const int& ExceptionContext::getLine() { return line_; }
+const int& ExceptionContext::getLine() const { return line_; }
 
 }  // namespace inviwo


### PR DESCRIPTION
Added a stacktrace to our exceptions, and the ability to log and view and ignore any unchought inviwo exception...

A potential problem is the overhead of creating the stacktrace in our exception

![image](https://user-images.githubusercontent.com/3638222/45485370-adc1d800-b757-11e8-9945-137fee301ef9.png)

