### PR TITLE
Cmake: Produce error when compiling for 32-bit architecture

### DIFF
--- a/cmake/globalconfig.cmake
+++ b/cmake/globalconfig.cmake
@@ -61,7 +61,8 @@ else()
 endif()
 
 if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
-    message(WARNING "Inviwo is only supported for 64-bit architectures.")
+    message(FATAL_ERROR "Inviwo is only supported for 64-bit architectures. Resolve the error by deleting "
+	        "the cache (File->Delete Cache) and selecting 64-bit architecture when configuring.")
 endif()
 
 set_property(GLOBAL PROPERTY USE_FOLDERS On)


### PR DESCRIPTION
Cmake: Produce error when compiling for 32-bit architecture since it does not compile otherwise (tested on Windows 10 with Visual studio 2017).
