### PR TITLE
UserInterfaceGL/Webbrowser: Mac fixes

### DIFF
--- a/modules/plottinggl/glsl/legend.frag
+++ b/modules/plottinggl/glsl/legend.frag
@@ -75,8 +75,8 @@ void main() {
     // blend in the checkerboard as background to the TF depending on its opacity
     vec4 finalColor = over(checkerBoard(centeredPos), colorTF);
 
-    // set border flag iff the fragment coord is within the border
-    bool border = borderWidth > 0 && any(greaterThan(abs(centeredPos), outputDim * 0.5));
+    // set border flag if the fragment coord is within the border
+    float border = borderWidth > 0 && any(greaterThan(abs(centeredPos), outputDim * 0.5)) ? 1.f : 0.f;
     FragData0 =  mix(finalColor, color, border);
 
     // no depth input, reset depth to largest value

--- a/modules/plottinggl/glsl/legend.frag
+++ b/modules/plottinggl/glsl/legend.frag
@@ -70,14 +70,14 @@ void main() {
 
     // increase alpha to allow better visibility by 1 - (1 - a)^4 and then add "backgroundAlpha" to
     // set alpha to 1 if no background is wanted
-    colorTF.a = mix(1.0f - pow(1.0f - colorTF.a, 4.0f), 1.0, float(backgroundStyle));
+    colorTF.a = mix(1.0 - pow(1.0 - colorTF.a, 4.0), 1.0, float(backgroundStyle));
 
     // blend in the checkerboard as background to the TF depending on its opacity
     vec4 finalColor = over(checkerBoard(centeredPos), colorTF);
 
     // set border flag if the fragment coord is within the border
-    float border = borderWidth > 0 && any(greaterThan(abs(centeredPos), outputDim * 0.5)) ? 1.f : 0.f;
-    FragData0 =  mix(finalColor, color, border);
+    bool border = borderWidth > 0 && any(greaterThan(abs(centeredPos), outputDim * 0.5));
+    FragData0 =  mix(finalColor, color, bvec4(border));
 
     // no depth input, reset depth to largest value
     gl_FragDepth = 1.0;

--- a/modules/userinterfacegl/glsl/renderui.frag
+++ b/modules/userinterfacegl/glsl/renderui.frag
@@ -33,7 +33,7 @@ uniform sampler2DArray arrayTexSampler;
 // texture indices for normal, pressed, checked, 
 // halo normal, halo pressed, halo checked
 // border normal, border pressed, border checked
-uniform int arrayTexMap[9] = { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+uniform int arrayTexMap[9] = int[]( 0, 0, 0, 0, 0, 0, 0, 0, 0 );
 
 uniform vec4 uiColor = vec4(0.0, 0.0, 0.0, 1.0);
 uniform vec4 uiBorderColor = vec4(0.0, 0.0, 0.0, 1.0);

--- a/modules/webbrowser/CMakeLists.txt
+++ b/modules/webbrowser/CMakeLists.txt
@@ -213,6 +213,8 @@ ivw_folder(${CEF_HELPER_TARGET} ext/CEF)
 
 if (OS_MACOSX)
 	target_link_libraries(inviwo-module-webbrowser PUBLIC libcef_dll_wrapper ${CEF_STANDARD_LIBS})
+    target_link_libraries(${CEF_HELPER_TARGET} PRIVATE libcef_dll_wrapper ${CEF_STANDARD_LIBS})
+
     # Output paths for the app bundles: bin/configuration, for example bin/Debug.
     # Note: This is hardcoded to inviwo app.
     # Other apps need to copy the helper and the cef framework to its framework dir,


### PR DESCRIPTION
UserInterfaceGL/Webbrowser: Mac fixes: Array initialization according to GLSL spec (see section 4.1.4) and added missing link libraries for CEF.
