### PR TITLE
Webbrowser: Enable loading files from other locations than where the html file is

### DIFF
--- a/modules/webbrowser/src/processors/webbrowserprocessor.cpp
+++ b/modules/webbrowser/src/processors/webbrowserprocessor.cpp
@@ -116,6 +116,9 @@ WebBrowserProcessor::WebBrowserProcessor()
     CefWindowInfo window_info;
 
     CefBrowserSettings browserSettings;
+    
+    // Enable loading files from other locations than where the .html file is
+    browserSettings.file_access_from_file_urls = STATE_ENABLED;
 
     browserSettings.windowless_frame_rate = 30;  // Must be between 1-60, 30 is default
 


### PR DESCRIPTION
Related to cross-origin-sharing
https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS