### PR TITLE
Testing: VS fix for failing core unit test on build

### DIFF
--- a/src/core/tests/unittests/network-evaluator-test.cpp
+++ b/src/core/tests/unittests/network-evaluator-test.cpp
@@ -245,12 +245,16 @@ TEST(NetworkEvaluator, Error) {
 
     {
         SCOPED_TRACE("Invalid output with throw");
+        unsigned int throwCount = 0;
+        evaluator.setExceptionHandler(
+            [&throwCount](Processor*, EvaluationType, ExceptionContext) { ++throwCount; });
+
         shouldThrow = true;
         a->invalidate(InvalidationLevel::InvalidOutput);
+        EXPECT_EQ(throwCount, 1);
         ai.checkAndReset(0, 1, 0);
         bi.checkAndReset(0, 1, 0);
     }
-
 }
 
 }  // namespace inviwo


### PR DESCRIPTION
* the default log message by the StandardEvaluationErrorHandler (caused by a non-caught exception) was interpreted by Visual Studio as a build error, thereby failing the unit test on build

![image](https://user-images.githubusercontent.com/9251300/48954372-7e92c880-ef49-11e8-9f7f-2a7e3ca99e2c.png)
