### PR TITLE
Auto link / connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Here we document changes that affect the public API or changes that needs to be communicated to other developers. 
 
+## 2918-11-22
+Better handling of linking in port inspectors. Show auto links when dragging in processors, disable auto links by pressing alt. Pressing shift while dragging when dragging in processors enables auto connection for inports.
+
 ## 2018-11-19
     Converted all Inviwo core modules to use the new structure with include and src folders. 
 

--- a/include/inviwo/core/network/autolinker.h
+++ b/include/inviwo/core/network/autolinker.h
@@ -1,0 +1,69 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2018 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <inviwo/core/common/inviwocoredefine.h>
+#include <inviwo/core/common/inviwo.h>
+#include <inviwo/core/network/processornetwork.h>
+
+namespace inviwo {
+
+class Processor;
+
+/**
+ * \brief Utility class to calculate and apply auto linking
+ */
+class IVW_CORE_API AutoLinker {
+public:
+    /**
+     * Construct an auto link helper
+     * @param network the processor network in which to add autolinks
+     * @param target the processor onto which auto links should be added
+     * @param source source of links. If source is not null we consider all predecessors of source
+     * as input for linking, if source is null we consider all processor in the network
+     */
+    AutoLinker(ProcessorNetwork* network, Processor* target, Processor* source = nullptr);
+    virtual ~AutoLinker() = default;
+
+    const std::unordered_map<Property*, std::vector<Property*>>& getAutoLinkCandidates() const;
+
+    void sortAutoLinkCandidates();
+    void sortAutoLinkCandidates(dvec2 pos);
+
+    void addLinksToClosestCandidates(bool bidirectional);
+
+    static void addLinks(ProcessorNetwork* network, Processor* target, Processor* source = nullptr);
+
+private:
+    ProcessorNetwork* network_;
+    Processor* target_;
+    std::unordered_map<Property*, std::vector<Property*>> autoLinkCandiates_;
+};
+
+}  // namespace inviwo

--- a/include/inviwo/core/network/networkutils.h
+++ b/include/inviwo/core/network/networkutils.h
@@ -211,6 +211,13 @@ IVW_CORE_API std::vector<Processor*> appendDeserialized(ProcessorNetwork* networ
                                                         const std::string& refPath,
                                                         InviwoApplication* app);
 
+IVW_CORE_API bool addProcessorOnConnection(ProcessorNetwork* network,
+                                           std::unique_ptr<Processor> processor,
+                                           PortConnection connection);
+
+IVW_CORE_API void replaceProcessor(ProcessorNetwork* network, std::unique_ptr<Processor> newProcessor,
+                                   Processor* oldProcessor);
+
 }  // namespace util
 
 }  // namespace inviwo

--- a/include/inviwo/core/network/networkutils.h
+++ b/include/inviwo/core/network/networkutils.h
@@ -149,6 +149,7 @@ IVW_CORE_API std::vector<Processor*> topologicalSort(ProcessorNetwork* network);
 
 struct IVW_CORE_API PropertyDistanceSorter {
     PropertyDistanceSorter();
+    void setTarget(vec2 pos);
     void setTarget(const Property* target);
     bool operator()(const Property* a, const Property* b);
 
@@ -159,7 +160,6 @@ private:
     vec2 pos_ = {0, 0};
     std::map<const Property*, vec2> cache_;
 };
-
 
 /**
  * Retrieve the positions of the processors in the list.
@@ -202,8 +202,6 @@ IVW_CORE_API void offsetPosition(const std::vector<Processor*>& processors, ivec
  * Set the listed processors as selected or unSelected.
  */
 IVW_CORE_API void setSelected(const std::vector<Processor*>& processors, bool selected);
-
-IVW_CORE_API void autoLinkProcessor(ProcessorNetwork* network, Processor* processor);
 
 IVW_CORE_API void serializeSelected(ProcessorNetwork* network, std::ostream& os,
                                     const std::string& refPath);

--- a/include/inviwo/core/ports/portinspectormanager.h
+++ b/include/inviwo/core/ports/portinspectormanager.h
@@ -81,7 +81,7 @@ private:
     void returnPortInspector(std::unique_ptr<PortInspector>);
 
     static void insertNetwork(PortInspector* portInspector, ProcessorNetwork* network,
-                              Outport* outport);
+                              Outport* outport, bool bidirectionalAutoLinks);
     static void removeNetwork(PortInspector* portInspector, ProcessorNetwork* network);
 
     virtual void onProcessorNetworkWillRemoveProcessor(Processor* processor) override;

--- a/include/inviwo/qt/editor/connectiondraghelper.h
+++ b/include/inviwo/qt/editor/connectiondraghelper.h
@@ -39,6 +39,7 @@
 
 #include <memory>
 
+class QEvent;
 
 namespace inviwo {
 
@@ -54,7 +55,7 @@ class IVW_QTEDITOR_API ConnectionDragHelper : public QObject {
 
 public:
     ConnectionDragHelper(NetworkEditor& editor);
-    virtual ~ConnectionDragHelper() = default;
+    virtual ~ConnectionDragHelper();
 
     void start(ProcessorOutportGraphicsItem* outport, QPointF endPoint, uvec3 color);
     void reset();

--- a/include/inviwo/qt/editor/connectiondraghelper.h
+++ b/include/inviwo/qt/editor/connectiondraghelper.h
@@ -37,6 +37,9 @@
 #include <QPointF>
 #include <warn/pop>
 
+#include <memory>
+
+
 namespace inviwo {
 
 class NetworkEditor;
@@ -50,7 +53,7 @@ class IVW_QTEDITOR_API ConnectionDragHelper : public QObject {
 #include <warn/pop>
 
 public:
-    ConnectionDragHelper(NetworkEditor* editor);
+    ConnectionDragHelper(NetworkEditor& editor);
     virtual ~ConnectionDragHelper() = default;
 
     void start(ProcessorOutportGraphicsItem* outport, QPointF endPoint, uvec3 color);
@@ -59,8 +62,8 @@ public:
     virtual bool eventFilter(QObject* obj, QEvent* event) override;
 
 private:
-    NetworkEditor* editor_;
-    ConnectionDragGraphicsItem* connection_ = nullptr;
+    NetworkEditor& editor_;
+    std::unique_ptr<ConnectionDragGraphicsItem> connection_;
 };
 
 }  // namespace inviwo

--- a/include/inviwo/qt/editor/connectiondraghelper.h
+++ b/include/inviwo/qt/editor/connectiondraghelper.h
@@ -1,0 +1,66 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2018 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <inviwo/qt/editor/inviwoqteditordefine.h>
+#include <inviwo/core/common/inviwo.h>
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <QObject>
+#include <QPointF>
+#include <warn/pop>
+
+namespace inviwo {
+
+class NetworkEditor;
+class ConnectionDragGraphicsItem;
+class ProcessorOutportGraphicsItem;
+
+class IVW_QTEDITOR_API ConnectionDragHelper : public QObject {
+#include <warn/push>
+#include <warn/ignore/all>
+    Q_OBJECT
+#include <warn/pop>
+
+public:
+    ConnectionDragHelper(NetworkEditor* editor);
+    virtual ~ConnectionDragHelper() = default;
+
+    void start(ProcessorOutportGraphicsItem* outport, QPointF endPoint, uvec3 color);
+    void reset();
+
+    virtual bool eventFilter(QObject* obj, QEvent* event) override;
+
+private:
+    NetworkEditor* editor_;
+    ConnectionDragGraphicsItem* connection_ = nullptr;
+};
+
+}  // namespace inviwo

--- a/include/inviwo/qt/editor/connectiongraphicsitem.h
+++ b/include/inviwo/qt/editor/connectiongraphicsitem.h
@@ -140,6 +140,7 @@ public:
     ProcessorGraphicsItem* getInProcessor() const;
     Outport* getOutport() const;
     Inport* getInport() const;
+    PortConnection getPortConnection() const;
     ProcessorInportGraphicsItem* getInportGraphicsItem() const;
 
     // override for qgraphicsitem_cast (refer qt documentation)

--- a/include/inviwo/qt/editor/linkdraghelper.h
+++ b/include/inviwo/qt/editor/linkdraghelper.h
@@ -37,6 +37,8 @@
 #include <QPointF>
 #include <warn/pop>
 
+#include <memory>
+
 namespace inviwo {
 
 class NetworkEditor;
@@ -50,7 +52,7 @@ class IVW_QTEDITOR_API LinkDragHelper : public QObject {
 #include <warn/pop>
 
 public:
-    LinkDragHelper(NetworkEditor* editor);
+    LinkDragHelper(NetworkEditor& editor);
     virtual ~LinkDragHelper() = default;
 
     void start(ProcessorLinkGraphicsItem* outLink, QPointF endPos);
@@ -59,8 +61,8 @@ public:
     virtual bool eventFilter(QObject* obj, QEvent* event) override;
 
 private:
-    NetworkEditor* editor_;
-    LinkConnectionDragGraphicsItem* link_ = nullptr;
+    NetworkEditor& editor_;
+    std::unique_ptr<LinkConnectionDragGraphicsItem> link_;
 };
 
 }  // namespace inviwo

--- a/include/inviwo/qt/editor/linkdraghelper.h
+++ b/include/inviwo/qt/editor/linkdraghelper.h
@@ -39,6 +39,8 @@
 
 #include <memory>
 
+class QEvent;
+
 namespace inviwo {
 
 class NetworkEditor;
@@ -53,7 +55,7 @@ class IVW_QTEDITOR_API LinkDragHelper : public QObject {
 
 public:
     LinkDragHelper(NetworkEditor& editor);
-    virtual ~LinkDragHelper() = default;
+    virtual ~LinkDragHelper();
 
     void start(ProcessorLinkGraphicsItem* outLink, QPointF endPos);
     void reset();

--- a/include/inviwo/qt/editor/linkdraghelper.h
+++ b/include/inviwo/qt/editor/linkdraghelper.h
@@ -1,0 +1,66 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2018 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <inviwo/qt/editor/inviwoqteditordefine.h>
+#include <inviwo/core/common/inviwo.h>
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <QObject>
+#include <QPointF>
+#include <warn/pop>
+
+namespace inviwo {
+
+class NetworkEditor;
+class ProcessorLinkGraphicsItem;
+class LinkConnectionDragGraphicsItem;
+
+class IVW_QTEDITOR_API LinkDragHelper : public QObject {
+#include <warn/push>
+#include <warn/ignore/all>
+    Q_OBJECT
+#include <warn/pop>
+
+public:
+    LinkDragHelper(NetworkEditor* editor);
+    virtual ~LinkDragHelper() = default;
+
+    void start(ProcessorLinkGraphicsItem* outLink, QPointF endPos);
+    void reset();
+
+    virtual bool eventFilter(QObject* obj, QEvent* event) override;
+
+private:
+    NetworkEditor* editor_;
+    LinkConnectionDragGraphicsItem* link_ = nullptr;
+};
+
+}  // namespace inviwo

--- a/include/inviwo/qt/editor/linkgraphicsitem.h
+++ b/include/inviwo/qt/editor/linkgraphicsitem.h
@@ -24,7 +24,7 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  *********************************************************************************/
 
 #ifndef IVW_LINKGRAPHICSITEM_H
@@ -48,19 +48,13 @@ class ProcessorLink;
 
 class IVW_QTEDITOR_API LinkGraphicsItem : public EditorGraphicsItem {
 public:
-    LinkGraphicsItem(QPointF startPoint, QPointF endPoint, ivec3 color = ivec3(0xbd, 0xcd, 0xd5),
-                     QPointF startDir = QPointF(1.0f, 0.0), QPointF endDir = QPointF(0.0f, 0.0f));
+    LinkGraphicsItem(ivec3 color = ivec3(0xbd, 0xcd, 0xd5));
     ~LinkGraphicsItem();
 
-    QPointF getStartPoint() const;
-    QPointF getEndPoint() const;
-    QPointF getStartDir() const;
-    QPointF getEndDir() const;
-
-    void setStartPoint(QPointF startPoint);
-    void setEndPoint(QPointF endPoint);
-    void setStartDir(QPointF dir);
-    void setEndDir(QPointF dir);
+    virtual QPointF getStartPoint() const = 0;
+    virtual QPointF getEndPoint() const = 0;
+    virtual QPointF getStartDir() const = 0;
+    virtual QPointF getEndDir() const = 0;
 
     virtual void updateShape();
 
@@ -78,36 +72,39 @@ public:
 protected:
     virtual QPainterPath obtainCurvePath() const;
 
-    QPointF startPoint_;
-    QPointF endPoint_;
     QColor color_;
-    QPointF startDir_;
-    QPointF endDir_;
-
     QPainterPath path_;
     QRectF rect_;
 };
 
 class IVW_QTEDITOR_API LinkConnectionDragGraphicsItem : public LinkGraphicsItem {
 public:
-    LinkConnectionDragGraphicsItem(ProcessorLinkGraphicsItem* outLink,
-                                   QPointF endPos);
+    LinkConnectionDragGraphicsItem(ProcessorLinkGraphicsItem* outLink, QPointF endPos);
     ~LinkConnectionDragGraphicsItem();
+
+    virtual QPointF getStartPoint() const override;
+    virtual QPointF getEndPoint() const override;
+    virtual QPointF getStartDir() const override;
+    virtual QPointF getEndDir() const override;
+    virtual void setEndPoint(QPointF endPoint);
+    virtual void setEndPoint(QPointF endPointLeft, QPointF endPointRight);
 
     void reactToProcessorHover(ProcessorGraphicsItem* processor);
     virtual ProcessorLinkGraphicsItem* getSrcProcessorLinkGraphicsItem() const;
     virtual ProcessorGraphicsItem* getSrcProcessorGraphicsItem() const;
-    virtual void updateShape();
 
     enum { Type = UserType + LinkConnectionDragGraphicsType };
     int type() const { return Type; }
 
 protected:
+    static QPointF compare(const QPointF startLeft, const QPointF& startRight,
+                           const QPointF& endLeft, const QPointF& endRight, const QPointF& left,
+                           const QPointF& center, const QPointF& right);
+
     QPointF inLeft_;
     QPointF inRight_;
 
-    virtual QPainterPath obtainCurvePath() const;
-    ProcessorLinkGraphicsItem* outLink_;  //< non-onwing reference
+    ProcessorLinkGraphicsItem* outLink_;  //< non-owning reference
 };
 
 class IVW_QTEDITOR_API LinkConnectionGraphicsItem : public LinkConnectionDragGraphicsItem {
@@ -116,9 +113,13 @@ public:
                                ProcessorLinkGraphicsItem* inLink);
     ~LinkConnectionGraphicsItem();
 
+    virtual QPointF getStartPoint() const override;
+    virtual QPointF getEndPoint() const override;
+    virtual QPointF getStartDir() const override;
+    virtual QPointF getEndDir() const override;
+
     virtual ProcessorLinkGraphicsItem* getDestProcessorLinkGraphicsItem() const;
     virtual ProcessorGraphicsItem* getDestProcessorGraphicsItem() const;
-    virtual void updateShape();
 
     enum { Type = UserType + LinkConnectionGraphicsType };
     int type() const { return Type; }
@@ -126,10 +127,9 @@ public:
     virtual void showToolTip(QGraphicsSceneHelpEvent* e);
 
 protected:
-    virtual QPainterPath obtainCurvePath() const;
-    ProcessorLinkGraphicsItem* inLink_;  //< non-onwing reference
+    ProcessorLinkGraphicsItem* inLink_;  //< non-owning reference
 };
 
-}  // namespace
+}  // namespace inviwo
 
 #endif  // IVW_CONNECTIONGRAPHICSITEM_H

--- a/include/inviwo/qt/editor/networkeditor.h
+++ b/include/inviwo/qt/editor/networkeditor.h
@@ -87,9 +87,6 @@ class IVW_QTEDITOR_API NetworkEditor : public QGraphicsScene,
 #include <warn/ignore/all>
     Q_OBJECT
 #include <warn/pop>
-    friend ProcessorDragHelper;
-    friend ConnectionDragHelper;
-    friend LinkDragHelper;
 public:
     NetworkEditor(InviwoMainWindow* mainwindow);
     virtual ~NetworkEditor() = default;
@@ -101,7 +98,8 @@ public:
     void selectAll();
     void deleteSelection();
 
-    std::string getCurrentFilename() const { return filename_; }
+    const std::string& getCurrentFilename() const;
+    ProcessorNetwork* getNetwork() const;
 
     void addPropertyWidgets(Processor* processor);
     void removeAndDeletePropertyWidgets(Processor* processor);
@@ -128,6 +126,10 @@ public:
     LinkConnectionGraphicsItem* getLinkGraphicsItem(const ProcessorPair& key) const;
     LinkConnectionGraphicsItem* getLinkGraphicsItem(Processor* processor1,
                                                     Processor* processor2) const;
+    ProcessorGraphicsItem* getProcessorGraphicsItemAt(const QPointF pos) const;
+    ProcessorInportGraphicsItem* getProcessorInportGraphicsItemAt(const QPointF pos) const;
+    ConnectionGraphicsItem* getConnectionGraphicsItemAt(const QPointF pos) const;
+    LinkConnectionGraphicsItem* getLinkGraphicsItemAt(const QPointF pos) const;
 
     void setBackgroundVisible(bool visible);
     bool isBackgroundVisible() const;
@@ -138,9 +140,10 @@ public:
     static std::string getMimeTag();
     void resetAllTimeMeasurements();
 
+    void showLinkDialog(Processor* processor1, Processor* processor2);
+
 protected:
     virtual void mousePressEvent(QGraphicsSceneMouseEvent* e) override;
-    virtual void mouseMoveEvent(QGraphicsSceneMouseEvent* e) override;
     virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent* e) override;
     virtual void mouseDoubleClickEvent(QGraphicsSceneMouseEvent* e) override;
 
