### PR TITLE
QtWidgets: TF preview high-dpi fix, closes #443

### DIFF
--- a/modules/qtwidgets/src/tf/tfutils.cpp
+++ b/modules/qtwidgets/src/tf/tfutils.cpp
@@ -106,8 +106,12 @@ QMenu* addTFPresetsMenu(QWidget* parent, QMenu* menu, TransferFunctionProperty* 
     auto presets = menu->addMenu("&TF Presets");
     presets->setObjectName("TF");
     presets->setEnabled(!property->getReadOnly());
+    const int iconWidth = utilqt::emToPx(presets, 11);
+    // need to set the stylesheet explicitely since Qt _only_ supports 'px' for icon sizes
+    presets->setStyleSheet(QString("QMenu { icon-size: %1px; }").arg(iconWidth));
     if (!property->getReadOnly()) {
-        auto addPresetActions = [presets, parent, property](const std::string& basePath) {
+        auto addPresetActions = [presets, parent, property,
+                                 iconWidth](const std::string& basePath) {
             TransferFunction tf;
             auto files = filesystem::getDirectoryContentsRecursively(basePath);
             for (auto file : files) {
@@ -131,7 +135,7 @@ QMenu* addTFPresetsMenu(QWidget* parent, QMenu* menu, TransferFunctionProperty* 
                                              property->get().load(file, ext);
                                          });
 
-                        action->setIcon(QIcon(utilqt::toQPixmap(tf, QSize(120, 20))));
+                        action->setIcon(QIcon(utilqt::toQPixmap(tf, QSize{iconWidth, 20})));
                         break;
                     }
                 }

--- a/resources/stylesheets/inviwo.qss
+++ b/resources/stylesheets/inviwo.qss
@@ -280,9 +280,6 @@ QMenu::separator {
     border-top: 0.125em groove #383838;
     margin-left: 1.5675em;
 }
-QMenu#TF {
-    icon-size: 7.5em;
-}
 
 /************************ 
 QScrollBar 


### PR DESCRIPTION
* Qt Stylesheet does not support other units than 'px' for 'icon-size'