### PR TITLE
BrushingAndLinking: Ensure that selection is common to all connected …

### DIFF
--- a/modules/brushingandlinking/include/modules/brushingandlinking/brushingandlinkingmanager.h
+++ b/modules/brushingandlinking/include/modules/brushingandlinking/brushingandlinkingmanager.h
@@ -48,26 +48,26 @@ public:
                               InvalidationLevel validationLevel = InvalidationLevel::InvalidOutput);
     virtual ~BrushingAndLinkingManager();
     /* 
-     * Return number of selected rows.
+     * Return the number of selected items/rows.
      */
     size_t getNumberOfSelected() const;
     /* 
-     * Return number of filtered rows.
+     * Return the number of filtered items/rows, i.e. the number of items/rows that should not be displayed.
      */
     size_t getNumberOfFiltered() const;
 
     void remove(const BrushingAndLinkingInport* src);
 
-    bool isFiltered(size_t row) const;
-    bool isSelected(size_t row) const;
+    bool isFiltered(size_t idx) const;
+    bool isSelected(size_t idx) const;
 
     bool isColumnSelected(size_t column) const;
 
     void setSelected(const BrushingAndLinkingInport* src,
-                     const std::unordered_set<size_t>& rowIndices);
+                     const std::unordered_set<size_t>& idx);
 
     void setFiltered(const BrushingAndLinkingInport* src,
-                     const std::unordered_set<size_t>& rowIndices);
+                     const std::unordered_set<size_t>& idx);
 
     void setSelectedColumn(const BrushingAndLinkingInport* src,
                            const std::unordered_set<size_t>& columnIndices);

--- a/modules/brushingandlinking/include/modules/brushingandlinking/brushingandlinkingmanager.h
+++ b/modules/brushingandlinking/include/modules/brushingandlinking/brushingandlinkingmanager.h
@@ -40,46 +40,49 @@ class BrushingAndLinkingInport;
 class BrushingAndLinkingProcessor;
 /**
  * \class BrushingAndLinkingManager
- * \brief VERY_BRIEFLY_DESCRIBE_THE_CLASS
- * DESCRIBE_THE_CLASS
+ * \brief Manages row filtering, row selection and column selection from multiple sources.
  */
 class IVW_MODULE_BRUSHINGANDLINKING_API BrushingAndLinkingManager {
 public:
     BrushingAndLinkingManager(Processor* p,
                               InvalidationLevel validationLevel = InvalidationLevel::InvalidOutput);
     virtual ~BrushingAndLinkingManager();
-
+    /* 
+     * Return number of selected rows.
+     */
     size_t getNumberOfSelected() const;
+    /* 
+     * Return number of filtered rows.
+     */
     size_t getNumberOfFiltered() const;
 
     void remove(const BrushingAndLinkingInport* src);
 
-    bool isFiltered(size_t idx) const;
-    bool isSelected(size_t idx) const;
+    bool isFiltered(size_t row) const;
+    bool isSelected(size_t row) const;
 
-    bool isColumnSelected(size_t idx) const;
+    bool isColumnSelected(size_t column) const;
 
     void setSelected(const BrushingAndLinkingInport* src,
-                     const std::unordered_set<size_t>& indices);
+                     const std::unordered_set<size_t>& rowIndices);
 
     void setFiltered(const BrushingAndLinkingInport* src,
-                     const std::unordered_set<size_t>& indices);
+                     const std::unordered_set<size_t>& rowIndices);
 
     void setSelectedColumn(const BrushingAndLinkingInport* src,
-                           const std::unordered_set<size_t>& indices);
+                           const std::unordered_set<size_t>& columnIndices);
 
     const std::unordered_set<size_t>& getSelectedIndices() const;
     const std::unordered_set<size_t>& getFilteredIndices() const;
     const std::unordered_set<size_t>& getSelectedColumns() const;
 
 private:
-    IndexList selected_;
-    IndexList filtered_;
-    IndexList selectedColumns_;
+    std::unordered_set<size_t> selected_;
+    std::unordered_set<size_t> selectedColumns_;
+    IndexList filtered_;  // Use IndexList to be able to remove filtered rows on port disconnection
 
-    std::shared_ptr<std::function<void()>> callback1_;
-    std::shared_ptr<std::function<void()>> callback2_;
-    std::shared_ptr<std::function<void()>> callback3_;
+    Processor* owner_;  // Non-owning reference
+    InvalidationLevel invalidationLevel_;
 };
 
 }  // namespace inviwo

