### PR TITLE
Base: InputSelector: Fix for updatePorts being called multiple times while deserialzing

### DIFF
--- a/modules/base/include/modules/base/processors/inputselector.h
+++ b/modules/base/include/modules/base/processors/inputselector.h
@@ -118,7 +118,8 @@ void InputSelector<Inport, Outport>::updateOptions() {
 
     for (auto port : inport_.getConnectedOutports()) {
         auto id = port->getProcessor()->getIdentifier();
-        options.emplace_back(id, id, static_cast<int>(options.size()));
+        auto dispName = port->getProcessor()->getDisplayName();
+        options.emplace_back(id, dispName, static_cast<int>(options.size()));
     }
     selectedPort_.replaceOptions(options);
     selectedPort_.setCurrentStateAsDefault();

--- a/modules/base/include/modules/base/processors/inputselector.h
+++ b/modules/base/include/modules/base/processors/inputselector.h
@@ -114,28 +114,20 @@ InputSelector<Inport, Outport>::InputSelector()
 
 template <typename Inport, typename Outport>
 void InputSelector<Inport, Outport>::updateOptions() {
-    std::string selectedID;
-    if(selectedPort_.size() != 0){
-        selectedID = selectedPort_.getSelectedIdentifier();
-    }
-    selectedPort_.clearOptions();
-    
-    int idx = 0;
+    std::vector<OptionPropertyIntOption> options;
+
     for (auto port : inport_.getConnectedOutports()) {
         auto id = port->getProcessor()->getIdentifier();
-        selectedPort_.addOption(id, id, idx++);
+        options.emplace_back(id, id, static_cast<int>(options.size()));
     }
-    if (!selectedID.empty()) {
-        selectedPort_.setSelectedIdentifier(selectedID);
-    }
+    selectedPort_.replaceOptions(options);
     selectedPort_.setCurrentStateAsDefault();
-    invalidate(InvalidationLevel::InvalidResources);
     updatedNedded_ = false;
 }
 
 template <typename Inport, typename Outport>
 void InputSelector<Inport, Outport>::process() {
-    if(updatedNedded_) updateOptions();
+    if (updatedNedded_) updateOptions();
     outport_.setData(inport_.getVectorData().at(selectedPort_.get()));
 }
 


### PR DESCRIPTION
An inports onConnect function is called several times while deserializing a network. Once per connected outport, first time it is called it only has one connection, second time two connections and so on. This lead to losing which option was selected when serializing and always the first connected port would be used. 