### PR TITLE
Core/Base: Fix for basis/world-matrix property ranges in the volumeinformation processor

### DIFF
--- a/include/inviwo/core/util/glm.h
+++ b/include/inviwo/core/util/glm.h
@@ -812,7 +812,7 @@ struct almostEqual<glm::mat<C, R, T, Q>> {
 
 }  // namespace detail
 
-template <typename M, typename T = M::value_type>
+template <typename M, typename T = typename M::value_type>
 M filledMat(T v) {
     return M{T(0)} + v;
 }

--- a/include/inviwo/core/util/glm.h
+++ b/include/inviwo/core/util/glm.h
@@ -812,6 +812,11 @@ struct almostEqual<glm::mat<C, R, T, Q>> {
 
 }  // namespace detail
 
+template <typename M, typename T = M::value_type>
+M filledMat(T v) {
+    return M{T(0)} + v;
+}
+
 template <typename T>
 T epsilon() {
     return detail::epsilon<T>::value();

--- a/modules/base/src/processors/volumeinformation.cpp
+++ b/modules/base/src/processors/volumeinformation.cpp
@@ -109,11 +109,13 @@ VolumeInformation::VolumeInformation()
                       DataFloat64::max(), 0.0, 0.0, InvalidationLevel::Valid,
                       PropertySemantics::Text)
     , worldTransform_("worldTransform_", "World Transform", mat4(1.0f),
-                      mat4(std::numeric_limits<float>::lowest()),
-                      mat4(std::numeric_limits<float>::max()), mat4(0.001f),
-                      InvalidationLevel::Valid)
-    , basis_("basis", "Basis", mat3(1.0f), mat3(std::numeric_limits<float>::lowest()),
-             mat3(std::numeric_limits<float>::max()), mat3(0.001f), InvalidationLevel::Valid)
+                      util::filledMat<mat3>(std::numeric_limits<float>::lowest()),
+                      util::filledMat<mat3>(std::numeric_limits<float>::max()),
+                      util::filledMat<mat3>(0.001f), InvalidationLevel::Valid)
+    , basis_("basis", "Basis", mat3(1.0f),
+             util::filledMat<mat3>(std::numeric_limits<float>::lowest()),
+             util::filledMat<mat3>(std::numeric_limits<float>::max()),
+             util::filledMat<mat3>(0.001f), InvalidationLevel::Valid)
     , offset_("offset", "Offset", vec3(0.0f), vec3(std::numeric_limits<float>::lowest()),
               vec3(std::numeric_limits<float>::max()), vec3(0.001f), InvalidationLevel::Valid,
               PropertySemantics::Text)


### PR DESCRIPTION
The min/max/inc values for the matrixPorperties in VolumeInformationProcessor was a diagonal matrix and hence could not display a rotation matrix (or any non-diagonal matrix) correctly. 