### PR TITLE
Regression: ImageCompare: Fix and speedup for creating maskImage

### DIFF
--- a/tools/ivwpy/regression/imagecompare.py
+++ b/tools/ivwpy/regression/imagecompare.py
@@ -76,7 +76,9 @@ class ImageCompare:
         elif channels == 4:
             (a,b,c,d) = self.diffImage.split()
             normImage = ImageMath.eval("convert((a+b+c+d), 'L')" , a=a, b=b, c=c, d=d)
-
+        
+        self.maskImage = normImage.point(lambda p: 0 if p > 0 else 255, 'L')
+        
         stats = ImageStat.Stat(normImage)
         self.maxDifference = stats.extrema[0][1] / (channels*255)
         self.difference = (sum(stats.sum)/(255*channels)) * 100.0 / numPixels
@@ -85,7 +87,6 @@ class ImageCompare:
             self.diffImage = self.diffImage.point(lambda i : i * (enhance))
         self.diffImage = ImageChops.invert(self.diffImage)
 
-        self.maskImage = self.diffImage.convert('1')
         self.numberOfDifferentPixels = int(numPixels - ImageStat.Stat(self.maskImage).sum[0] / 255)
 
     def saveDifferenceImage(self, difffile):


### PR DESCRIPTION
Have noticed for a while the the mask image in our regression tests looks wrong. Did some testing and it seems that PIL's convert('1') does not work as expected, it is also quite slow. 
Converting it to a single channel 8-bit image (mode = 'L') using the 'img.point' function does give the expected output. 
It is also about 30 times faster on my machine(0.08ms vs 2.3 ms for calling the function 1000 times). (Note: this is not the bottleneck in regression system so we won't notice the speedup) 

Here is an example of the incorrect mask image before the fix, comparing two images filled with a single color: 
![image](https://user-images.githubusercontent.com/534670/50957124-b89a3880-14bd-11e9-80e9-28722f94d4fc.png)
