### PR TITLE
Fix/numberedit

### DIFF
--- a/include/inviwo/core/properties/propertysemantics.h
+++ b/include/inviwo/core/properties/propertysemantics.h
@@ -54,6 +54,7 @@ public:
 
     static const PropertySemantics Default;
     static const PropertySemantics Text;
+    static const PropertySemantics SpinBox;
     static const PropertySemantics Color;
     static const PropertySemantics LightPosition;
     static const PropertySemantics TextEditor;

--- a/modules/qtwidgets/CMakeLists.txt
+++ b/modules/qtwidgets/CMakeLists.txt
@@ -47,6 +47,7 @@ set(HEADER_FILES
     include/modules/qtwidgets/inviwoqtutils.h
     include/modules/qtwidgets/keyboardutils.h
     include/modules/qtwidgets/labelgraphicsitem.h
+    include/modules/qtwidgets/numberlineedit.h
     include/modules/qtwidgets/ordinalbasewidget.h
     include/modules/qtwidgets/properties/anglepropertywidgetqt.h
     include/modules/qtwidgets/properties/boolcompositepropertywidgetqt.h
@@ -112,6 +113,7 @@ set(SOURCE_FILES
     src/labelgraphicsitem.cpp
     src/lightpositionwidgetqt.cpp
     src/lineeditqt.cpp
+    src/numberlineedit.cpp
     src/ordinalbasewidget.cpp
     src/ordinaleditorwidget.cpp
     src/processors/processordockwidgetqt.cpp

--- a/modules/qtwidgets/include/modules/qtwidgets/numberlineedit.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/numberlineedit.h
@@ -1,0 +1,92 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2019 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <modules/qtwidgets/qtwidgetsmoduledefine.h>
+#include <inviwo/core/common/inviwo.h>
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <QDoubleSpinBox>
+#include <warn/pop>
+
+namespace inviwo {
+
+class NumberLineEditPrivate;
+
+/**
+ * \brief widget for entering numbers with spinbox functionality. It uses less horizontal space than
+ * a QSpinBox and allows entering numbers in scientific notation.
+ *
+ * The widget supports the functionality of a regular QSpinBox, i.e. the value can also be adjusted
+ * using arrow keys and mouse wheel. If the widget cannot accomodate the current number
+ * representation of the value, the representation will be changed to scientific notation once the
+ * widget looses focus. While the widget is in focues the number is shown in regular notation,
+ * except for values less than 1e-6 which are depicted in scientific representation.
+ */
+class IVW_MODULE_QTWIDGETS_API NumberLineEdit : public QDoubleSpinBox {
+public:
+    explicit NumberLineEdit(QWidget *parent = nullptr);
+    NumberLineEdit(bool intMode, QWidget *parent = nullptr);
+
+    virtual ~NumberLineEdit() override;
+
+    virtual QSize sizeHint() const override;
+    virtual QSize minimumSizeHint() const override;
+
+    // consider the current size of the widget in order to determine the best suitable number
+    // representation, i.e. either regular floating point notation or scientific
+    virtual QString textFromValue(double value) const override;
+    virtual double valueFromText(const QString &str) const override;
+
+    void setDecimals(int decimals);
+    void setMinimum(double min);
+    void setMaximum(double max);
+    void setRange(double min, double max);
+
+protected:
+    virtual QValidator::State validate(QString &text, int &pos) const override;
+    virtual void focusInEvent(QFocusEvent *e) override;
+    virtual void focusOutEvent(QFocusEvent *e) override;
+    virtual void resizeEvent(QResizeEvent *e) override;
+    virtual void changeEvent(QEvent *e) override;
+
+private:
+    const bool integerMode_;
+    const int minimumWidth_ = 40;
+
+    QDoubleValidator *validator_;
+    mutable QSize cachedMinimumSizeHint_;
+    int visibleDecimals_ = 2;
+    bool abbreviated_ = true;
+
+    static std::unique_ptr<NumberLineEditPrivate> nlePrivate_;
+};
+
+}  // namespace inviwo

--- a/modules/qtwidgets/include/modules/qtwidgets/properties/doublevaluedragspinbox.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/properties/doublevaluedragspinbox.h
@@ -40,7 +40,7 @@
 
 namespace inviwo {
 
-class CustomDoubleSpinBoxQt;
+class NumberLineEdit;
 
 template <typename T>
 class ValueDragger;
@@ -93,7 +93,7 @@ public slots:
     void stepUp();
 
 private:
-    CustomDoubleSpinBoxQt *spinBox_;
+    NumberLineEdit *spinBox_;
     ValueDragger<double> *valueDragger_;
 };
 

--- a/modules/qtwidgets/include/modules/qtwidgets/properties/lightpropertywidgetqt.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/properties/lightpropertywidgetqt.h
@@ -32,14 +32,13 @@
 
 #include <modules/qtwidgets/qtwidgetsmoduledefine.h>
 #include <inviwo/core/properties/ordinalproperty.h>
-#include <modules/qtwidgets/customdoublespinboxqt.h>
 #include <modules/qtwidgets/editablelabelqt.h>
 #include <modules/qtwidgets/lightpositionwidgetqt.h>
 #include <modules/qtwidgets/properties/propertywidgetqt.h>
 
-class CustomDoubleSpinBoxQt;
-
 namespace inviwo {
+
+class NumberLineEdit;
 
 class IVW_MODULE_QTWIDGETS_API LightPropertyWidgetQt : public PropertyWidgetQt {
 public:
@@ -51,7 +50,7 @@ public:
 private:
     FloatVec3Property* property_;
     LightPositionWidgetQt* lightWidget_;
-    CustomDoubleSpinBoxQt* radiusSpinBox_;
+    NumberLineEdit* radiusSpinBox_;
     EditableLabelQt* label_;
 
     void onPositionLightWidgetChanged();

--- a/modules/qtwidgets/include/modules/qtwidgets/properties/ordinalminmaxpropertywidgetqt.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/properties/ordinalminmaxpropertywidgetqt.h
@@ -35,7 +35,7 @@
 #include <modules/qtwidgets/properties/propertywidgetqt.h>
 #include <modules/qtwidgets/properties/propertysettingswidgetqt.h>
 #include <inviwo/core/properties/minmaxproperty.h>
-#include <modules/qtwidgets/customdoublespinboxqt.h>
+#include <modules/qtwidgets/numberlineedit.h>
 #include <modules/qtwidgets/editablelabelqt.h>
 #include <modules/qtwidgets/rangesliderqt.h>
 #include <inviwo/core/properties/propertyowner.h>
@@ -100,8 +100,8 @@ private:
 
     TemplateMinMaxPropertySettingsWidgetQt<T>* settingsWidget_;
     RangeSliderQt* slider_;
-    CustomDoubleSpinBoxQt* spinBoxMin_;
-    CustomDoubleSpinBoxQt* spinBoxMax_;
+    NumberLineEdit* spinBoxMin_;
+    NumberLineEdit* spinBoxMax_;
     EditableLabelQt* label_;
     MinMaxProperty<T>* minMaxProperty_;
 };
@@ -117,8 +117,8 @@ OrdinalMinMaxPropertyWidgetQt<T>::OrdinalMinMaxPropertyWidgetQt(MinMaxProperty<T
     : PropertyWidgetQt(property)
     , settingsWidget_(nullptr)
     , slider_(new RangeSliderQt(Qt::Horizontal, this))
-    , spinBoxMin_(new CustomDoubleSpinBoxQt(this))
-    , spinBoxMax_(new CustomDoubleSpinBoxQt(this))
+    , spinBoxMin_(new NumberLineEdit(std::is_integral<T>::value, this))
+    , spinBoxMax_(new NumberLineEdit(std::is_integral<T>::value, this))
     , label_(new EditableLabelQt(this, property_))
     , minMaxProperty_(property) {
 
@@ -158,11 +158,11 @@ OrdinalMinMaxPropertyWidgetQt<T>::OrdinalMinMaxPropertyWidgetQt(MinMaxProperty<T
             &OrdinalMinMaxPropertyWidgetQt<T>::updateFromSlider);
     connect(
         spinBoxMin_,
-        static_cast<void (CustomDoubleSpinBoxQt::*)(double)>(&CustomDoubleSpinBoxQt::valueChanged),
+        static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
         this, &OrdinalMinMaxPropertyWidgetQt<T>::updateFromSpinBoxMin);
     connect(
         spinBoxMax_,
-        static_cast<void (CustomDoubleSpinBoxQt::*)(double)>(&CustomDoubleSpinBoxQt::valueChanged),
+        static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
         this, &OrdinalMinMaxPropertyWidgetQt<T>::updateFromSpinBoxMax);
 
     updateFromProperty();

--- a/modules/qtwidgets/include/modules/qtwidgets/properties/ordinalspinboxwidget.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/properties/ordinalspinboxwidget.h
@@ -55,7 +55,10 @@ class IVW_MODULE_QTWIDGETS_API BaseOrdinalSpinBoxWidget : public QWidget {
 #include <warn/pop>
 public:
     BaseOrdinalSpinBoxWidget();
-    virtual ~BaseOrdinalSpinBoxWidget();
+    virtual ~BaseOrdinalSpinBoxWidget();    
+
+    void setWrapping(bool wrap);
+    bool wrapping() const;
 
 protected:
     virtual double transformValueToEditor() = 0;

--- a/modules/qtwidgets/include/modules/qtwidgets/properties/valuedragger.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/properties/valuedragger.h
@@ -241,6 +241,15 @@ void ValueDragger<T>::timerEvent(QTimerEvent *e) {
 
     if (doStep) {
         currentValue_ += delta_ * timerInterval_ / 1000;
+        if (spinBox_->wrapping()) {
+            auto remainder = std::remainder(currentValue_ - spinBox_->minimum(),
+                                            spinBox_->maximum() - spinBox_->minimum());
+            if (remainder < 0.0) {
+                remainder += spinBox_->maximum() - spinBox_->minimum();
+            }
+            currentValue_ = remainder + spinBox_->minimum();
+        }
+
         currentValue_ = std::max<double>(std::min<double>(currentValue_, spinBox_->maximum()),
                                          spinBox_->minimum());
 

--- a/modules/qtwidgets/include/modules/qtwidgets/properties/valuedragger.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/properties/valuedragger.h
@@ -34,12 +34,11 @@
 #include <inviwo/core/common/inviwo.h>
 
 #include <modules/qtwidgets/properties/indicatorwidget.h>
-#include <modules/qtwidgets/customdoublespinboxqt.h>
+#include <modules/qtwidgets/numberlineedit.h>
 
 #include <warn/push>
 #include <warn/ignore/all>
 #include <QWidget>
-#include <QSpinBox>
 #include <QTimerEvent>
 #include <QPaintEvent>
 #include <QMouseEvent>
@@ -58,10 +57,7 @@ namespace inviwo {
 template <typename T>
 class ValueDragger : public QWidget {
 public:
-    using SpinBoxType = typename std::conditional<std::is_integral<T>::value, QSpinBox,
-                                                  CustomDoubleSpinBoxQt>::type;
-
-    explicit ValueDragger(SpinBoxType *spinBox, QWidget *parent = nullptr);
+    explicit ValueDragger(NumberLineEdit *spinBox, QWidget *parent = nullptr);
     virtual ~ValueDragger() override = default;
 
     virtual QSize sizeHint() const override;
@@ -91,7 +87,7 @@ private:
     double defaultIncrement_ = 0.01;
     double exponent_ = 1.2;
 
-    SpinBoxType *spinBox_;
+    NumberLineEdit *spinBox_;
     IndicatorWidget *indicator_;
     int spinDeltaTimerId_ = -1;
     QPoint clickPos_;
@@ -103,7 +99,7 @@ private:
 };
 
 template <typename T>
-ValueDragger<T>::ValueDragger(SpinBoxType *spinBox, QWidget *parent)
+ValueDragger<T>::ValueDragger(NumberLineEdit *spinBox, QWidget *parent)
     : QWidget(parent), spinBox_(spinBox), indicator_(new IndicatorWidget()) {
     indicator_->setVisible(false);
     setObjectName("valueDragger");
@@ -127,7 +123,7 @@ void ValueDragger<T>::setValue(T i) {
 
 template <typename T>
 T ValueDragger<T>::value() const {
-    return spinBox_->value();
+    return static_cast<T>(spinBox_->value());
 }
 
 template <typename T>

--- a/modules/qtwidgets/include/modules/qtwidgets/properties/valuedragspinbox.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/properties/valuedragspinbox.h
@@ -38,9 +38,9 @@
 #include <QWidget>
 #include <warn/pop>
 
-class QSpinBox;
-
 namespace inviwo {
+
+class NumberLineEdit;
 
 template <typename T>
 class ValueDragger;
@@ -93,7 +93,7 @@ public slots:
     void stepUp();
 
 private:
-    QSpinBox *spinBox_;
+    NumberLineEdit *spinBox_;
     ValueDragger<int> *valueDragger_;
 };
 

--- a/modules/qtwidgets/include/modules/qtwidgets/sliderwidgetqt.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/sliderwidgetqt.h
@@ -44,7 +44,7 @@ class QSlider;
 
 namespace inviwo {
 
-class CustomDoubleSpinBoxQt;
+class NumberLineEdit;
 
 class IVW_MODULE_QTWIDGETS_API BaseSliderWidgetQt : public QWidget {
 #include <warn/push>
@@ -52,7 +52,7 @@ class IVW_MODULE_QTWIDGETS_API BaseSliderWidgetQt : public QWidget {
     Q_OBJECT
 #include <warn/pop>
 public:
-    BaseSliderWidgetQt();
+    BaseSliderWidgetQt(bool intMode = false);
     virtual ~BaseSliderWidgetQt() = default;
 
 protected:
@@ -98,7 +98,7 @@ private:
 
     virtual bool eventFilter(QObject* watched, QEvent* event) override;
 
-    CustomDoubleSpinBoxQt* spinBox_;
+    NumberLineEdit* spinBox_;
     QSlider* slider_;
     double spinnerValue_;
     int sliderValue_;
@@ -108,7 +108,11 @@ template <typename T>
 class TemplateSliderWidget : public BaseSliderWidgetQt, public OrdinalBaseWidget<T> {
 public:
     TemplateSliderWidget()
-        : BaseSliderWidgetQt(), value_(0), minValue_(0), maxValue_(0), increment_(0) {}
+        : BaseSliderWidgetQt(std::is_integral<T>::value)
+        , value_(0)
+        , minValue_(0)
+        , maxValue_(0)
+        , increment_(0) {}
     virtual ~TemplateSliderWidget() = default;
 
     virtual T getValue() override;

--- a/modules/qtwidgets/include/modules/qtwidgets/sliderwidgetqt.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/sliderwidgetqt.h
@@ -55,6 +55,9 @@ public:
     BaseSliderWidgetQt(bool intMode = false);
     virtual ~BaseSliderWidgetQt() = default;
 
+    void setWrapping(bool wrap);
+    bool wrapping() const;
+
 protected:
     virtual double transformValueToSpinner() = 0;
     virtual int transformValueToSlider() = 0;

--- a/modules/qtwidgets/src/numberlineedit.cpp
+++ b/modules/qtwidgets/src/numberlineedit.cpp
@@ -37,13 +37,14 @@
 #include <QDoubleValidator>
 #include <QEvent>
 #include <QLocale>
+#include <QStyleOptionSpinBox>
+#include <QStyle>
+#include <QApplication>
 #include <warn/pop>
 
 #include <numeric>
 #include <unordered_map>
 #include <array>
-
-#pragma optimize("", off)
 
 namespace inviwo {
 
@@ -247,12 +248,7 @@ void NumberLineEdit::setRange(double min, double max) {
 
 void NumberLineEdit::focusInEvent(QFocusEvent *e) {
     abbreviated_ = false;
-    // FIXME: find a better way to update the contents
-    // setSpecialValueText will trigger an internal update of the spin box without any side effects
-    //setSpecialValueText(specialValueText());
-
     lineEdit()->setText(textFromValue(value()));
-
     QDoubleSpinBox::focusInEvent(e);
 }
 

--- a/modules/qtwidgets/src/numberlineedit.cpp
+++ b/modules/qtwidgets/src/numberlineedit.cpp
@@ -1,0 +1,279 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2019 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <modules/qtwidgets/numberlineedit.h>
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <QFont>
+#include <QFontMetrics>
+#include <QLineEdit>
+#include <QDoubleValidator>
+#include <QEvent>
+#include <QLocale>
+#include <warn/pop>
+
+#include <numeric>
+#include <unordered_map>
+#include <array>
+
+#pragma optimize("", off)
+
+namespace inviwo {
+
+class NumberLineEditPrivate {
+public:
+    NumberLineEditPrivate();
+
+    void clear();
+
+    int getPrecision(int availableWidth, uint fontHash, const QFontMetrics &fm);
+
+    QString formatAsScientific(double value, int availableWidth, uint fontHash,
+                               const QFontMetrics &fm);
+    QString formatAsScientific(double value, int precision);
+    QString formatAsNonscientific(double v) const;
+    QString formatAsInt(double value) const;
+
+    void updateLocale();
+
+    QLocale getLocale() const;
+
+private:
+    QLocale locale_;
+    // hash map with qHash(QFont) as a key and the value mapping the available width of a QLineEdit
+    // to the number of digits fitting inside the widget
+    std::unordered_map<unsigned int, std::array<int, 513>> widthToDigits_;
+};
+
+NumberLineEditPrivate::NumberLineEditPrivate() { updateLocale(); }
+
+void NumberLineEditPrivate::clear() { widthToDigits_.clear(); }
+
+int NumberLineEditPrivate::getPrecision(int availableWidth, uint fontHash, const QFontMetrics &fm) {
+    availableWidth = std::min(std::max(availableWidth, 0), 512);
+    auto it = widthToDigits_.find(fontHash);
+    if (it == widthToDigits_.end()) {
+        it = widthToDigits_
+                 .insert({fontHash,
+                          []() {
+                              std::array<int, 513> ret;
+                              ret.fill(-1);
+                              return ret;
+                          }()})
+                 .first;
+    } else {
+        const int digits = it->second[availableWidth];
+        if (digits > -1) {
+            return digits;
+        }
+    }
+    const double refValue = -8.88888888888888888888;
+
+    int precision = 16;
+    QString str = locale_.toString(refValue, 'g', precision);
+    while ((precision > 0) && (fm.horizontalAdvance(str) > availableWidth)) {
+        str = locale_.toString(refValue, 'g', --precision);
+    }
+    it->second[availableWidth] = precision;
+    return precision;
+}
+
+QString NumberLineEditPrivate::formatAsScientific(double value, int availableWidth, uint fontHash,
+                                                  const QFontMetrics &fm) {
+    return formatAsScientific(value, getPrecision(availableWidth, fontHash, fm));
+}
+
+QString NumberLineEditPrivate::formatAsScientific(double value, int precision) {
+    return locale_.toString(value, 'g', precision);
+}
+
+QString NumberLineEditPrivate::formatAsNonscientific(double value) const {
+    // default representation has 8 decimals after the decimal point, e.g. a value of
+    // 0.123456789 yields "0.12345679". Each order of magnitude reduces the number of decimals by
+    // one, i.e. 100.12345678 will be represented as "100.123457". Numbers smaller than 1e-6 are
+    // shown in scientific representation.
+    const int visibleDigits = 8;
+    const double scientificRepThreshold = 1e-6;
+
+    if (std::abs(value) < scientificRepThreshold) {
+        return locale_.toString(value, 'g', visibleDigits + 1);
+    } else {
+        const int int_digits =
+            static_cast<int>(std::floor(std::log10(std::max(std::abs(value), 1.0)))) + 1;
+        QString str = locale_.toString(value, 'f', std::max(visibleDigits + 1 - int_digits, 1));
+        if (str.contains(locale_.decimalPoint())) {
+            // remove trailing zeros
+            while (*str.rbegin() == '0') {
+                str.chop(1);
+            }
+            if (*str.rbegin() == locale_.decimalPoint()) {
+                str.chop(1);
+            }
+        }
+        return str;
+    }
+}
+
+QString NumberLineEditPrivate::formatAsInt(double value) const {
+    return locale_.toString(static_cast<long long int>(value));
+}
+
+void NumberLineEditPrivate::updateLocale() {
+    locale_ = QLocale::system();
+    locale_.setNumberOptions(locale_.numberOptions().setFlag(QLocale::OmitGroupSeparator, true));
+}
+
+QLocale NumberLineEditPrivate::getLocale() const { return locale_; }
+
+std::unique_ptr<NumberLineEditPrivate> NumberLineEdit::nlePrivate_(new NumberLineEditPrivate);
+
+NumberLineEdit::NumberLineEdit(QWidget *parent) : NumberLineEdit(false, parent) {}
+
+NumberLineEdit::NumberLineEdit(bool intMode, QWidget *parent)
+    : QDoubleSpinBox(parent), integerMode_(intMode) {
+    validator_ = new QDoubleValidator(this);
+    validator_->setNotation(QDoubleValidator::ScientificNotation);
+    lineEdit()->setValidator(validator_);
+}
+
+NumberLineEdit::~NumberLineEdit() = default;
+
+QSize NumberLineEdit::sizeHint() const {
+    QSize hint = QDoubleSpinBox::sizeHint();
+    hint.setWidth(hint.height());
+    return hint;
+}
+
+QSize NumberLineEdit::minimumSizeHint() const {
+    if (cachedMinimumSizeHint_.isEmpty()) {
+        ensurePolished();
+        QSize hint(minimumWidth_, lineEdit()->minimumSizeHint().height());
+        QStyleOptionSpinBox opt;
+        initStyleOption(&opt);
+
+        QSize sizeContents = style()->sizeFromContents(QStyle::CT_SpinBox, &opt, hint, this);
+        // For some odd reason, sizeFromContents always includes the spinbox buttons
+        if (opt.buttonSymbols == QAbstractSpinBox::NoButtons) {
+            sizeContents.setWidth(sizeContents.width() -
+                                  static_cast<int>(sizeContents.height() / 1.2));
+        }
+        cachedMinimumSizeHint_ = sizeContents.expandedTo(QApplication::globalStrut());
+    }
+    return cachedMinimumSizeHint_;
+}
+
+QString NumberLineEdit::textFromValue(double value) const {
+    auto formatNumber = [&](double v) {
+        if (integerMode_) {
+            return nlePrivate_->formatAsInt(v);
+        } else {
+            return nlePrivate_->formatAsNonscientific(v);
+        }
+    };
+
+    if (abbreviated_) {
+        ensurePolished();
+        const int availableWidth = lineEdit()->geometry().width() - 4;
+        QFontMetrics fm = lineEdit()->fontMetrics();
+
+        auto str = formatNumber(value);
+        if (fm.horizontalAdvance(str) < availableWidth) {
+            return str;
+        }
+
+        str = nlePrivate_->formatAsScientific(value, availableWidth, qHash(lineEdit()->font()), fm);
+        if (fm.horizontalAdvance(str) > availableWidth) {
+            str = nlePrivate_->formatAsScientific(value, 1);
+        }
+        return str;
+    }
+    return formatNumber(value);
+}
+
+double NumberLineEdit::valueFromText(const QString &str) const {
+    bool ok = false;
+    double value = nlePrivate_->getLocale().toDouble(str, &ok);
+    return ok ? value : QDoubleSpinBox::value();
+}
+
+QValidator::State NumberLineEdit::validate(QString &text, int &pos) const {
+    return validator_->validate(text, pos);
+}
+
+void NumberLineEdit::setDecimals(int decimals) { visibleDecimals_ = decimals; }
+
+void NumberLineEdit::setMinimum(double min) {
+    validator_->setBottom(min);
+    QDoubleSpinBox::setMinimum(min);
+}
+
+void NumberLineEdit::setMaximum(double max) {
+    validator_->setTop(max);
+    QDoubleSpinBox::setMaximum(max);
+}
+
+void NumberLineEdit::setRange(double min, double max) {
+    validator_->setBottom(min);
+    validator_->setTop(max);
+    QDoubleSpinBox::setRange(min, max);
+}
+
+void NumberLineEdit::focusInEvent(QFocusEvent *e) {
+    abbreviated_ = false;
+    // FIXME: find a better way to update the contents
+    // setSpecialValueText will trigger an internal update of the spin box without any side effects
+    //setSpecialValueText(specialValueText());
+
+    lineEdit()->setText(textFromValue(value()));
+
+    QDoubleSpinBox::focusInEvent(e);
+}
+
+void NumberLineEdit::focusOutEvent(QFocusEvent *e) {
+    abbreviated_ = true;
+    QDoubleSpinBox::focusOutEvent(e);
+}
+
+void NumberLineEdit::resizeEvent(QResizeEvent *e) {
+    QDoubleSpinBox::resizeEvent(e);
+    setSpecialValueText(specialValueText());
+}
+
+void NumberLineEdit::changeEvent(QEvent *e) {
+    if (e->type() == QEvent::LocaleChange) {
+        nlePrivate_->updateLocale();
+    } else if (e->type() == QEvent::StyleChange) {
+        cachedMinimumSizeHint_ = QSize();
+        updateGeometry();
+    }
+    QDoubleSpinBox::changeEvent(e);
+}
+
+}  // namespace inviwo

--- a/modules/qtwidgets/src/properties/doublevaluedragspinbox.cpp
+++ b/modules/qtwidgets/src/properties/doublevaluedragspinbox.cpp
@@ -29,7 +29,7 @@
 
 #include <modules/qtwidgets/properties/doublevaluedragspinbox.h>
 #include <modules/qtwidgets/properties/valuedragger.h>
-#include <modules/qtwidgets/customdoublespinboxqt.h>
+#include <modules/qtwidgets/numberlineedit.h>
 
 #include <warn/push>
 #include <warn/ignore/all>
@@ -40,9 +40,11 @@ namespace inviwo {
 
 DoubleValueDragSpinBox::DoubleValueDragSpinBox(QWidget *parent)
     : QWidget(parent)
-    , spinBox_(new CustomDoubleSpinBoxQt())
+    , spinBox_(new NumberLineEdit())
     , valueDragger_(new ValueDragger<double>(spinBox_)) {
     setObjectName("valueDragSpinBox");
+    spinBox_->setButtonSymbols(QAbstractSpinBox::NoButtons);
+
     auto layout = new QHBoxLayout();
     layout->setSpacing(2);
     layout->setMargin(0);
@@ -55,7 +57,6 @@ DoubleValueDragSpinBox::DoubleValueDragSpinBox(QWidget *parent)
     spinBox_->setFocusPolicy(Qt::WheelFocus);
     setFocusProxy(spinBox_);
     setFocusPolicy(spinBox_->focusPolicy());
-    spinBox_->setButtonSymbols(QAbstractSpinBox::NoButtons);
 
     connect(spinBox_, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
             this,

--- a/modules/qtwidgets/src/properties/lightpropertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/lightpropertywidgetqt.cpp
@@ -29,6 +29,7 @@
 
 #include <modules/qtwidgets/properties/lightpropertywidgetqt.h>
 #include <modules/qtwidgets/properties/compositepropertywidgetqt.h>
+#include <modules/qtwidgets/numberlineedit.h>
 
 #include <warn/push>
 #include <warn/ignore/all>
@@ -44,7 +45,7 @@ LightPropertyWidgetQt::LightPropertyWidgetQt(FloatVec3Property* property)
     : PropertyWidgetQt(property)
     , property_(property)
     , lightWidget_{new LightPositionWidgetQt()}
-    , radiusSpinBox_{new CustomDoubleSpinBoxQt(this)}
+    , radiusSpinBox_{new NumberLineEdit(this)}
     , label_{new EditableLabelQt(this, property_)} {
 
     setFocusPolicy(radiusSpinBox_->focusPolicy());
@@ -62,7 +63,7 @@ LightPropertyWidgetQt::LightPropertyWidgetQt(FloatVec3Property* property)
     radiusSpinBox_->setKeyboardTracking(false);
     connect(
         radiusSpinBox_,
-        static_cast<void (CustomDoubleSpinBoxQt::*)(double)>(&CustomDoubleSpinBoxQt::valueChanged),
+        static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
         this, &LightPropertyWidgetQt::onRadiusSpinBoxChanged);
 
     // Assuming that minimum value is negative and maximum value is positive

--- a/modules/qtwidgets/src/properties/ordinalspinboxwidget.cpp
+++ b/modules/qtwidgets/src/properties/ordinalspinboxwidget.cpp
@@ -62,6 +62,10 @@ BaseOrdinalSpinBoxWidget::BaseOrdinalSpinBoxWidget() : editor_{new DoubleValueDr
 
 BaseOrdinalSpinBoxWidget::~BaseOrdinalSpinBoxWidget() = default;
 
+void BaseOrdinalSpinBoxWidget::setWrapping(bool wrap) { editor_->setWrapping(wrap); }
+
+bool BaseOrdinalSpinBoxWidget::wrapping() const { return editor_->wrapping(); }
+
 void BaseOrdinalSpinBoxWidget::updateEditor() {
     QSignalBlocker block{editor_};
     editor_->setRange(minimumValue(), maximumValue());

--- a/modules/qtwidgets/src/properties/valuedragspinbox.cpp
+++ b/modules/qtwidgets/src/properties/valuedragspinbox.cpp
@@ -29,18 +29,22 @@
 
 #include <modules/qtwidgets/properties/valuedragspinbox.h>
 #include <modules/qtwidgets/properties/valuedragger.h>
+#include <modules/qtwidgets/numberlineedit.h>
 
 #include <warn/push>
 #include <warn/ignore/all>
-#include <QSpinBox>
 #include <QHBoxLayout>
 #include <warn/pop>
 
 namespace inviwo {
 
 ValueDragSpinBox::ValueDragSpinBox(QWidget *parent)
-    : QWidget(parent), spinBox_(new QSpinBox()), valueDragger_(new ValueDragger<int>(spinBox_)) {
+    : QWidget(parent)
+    , spinBox_(new NumberLineEdit())
+    , valueDragger_(new ValueDragger<int>(spinBox_)) {
     setObjectName("valueDragSpinBox");
+    spinBox_->setButtonSymbols(QAbstractSpinBox::NoButtons);
+
     auto layout = new QHBoxLayout();
     layout->setSpacing(0);
     layout->setMargin(0);
@@ -52,12 +56,12 @@ ValueDragSpinBox::ValueDragSpinBox(QWidget *parent)
     setFocusProxy(spinBox_);
     spinBox_->setFocusPolicy(Qt::WheelFocus);
     valueDragger_->setFocusPolicy(Qt::ClickFocus);
-    spinBox_->setButtonSymbols(QAbstractSpinBox::NoButtons);
 
-    connect(spinBox_, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
-            static_cast<void (ValueDragSpinBox::*)(int)>(&ValueDragSpinBox::valueChanged));
+    connect(spinBox_, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
+            this, [&](double value) { emit valueChanged(static_cast<int>(value)); });
     connect(
-        spinBox_, static_cast<void (QSpinBox::*)(const QString &)>(&QSpinBox::valueChanged), this,
+        spinBox_,
+        static_cast<void (QDoubleSpinBox::*)(const QString &)>(&QDoubleSpinBox::valueChanged), this,
         static_cast<void (ValueDragSpinBox::*)(const QString &)>(&ValueDragSpinBox::valueChanged));
     connect(spinBox_, &QSpinBox::editingFinished, this, &ValueDragSpinBox::editingFinished);
 }
@@ -80,15 +84,11 @@ QString ValueDragSpinBox::text() const { return spinBox_->text(); }
 
 QString ValueDragSpinBox::cleanText() const { return spinBox_->cleanText(); }
 
-int ValueDragSpinBox::displayIntegerBase() const { return spinBox_->displayIntegerBase(); }
-
 int ValueDragSpinBox::maximum() const { return spinBox_->maximum(); }
 
 int ValueDragSpinBox::minimum() const { return spinBox_->minimum(); }
 
 QString ValueDragSpinBox::prefix() const { return spinBox_->prefix(); }
-
-void ValueDragSpinBox::setDisplayIntegerBase(int base) { spinBox_->setDisplayIntegerBase(base); }
 
 void ValueDragSpinBox::setMaximum(int max) { spinBox_->setMaximum(max); }
 

--- a/modules/qtwidgets/src/qtwidgetsmodule.cpp
+++ b/modules/qtwidgets/src/qtwidgetsmodule.cpp
@@ -204,6 +204,8 @@ QtWidgetsModule::QtWidgetsModule(InviwoApplication* app)
 
     registerPropertyWidget<FloatVec3PropertyWidgetQt, FloatVec3Property>("Spherical");
     registerPropertyWidget<DoubleVec3PropertyWidgetQt, DoubleVec3Property>("Spherical");
+    registerPropertyWidget<FloatVec3PropertyWidgetQt, FloatVec3Property>("SphericalSpinBox");
+    registerPropertyWidget<DoubleVec3PropertyWidgetQt, DoubleVec3Property>("SphericalSpinBox");
 
     registerPropertyWidget<LightPropertyWidgetQt, FloatVec3Property>("LightPosition");
 

--- a/modules/qtwidgets/src/sliderwidgetqt.cpp
+++ b/modules/qtwidgets/src/sliderwidgetqt.cpp
@@ -28,7 +28,7 @@
  *********************************************************************************/
 
 #include <modules/qtwidgets/sliderwidgetqt.h>
-#include <modules/qtwidgets/customdoublespinboxqt.h>
+#include <modules/qtwidgets/NumberLineEdit.h>
 
 #include <limits>
 #include <cmath>
@@ -44,9 +44,9 @@
 
 namespace inviwo {
 
-BaseSliderWidgetQt::BaseSliderWidgetQt()
+BaseSliderWidgetQt::BaseSliderWidgetQt(bool intMode)
     : QWidget()
-    , spinBox_(new CustomDoubleSpinBoxQt())
+    , spinBox_(new NumberLineEdit(intMode))
     , slider_(new QSlider())
     , spinnerValue_(0.0)
     , sliderValue_(0) {
@@ -69,12 +69,13 @@ BaseSliderWidgetQt::BaseSliderWidgetQt()
     hLayout->addWidget(spinBox_);
     hLayout->setContentsMargins(0, 0, 0, 0);
     hLayout->setSpacing(5);
+    hLayout->setStretch(0, 3);
+    hLayout->setStretch(1, 1);
+
     setLayout(hLayout);
     connect(slider_, &QSlider::valueChanged, this, &BaseSliderWidgetQt::updateFromSlider);
-    connect(
-        spinBox_,
-        static_cast<void (CustomDoubleSpinBoxQt::*)(double)>(&CustomDoubleSpinBoxQt::valueChanged),
-        this, &BaseSliderWidgetQt::updateFromSpinBox);
+    connect(spinBox_, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
+            this, &BaseSliderWidgetQt::updateFromSpinBox);
 
     QSizePolicy sp = sizePolicy();
     sp.setVerticalPolicy(QSizePolicy::Fixed);

--- a/modules/qtwidgets/src/sliderwidgetqt.cpp
+++ b/modules/qtwidgets/src/sliderwidgetqt.cpp
@@ -82,6 +82,10 @@ BaseSliderWidgetQt::BaseSliderWidgetQt(bool intMode)
     setSizePolicy(sp);
 }
 
+void BaseSliderWidgetQt::setWrapping(bool wrap) { spinBox_->setWrapping(wrap); }
+
+bool BaseSliderWidgetQt::wrapping() const { return spinBox_->wrapping(); }
+
 void BaseSliderWidgetQt::applyInit() {
     updateSlider();
     updateSpinBox();

--- a/modules/qtwidgets/src/sliderwidgetqt.cpp
+++ b/modules/qtwidgets/src/sliderwidgetqt.cpp
@@ -28,7 +28,7 @@
  *********************************************************************************/
 
 #include <modules/qtwidgets/sliderwidgetqt.h>
-#include <modules/qtwidgets/NumberLineEdit.h>
+#include <modules/qtwidgets/numberlineedit.h>
 
 #include <limits>
 #include <cmath>

--- a/src/core/properties/propertysemantics.cpp
+++ b/src/core/properties/propertysemantics.cpp
@@ -47,6 +47,7 @@ void PropertySemantics::deserialize(Deserializer& d) {
 
 const PropertySemantics PropertySemantics::Default("Default");
 const PropertySemantics PropertySemantics::Text("Text");
+const PropertySemantics PropertySemantics::SpinBox("SpinBox");
 const PropertySemantics PropertySemantics::Color("Color");
 const PropertySemantics PropertySemantics::LightPosition("LightPosition");
 const PropertySemantics PropertySemantics::Multiline("Multiline");


### PR DESCRIPTION
* new widget `NumerLineEdit` based on a Qt SpinBox with the following improvements
   - needs less space (QSpinBox reserves space for lower/upper limit including full precision making it really wide for arbitrary precision)
   - if the number does not fit, it is rounded. If still too long, it is shown in scientific notation
   - full number shown during editing
   - accepts scientific notation, i.e. `1.434e-4` (also for integer values, assuming positive exponent)
* proper alignment of sliders and spinboxes in property list
* `NumberLineEdit` replaces all `CustomDoubleSpinBoxQt` widgets for ordinal and range properties
* `Spherical` and `SpinBoxSpherical` semantics have wrap-around enabled for phi and theta

**Before:**
![image](https://user-images.githubusercontent.com/9251300/52295726-ce93ff80-297c-11e9-974f-823056ce27c2.png)

**After:**
![image](https://user-images.githubusercontent.com/9251300/52295744-d81d6780-297c-11e9-8437-3ce7344d56e7.png)

**While editing**
![image](https://user-images.githubusercontent.com/9251300/52295795-f6836300-297c-11e9-84fa-ee5068f6978b.png)

