### PR TITLE
Eigen: Fix for port inspector not working

### DIFF
--- a/modules/eigenutils/src/eigenutilsmodule.cpp
+++ b/modules/eigenutils/src/eigenutilsmodule.cpp
@@ -59,8 +59,8 @@ EigenUtilsModule::EigenUtilsModule(InviwoApplication* app) : InviwoModule(app, "
 
     // Ports
     registerDefaultsForDataType<Eigen::MatrixXf>();
-
-    registerPortInspector("EigenMatrixXfOutport",
+    
+    registerPortInspector(PortTraits<DataOutport<Eigen::MatrixXf>>::classIdentifier(),
                           this->getPath(ModulePath::PortInspectors) + "/eigenmatrix.inv");
 
     // PropertyWidgets


### PR DESCRIPTION
The port inspector for ports with eigen matrices was broken due to registering the inspector for wrong identifier. 