### PR TITLE
propagate event from port, not processor

### DIFF
--- a/modules/brushingandlinking/src/ports/brushingandlinkingports.cpp
+++ b/modules/brushingandlinking/src/ports/brushingandlinkingports.cpp
@@ -45,14 +45,14 @@ void BrushingAndLinkingInport::sendFilterEvent(const std::unordered_set<size_t> 
     if (filterCache_.size() == 0 && indices.size() == 0) return;
     filterCache_ = indices;
     FilteringEvent event(this, filterCache_);
-    getProcessor()->propagateEvent(&event, nullptr);
+    propagateEvent(&event, nullptr);
 }
 
 void BrushingAndLinkingInport::sendSelectionEvent(const std::unordered_set<size_t> &indices) {
     if (selectionCache_.size() == 0 && indices.size() == 0) return;
     selectionCache_ = indices;
     SelectionEvent event(this, selectionCache_);
-    getProcessor()->propagateEvent(&event, nullptr);
+    propagateEvent(&event, nullptr);
 }
 
 bool BrushingAndLinkingInport::isFiltered(size_t idx) const {


### PR DESCRIPTION
BrushingAndLinkingPorts propagated filter and selection events from their processor, not the ports themselves. This meant that if a processor had two such inports A and B, sending an event to A would also send that event to B. 

**What evineroment has the code been compiled and tested on?** 

* Windows 10
* Visual Studio 2017
* QT 5.9.1/CMake 3.13.3