@@ -150,10 +153,6 @@ protected:
 
     virtual void keyReleaseEvent(QKeyEvent* keyEvent) override;
     virtual void contextMenuEvent(QGraphicsSceneContextMenuEvent* e) override;
-
-    void placeProcessorOnConnection(Processor* processorItem,
-                                    ConnectionGraphicsItem* connectionItem);
-    void placeProcessorOnProcessor(Processor* processorItem, Processor* oldProcessorItem);
 
     // Override for tooltips
     virtual void helpEvent(QGraphicsSceneHelpEvent* helpEvent) override;
@@ -202,15 +201,10 @@ private:
     void removeLink(LinkConnectionGraphicsItem* linkGraphicsItem);
     LinkConnectionGraphicsItem* addLinkGraphicsItem(Processor* processor1, Processor* processor2);
     void removeLinkGraphicsItem(LinkConnectionGraphicsItem* linkGraphicsItem);
-    void showLinkDialog(Processor* processor1, Processor* processor2);
 
     // Get QGraphicsItems
     template <typename T>
     T* getGraphicsItemAt(const QPointF pos) const;
-    ProcessorGraphicsItem* getProcessorGraphicsItemAt(const QPointF pos) const;
-    ProcessorInportGraphicsItem* getProcessorInportGraphicsItemAt(const QPointF pos) const;
-    ConnectionGraphicsItem* getConnectionGraphicsItemAt(const QPointF pos) const;
-    LinkConnectionGraphicsItem* getLinkGraphicsItemAt(const QPointF pos) const;
 
     virtual void drawBackground(QPainter* painter, const QRectF& rect) override;
     virtual void drawForeground(QPainter* painter, const QRectF& rect) override;

--- a/include/inviwo/qt/editor/networkeditor.h
+++ b/include/inviwo/qt/editor/networkeditor.h
@@ -69,6 +69,9 @@ class LinkDialog;
 class InviwoMainWindow;
 class Image;
 class MenuItem;
+class ProcessorDragHelper;
+class ConnectionDragHelper;
+class LinkDragHelper;
 
 /**
  * The NetworkEditor supports interactive editing of a ProcessorNetwork. Processors can be added
@@ -84,6 +87,9 @@ class IVW_QTEDITOR_API NetworkEditor : public QGraphicsScene,
 #include <warn/ignore/all>
     Q_OBJECT
 #include <warn/pop>
+    friend ProcessorDragHelper;
+    friend ConnectionDragHelper;
+    friend LinkDragHelper;
 public:
     NetworkEditor(InviwoMainWindow* mainwindow);
     virtual ~NetworkEditor() = default;
@@ -144,10 +150,6 @@ protected:
 
     virtual void keyReleaseEvent(QKeyEvent* keyEvent) override;
     virtual void contextMenuEvent(QGraphicsSceneContextMenuEvent* e) override;
-
-    virtual void dragEnterEvent(QGraphicsSceneDragDropEvent* de) override;
-    virtual void dragMoveEvent(QGraphicsSceneDragDropEvent* de) override;
-    virtual void dropEvent(QGraphicsSceneDragDropEvent* de) override;
 
     void placeProcessorOnConnection(Processor* processorItem,
                                     ConnectionGraphicsItem* connectionItem);
@@ -219,23 +221,20 @@ private:
     using ConnectionMap = std::map<PortConnection, ConnectionGraphicsItem*>;
     using LinkMap = std::map<ProcessorPair, LinkConnectionGraphicsItem*>;
 
+    // Drag n drop state
+    ProcessorDragHelper* processorDragHelper_;
+    LinkDragHelper* linkDragHelper_;
+    ConnectionDragHelper* connectionDragHelper_;
+    ProcessorGraphicsItem* processorItem_;
+
     ProcessorMap processorGraphicsItems_;
     ConnectionMap connectionGraphicsItems_;
     LinkMap linkGraphicsItems_;
-
-    // Drag n drop state
-    ConnectionGraphicsItem* oldConnectionTarget_;
-    ProcessorGraphicsItem* oldProcessorTarget_;
-    bool validConnectionTarget_;
 
     QList<QGraphicsItem*> clickedOnItems_;
     std::pair<bool, ivec2> clickedPosition_ = {false, ivec2{0, 0}};
     mutable std::pair<bool, ivec2> pastePos_ = {false, ivec2{0, 0}};
 
-    // Connection and link state
-    ProcessorGraphicsItem* processorItem_;
-    ConnectionDragGraphicsItem* connectionCurve_;
-    LinkConnectionDragGraphicsItem* linkCurve_;
 
     InviwoMainWindow* mainwindow_;
     ProcessorNetwork* network_;

--- a/include/inviwo/qt/editor/processordraghelper.h
+++ b/include/inviwo/qt/editor/processordraghelper.h
@@ -64,7 +64,7 @@ class IVW_QTEDITOR_API ProcessorDragHelper : public QObject {
 
 public:
     ProcessorDragHelper(NetworkEditor& editor);
-    virtual ~ProcessorDragHelper() = default;
+    virtual ~ProcessorDragHelper();
 
     virtual bool eventFilter(QObject *obj, QEvent *event) override;
 

--- a/include/inviwo/qt/editor/processordraghelper.h
+++ b/include/inviwo/qt/editor/processordraghelper.h
@@ -58,7 +58,7 @@ class IVW_QTEDITOR_API ProcessorDragHelper : public QObject {
 #include <warn/pop>
 
 public:
-    ProcessorDragHelper(NetworkEditor *editor);
+    ProcessorDragHelper(NetworkEditor& editor);
     virtual ~ProcessorDragHelper() = default;
 
     virtual bool eventFilter(QObject *obj, QEvent *event) override;
@@ -83,7 +83,7 @@ private:
     void resetAutoConnections();
     void resetAutoLinks();
 
-    NetworkEditor* editor_;
+    NetworkEditor& editor_;
     ConnectionGraphicsItem* connectionTarget_ = nullptr;
     ProcessorGraphicsItem* processorTarget_ = nullptr;
 

--- a/include/inviwo/qt/editor/processordraghelper.h
+++ b/include/inviwo/qt/editor/processordraghelper.h
@@ -72,8 +72,8 @@ private:
     bool leave(QGraphicsSceneDragDropEvent* e, const ProcessorMimeData* mime);
     bool drop(QGraphicsSceneDragDropEvent* e, const ProcessorMimeData* mime);
     
-    void updateAutoConnections(QPointF pos);
-    void updateAutoLinks(QPointF pos);
+    void updateAutoConnections(QGraphicsSceneDragDropEvent* e);
+    void updateAutoLinks(QGraphicsSceneDragDropEvent* e);
 
 
     static bool canSplitConnection(Processor* p, ConnectionGraphicsItem* connection);

--- a/include/inviwo/qt/editor/processordraghelper.h
+++ b/include/inviwo/qt/editor/processordraghelper.h
@@ -1,0 +1,98 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2018 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <inviwo/qt/editor/inviwoqteditordefine.h>
+#include <inviwo/core/common/inviwo.h>
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <QObject>
+#include <warn/pop>
+
+#include <unordered_map>
+#include <memory>
+
+class QGraphicsSceneDragDropEvent;
+
+namespace inviwo {
+
+class Processor;
+class ProcessorMimeData;
+class ConnectionGraphicsItem;
+class NetworkEditor;
+class AutoLinker;
+class LinkConnectionDragGraphicsItem;
+class Property;
+
+class IVW_QTEDITOR_API ProcessorDragHelper : public QObject {
+#include <warn/push>
+#include <warn/ignore/all>
+    Q_OBJECT
+#include <warn/pop>
+
+public:
+    ProcessorDragHelper(NetworkEditor *editor);
+    virtual ~ProcessorDragHelper() = default;
+
+    virtual bool eventFilter(QObject *obj, QEvent *event) override;
+
+    void clear(ConnectionGraphicsItem* connection);
+    void clear(ProcessorGraphicsItem* processor);
+
+private:
+    bool enter(QGraphicsSceneDragDropEvent* e, const ProcessorMimeData* mime);
+    bool move(QGraphicsSceneDragDropEvent* e, const ProcessorMimeData* mime);
+    bool leave(QGraphicsSceneDragDropEvent* e, const ProcessorMimeData* mime);
+    bool drop(QGraphicsSceneDragDropEvent* e, const ProcessorMimeData* mime);
+    
+    void updateAutoConnections(QPointF pos);
+    void updateAutoLinks(QPointF pos);
+
+
+    static bool canSplitConnection(Processor* p, ConnectionGraphicsItem* connection);
+
+    void resetConnection();
+    void resetProcessor();
+    void resetAutoConnections();
+    void resetAutoLinks();
+
+    NetworkEditor* editor_;
+    ConnectionGraphicsItem* connectionTarget_ = nullptr;
+    ProcessorGraphicsItem* processorTarget_ = nullptr;
+
+    std::vector<std::pair<Inport*, std::vector<Outport*>>> autoConnectCandidates_;
+    std::unordered_map<Inport*, std::unique_ptr<ConnectionDragGraphicsItem>> autoConnections_;
+
+    std::unique_ptr<AutoLinker> autoLinker_;
+    std::unordered_map<Processor*, std::unique_ptr<LinkConnectionDragGraphicsItem>> autoLinks_;
+
+};
+
+}  // namespace inviwo

--- a/include/inviwo/qt/editor/processordraghelper.h
+++ b/include/inviwo/qt/editor/processordraghelper.h
@@ -39,6 +39,7 @@
 #include <unordered_map>
 #include <memory>
 
+class QEvent;
 class QGraphicsSceneDragDropEvent;
 
 namespace inviwo {
@@ -49,7 +50,11 @@ class ConnectionGraphicsItem;
 class NetworkEditor;
 class AutoLinker;
 class LinkConnectionDragGraphicsItem;
+class ConnectionDragGraphicsItem;
+class ProcessorGraphicsItem;
 class Property;
+class Inport;
+class Outport;
 
 class IVW_QTEDITOR_API ProcessorDragHelper : public QObject {
 #include <warn/push>

--- a/include/inviwo/qt/editor/processorgraphicsitem.h
+++ b/include/inviwo/qt/editor/processorgraphicsitem.h
@@ -90,14 +90,17 @@ public:
 
     static const QSizeF size_;
 
+    enum class PortType { In, Out };
+    static QPointF portOffset(PortType type, size_t index);
+    QPointF portPosition(PortType type, size_t index);
+
 protected:
     void paint(QPainter* p, const QStyleOptionGraphicsItem* options, QWidget* widget) override;
     virtual QVariant itemChange(GraphicsItemChange change, const QVariant& value) override;
 
     void updateWidgets();
 
-    enum class PortType { In, Out };
-    QPointF portPosition(PortType type, size_t index);
+
     void addInport(Inport* port);
     void addOutport(Outport* port);
     void removeInport(Inport* port);

--- a/include/inviwo/qt/editor/processorlistwidget.h
+++ b/include/inviwo/qt/editor/processorlistwidget.h
@@ -141,9 +141,6 @@ private:
 class IVW_QTEDITOR_API ProcessorDragObject : public QDrag {
 public:
     ProcessorDragObject(QWidget* source, std::unique_ptr<Processor> processor);
-
-    static bool canDecode(const QMimeData* mimeData);
-    static bool decode(const QMimeData* mimeData, QString& className);
 };
 
 }  // namespace inviwo

--- a/modules/qtwidgets/src/properties/propertyeditorwidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/propertyeditorwidgetqt.cpp
@@ -167,13 +167,13 @@ void PropertyEditorWidgetQt::loadState() {
     }
 
     if (property_->hasMetaData<IntVec2MetaData>(sizeKey)) {
-        resize(utilqt::toQSize(property_->getMetaData<IntVec2MetaData>(sizeKey, ivec2{})));
+        resize(utilqt::toQSize(property_->getMetaData<IntVec2MetaData>(sizeKey, ivec2{0})));
     } else if (settings.contains("size")) {
         resize(settings.value("size").toSize());
     }
 
     if (property_->hasMetaData<IntVec2MetaData>(positionKey)) {
-        auto pos = utilqt::toQPoint(property_->getMetaData<IntVec2MetaData>(positionKey, ivec2{}));
+        auto pos = utilqt::toQPoint(property_->getMetaData<IntVec2MetaData>(positionKey, ivec2{0}));
         auto newPos = utilqt::movePointOntoDesktop(pos, InviwoDockWidget::size(), false);
         move(newPos);
     } else if (auto mainWindow = utilqt::getApplicationMainWindow()) {

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -136,6 +136,7 @@ set(HEADER_FILES
     ${IVW_INCLUDE_DIR}/inviwo/core/metadata/positionmetadata.h
     ${IVW_INCLUDE_DIR}/inviwo/core/metadata/processormetadata.h
     ${IVW_INCLUDE_DIR}/inviwo/core/metadata/processorwidgetmetadata.h
+    ${IVW_INCLUDE_DIR}/inviwo/core/network/autolinker.h
     ${IVW_INCLUDE_DIR}/inviwo/core/network/evaluationerrorhandler.h
     ${IVW_INCLUDE_DIR}/inviwo/core/network/networklock.h
     ${IVW_INCLUDE_DIR}/inviwo/core/network/networkutils.h
@@ -426,6 +427,7 @@ set(SOURCE_FILES
     metadata/positionmetadata.cpp
     metadata/processormetadata.cpp
     metadata/processorwidgetmetadata.cpp
+    network/autolinker.cpp
     network/evaluationerrorhandler.cpp
     network/networklock.cpp
     network/networkutils.cpp

--- a/src/core/network/autolinker.cpp
+++ b/src/core/network/autolinker.cpp
@@ -30,6 +30,9 @@
 #include <inviwo/core/network/autolinker.h>
 #include <inviwo/core/network/networkutils.h>
 #include <inviwo/core/network/networklock.h>
+#include <inviwo/core/common/inviwoapplication.h>
+#include <inviwo/core/util/settings/linksettings.h>
+
 #include <algorithm>
 
 namespace inviwo {

--- a/src/core/network/autolinker.cpp
+++ b/src/core/network/autolinker.cpp
@@ -1,0 +1,128 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2018 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/core/network/autolinker.h>
+#include <inviwo/core/network/networkutils.h>
+#include <inviwo/core/network/networklock.h>
+#include <algorithm>
+
+namespace inviwo {
+
+AutoLinker::AutoLinker(ProcessorNetwork* network, Processor* target, Processor* source)
+    : network_{network}, target_{target} {
+
+    std::vector<Property*> sourceProperties;
+    if (source) {
+        for (auto& p : util::getPredecessors(source)) {
+            std::vector<Property*> props = p->getPropertiesRecursive();
+            sourceProperties.insert(sourceProperties.end(), props.begin(), props.end());
+        }
+    } else {
+        network->forEachProcessor([&](Processor* p) {
+            if (p != target_) {
+                std::vector<Property*> props = p->getPropertiesRecursive();
+                sourceProperties.insert(sourceProperties.end(), props.begin(), props.end());
+            }
+        });
+    }
+
+    const auto targetProperties = target_->getPropertiesRecursive();
+
+    // auto link based on global settings
+    auto app = network->getApplication();
+    const auto linkSettings = app->getSettingsByType<LinkSettings>();
+    const auto linkChecker = [&](const Property* p) { return linkSettings->isLinkable(p); };
+
+    for (auto& targetProperty : targetProperties) {
+        if (!linkChecker(targetProperty)) continue;
+
+        auto isAutoLinkAble = [&](const Property* p) {
+            return linkChecker(p) && network->canLink(p, targetProperty) &&
+                   p->getClassIdentifier() == targetProperty->getClassIdentifier() &&
+                   p->getIdentifier() == targetProperty->getIdentifier();
+        };
+        std::vector<Property*> candidates;
+
+        std::copy_if(sourceProperties.begin(), sourceProperties.end(),
+                     std::back_inserter(candidates), isAutoLinkAble);
+
+        if (!candidates.empty()) {
+            autoLinkCandiates_[targetProperty] = std::move(candidates);
+        }
+    }
+
+    // Auto link based property
+    for (const auto& targetProperty : targetProperties) {
+        std::vector<Property*> candidates;
+        for (const auto& item : targetProperty->getAutoLinkToProperty()) {
+            std::copy_if(sourceProperties.begin(), sourceProperties.end(),
+                         std::back_inserter(candidates), [&](Property* prop) {
+                             auto proc = prop->getOwner()->getProcessor();
+                             return proc && proc->getClassIdentifier() != item.first &&
+                                    joinString(prop->getPath(), ".") == item.second;
+                         });
+        }
+        if (!candidates.empty()) {
+            autoLinkCandiates_[targetProperty] = std::move(candidates);
+        }
+    }
+}
+
+void AutoLinker::sortAutoLinkCandidates() {
+    util::PropertyDistanceSorter distSorter;
+    for (auto& item : autoLinkCandiates_) {
+        distSorter.setTarget(item.first);
+        std::sort(item.second.begin(), item.second.end(), distSorter);
+    }
+}
+
+void AutoLinker::addLinksToClosestCandidates(bool bidirectional) {
+    NetworkLock lock(network_);
+    sortAutoLinkCandidates();
+    for (auto& item : getAutoLinkCandidates()) {
+        network_->addLink(item.second.front(), item.first);
+        // Propagate the link to the new Processor.
+        network_->evaluateLinksFromProperty(item.second.front());
+        if (bidirectional) {
+            network_->addLink(item.first, item.second.front());
+        }
+    }
+}
+
+const std::unordered_map<Property*, std::vector<Property*>>& AutoLinker::getAutoLinkCandidates()
+    const {
+    return autoLinkCandiates_;
+}
+
+void AutoLinker::addLinks(ProcessorNetwork* network, Processor* target, Processor* source) {
+    AutoLinker al(network, target, source);
+    al.addLinksToClosestCandidates(true);
+}
+
+}  // namespace inviwo

--- a/src/core/network/networkutils.cpp
+++ b/src/core/network/networkutils.cpp
@@ -42,7 +42,9 @@
 
 namespace inviwo {
 
-std::unordered_set<Processor*> util::getDirectPredecessors(Processor* processor) {
+namespace util {
+
+std::unordered_set<Processor*> getDirectPredecessors(Processor* processor) {
     std::unordered_set<Processor*> predecessors;
     for (auto port : processor->getInports()) {
         for (auto connectedPort : port->getConnectedOutports()) {
@@ -52,7 +54,7 @@ std::unordered_set<Processor*> util::getDirectPredecessors(Processor* processor)
     return predecessors;
 }
 
-std::unordered_set<Processor*> util::getDirectSuccessors(Processor* processor) {
+std::unordered_set<Processor*> getDirectSuccessors(Processor* processor) {
     std::unordered_set<Processor*> successors;
     for (auto port : processor->getOutports()) {
         for (auto connectedPort : port->getConnectedInports()) {
@@ -62,7 +64,7 @@ std::unordered_set<Processor*> util::getDirectSuccessors(Processor* processor) {
     return successors;
 }
 
-std::unordered_set<Processor*> util::getPredecessors(Processor* processor) {
+std::unordered_set<Processor*> getPredecessors(Processor* processor) {
     std::unordered_set<Processor*> predecessors;
     std::unordered_set<Processor*> state;
     traverseNetwork<TraversalDirection::Up, VisitPattern::Post>(
@@ -71,7 +73,7 @@ std::unordered_set<Processor*> util::getPredecessors(Processor* processor) {
     return predecessors;
 }
 
-std::unordered_set<Processor*> util::getSuccessors(Processor* processor) {
+std::unordered_set<Processor*> getSuccessors(Processor* processor) {
     std::unordered_set<Processor*> successors;
     std::unordered_set<Processor*> state;
     traverseNetwork<TraversalDirection::Down, VisitPattern::Post>(
@@ -80,7 +82,7 @@ std::unordered_set<Processor*> util::getSuccessors(Processor* processor) {
     return successors;
 }
 
-std::vector<Processor*> util::topologicalSort(ProcessorNetwork* network) {
+std::vector<Processor*> topologicalSort(ProcessorNetwork* network) {
     // perform topological sorting and store processor order in sorted
 
     std::vector<Processor*> sinkProcessors;
@@ -96,31 +98,31 @@ std::vector<Processor*> util::topologicalSort(ProcessorNetwork* network) {
     return sorted;
 }
 
-std::vector<ivec2> util::getPositions(const std::vector<Processor*>& processors) {
-    return util::transform(processors, [](Processor* p) { return util::getPosition(p); });
+std::vector<ivec2> getPositions(const std::vector<Processor*>& processors) {
+    return util::transform(processors, [](Processor* p) { return getPosition(p); });
 }
 
-std::vector<ivec2> util::getPositions(ProcessorNetwork* network) {
+std::vector<ivec2> getPositions(ProcessorNetwork* network) {
     std::vector<ivec2> res;
-    network->forEachProcessor([&](Processor* p) { res.push_back(util::getPosition(p)); });
+    network->forEachProcessor([&](Processor* p) { res.push_back(getPosition(p)); });
     return res;
 }
 
-ivec2 util::getCenterPosition(const std::vector<Processor*>& processors) {
+ivec2 getCenterPosition(const std::vector<Processor*>& processors) {
     ivec2 center{0};
     if (processors.empty()) return center;
 
     for (auto p : processors) {
-        center += util::getPosition(p);
+        center += getPosition(p);
     }
     return center / static_cast<int>(processors.size());
 }
 
-ivec2 util::getCenterPosition(ProcessorNetwork* network) {
+ivec2 getCenterPosition(ProcessorNetwork* network) {
     ivec2 center{0};
     int count = 0;
     network->forEachProcessor([&](Processor* p) {
-        center += util::getPosition(p);
+        center += getPosition(p);
         ++count;
     });
     if (count == 0) {
@@ -130,25 +132,25 @@ ivec2 util::getCenterPosition(ProcessorNetwork* network) {
     }
 }
 
-std::pair<ivec2, ivec2> util::getBoundingBox(const std::vector<Processor*>& processors) {
+std::pair<ivec2, ivec2> getBoundingBox(const std::vector<Processor*>& processors) {
     if (processors.empty()) return {ivec2{0}, ivec2{0}};
     ivec2 minPos{std::numeric_limits<int>::max()};
     ivec2 maxPos{std::numeric_limits<int>::lowest()};
 
     for (auto p : processors) {
-        auto pos = util::getPosition(p);
+        auto pos = getPosition(p);
         minPos = glm::min(minPos, pos);
         maxPos = glm::max(maxPos, pos);
     }
     return {minPos, maxPos};
 }
 
-std::pair<ivec2, ivec2> util::getBoundingBox(ProcessorNetwork* network) {
+std::pair<ivec2, ivec2> getBoundingBox(ProcessorNetwork* network) {
     ivec2 minPos{std::numeric_limits<int>::max()};
     ivec2 maxPos{std::numeric_limits<int>::lowest()};
     bool empty = true;
     network->forEachProcessor([&](Processor* p) {
-        auto pos = util::getPosition(p);
+        auto pos = getPosition(p);
         minPos = glm::min(minPos, pos);
         maxPos = glm::max(maxPos, pos);
         empty = false;
@@ -160,43 +162,42 @@ std::pair<ivec2, ivec2> util::getBoundingBox(ProcessorNetwork* network) {
     }
 }
 
-void util::offsetPosition(const std::vector<Processor*>& processors, ivec2 offset) {
+void offsetPosition(const std::vector<Processor*>& processors, ivec2 offset) {
     for (auto p : processors) {
-        if (auto meta = util::getMetaData(p)) {
+        if (auto meta = getMetaData(p)) {
             meta->setPosition(meta->getPosition() + offset);
         }
     }
 }
 
-void util::setSelected(const std::vector<Processor*>& processors, bool selected) {
+void setSelected(const std::vector<Processor*>& processors, bool selected) {
     for (auto p : processors) {
         setSelected(p, selected);
     }
 }
 
-util::PropertyDistanceSorter::PropertyDistanceSorter() {}
+PropertyDistanceSorter::PropertyDistanceSorter() {}
 
-void util::PropertyDistanceSorter::setTarget(vec2 pos) { pos_ = pos; }
-void util::PropertyDistanceSorter::setTarget(const Property* target) { pos_ = getPosition(target); }
+void PropertyDistanceSorter::setTarget(vec2 pos) { pos_ = pos; }
+void PropertyDistanceSorter::setTarget(const Property* target) { pos_ = getPosition(target); }
 
-bool util::PropertyDistanceSorter::operator()(const Property* a, const Property* b) {
+bool PropertyDistanceSorter::operator()(const Property* a, const Property* b) {
     float da = glm::distance(pos_, getPosition(a));
     float db = glm::distance(pos_, getPosition(b));
     return da < db;
 }
 
-vec2 util::PropertyDistanceSorter::getPosition(const Property* p) {
+vec2 PropertyDistanceSorter::getPosition(const Property* p) {
     auto it = cache_.find(p);
     if (it != cache_.end()) return it->second;
     return cache_[p] = getPosition(p->getOwner()->getProcessor());
 }
 
-vec2 util::PropertyDistanceSorter::getPosition(const Processor* processor) {
+vec2 PropertyDistanceSorter::getPosition(const Processor* processor) {
     return util::getPosition(processor);
 }
 
-void util::serializeSelected(ProcessorNetwork* network, std::ostream& os,
-                             const std::string& refPath) {
+void serializeSelected(ProcessorNetwork* network, std::ostream& os, const std::string& refPath) {
     Serializer serializer(refPath);
 
     detail::PartialProcessorNetwork ppc(network);
@@ -204,9 +205,8 @@ void util::serializeSelected(ProcessorNetwork* network, std::ostream& os,
     serializer.writeFile(os);
 }
 
-std::vector<Processor*> util::appendDeserialized(ProcessorNetwork* network, std::istream& is,
-                                                 const std::string& refPath,
-                                                 InviwoApplication* app) {
+std::vector<Processor*> appendDeserialized(ProcessorNetwork* network, std::istream& is,
+                                           const std::string& refPath, InviwoApplication* app) {
     NetworkLock lock(network);
     auto deserializer = app->getWorkspaceManager()->createWorkspaceDeserializer(is, refPath);
 
@@ -216,14 +216,14 @@ std::vector<Processor*> util::appendDeserialized(ProcessorNetwork* network, std:
     return ppc.getAddedProcessors();
 }
 
-util::detail::PartialProcessorNetwork::PartialProcessorNetwork(ProcessorNetwork* network)
+detail::PartialProcessorNetwork::PartialProcessorNetwork(ProcessorNetwork* network)
     : network_(network) {}
 
-std::vector<Processor*> util::detail::PartialProcessorNetwork::getAddedProcessors() const {
+std::vector<Processor*> detail::PartialProcessorNetwork::getAddedProcessors() const {
     return addedProcessors_;
 }
 
-void util::detail::PartialProcessorNetwork::serialize(Serializer& s) const {
+void detail::PartialProcessorNetwork::serialize(Serializer& s) const {
     std::vector<Processor*> selected;
     util::copy_if(network_->getProcessors(), std::back_inserter(selected), [](const Processor* p) {
         auto m = p->getMetaData<ProcessorMetaData>(ProcessorMetaData::CLASS_IDENTIFIER);
@@ -293,7 +293,7 @@ void util::detail::PartialProcessorNetwork::serialize(Serializer& s) const {
     s.serialize("PartialDstLinks", partialDstLinks, "PropertyLink");
 }
 
-void util::detail::PartialProcessorNetwork::deserialize(Deserializer& d) {
+void detail::PartialProcessorNetwork::deserialize(Deserializer& d) {
     try {
         std::vector<std::unique_ptr<Processor>> processors;
         std::vector<std::unique_ptr<PortConnection>> connections;
@@ -355,49 +355,167 @@ void util::detail::PartialProcessorNetwork::deserialize(Deserializer& d) {
     }
 }
 
-util::detail::PartialConnection::PartialConnection(std::string path, Inport* inport)
+detail::PartialConnection::PartialConnection(std::string path, Inport* inport)
     : outportPath_(path), inport_(inport) {}
 
-util::detail::PartialConnection::PartialConnection() {}
+detail::PartialConnection::PartialConnection() {}
 
-void util::detail::PartialConnection::serialize(Serializer& s) const {
+void detail::PartialConnection::serialize(Serializer& s) const {
     s.serialize("OutPortPath", outportPath_);
     s.serialize("InPort", inport_);
 }
 
-void util::detail::PartialConnection::deserialize(Deserializer& d) {
+void detail::PartialConnection::deserialize(Deserializer& d) {
     d.deserialize("OutPortPath", outportPath_);
     d.deserialize("InPort", inport_);
 }
 
-util::detail::PartialSrcLink::PartialSrcLink(Property* src, std::string path)
+detail::PartialSrcLink::PartialSrcLink(Property* src, std::string path)
     : src_(src), dstPath_(path) {}
 
-util::detail::PartialSrcLink::PartialSrcLink() {}
+detail::PartialSrcLink::PartialSrcLink() {}
 
-void util::detail::PartialSrcLink::serialize(Serializer& s) const {
+void detail::PartialSrcLink::serialize(Serializer& s) const {
     s.serialize("SourceProperty", src_);
     s.serialize("DestinationPropertyPath", dstPath_);
 }
 
-void util::detail::PartialSrcLink::deserialize(Deserializer& d) {
+void detail::PartialSrcLink::deserialize(Deserializer& d) {
     d.deserialize("SourceProperty", src_);
     d.deserialize("DestinationPropertyPath", dstPath_);
 }
 
-util::detail::PartialDstLink::PartialDstLink(std::string path, Property* dst)
+detail::PartialDstLink::PartialDstLink(std::string path, Property* dst)
     : srcPath_(path), dst_(dst) {}
 
-util::detail::PartialDstLink::PartialDstLink() {}
+detail::PartialDstLink::PartialDstLink() {}
 
-void util::detail::PartialDstLink::serialize(Serializer& s) const {
+void detail::PartialDstLink::serialize(Serializer& s) const {
     s.serialize("SourcePropertyPath", srcPath_);
     s.serialize("DestinationProperty", dst_);
 }
 
-void util::detail::PartialDstLink::deserialize(Deserializer& d) {
+void detail::PartialDstLink::deserialize(Deserializer& d) {
     d.deserialize("SourcePropertyPath", srcPath_);
     d.deserialize("DestinationProperty", dst_);
 }
 
+bool addProcessorOnConnection(ProcessorNetwork* network, std::unique_ptr<Processor> processor,
+                              PortConnection connection) {
+
+    Inport* connectionInport = connection.getInport();
+    Outport* connectionOutport = connection.getOutport();
+
+    Inport* inport = util::find_if_or_null(
+        processor->getInports(),
+        [connectionOutport](Inport* port) { return port->canConnectTo(connectionOutport); });
+
+    Outport* outport = util::find_if_or_null(
+        processor->getOutports(),
+        [connectionInport](Outport* port) { return connectionInport->canConnectTo(port); });
+
+    if (inport && outport) {
+        NetworkLock lock(network);
+        network->addProcessor(std::move(processor));
+
+        // Remove old connection
+        network->removeConnection(connection);
+
+        // Add new Connections
+        network->addConnection(connectionOutport, inport);
+        network->addConnection(outport, connectionInport);
+        return true;
+    } else {
+        return false;
+    }
+}
+
+void replaceProcessor(ProcessorNetwork* network, std::unique_ptr<Processor> aNewProcessor,
+                                   Processor* oldProcessor) {
+
+    auto newProcessor = network->addProcessor(std::move(aNewProcessor));
+
+    util::setPosition(newProcessor, util::getPosition(oldProcessor));
+
+    const std::vector<Inport*>& inports = newProcessor->getInports();
+    const std::vector<Outport*>& outports = newProcessor->getOutports();
+    const std::vector<Inport*>& oldInports = oldProcessor->getInports();
+    const std::vector<Outport*>& oldOutports = oldProcessor->getOutports();
+
+    NetworkLock lock(network);
+
+    std::vector<PortConnection> newConnections;
+
+    for (size_t i = 0; i < std::min(inports.size(), oldInports.size()); ++i) {
+        for (auto outport : oldInports[i]->getConnectedOutports()) {
+            if (inports[i]->canConnectTo(outport)) {
+                // save new connection connectionOutportoldInport-processorInport
+                newConnections.emplace_back(outport, inports[i]);
+            }
+        }
+    }
+
+    for (size_t i = 0; i < std::min(outports.size(), oldOutports.size()); ++i) {
+        for (auto inport : oldOutports[i]->getConnectedInports()) {
+            if (inport->canConnectTo(outports[i])) {
+                // save new connection processorOutport-connectionInport
+                newConnections.emplace_back(outports[i], inport);
+            }
+        }
+    }
+
+    // Copy over the value of old props to new ones if id and class name are equal.
+    auto newProps = newProcessor->getProperties();
+    auto oldProps = oldProcessor->getProperties();
+
+    std::map<Property*, Property*> propertymap;
+
+    for (auto newProp : newProps) {
+        for (auto oldProp : oldProps) {
+            if (newProp->getIdentifier() == oldProp->getIdentifier() &&
+                newProp->getClassIdentifier() == oldProp->getClassIdentifier()) {
+                newProp->set(oldProp);
+                propertymap[oldProp] = newProp;
+            }
+        }
+    }
+
+    // Move property links to the new processor
+    auto links = network->getLinks();
+    for (auto oldProp : oldProps) {
+        for (auto link : links) {
+            if (link.getDestination() == oldProp) {
+                auto match = propertymap.find(oldProp);
+                if (match != propertymap.end()) {
+                    // add link from
+                    Property* start = link.getSource();
+                    // to
+                    Property* end = match->second;
+
+                    network->addLink(start, end);
+                }
+            }
+            if (link.getSource() == oldProp) {
+                auto match = propertymap.find(oldProp);
+                if (match != propertymap.end()) {
+                    // add link from
+                    Property* start = match->second;
+                    // to
+                    Property* end = link.getDestination();
+
+                    network->addLink(start, end);
+                }
+            }
+        }
+    }
+
+    // remove old processor
+    network->removeProcessor(oldProcessor);
+    delete oldProcessor;
+
+    // create all new connections
+    for (auto& con : newConnections) network->addConnection(con);
+}
+
+}  // namespace util
 }  // namespace inviwo

--- a/src/qt/editor/CMakeLists.txt
+++ b/src/qt/editor/CMakeLists.txt
@@ -5,11 +5,14 @@ project(inviwo-qteditor)
 #--------------------------------------------------------------------
 # Add MOC files
 set(MOC_FILES
+    ${IVW_INCLUDE_DIR}/inviwo/qt/editor/connectiondraghelper.h
     ${IVW_INCLUDE_DIR}/inviwo/qt/editor/consolewidget.h
     ${IVW_INCLUDE_DIR}/inviwo/qt/editor/networkeditor.h
+    ${IVW_INCLUDE_DIR}/inviwo/qt/editor/linkdraghelper.h
     ${IVW_INCLUDE_DIR}/inviwo/qt/editor/linkdialog/linkdialogscene.h
     ${IVW_INCLUDE_DIR}/inviwo/qt/editor/linkdialog/linkdialogprocessorgraphicsitems.h
     ${IVW_INCLUDE_DIR}/inviwo/qt/editor/processormimedata.h
+    ${IVW_INCLUDE_DIR}/inviwo/qt/editor/processordraghelper.h
 )
 
 #--------------------------------------------------------------------
@@ -55,6 +58,7 @@ ivw_group("Header Files" BASE ${IVW_INCLUDE_DIR}/inviwo/qt/editor/ ${HEADER_FILE
 #--------------------------------------------------------------------
 # Add source files
 set(SOURCE_FILES
+    connectiondraghelper.cpp
     connectiongraphicsitem.cpp
     consolewidget.cpp
     dataopener.cpp
@@ -71,10 +75,12 @@ set(SOURCE_FILES
     linkdialog/linkdialogpropertygraphicsitems.cpp
     linkdialog/linkdialogscene.cpp
     linkdialog/linkdialogview.cpp
+    linkdraghelper.cpp
     linkgraphicsitem.cpp
     networkeditor.cpp
     networkeditorview.cpp
     networksearch.cpp
+    processordraghelper.cpp
     processorgraphicsitem.cpp
     processorlinkgraphicsitem.cpp
     processorlistwidget.cpp

--- a/src/qt/editor/connectiondraghelper.cpp
+++ b/src/qt/editor/connectiondraghelper.cpp
@@ -1,0 +1,88 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2018 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/qt/editor/connectiondraghelper.h>
+#include <inviwo/qt/editor/networkeditor.h>
+#include <inviwo/core/network/processornetwork.h>
+#include <inviwo/qt/editor/connectiongraphicsitem.h>
+
+#include <inviwo/core/ports/inport.h>
+#include <inviwo/core/ports/outport.h>
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <QGraphicsItem>
+#include <QGraphicsSceneMouseEvent>
+#include <warn/pop>
+
+namespace inviwo {
+
+ConnectionDragHelper::ConnectionDragHelper(NetworkEditor *editor)
+    : QObject(editor), editor_{editor} {}
+
+bool ConnectionDragHelper::eventFilter(QObject *, QEvent *event) {
+    if (connection_ && event->type() == QEvent::GraphicsSceneMouseMove) {
+        auto e = static_cast<QGraphicsSceneMouseEvent *>(event);
+        connection_->setEndPoint(e->scenePos());
+        connection_->reactToPortHover(editor_->getProcessorInportGraphicsItemAt(e->scenePos()));
+        e->accept();
+    } else if (connection_ && event->type() == QEvent::GraphicsSceneMouseRelease) {
+        auto e = static_cast<QGraphicsSceneMouseEvent *>(event);
+
+        auto startPort = connection_->getOutportGraphicsItem()->getPort();
+        reset();
+
+        auto endItem = editor_->getProcessorInportGraphicsItemAt(e->scenePos());
+        if (endItem && endItem->getPort()->canConnectTo(startPort)) {
+            Inport *endPort = endItem->getPort();
+
+            if (endPort->getNumberOfConnections() >= endPort->getMaxNumberOfConnections()) {
+                editor_->network_->removeConnection(endPort->getConnectedOutport(), endPort);
+            }
+            editor_->network_->addConnection(startPort, endPort);
+        }
+        e->accept();
+    }
+    return false;
+}
+
+void ConnectionDragHelper::start(ProcessorOutportGraphicsItem *outport, QPointF endPoint,
+                                 uvec3 color) {
+    reset();
+    connection_ = new ConnectionDragGraphicsItem(outport, endPoint, color);
+    editor_->addItem(connection_);
+    connection_->show();
+}
+
+void ConnectionDragHelper::reset() {
+    delete connection_;
+    connection_ = nullptr;
+}
+
+}  // namespace inviwo

--- a/src/qt/editor/connectiondraghelper.cpp
+++ b/src/qt/editor/connectiondraghelper.cpp
@@ -47,6 +47,8 @@ namespace inviwo {
 ConnectionDragHelper::ConnectionDragHelper(NetworkEditor &editor)
     : QObject(&editor), editor_{editor} {}
 
+ConnectionDragHelper::~ConnectionDragHelper() = default;
+
 bool ConnectionDragHelper::eventFilter(QObject *, QEvent *event) {
     if (connection_ && event->type() == QEvent::GraphicsSceneMouseMove) {
         auto e = static_cast<QGraphicsSceneMouseEvent *>(event);

--- a/src/qt/editor/connectiongraphicsitem.cpp
+++ b/src/qt/editor/connectiongraphicsitem.cpp
@@ -156,11 +156,6 @@ QColor CurveGraphicsItem::getColor() const {
     return color_;
 }
 
-
-
-//////////////////////////////////////////////////////////////////////////
-
-
 ConnectionDragGraphicsItem::ConnectionDragGraphicsItem(ProcessorOutportGraphicsItem* outport,
                                                        QPointF endPoint,
                                                        uvec3 color)

--- a/src/qt/editor/connectiongraphicsitem.cpp
+++ b/src/qt/editor/connectiongraphicsitem.cpp
@@ -221,6 +221,8 @@ Outport* ConnectionGraphicsItem::getOutport() const { return connection_.getOutp
 
 Inport* ConnectionGraphicsItem::getInport() const { return connection_.getInport(); }
 
+PortConnection ConnectionGraphicsItem::getPortConnection() const { return connection_; }
+
 QPointF ConnectionGraphicsItem::getEndPoint() const {   
     return inport_->mapToScene(inport_->rect().center());
 }

--- a/src/qt/editor/linkdraghelper.cpp
+++ b/src/qt/editor/linkdraghelper.cpp
@@ -45,6 +45,8 @@ namespace inviwo {
 
 LinkDragHelper::LinkDragHelper(NetworkEditor &editor) : QObject(&editor), editor_{editor} {}
 
+LinkDragHelper::~LinkDragHelper() = default;
+
 void LinkDragHelper::start(ProcessorLinkGraphicsItem *item, QPointF endPos) {
     link_ = std::make_unique<LinkConnectionDragGraphicsItem>(item, endPos);
     editor_.addItem(link_.get());

--- a/src/qt/editor/linkdraghelper.cpp
+++ b/src/qt/editor/linkdraghelper.cpp
@@ -1,0 +1,87 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2018 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/qt/editor/linkdraghelper.h>
+#include <inviwo/qt/editor/networkeditor.h>
+#include <inviwo/core/network/processornetwork.h>
+#include <inviwo/qt/editor/editorgrapicsitem.h>
+#include <inviwo/qt/editor/linkgraphicsitem.h>
+#include <inviwo/qt/editor/processorgraphicsitem.h>
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <QGraphicsItem>
+#include <QGraphicsSceneMouseEvent>
+#include <warn/pop>
+
+namespace inviwo {
+
+LinkDragHelper::LinkDragHelper(NetworkEditor *editor) : QObject(editor), editor_{editor} {}
+
+void LinkDragHelper::start(ProcessorLinkGraphicsItem *item, QPointF endPos) {
+    link_ = new LinkConnectionDragGraphicsItem(item, endPos);
+    editor_->addItem(link_);
+    link_->setZValue(DRAGING_ITEM_DEPTH);
+    link_->show();
+}
+
+void LinkDragHelper::reset() {
+    delete link_;
+    link_ = nullptr;
+}
+
+bool LinkDragHelper::eventFilter(QObject *, QEvent *event) {
+    if (link_ && event->type() == QEvent::GraphicsSceneMouseMove) {
+        auto e = static_cast<QGraphicsSceneMouseEvent *>(event);
+        link_->setEndPoint(e->scenePos());
+        link_->reactToProcessorHover(editor_->getProcessorGraphicsItemAt(e->scenePos()));
+        e->accept();
+    } else if (link_ && event->type() == QEvent::GraphicsSceneMouseRelease) {
+        auto e = static_cast<QGraphicsSceneMouseEvent *>(event);
+        // link drag mode
+        auto startProcessor =
+            link_->getSrcProcessorLinkGraphicsItem()->getProcessorGraphicsItem()->getProcessor();
+
+        reset();
+
+        if (auto endProcessorItem = editor_->getProcessorGraphicsItemAt(e->scenePos())) {
+            Processor *endProcessor = endProcessorItem->getProcessor();
+            if (startProcessor != endProcessor) {
+                editor_->showLinkDialog(startProcessor, endProcessor);
+            }
+        }
+        e->accept();
+    }
+    return false;
+}
+
+
+
+
+}  // namespace inviwo

--- a/src/qt/editor/linkdraghelper.cpp
+++ b/src/qt/editor/linkdraghelper.cpp
@@ -33,6 +33,7 @@
 #include <inviwo/qt/editor/editorgrapicsitem.h>
 #include <inviwo/qt/editor/linkgraphicsitem.h>
 #include <inviwo/qt/editor/processorgraphicsitem.h>
+#include <inviwo/qt/editor/processorlinkgraphicsitem.h>
 
 #include <warn/push>
 #include <warn/ignore/all>

--- a/src/qt/editor/linkgraphicsitem.cpp
+++ b/src/qt/editor/linkgraphicsitem.cpp
@@ -43,6 +43,8 @@
 #include <inviwo/core/common/inviwoapplication.h>
 #include <inviwo/core/network/processornetwork.h>
 
+#include <modules/qtwidgets/inviwoqtutils.h>
+
 namespace inviwo {
 
 LinkGraphicsItem::LinkGraphicsItem(ivec3 color) : color_(color.r, color.g, color.b) {

--- a/src/qt/editor/linkgraphicsitem.cpp
+++ b/src/qt/editor/linkgraphicsitem.cpp
@@ -114,9 +114,9 @@ QPointF LinkConnectionDragGraphicsItem::compare(const QPointF startLeft, const Q
                                                 const QPointF& endLeft, const QPointF& endRight,
                                                 const QPointF& left,const QPointF& center, const QPointF& right) {
 
-    if (endLeft.x() < startLeft.x()) {
+    if (startLeft.x() > endRight.x()) {
         return left;
-    } else if (startRight.x() > endRight.x()) {
+    } else if (startRight.x() < endLeft.x()) {
         return right;
     } else {
         return center;
@@ -131,7 +131,7 @@ QPointF LinkConnectionDragGraphicsItem::getStartPoint() const {
 QPointF LinkConnectionDragGraphicsItem::getEndPoint() const {
     const auto startLeft = outLink_->getLeftPos();
     const auto startRight = outLink_->getRightPos();
-    return compare(startLeft, startRight, inLeft_, inRight_, inRight_, inLeft_, inLeft_);
+    return compare(startLeft, startRight, inLeft_, inRight_, inRight_, inRight_, inLeft_);
 }
 
 QPointF LinkConnectionDragGraphicsItem::getStartDir() const {
@@ -144,7 +144,7 @@ QPointF LinkConnectionDragGraphicsItem::getEndDir() const {
     const auto qp = QPointF(1, 0);
     const auto startLeft = outLink_->getLeftPos();
     const auto startRight = outLink_->getRightPos();
-    return compare(startLeft, startRight, inLeft_, inRight_, qp, -qp, -qp);
+    return compare(startLeft, startRight, inLeft_, inRight_, qp, qp, -qp);
 }
 
 void LinkConnectionDragGraphicsItem::setEndPoint(QPointF endPoint) {
@@ -195,7 +195,7 @@ QPointF LinkConnectionGraphicsItem::getEndPoint() const {
     const auto startRight = outLink_->getRightPos();
     const auto endRight = inLink_->getRightPos();
     const auto endLeft = inLink_->getLeftPos();
-    return compare(startLeft, startRight, endLeft, endRight, endRight, endLeft, endLeft);
+    return compare(startLeft, startRight, endLeft, endRight, endRight, endRight, endLeft);
 }
 
 QPointF LinkConnectionGraphicsItem::getStartDir() const {
@@ -212,7 +212,7 @@ QPointF LinkConnectionGraphicsItem::getEndDir() const {
     const auto startRight = outLink_->getRightPos();
     const auto endRight = inLink_->getRightPos();
     const auto endLeft = inLink_->getLeftPos();
-    return compare(startLeft, startRight, endLeft, endRight, qp, -qp, -qp);
+    return compare(startLeft, startRight, endLeft, endRight, qp, qp, -qp);
 }
 
 ProcessorLinkGraphicsItem* LinkConnectionGraphicsItem::getDestProcessorLinkGraphicsItem() const {

--- a/src/qt/editor/networkeditor.cpp
+++ b/src/qt/editor/networkeditor.cpp
@@ -78,6 +78,10 @@
 
 #include <inviwo/core/rendering/datavisualizermanager.h>
 
+#include <inviwo/qt/editor/processordraghelper.h>
+#include <inviwo/qt/editor/connectiondraghelper.h>
+#include <inviwo/qt/editor/linkdraghelper.h>
+
 #include <warn/push>
 #include <warn/ignore/all>
 #include <QApplication>
@@ -99,12 +103,10 @@ const int NetworkEditor::gridSpacing_ = 25;
 
 NetworkEditor::NetworkEditor(InviwoMainWindow* mainwindow)
     : QGraphicsScene()
-    , oldConnectionTarget_(nullptr)
-    , oldProcessorTarget_(nullptr)
-    , validConnectionTarget_(false)
+    , processorDragHelper_{new ProcessorDragHelper(this)}
+    , linkDragHelper_{new LinkDragHelper(this)}
+    , connectionDragHelper_{new ConnectionDragHelper(this)}
     , processorItem_(nullptr)
-    , connectionCurve_(nullptr)
-    , linkCurve_(nullptr)
     , mainwindow_(mainwindow)
     , network_(mainwindow->getInviwoApplication()->getProcessorNetwork())
     , filename_("")
@@ -113,6 +115,10 @@ NetworkEditor::NetworkEditor(InviwoMainWindow* mainwindow)
     , adjustSceneToChange_(true) {
 
     network_->addObserver(this);
+
+    installEventFilter(processorDragHelper_);
+    installEventFilter(linkDragHelper_);
+    installEventFilter(connectionDragHelper_);
 
     // The default BSP tends to crash...
     setItemIndexMethod(QGraphicsScene::NoIndex);
@@ -180,7 +186,7 @@ void NetworkEditor::removeProcessorGraphicsItem(Processor* processor) {
     // obtain processor graphics item through processor
     auto processorGraphicsItem = getProcessorGraphicsItem(processor);
 
-    if (oldProcessorTarget_ == processorGraphicsItem) oldProcessorTarget_ = nullptr;
+    processorDragHelper_->clear(processorGraphicsItem);
 
     removeItem(processorGraphicsItem);
     processorGraphicsItems_.erase(processor);
@@ -235,10 +241,7 @@ void NetworkEditor::removeConnection(ConnectionGraphicsItem* connectionGraphicsI
 
 void NetworkEditor::removeConnectionGraphicsItem(const PortConnection& connection) {
     ConnectionGraphicsItem* connectionGraphicsItem = connectionGraphicsItems_[connection];
-    if (oldProcessorTarget_ && (oldConnectionTarget_ == connectionGraphicsItem)) {
-        oldConnectionTarget_->resetBorderColors();
-        oldConnectionTarget_ = nullptr;
-    }
+    processorDragHelper_->clear(connectionGraphicsItem);
     connectionGraphicsItems_.erase(connection);
     delete connectionGraphicsItem;
 }
@@ -372,19 +375,6 @@ void NetworkEditor::mousePressEvent(QGraphicsSceneMouseEvent* e) {
 }
 
 void NetworkEditor::mouseMoveEvent(QGraphicsSceneMouseEvent* e) {
-    if (connectionCurve_) {
-        // Connection drag mode
-        connectionCurve_->setEndPoint(e->scenePos());
-        connectionCurve_->reactToPortHover(getProcessorInportGraphicsItemAt(e->scenePos()));
-        e->accept();
-
-    } else if (linkCurve_) {
-        // Link drag mode
-        linkCurve_->setEndPoint(e->scenePos());
-        linkCurve_->reactToProcessorHover(getProcessorGraphicsItemAt(e->scenePos()));
-        e->accept();
-    }
-
     QGraphicsScene::mouseMoveEvent(e);
 }
 
@@ -394,42 +384,8 @@ void NetworkEditor::mouseReleaseEvent(QGraphicsSceneMouseEvent* e) {
         QPointF newpos = snapToGrid(pos);
         if (pos != newpos) elem.second->setPos(newpos);
     }
-
-    if (connectionCurve_) {
-        // connection drag mode
-        Outport* startPort = connectionCurve_->getOutportGraphicsItem()->getPort();
-
-        delete connectionCurve_;
-        connectionCurve_ = nullptr;
-
-        auto endItem = getProcessorInportGraphicsItemAt(e->scenePos());
-        if (endItem && endItem->getPort()->canConnectTo(startPort)) {
-            Inport* endPort = endItem->getPort();
-
-            if (endPort->getNumberOfConnections() >= endPort->getMaxNumberOfConnections()) {
-                network_->removeConnection(endPort->getConnectedOutport(), endPort);
-            }
-            network_->addConnection(startPort, endPort);
-        }
-        e->accept();
-
-    } else if (linkCurve_) {
-        // link drag mode
-        Processor* startProcessor = linkCurve_->getSrcProcessorLinkGraphicsItem()
-                                        ->getProcessorGraphicsItem()
-                                        ->getProcessor();
-
-        delete linkCurve_;
-        linkCurve_ = nullptr;
-
-        if (auto endProcessorItem = getProcessorGraphicsItemAt(e->scenePos())) {
-            Processor* endProcessor = endProcessorItem->getProcessor();
-            if (startProcessor != endProcessor) {
-                showLinkDialog(startProcessor, endProcessor);
-            }
-        }
-        e->accept();
-    } else if (processorItem_) {
+    
+    if (processorItem_) {
         processorItem_ = nullptr;
         updateSceneSize();
     }
@@ -838,125 +794,6 @@ void NetworkEditor::deleteItems(QList<QGraphicsItem*> items) {
     });
 }
 
-/////////////////////////////////////////
-//   PROCESSOR DRAG AND DROP METHODS   //
-/////////////////////////////////////////
-void NetworkEditor::dragEnterEvent(QGraphicsSceneDragDropEvent* e) {
-    if (auto mime = ProcessorMimeData::toProcessorMimeData(e->mimeData())) {
-        e->acceptProposedAction();
-        dragMoveEvent(e);
-    } else {
-        e->ignore();
-    }
-}
-
-void NetworkEditor::dragMoveEvent(QGraphicsSceneDragDropEvent* e) {
-    if (auto mime = ProcessorMimeData::toProcessorMimeData(e->mimeData())) {
-        e->accept();
-        auto connectionItem = getConnectionGraphicsItemAt(e->scenePos());
-
-        if (connectionItem && !oldConnectionTarget_) {  //< New connection found
-            QString className;
-            ProcessorDragObject::decode(e->mimeData(), className);
-
-            validConnectionTarget_ = false;
-            try {
-                auto processor = mime->processor();
-
-                bool inputmatch =
-                    util::any_of(processor->getInports(), [&connectionItem](Inport* inport) {
-                        return inport->canConnectTo(connectionItem->getOutport());
-                    });
-                bool outputmatch =
-                    util::any_of(processor->getOutports(), [&connectionItem](Outport* outport) {
-                        return connectionItem->getInport()->canConnectTo(outport);
-                    });
-
-                validConnectionTarget_ = (inputmatch && outputmatch);
-                connectionItem->setBorderColor(validConnectionTarget_ ? Qt::green : Qt::red);
-                // force update of connection item since color has changed
-                connectionItem->update();
-            } catch (Exception&) {
-                connectionItem->setBorderColor(Qt::red);
-                connectionItem->update();
-            }
-            oldConnectionTarget_ = connectionItem;
-
-        } else if (oldConnectionTarget_ && !connectionItem) {  //< Connection no longer targeted
-            oldConnectionTarget_->resetBorderColors();
-            oldConnectionTarget_ = nullptr;
-
-        } else if (!connectionItem) {  // processor replacement
-            auto processorItem = getProcessorGraphicsItemAt(e->scenePos());
-            if (processorItem && !oldProcessorTarget_) {  //< New processor found
-                processorItem->setHighlight(true);
-                processorItem->setSelected(true);
-                oldProcessorTarget_ = processorItem;
-            } else if (!processorItem && oldProcessorTarget_) {  // processor no longer targeted
-                oldProcessorTarget_->setHighlight(false);
-                oldProcessorTarget_->setSelected(false);
-                oldProcessorTarget_ = nullptr;
-            }
-        }
-    } else {
-        e->ignore();
-    }
-}
-
-void NetworkEditor::dropEvent(QGraphicsSceneDragDropEvent* e) {
-    if (auto mime = ProcessorMimeData::toProcessorMimeData(e->mimeData())) {
-        e->accept();
-        NetworkLock lock(network_);
-
-        try {
-            // activate default render context
-            RenderContext::getPtr()->activateDefaultRenderContext();
-
-            auto processor = mime->get();
-            if (!processor) {
-                LogError("Unable to get processor from drag object");
-                return;
-            }
-            clearSelection();
-
-            auto meta =
-                processor->getMetaData<ProcessorMetaData>(ProcessorMetaData::CLASS_IDENTIFIER);
-
-            if (oldProcessorTarget_) {
-                meta->setPosition(
-                    vec2(oldProcessorTarget_->scenePos().x(), oldProcessorTarget_->scenePos().y()));
-            } else {
-                QPointF spos = snapToGrid(e->scenePos());
-                meta->setPosition(vec2(spos.x(), spos.y()));
-            }
-
-            auto p = processor.get();
-            network_->addProcessor(processor.release());
-            util::autoLinkProcessor(network_, p);
-
-            if (oldConnectionTarget_) {
-                placeProcessorOnConnection(p, oldConnectionTarget_);
-            } else if (oldProcessorTarget_) {
-                placeProcessorOnProcessor(p, oldProcessorTarget_->getProcessor());
-            }
-        } catch (Exception& exception) {
-            if (oldConnectionTarget_) {
-                oldConnectionTarget_->resetBorderColors();
-            }
-            util::log(exception.getContext(),
-                      "Unable to create processor " + utilqt::fromQString(mime->text()) +
-                          " due to " + exception.getMessage(),
-                      LogLevel::Error);
-        }
-
-        // clear oldDragTarget
-        oldConnectionTarget_ = nullptr;
-        oldProcessorTarget_ = nullptr;
-    } else {
-        e->ignore();
-    }
-}
-
 void NetworkEditor::placeProcessorOnConnection(Processor* processor,
                                                ConnectionGraphicsItem* connectionItem) {
     Inport* connectionInport = connectionItem->getInport();
@@ -1244,28 +1081,23 @@ void NetworkEditor::drawForeground(QPainter* /*painter*/, const QRectF& /*rect*/
 }
 
 void NetworkEditor::initiateConnection(ProcessorOutportGraphicsItem* item) {
-    QPointF pos = item->mapToScene(item->rect().center());
-    connectionCurve_ = new ConnectionDragGraphicsItem(item, pos, item->getPort()->getColorCode());
-    addItem(connectionCurve_);
-    connectionCurve_->show();
+    const auto pos = item->mapToScene(item->rect().center());
+    const auto color = item->getPort()->getColorCode();
+    connectionDragHelper_->start(item, pos, color);
 }
 
 void NetworkEditor::releaseConnection(ProcessorInportGraphicsItem* item) {
     // remove the old connection and add a new connection curve to be connected.
-    ConnectionGraphicsItem* oldConnection = item->getConnections()[0];
-    connectionCurve_ = new ConnectionDragGraphicsItem(oldConnection->getOutportGraphicsItem(),
-                                                      oldConnection->getEndPoint(),
-                                                      oldConnection->getOutport()->getColorCode());
+    auto oldConnection = item->getConnections()[0];
+    auto port = oldConnection->getOutportGraphicsItem();
+    const auto pos = oldConnection->getEndPoint();
+    const auto color = oldConnection->getOutport()->getColorCode();
     removeConnection(oldConnection);
-    addItem(connectionCurve_);
-    connectionCurve_->show();
+    connectionDragHelper_->start(port, pos, color);
 }
 
 void NetworkEditor::initiateLink(ProcessorLinkGraphicsItem* item, QPointF pos) {
-    linkCurve_ = new LinkConnectionDragGraphicsItem(item, pos);
-    addItem(linkCurve_);
-    linkCurve_->setZValue(DRAGING_ITEM_DEPTH);
-    linkCurve_->show();
+    linkDragHelper_->start(item, pos);
 }
 
 void NetworkEditor::resetAllTimeMeasurements() {

--- a/src/qt/editor/processordraghelper.cpp
+++ b/src/qt/editor/processordraghelper.cpp
@@ -1,0 +1,365 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2018 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/qt/editor/processordraghelper.h>
+
+#include <inviwo/core/processors/processor.h>
+#include <inviwo/core/network/networkutils.h>
+#include <inviwo/core/util/zip.h>
+
+#include <inviwo/qt/editor/connectiongraphicsitem.h>
+#include <inviwo/qt/editor/networkeditor.h>
+#include <modules/qtwidgets/inviwoqtutils.h>
+#include <inviwo/qt/editor/processormimedata.h>
+#include <inviwo/core/network/autolinker.h>
+#include <inviwo/core/processors/processorutils.h>
+#include <inviwo/qt/editor/linkgraphicsitem.h>
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <QGraphicsItem>
+#include <QGraphicsSceneDragDropEvent>
+#include <QMimeData>
+#include <QGuiApplication>
+#include <QGraphicsView>
+#include <warn/pop>
+
+namespace inviwo {
+
+namespace {
+
+template <typename Iter, typename Pred>
+std::pair<Iter, Iter> filterAndSortOutports(Iter begin, Iter end, dvec2 pos, Pred pred) {
+
+    end = std::partition(begin, end, [&](Outport* p) {
+        return static_cast<double>(util::getPosition(p->getProcessor()).y) +
+                       ProcessorGraphicsItem::size_.height() <
+                   pos.y &&
+               pred(p);
+    });
+
+    std::sort(begin, end, [&](Outport* p1, Outport* p2) {
+        // weight horizontal distance 3 times over vertical distance
+        auto d1 =
+            glm::length2(dvec2(3.0, 1.0) * (pos - dvec2(util::getPosition(p1->getProcessor()))));
+        auto d2 =
+            glm::length2(dvec2(3.0, 1.0) * (pos - dvec2(util::getPosition(p2->getProcessor()))));
+        return d1 < d2;
+    });
+    return {begin, end};
+}
+
+}  // namespace
+
+ProcessorDragHelper::ProcessorDragHelper(NetworkEditor* editor)
+    : QObject(editor), editor_{editor} {}
+
+bool ProcessorDragHelper::eventFilter(QObject*, QEvent* event) {
+    if (event->type() == QEvent::GraphicsSceneDragEnter) {
+        auto e = static_cast<QGraphicsSceneDragDropEvent*>(event);
+        if (auto mime = ProcessorMimeData::toProcessorMimeData(e->mimeData())) {
+            return enter(e, mime);
+        }
+
+    } else if (event->type() == QEvent::GraphicsSceneDragMove) {
+        auto e = static_cast<QGraphicsSceneDragDropEvent*>(event);
+        if (auto mime = ProcessorMimeData::toProcessorMimeData(e->mimeData())) {
+            return move(e, mime);
+        }
+    } else if (event->type() == QEvent::GraphicsSceneDragLeave) {
+        auto e = static_cast<QGraphicsSceneDragDropEvent*>(event);
+        if (auto mime = ProcessorMimeData::toProcessorMimeData(e->mimeData())) {
+            return leave(e, mime);
+        }
+    } else if (event->type() == QEvent::GraphicsSceneDrop) {
+        auto e = static_cast<QGraphicsSceneDragDropEvent*>(event);
+        if (auto mime = ProcessorMimeData::toProcessorMimeData(e->mimeData())) {
+            return drop(e, mime);
+        }
+    }
+
+    return false;
+}
+
+bool ProcessorDragHelper::enter(QGraphicsSceneDragDropEvent* e, const ProcessorMimeData* mime) {
+    e->acceptProposedAction();
+
+    auto processor = mime->processor();
+    autoConnectCandidates_.clear();
+    for (auto& inport : processor->getInports()) {
+        std::vector<Outport*> candidates;
+        editor_->network_->forEachProcessor([&](Processor* sourceProcessor) {
+            for (auto outport : sourceProcessor->getOutports()) {
+                if (inport->canConnectTo(outport)) {
+                    candidates.push_back(outport);
+                }
+            }
+        });
+
+        autoConnectCandidates_.emplace_back(inport, std::move(candidates));
+    }
+
+    autoLinker_ = std::make_unique<AutoLinker>(editor_->network_, processor, nullptr);
+
+    move(e, mime);
+    return true;
+}
+bool ProcessorDragHelper::move(QGraphicsSceneDragDropEvent* e, const ProcessorMimeData* mime) {
+    e->accept();
+
+    auto processor = mime->processor();
+    auto meta = processor->getMetaData<ProcessorMetaData>(ProcessorMetaData::CLASS_IDENTIFIER);
+    meta->setPosition(utilqt::toGLM(e->scenePos()));
+
+    auto connectionItem = editor_->getConnectionGraphicsItemAt(e->scenePos());
+    if (connectionItem) {
+        if (!connectionTarget_) {
+            connectionItem->setBorderColor(canSplitConnection(processor, connectionItem) ? Qt::green
+                                                                                         : Qt::red);
+            // force update of connection item since color has changed
+            connectionItem->update();
+            connectionTarget_ = connectionItem;
+        }
+    } else {
+        resetConnection();
+    }
+
+    auto processorItem = editor_->getProcessorGraphicsItemAt(e->scenePos());
+    if (processorItem) {
+        if (!processorTarget_) {
+            processorItem->setHighlight(true);
+            processorItem->setSelected(true);
+            processorTarget_ = processorItem;
+        }
+    } else {
+        resetProcessor();
+    }
+
+    if (!processorItem && !connectionItem) {
+        updateAutoConnections(e->scenePos());
+    } else {
+        resetAutoConnections();
+    }
+
+    updateAutoLinks(e->scenePos());
+
+    return true;
+}
+
+void ProcessorDragHelper::updateAutoConnections(QPointF pos) {
+    bool enable = QGuiApplication::keyboardModifiers().testFlag(Qt::ShiftModifier);
+
+    if (!enable) {
+        resetAutoConnections();
+        return;
+    }
+
+    const auto zoom = 1.0 / editor_->views().front()->transform().m11();
+    decltype(autoConnections_) updatedConnections;
+    for (auto&& item : util::enumerate(autoConnectCandidates_)) {
+        const auto ind = item.first();
+        const auto inport = item.second().first;
+        auto& outportCandidates = item.second().second;
+
+        auto validOutports = filterAndSortOutports(
+            outportCandidates.begin(), outportCandidates.end(), utilqt::toGLM(pos),
+            [&](Outport* p) {
+                return std::none_of(
+                    updatedConnections.begin(), updatedConnections.end(), [&](auto& item) {
+                        if (!item.second) return false;
+                        return item.second->getOutportGraphicsItem()->getPort() == p;
+                    });
+            });
+
+        if (validOutports.first != validOutports.second) {
+            const auto endpos = pos + zoom * ProcessorGraphicsItem::portOffset(
+                                                  ProcessorGraphicsItem::PortType::In, ind);
+            auto oldit = autoConnections_.find(inport);
+            if (oldit == autoConnections_.end() ||
+                oldit->second->getOutportGraphicsItem()->getPort() != *validOutports.first) {
+                auto outport = *validOutports.first;
+
+                auto pgi = editor_->getProcessorGraphicsItem(outport->getProcessor());
+                auto ogi = pgi->getOutportGraphicsItem(outport);
+                auto connection = std::make_unique<ConnectionDragGraphicsItem>(
+                    ogi, endpos, outport->getColorCode());
+                editor_->addItem(connection.get());
+                connection->show();
+                updatedConnections[inport] = std::move(connection);
+            } else {
+                oldit->second->setEndPoint(endpos);
+                updatedConnections[inport] = std::move(oldit->second);
+            }
+        }
+    }
+    std::swap(autoConnections_, updatedConnections);
+}
+
+void ProcessorDragHelper::updateAutoLinks(QPointF pos) {
+    bool enable = !QGuiApplication::keyboardModifiers().testFlag(Qt::AltModifier);
+
+    if (!enable) {
+        resetAutoLinks();
+        return;
+    }
+    const auto zoom = 1.0 / editor_->views().front()->transform().m11();
+    decltype(autoLinks_) links;
+
+    autoLinker_->sortAutoLinkCandidates();
+    for (auto& item : autoLinker_->getAutoLinkCandidates()) {
+        const auto& sourceProperties = item.second;
+        if (!sourceProperties.empty()) {
+            auto sourceProperty = sourceProperties.front();
+            auto sourceProcessor = sourceProperty->getOwner()->getProcessor();
+
+            auto it = autoLinks_.find(sourceProcessor);
+            if (it != autoLinks_.end()) {
+                it->second->setEndPoint(pos + zoom * QPointF{-75.0, 0.0},
+                                        pos + zoom * QPointF{75.0, 0.0});
+                links[sourceProcessor] = std::move(it->second);
+            } else {
+                auto pgi = editor_->getProcessorGraphicsItem(sourceProcessor);
+                auto lgi = std::make_unique<LinkConnectionDragGraphicsItem>(
+                    pgi->getLinkGraphicsItem(), pos);
+                editor_->addItem(lgi.get());
+                lgi->show();
+                links[sourceProcessor] = std::move(lgi);
+            }
+        }
+    }
+    std::swap(links, autoLinks_);
+}
+
+bool ProcessorDragHelper::leave(QGraphicsSceneDragDropEvent* e, const ProcessorMimeData*) {
+    e->accept();
+
+    resetConnection();
+    resetProcessor();
+    resetAutoConnections();
+    resetAutoLinks();
+    return true;
+}
+bool ProcessorDragHelper::drop(QGraphicsSceneDragDropEvent* e, const ProcessorMimeData* mime) {
+    e->accept();
+
+    bool enableAutoLinks = !QGuiApplication::keyboardModifiers().testFlag(Qt::AltModifier);
+    bool enableAutoConnections = QGuiApplication::keyboardModifiers().testFlag(Qt::ShiftModifier);
+
+    auto network = editor_->network_;
+    NetworkLock lock(network);
+    try {
+        // activate default render context
+        RenderContext::getPtr()->activateDefaultRenderContext();
+
+        auto processor = mime->get();
+        if (!processor) {
+            LogError("Unable to get processor from drag object");
+            return true;
+        }
+        editor_->clearSelection();
+
+        auto meta = processor->getMetaData<ProcessorMetaData>(ProcessorMetaData::CLASS_IDENTIFIER);
+
+        if (processorTarget_) {
+            meta->setPosition(utilqt::toGLM(processorTarget_->scenePos()));
+        } else {
+            meta->setPosition(utilqt::toGLM(editor_->snapToGrid(e->scenePos())));
+        }
+
+        auto p = processor.get();
+        network->addProcessor(processor.release());
+
+        if (enableAutoLinks) {
+            autoLinker_->addLinksToClosestCandidates(true);
+        }
+
+        if (connectionTarget_) {
+            editor_->placeProcessorOnConnection(p, connectionTarget_);
+        } else if (processorTarget_) {
+            editor_->placeProcessorOnProcessor(p, processorTarget_->getProcessor());
+        } else if (enableAutoConnections) {
+            for (auto& item : autoConnections_) {
+                if (item.second) {
+                    item.second->hide();
+                    editor_->network_->addConnection(
+                        item.second->getOutportGraphicsItem()->getPort(), item.first);
+                }
+            }
+        }
+    } catch (Exception& exception) {
+        util::log(exception.getContext(),
+                  "Unable to create processor " + utilqt::fromQString(mime->text()) + " due to " +
+                      exception.getMessage(),
+                  LogLevel::Error);
+    }
+
+    resetConnection();
+    resetProcessor();
+    resetAutoConnections();
+    resetAutoLinks();
+    return true;
+}
+
+void ProcessorDragHelper::resetConnection() {
+    if (connectionTarget_) {
+        connectionTarget_->resetBorderColors();
+        connectionTarget_ = nullptr;
+    }
+}
+void ProcessorDragHelper::resetProcessor() {
+    if (processorTarget_) {
+        processorTarget_->setHighlight(false);
+        processorTarget_->setSelected(false);
+        processorTarget_ = nullptr;
+    }
+}
+
+void ProcessorDragHelper::resetAutoLinks() { autoLinks_.clear(); }
+
+void ProcessorDragHelper::resetAutoConnections() { autoConnections_.clear(); }
+
+void ProcessorDragHelper::clear(ConnectionGraphicsItem* connection) {
+    if (connectionTarget_ == connection) resetConnection();
+}
+void ProcessorDragHelper::clear(ProcessorGraphicsItem* processor) {
+    if (processorTarget_ == processor) resetProcessor();
+}
+
+bool ProcessorDragHelper::canSplitConnection(Processor* p, ConnectionGraphicsItem* connection) {
+    bool inputmatch = util::any_of(p->getInports(), [&connection](Inport* inport) {
+        return inport->canConnectTo(connection->getOutport());
+    });
+    bool outputmatch = util::any_of(p->getOutports(), [&connection](Outport* outport) {
+        return connection->getInport()->canConnectTo(outport);
+    });
+
+    return inputmatch && outputmatch;
+}
+
+}  // namespace inviwo

--- a/src/qt/editor/processordraghelper.cpp
+++ b/src/qt/editor/processordraghelper.cpp
@@ -39,9 +39,11 @@
 #include <modules/qtwidgets/inviwoqtutils.h>
 
 #include <inviwo/qt/editor/connectiongraphicsitem.h>
+#include <inviwo/qt/editor/processorgraphicsitem.h>
+#include <inviwo/qt/editor/linkgraphicsitem.h>
+
 #include <inviwo/qt/editor/networkeditor.h>
 #include <inviwo/qt/editor/processormimedata.h>
-#include <inviwo/qt/editor/linkgraphicsitem.h>
 
 #include <warn/push>
 #include <warn/ignore/all>

--- a/src/qt/editor/processordraghelper.cpp
+++ b/src/qt/editor/processordraghelper.cpp
@@ -35,11 +35,13 @@
 #include <inviwo/core/network/autolinker.h>
 #include <inviwo/core/util/zip.h>
 #include <inviwo/core/util/raiiutils.h>
+#include <inviwo/core/network/networklock.h>
 
 #include <modules/qtwidgets/inviwoqtutils.h>
 
 #include <inviwo/qt/editor/connectiongraphicsitem.h>
 #include <inviwo/qt/editor/processorgraphicsitem.h>
+#include <inviwo/qt/editor/processorportgraphicsitem.h>
 #include <inviwo/qt/editor/linkgraphicsitem.h>
 
 #include <inviwo/qt/editor/networkeditor.h>
@@ -82,6 +84,8 @@ std::pair<Iter, Iter> filterAndSortOutports(Iter begin, Iter end, dvec2 pos, Pre
 
 ProcessorDragHelper::ProcessorDragHelper(NetworkEditor& editor)
     : QObject(&editor), editor_{editor} {}
+
+ProcessorDragHelper::~ProcessorDragHelper() = default;
 
 bool ProcessorDragHelper::eventFilter(QObject*, QEvent* event) {
     if (event->type() == QEvent::GraphicsSceneDragEnter) {
@@ -284,9 +288,6 @@ bool ProcessorDragHelper::drop(QGraphicsSceneDragDropEvent* e, const ProcessorMi
     }};
 
     try {
-        // activate default render context
-        RenderContext::getPtr()->activateDefaultRenderContext();
-
         auto processor = mime->get();
         if (!processor) {
             LogError("Unable to get processor from drag object");

--- a/src/qt/editor/processorgraphicsitem.cpp
+++ b/src/qt/editor/processorgraphicsitem.cpp
@@ -183,15 +183,22 @@ void ProcessorGraphicsItem::positionLablels() {
     tagLabel_->setPos(QPointF(rect().left() + labelMargin + offset + 4, -3));
 }
 
-QPointF ProcessorGraphicsItem::portPosition(PortType type, size_t index) {
+QPointF ProcessorGraphicsItem::portOffset(PortType type, size_t index) {
     const QPointF offset = {12.5f, (type == PortType::In ? 1.0f : -1.0f) * 4.5f};
     const QPointF delta = {12.5f, 0.0f};
     const QPointF rowDelta = {0.0f, (type == PortType::In ? -1.0f : 1.0f) * 12.5f};
     const size_t portsPerRow = 10;
 
-    return (type == PortType::In ? rect().topLeft() : rect().bottomLeft()) + offset +
-           rowDelta * static_cast<qreal>(index / portsPerRow) +
+    auto poffset = QPointF{-ProcessorGraphicsItem::size_.width() / 2,
+                           (type == PortType::In ? -ProcessorGraphicsItem::size_.height() / 2
+                                                 : ProcessorGraphicsItem::size_.height() / 2)};
+
+    return poffset + offset + rowDelta * static_cast<qreal>(index / portsPerRow) +
            delta * static_cast<qreal>(index % portsPerRow);
+}
+
+QPointF ProcessorGraphicsItem::portPosition(PortType type, size_t index) {
+    return rect().center() + portOffset(type, index);
 }
 
 void ProcessorGraphicsItem::addInport(Inport* port) {
@@ -395,9 +402,7 @@ void ProcessorGraphicsItem::onLabelGraphicsItemChanged(LabelGraphicsItem* item) 
     }
 }
 
-void ProcessorGraphicsItem::onLabelGraphicsItemEdited(LabelGraphicsItem*) {
-    positionLablels();
-}
+void ProcessorGraphicsItem::onLabelGraphicsItemEdited(LabelGraphicsItem*) { positionLablels(); }
 
 std::string ProcessorGraphicsItem::getIdentifier() const { return processor_->getIdentifier(); }
 

--- a/src/qt/editor/processorlinkgraphicsitem.cpp
+++ b/src/qt/editor/processorlinkgraphicsitem.cpp
@@ -24,7 +24,7 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  *********************************************************************************/
 
 #include <inviwo/qt/editor/processorlinkgraphicsitem.h>
@@ -41,13 +41,11 @@
 namespace inviwo {
 
 ProcessorLinkGraphicsItem::ProcessorLinkGraphicsItem(ProcessorGraphicsItem* parent)
-    : QGraphicsItem(parent), processor_(parent), leftItem_(nullptr), rightItem_(nullptr) {
+    : QGraphicsItem(parent)
+    , processor_(parent)
+    , leftItem_(new LinkItem(this, QPointF(parent->rect().left() - 1.0, 0.0), -90.0f))
+    , rightItem_(new LinkItem(this, QPointF(parent->rect().right() + 1.0, 0.0), 90.0f)) {
     setFlags(ItemSendsScenePositionChanges);
-
-    leftItem_ =
-        new LinkItem(this, QPointF(parent->rect().right()+1.0, 0.0), 90.0f);
-    rightItem_ =
-        new LinkItem(this, QPointF(parent->rect().left()-1.0, 0.0), -90.0f);
 }
 
 QPointF ProcessorLinkGraphicsItem::getLeftPos() const {
@@ -78,7 +76,7 @@ void ProcessorLinkGraphicsItem::addLink(LinkConnectionGraphicsItem* link) {
 }
 
 void ProcessorLinkGraphicsItem::removeLink(LinkConnectionGraphicsItem* link) {
-    links_.erase(std::find(links_.begin(),links_.end(), link));
+    links_.erase(std::find(links_.begin(), links_.end(), link));
 }
 
 void ProcessorLinkGraphicsItem::updateLinkPositions() {
@@ -100,7 +98,7 @@ ProcessorLinkGraphicsItem::LinkItem::LinkItem(ProcessorLinkGraphicsItem* parent,
     setPos(pos);
 }
 
-ProcessorLinkGraphicsItem::LinkItem::~LinkItem() {}
+ProcessorLinkGraphicsItem::LinkItem::~LinkItem() = default;
 
 void ProcessorLinkGraphicsItem::LinkItem::mousePressEvent(QGraphicsSceneMouseEvent* e) {
     getNetworkEditor()->initiateLink(parent_, e->scenePos());
@@ -119,4 +117,4 @@ void ProcessorLinkGraphicsItem::LinkItem::paint(QPainter* p, const QStyleOptionG
     p->restore();
 }
 
-}  // namespace
+}  // namespace inviwo

--- a/src/qt/editor/processorlistwidget.cpp
+++ b/src/qt/editor/processorlistwidget.cpp
@@ -37,6 +37,7 @@
 #include <inviwo/core/common/inviwomodule.h>
 #include <inviwo/core/util/document.h>
 #include <inviwo/core/util/rendercontext.h>
+#include <inviwo/core/network/autolinker.h>
 #include <modules/qtwidgets/inviwoqtutils.h>
 #include <inviwo/core/metadata/processormetadata.h>
 #include <inviwo/qt/editor/processorpreview.h>
@@ -285,7 +286,7 @@ void ProcessorTreeWidget::addProcessor(QString className) {
         meta->setPosition(ivec2{bb.first.x, bb.second.y} + ivec2(0, 75));
 
         auto p = network->addProcessor(std::move(processor));
-        util::autoLinkProcessor(network, p);
+        AutoLinker::addLinks(network, p);
     }
 }
 
@@ -562,20 +563,6 @@ ProcessorDragObject::ProcessorDragObject(QWidget* source, std::unique_ptr<Proces
     setMimeData(mime);
     setHotSpot(QPoint(img.width() / 2, img.height() / 2));
     start(Qt::MoveAction);
-}
-
-bool ProcessorDragObject::canDecode(const QMimeData* mimeData) {
-    return mimeData->hasFormat(mimeType);
-}
-
-bool ProcessorDragObject::decode(const QMimeData* mimeData, QString& className) {
-    QByteArray byteData = mimeData->data(mimeType);
-
-    if (byteData.isEmpty()) return false;
-
-    QDataStream ds(&byteData, QIODevice::ReadOnly);
-    ds >> className;
-    return true;
 }
 
 bool ProcessorTreeItem::operator<(const QTreeWidgetItem& other) const {


### PR DESCRIPTION
Better handling of linking in port inspectors. Show autolinks when dragging in processors, disable auto links by pressing alt. Pressing shift while dragging when dragging in processors enables auto connection for inports.