--- a/modules/brushingandlinking/src/brushingandlinkingmanager.cpp
+++ b/modules/brushingandlinking/src/brushingandlinkingmanager.cpp
@@ -34,46 +34,43 @@
 namespace inviwo {
 
 BrushingAndLinkingManager::BrushingAndLinkingManager(Processor* p,
-                                                     InvalidationLevel validationLevel) {
+                                                     InvalidationLevel validationLevel)
+    : owner_{p}, invalidationLevel_{validationLevel} {
     auto outPorts = p->getOutports();
     for (auto& op : outPorts) {
         if (dynamic_cast<BrushingAndLinkingOutport*>(op)) {
             op->onDisconnect([=]() {
-                selected_.update();
                 filtered_.update();
-                selectedColumns_.update();
             });
         }
     }
-    callback1_ = selected_.onChange([p, validationLevel]() { p->invalidate(validationLevel); });
-    callback2_ = filtered_.onChange([p, validationLevel]() { p->invalidate(validationLevel); });
-    callback3_ =
-        selectedColumns_.onChange([p, validationLevel]() { p->invalidate(validationLevel); });
+    filtered_.onChange([p, validationLevel]() { p->invalidate(validationLevel); });
 }
 
 BrushingAndLinkingManager::~BrushingAndLinkingManager() {}
 
-size_t BrushingAndLinkingManager::getNumberOfSelected() const { return selected_.getSize(); }
+size_t BrushingAndLinkingManager::getNumberOfSelected() const { return selected_.size(); }
 
 size_t BrushingAndLinkingManager::getNumberOfFiltered() const { return filtered_.getSize(); }
 
 void BrushingAndLinkingManager::remove(const BrushingAndLinkingInport* src) {
-    selected_.remove(src);
     filtered_.remove(src);
-    selectedColumns_.remove(src);
 }
 
 bool BrushingAndLinkingManager::isFiltered(size_t idx) const { return filtered_.has(idx); }
 
-bool BrushingAndLinkingManager::isSelected(size_t idx) const { return selected_.has(idx); }
-
-bool BrushingAndLinkingManager::isColumnSelected(size_t idx) const {
-    return selectedColumns_.has(idx);
+bool BrushingAndLinkingManager::isSelected(size_t idx) const {
+    return selected_.find(idx) != selected_.end();
 }
 
-void BrushingAndLinkingManager::setSelected(const BrushingAndLinkingInport* src,
+bool BrushingAndLinkingManager::isColumnSelected(size_t idx) const {
+    return selectedColumns_.find(idx) != selectedColumns_.end();
+}
+
+void BrushingAndLinkingManager::setSelected(const BrushingAndLinkingInport*,
                                             const std::unordered_set<size_t>& indices) {
-    selected_.set(src, indices);
+    selected_ = indices;
+    owner_->invalidate(invalidationLevel_);
 }
 
 void BrushingAndLinkingManager::setFiltered(const BrushingAndLinkingInport* src,
@@ -81,13 +78,14 @@ void BrushingAndLinkingManager::setFiltered(const BrushingAndLinkingInport* src,
     filtered_.set(src, indices);
 }
 
-void BrushingAndLinkingManager::setSelectedColumn(const BrushingAndLinkingInport* src,
+void BrushingAndLinkingManager::setSelectedColumn(const BrushingAndLinkingInport*,
                                                   const std::unordered_set<size_t>& indices) {
-    selectedColumns_.set(src, indices);
+    selectedColumns_ = indices;
+    owner_->invalidate(invalidationLevel_);
 }
 
 const std::unordered_set<size_t>& BrushingAndLinkingManager::getSelectedIndices() const {
-    return selected_.getIndices();
+    return selected_;
 }
 
 const std::unordered_set<size_t>& BrushingAndLinkingManager::getFilteredIndices() const {
@@ -95,7 +93,7 @@ const std::unordered_set<size_t>& BrushingAndLinkingManager::getFilteredIndices(
 }
 
 const std::unordered_set<size_t>& BrushingAndLinkingManager::getSelectedColumns() const {
-    return selectedColumns_.getIndices();
+    return selectedColumns_;
 }
 
 }  // namespace inviwo


### PR DESCRIPTION
…processors. In other words: Selection should be the same in all connected plots. Before, each processor had its own selection set, which is not desirable for selection.

This behavior can be seen if connecting two parallel coordinate plots to the same brushing and linking.