### PR TITLE
PlottingGL: Added properties to dataframeexporter…

### DIFF
--- a/modules/plotting/processors/dataframeexporter.cpp
+++ b/modules/plotting/processors/dataframeexporter.cpp
@@ -59,8 +59,7 @@ DataFrameExporter::DataFrameExporter()
     , overwrite_("overwrite", "Overwrite", false)
     , separateVectorTypesIntoColumns_("separateVectorTypesIntoColumns",
                                       "Separate Vector Types Into Columns", true)
-    , addCitationsOnStrings_("addCitationsOnStrings",
-                             "Add Citations (\"\") on Strings", true)
+    , addCitationsOnStrings_("addCitationsOnStrings", "Add Citations (\"\") on Strings", true)
     , delimiter_("delimiter", "Delimiter", ",")
     , export_(false) {
     exportFile_.clearNameFilters();

--- a/modules/plotting/processors/dataframeexporter.cpp
+++ b/modules/plotting/processors/dataframeexporter.cpp
@@ -59,6 +59,9 @@ DataFrameExporter::DataFrameExporter()
     , overwrite_("overwrite", "Overwrite", false)
     , separateVectorTypesIntoColumns_("separateVectorTypesIntoColumns",
                                       "Separate Vector Types Into Columns", true)
+    , addCitationsOnStrings_("addCitationsOnStrings",
+                             "Add Citations (\"\") on Strings", true)
+    , delimiter_("delimiter", "Delimiter", ",")
     , export_(false) {
     exportFile_.clearNameFilters();
     exportFile_.addNameFilter("CSV (*.csv)");
@@ -69,6 +72,8 @@ DataFrameExporter::DataFrameExporter()
     addProperty(exportButton_);
     addProperty(overwrite_);
     addProperty(separateVectorTypesIntoColumns_);
+    addProperty(addCitationsOnStrings_);
+    addProperty(delimiter_);
 
     exportFile_.setAcceptMode(AcceptMode::Save);
     exportFile_.onChange([&]() {
@@ -103,7 +108,9 @@ void DataFrameExporter::exportAsCSV(bool separateVectorTypesIntoColumns) {
     std::ofstream file(exportFile_);
     auto dataFrame = dataFrame_.getData();
 
-    const std::string delimiter = ", ";
+    const std::string delimiter = delimiter_.get();
+    std::string citation = "\"";
+    if (!addCitationsOnStrings_.get()) citation = "";
     const char lineterminator = '\n';
     const std::array<char, 4> componentNames = {'X', 'Y', 'Z', 'W'};
 
@@ -113,7 +120,7 @@ void DataFrameExporter::exportAsCSV(bool separateVectorTypesIntoColumns) {
         const auto components = col->getBuffer()->getDataFormat()->getComponents();
         if (components > 1 && separateVectorTypesIntoColumns) {
             for (size_t k = 0; k < components; k++) {
-                oj = col->getHeader() + ' ' + componentNames[k];
+                oj = citation + col->getHeader() + ' ' + componentNames[k] + citation;
             }
         } else {
             oj = col->getHeader();
@@ -125,8 +132,8 @@ void DataFrameExporter::exportAsCSV(bool separateVectorTypesIntoColumns) {
     for (const auto& col : *dataFrame) {
         auto df = col->getBuffer()->getDataFormat();
         if (auto cc = dynamic_cast<const CategoricalColumn*>(col.get())) {
-            printers.push_back([cc](std::ostream& os, size_t index) {
-                os << "\"" << cc->getAsString(index) << "\"";
+            printers.push_back([cc, citation](std::ostream& os, size_t index) {
+                os << citation << cc->getAsString(index) << citation;
             });
         } else if (df->getComponents() == 1) {
             col->getBuffer()
@@ -151,9 +158,9 @@ void DataFrameExporter::exportAsCSV(bool separateVectorTypesIntoColumns) {
         } else {
             col->getBuffer()
                 ->getRepresentation<BufferRAM>()
-                ->dispatch<void, dispatching::filter::Vecs>([&printers](auto br) {
-                    printers.push_back([br](std::ostream& os, size_t index) {
-                        os << "\"" << br->getDataContainer()[index] << "\"";
+                ->dispatch<void, dispatching::filter::Vecs>([&printers, citation](auto br) {
+                    printers.push_back([br, citation](std::ostream& os, size_t index) {
+                        os << citation << br->getDataContainer()[index] << citation;
                     });
                 });
         }

--- a/modules/plotting/processors/dataframeexporter.h
+++ b/modules/plotting/processors/dataframeexporter.h
@@ -43,6 +43,7 @@
 #include <inviwo/core/properties/fileproperty.h>
 #include <inviwo/core/properties/buttonproperty.h>
 #include <inviwo/core/properties/boolproperty.h>
+#include <inviwo/core/properties/stringproperty.h>
 #include <inviwo/core/ports/datainport.h>
 
 namespace inviwo {

--- a/modules/plotting/processors/dataframeexporter.h
+++ b/modules/plotting/processors/dataframeexporter.h
@@ -81,6 +81,8 @@ private:
     ButtonProperty exportButton_;
     BoolProperty overwrite_;
     BoolProperty separateVectorTypesIntoColumns_;
+    BoolProperty addCitationsOnStrings_;
+    StringProperty delimiter_;
 
     bool export_;
 };


### PR DESCRIPTION
…to let the user choose the csv delimiter and whether to use citations around strings or not.

**Updated feature / Fixes** 

Added two properties to Data Frame Exporter-processor, one StringProperty to let the user choose the csv delimiter and one BoolProperty to enable/disable the use of "".

**What evineroment has the code been compiled and tested on?** 
- Windows 10
- Visual Studio 15.7.6
- QT Community 4.6.1
- CMake 3.11.2
- Python 3.6 (32-bit)