### PR TITLE
Fix/pcp various fixes

### DIFF
--- a/modules/plottinggl/glsl/pcp_lines.frag
+++ b/modules/plottinggl/glsl/pcp_lines.frag
@@ -4,6 +4,7 @@ in float lfalloffAlpha;
 
 uniform bool additiveBlend;
 uniform float alpha;
+uniform float filteredAlpha;
 uniform float lineWidth;
 
 uniform int selected;
@@ -27,8 +28,10 @@ void main() {
         if(subtractiveBelnding == 1){
             res.rgb = 1-res.rgb;
         }
-        if (filtered == 1) 
+        if (filtered == 1) {
              res.xyz = mix(res.xyz, filterColor.xyz, filterIntensity);
+			 res.a = filteredAlpha;
+		}
         if (additiveBlend) {
             res.a *= alpha * pow(lfalloffAlpha, falllofPower);
         }

--- a/modules/plottinggl/glsl/pcp_lines.frag
+++ b/modules/plottinggl/glsl/pcp_lines.frag
@@ -32,7 +32,6 @@ void main() {
         }
         if (filtered == 1) {
             res = mix(res, filterColor, filterIntensity);
-            res.a = filterColor.w;
         }
         if (additiveBlend) {
             res.a *= alpha * pow(lfalloffAlpha, falllofPower);

--- a/modules/plottinggl/glsl/pcp_lines.frag
+++ b/modules/plottinggl/glsl/pcp_lines.frag
@@ -24,22 +24,20 @@ uniform sampler2D tfSelection;
 void main() {
     vec4 res = vec4(1);
     if (selected > 0) {
-        res = texture(tfSelection, vec2(ltexCoord.y,0.5f));
+        res = texture(tfSelection, vec2(ltexCoord.y, 0.5f));
     } else {
-        res = texture(tf, vec2(ltexCoord.x,0.5f));
-        if(subtractiveBelnding == 1){
-            res.rgb = 1-res.rgb;
+        res = texture(tf, vec2(ltexCoord.x, 0.5f));
+        if (subtractiveBelnding == 1) {
+            res.rgb = 1 - res.rgb;
         }
         if (filtered == 1) {
-             res.xyz = mix(res.xyz, filterColor.xyz, filterIntensity);
-			 res.a = filteredAlpha;
-		}
+            res.xyz = mix(res.xyz, filterColor.xyz, filterIntensity);
+            res.a = filteredAlpha;
+        }
         if (additiveBlend) {
             res.a *= alpha * pow(lfalloffAlpha, falllofPower);
         }
-		if (hovered == 1)
-			res.xyz = texture(tfSelection, vec2(ltexCoord.y,0.5f)).xyz;
-
+        if (hovered == 1) res.xyz = texture(tfSelection, vec2(ltexCoord.y, 0.5f)).xyz;
     }
 
     PickingData = vec4(lpickColor, 1.0);

--- a/modules/plottinggl/glsl/pcp_lines.frag
+++ b/modules/plottinggl/glsl/pcp_lines.frag
@@ -10,7 +10,7 @@ uniform float lineWidth;
 uniform int selected;
 uniform vec4 selectedColor = vec4(1, 0, 0, 1);
 
-uniform int hovered;
+uniform int hovering;
 
 uniform int filtered;
 uniform int subtractiveBelnding;
@@ -31,13 +31,13 @@ void main() {
             res.rgb = 1 - res.rgb;
         }
         if (filtered == 1) {
-            res.xyz = mix(res.xyz, filterColor.xyz, filterIntensity);
-            res.a = filteredAlpha;
+            res = mix(res, filterColor, filterIntensity);
+            res.a = filterColor.w;
         }
         if (additiveBlend) {
             res.a *= alpha * pow(lfalloffAlpha, falllofPower);
         }
-        if (hovered == 1) res.xyz = texture(tfSelection, vec2(ltexCoord.y, 0.5f)).xyz;
+        if (hovering == 1) res.xyz = texture(tfSelection, vec2(ltexCoord.y, 0.5f)).xyz;
     }
 
     PickingData = vec4(lpickColor, 1.0);

--- a/modules/plottinggl/glsl/pcp_lines.frag
+++ b/modules/plottinggl/glsl/pcp_lines.frag
@@ -10,6 +10,8 @@ uniform float lineWidth;
 uniform int selected;
 uniform vec4 selectedColor = vec4(1, 0, 0, 1);
 
+uniform int hovered;
+
 uniform int filtered;
 uniform int subtractiveBelnding;
 uniform vec4 filterColor;
@@ -35,6 +37,8 @@ void main() {
         if (additiveBlend) {
             res.a *= alpha * pow(lfalloffAlpha, falllofPower);
         }
+		if (hovered == 1)
+			res.xyz = texture(tfSelection, vec2(ltexCoord.y,0.5f)).xyz;
 
     }
 

--- a/modules/plottinggl/glsl/pcp_lines.frag
+++ b/modules/plottinggl/glsl/pcp_lines.frag
@@ -32,6 +32,7 @@ void main() {
         }
         if (filtered == 1) {
             res = mix(res, filterColor, filterIntensity);
+            res.a = filterColor.w;
         }
         if (additiveBlend) {
             res.a *= alpha * pow(lfalloffAlpha, falllofPower);

--- a/modules/plottinggl/include/modules/plottinggl/processors/parallelcoordinates/parallelcoordinates.h
+++ b/modules/plottinggl/include/modules/plottinggl/processors/parallelcoordinates/parallelcoordinates.h
@@ -133,7 +133,7 @@ private:
 
     TemplateOptionProperty<BlendMode> blendMode_;
     FloatProperty alpha_;
-    FloatProperty filteredAlpha_;
+    FloatProperty filterAlpha_;
     FloatProperty falllofPower_;
     FloatProperty lineWidth_;
     FloatProperty selectedLineWidth_;

--- a/modules/plottinggl/include/modules/plottinggl/processors/parallelcoordinates/parallelcoordinates.h
+++ b/modules/plottinggl/include/modules/plottinggl/processors/parallelcoordinates/parallelcoordinates.h
@@ -122,6 +122,7 @@ private:
     FloatVec4Property handleFilteredColor_;
     TransferFunctionProperty tf_;
     TransferFunctionProperty tfSelection_;
+    BoolProperty enableHoverColor_;
 
     CompositeProperty filteringOptions_;
     BoolProperty showFiltered_;
@@ -171,6 +172,8 @@ private:
     TextureQuadRenderer textureRenderer_;
 
     std::shared_ptr<Image> handleImg_;
+
+    int hoveredLine_ = -1;
 
     bool recreateLines_;
     bool textCacheDirty_;

--- a/modules/plottinggl/include/modules/plottinggl/processors/parallelcoordinates/parallelcoordinates.h
+++ b/modules/plottinggl/include/modules/plottinggl/processors/parallelcoordinates/parallelcoordinates.h
@@ -130,6 +130,7 @@ private:
 
     TemplateOptionProperty<BlendMode> blendMode_;
     FloatProperty alpha_;
+    FloatProperty filteredAlpha_;
     FloatProperty falllofPower_;
     FloatProperty lineWidth_;
     FloatProperty selectedLineWidth_;

--- a/modules/plottinggl/src/processors/parallelcoordinates/parallelcoordinates.cpp
+++ b/modules/plottinggl/src/processors/parallelcoordinates/parallelcoordinates.cpp
@@ -583,17 +583,21 @@ void ParallelCoordinates::drawLines(size2_t size) {
     auto iCol = dataFrame_.getData()->getIndexColumn();
     auto &indexCol = iCol->getTypedBuffer()->getRAMRepresentation()->getDataContainer();
 
-    std::vector<size_t> filteredIndices;
     std::vector<size_t> selectIndices;
 
     lineShader_.setUniform("selected", 0);
+    lineShader_.setUniform("hovering", 0);
+    if (showFiltered_) {
+        lineShader_.setUniform("filtered", 1);
+        for (size_t i = 0; i < numLines; i++) {
+            if (brushingAndLinking_.isFiltered(indexCol[i]))
+                drawObject.draw(i);
+        }
+    }
+
     lineShader_.setUniform("filtered", 0);
-    lineShader_.setUniform("hovered", 0);
     for (size_t i = 0; i < numLines; i++) {
         if (brushingAndLinking_.isFiltered(indexCol[i])) {
-            if (showFiltered_) {
-                filteredIndices.push_back(i);
-            }
             continue;
         }
         if (brushingAndLinking_.isSelected(indexCol[i])) {
@@ -601,14 +605,6 @@ void ParallelCoordinates::drawLines(size2_t size) {
             continue;
         }
         drawObject.draw(i);
-    }
-
-    if (showFiltered_) {
-        lineShader_.setUniform("selected", 0);
-        lineShader_.setUniform("filtered", 1);
-        for (const auto &i : filteredIndices) {
-            drawObject.draw(i);
-        }
     }
 
     lineShader_.setUniform("selected", 1);

--- a/modules/plottinggl/src/processors/parallelcoordinates/parallelcoordinates.cpp
+++ b/modules/plottinggl/src/processors/parallelcoordinates/parallelcoordinates.cpp
@@ -154,7 +154,6 @@ ParallelCoordinates::ParallelCoordinates()
     colors_.addProperty(tfSelection_);
     colors_.addProperty(enableHoverColor_);
     colors_.addProperty(alpha_);
-    colors_.addProperty(filteredAlpha_);
     colors_.addProperty(falllofPower_);
     colors_.addProperty(axisColor_);
     colors_.addProperty(handleBaseColor_);
@@ -180,6 +179,7 @@ ParallelCoordinates::ParallelCoordinates()
     filteringOptions_.addProperty(showFiltered_);
     filteringOptions_.addProperty(filterColor_);
     filteringOptions_.addProperty(filterIntensity_);
+    filteringOptions_.addProperty(filteredAlpha_);
     addProperty(filteringOptions_);
 
     addProperty(resetHandlePositions_);

--- a/modules/plottinggl/src/processors/parallelcoordinates/parallelcoordinates.cpp
+++ b/modules/plottinggl/src/processors/parallelcoordinates/parallelcoordinates.cpp
@@ -94,6 +94,7 @@ ParallelCoordinates::ParallelCoordinates()
 
     , blendMode_("blendMode", "Blend Mode")
     , alpha_("alpha", "Alpha", 0.9f)
+    , filteredAlpha_("filteredAlpha", "Filtered Alpha", 0.5)
     , falllofPower_("falllofPower", "Falloff Power", 2.0f, 0.01f, 10.f, 0.01f)
     , lineWidth_("lineWidth", "Line Width", 7.0f, 1.0f, 10.0f)
     , selectedLineWidth_("selectedLineWidth", "Line Width (selected lines)", 3.0f, 1.0f, 10.0f)
@@ -149,6 +150,7 @@ ParallelCoordinates::ParallelCoordinates()
     colors_.addProperty(selectedColorAxis_);
     colors_.addProperty(tfSelection_);
     colors_.addProperty(alpha_);
+    colors_.addProperty(filteredAlpha_);
     colors_.addProperty(falllofPower_);
     colors_.addProperty(axisColor_);
     colors_.addProperty(handleBaseColor_);
@@ -548,6 +550,7 @@ void ParallelCoordinates::drawLines(size2_t size) {
 
     lineShader_.setUniform("additiveBlend", enableBlending);
     lineShader_.setUniform("alpha", alpha_.get());
+    lineShader_.setUniform("filteredAlpha", filteredAlpha_.get());
     lineShader_.setUniform("falllofPower", falllofPower_.get());
     lineShader_.setUniform("lineWidth", lineWidth_.get());
     lineShader_.setUniform("selectedLineWidth", selectedLineWidth_.get());

--- a/modules/plottinggl/src/processors/parallelcoordinates/parallelcoordinates.cpp
+++ b/modules/plottinggl/src/processors/parallelcoordinates/parallelcoordinates.cpp
@@ -97,7 +97,7 @@ ParallelCoordinates::ParallelCoordinates()
 
     , blendMode_("blendMode", "Blend Mode")
     , alpha_("alpha", "Alpha", 0.9f)
-    , filteredAlpha_("filteredAlpha", "Filtered Alpha", 0.5)
+    , filteredAlpha_("filteredAlpha", "Filtered Alpha", 0.5f)
     , falllofPower_("falllofPower", "Falloff Power", 2.0f, 0.01f, 10.f, 0.01f)
     , lineWidth_("lineWidth", "Line Width", 7.0f, 1.0f, 10.0f)
     , selectedLineWidth_("selectedLineWidth", "Line Width (selected lines)", 3.0f, 1.0f, 10.0f)
@@ -621,7 +621,7 @@ void ParallelCoordinates::drawLines(size2_t size) {
     lineShader_.setUniform("hovered", 1);
     lineShader_.setUniform("selected", 0);
     lineShader_.setUniform("filtered", 0);
-    if (!brushingAndLinking_.isFiltered(hoveredLine_) && hoveredLine_ != -1)
+    if (hoveredLine_ != -1 && !brushingAndLinking_.isFiltered(hoveredLine_))
         drawObject.draw(hoveredLine_);
 
     lineShader_.deactivate();


### PR DESCRIPTION
Added a slider for controlling the alpha of the filtered lines in the PCP can be used to create a nicer looking plot.

Old plot:
<img width="354" alt="pcful" src="https://user-images.githubusercontent.com/8807821/52620515-11863380-2ea5-11e9-8d9a-58fa36299378.PNG">
(Notice how the non-filtered lines are parlty covered and occluded by the filtered lines)

New plot:
<img width="353" alt="pcfin" src="https://user-images.githubusercontent.com/8807821/52620523-164ae780-2ea5-11e9-9fd4-ef34b7159783.PNG">
(The non-filtered lines are much easier to distinct here. Since the filtered lines are in this case partly transparent, areas with many lines will appear brighter. I don't know if this is a wanted or unwanted behavior.)

Also added an option to enable different line color when hovering:
<img width="792" alt="pchover" src="https://user-images.githubusercontent.com/8807821/52620846-02ec4c00-2ea6-11e9-8c78-17f1b9402411.png">
(The color is based on the color of picked lines)

**What evineroment has the code been compiled and tested on?** 
* Windows 10
* Visual Studio 15.7.6
* QT Community 4.6.1
* CMake 3.11.2
* Python 3.6 (32-bit)
