### PR TITLE
BrushingAndLinking: Fixed a bug where the column selection would not …

### DIFF
--- a/modules/brushingandlinking/src/ports/brushingandlinkingports.cpp
+++ b/modules/brushingandlinking/src/ports/brushingandlinkingports.cpp
@@ -50,10 +50,12 @@ void BrushingAndLinkingInport::sendFilterEvent(const std::unordered_set<size_t> 
 
 void BrushingAndLinkingInport::sendSelectionEvent(const std::unordered_set<size_t> &indices) {
     bool noRemoteSelections = false;
-    if(isConnected() && hasData())
+    if (isConnected() && hasData()) {
         noRemoteSelections = getData()->getSelectedIndices().empty();
-    if (selectionColumnCache_.empty() && indices.empty() && noRemoteSelections) return;
-    if (selectionCache_.size() == 0 && indices.size() == 0) return;
+    }
+    if (selectionCache_.empty() && indices.empty() && noRemoteSelections) {
+        return;
+    }
     selectionCache_ = indices;
     SelectionEvent event(this, selectionCache_);
     propagateEvent(&event, nullptr);
@@ -61,9 +63,12 @@ void BrushingAndLinkingInport::sendSelectionEvent(const std::unordered_set<size_
 
 void BrushingAndLinkingInport::sendColumnSelectionEvent(const std::unordered_set<size_t> &indices) {
     bool noRemoteSelections = false;
-    if (isConnected() && hasData())
-        noRemoteSelections = getData()->getSelectedIndices().empty();
-    if (selectionColumnCache_.empty() && indices.empty() && noRemoteSelections) return;
+    if (isConnected() && hasData()) {
+        noRemoteSelections = getData()->getSelectedColumns().empty();
+    }
+    if (selectionColumnCache_.empty() && indices.empty() && noRemoteSelections) {
+        return;
+    }
     selectionColumnCache_ = indices;
     ColumnSelectionEvent event(this, selectionColumnCache_);
     propagateEvent(&event, nullptr);

--- a/modules/brushingandlinking/src/ports/brushingandlinkingports.cpp
+++ b/modules/brushingandlinking/src/ports/brushingandlinkingports.cpp
@@ -49,6 +49,10 @@ void BrushingAndLinkingInport::sendFilterEvent(const std::unordered_set<size_t> 
 }
 
 void BrushingAndLinkingInport::sendSelectionEvent(const std::unordered_set<size_t> &indices) {
+    bool noRemoteSelections = false;
+    if(isConnected() && hasData())
+        noRemoteSelections = getData()->getSelectedIndices().empty();
+    if (selectionColumnCache_.empty() && indices.empty() && noRemoteSelections) return;
     if (selectionCache_.size() == 0 && indices.size() == 0) return;
     selectionCache_ = indices;
     SelectionEvent event(this, selectionCache_);
@@ -56,8 +60,10 @@ void BrushingAndLinkingInport::sendSelectionEvent(const std::unordered_set<size_
 }
 
 void BrushingAndLinkingInport::sendColumnSelectionEvent(const std::unordered_set<size_t> &indices) {
-    auto remoteSelections = getData()->getSelectedColumns();
-    if (selectionColumnCache_.size() == 0 && indices.size() == 0 && remoteSelections.size() == 0) return;
+    bool noRemoteSelections = false;
+    if (isConnected() && hasData())
+        noRemoteSelections = getData()->getSelectedIndices().empty();
+    if (selectionColumnCache_.empty() && indices.empty() && noRemoteSelections) return;
     selectionColumnCache_ = indices;
     ColumnSelectionEvent event(this, selectionColumnCache_);
     propagateEvent(&event, nullptr);

--- a/modules/brushingandlinking/src/ports/brushingandlinkingports.cpp
+++ b/modules/brushingandlinking/src/ports/brushingandlinkingports.cpp
@@ -56,7 +56,8 @@ void BrushingAndLinkingInport::sendSelectionEvent(const std::unordered_set<size_
 }
 
 void BrushingAndLinkingInport::sendColumnSelectionEvent(const std::unordered_set<size_t> &indices) {
-    if (selectionColumnCache_.size() == 0 && indices.size() == 0) return;
+    auto remoteSelections = getData()->getSelectedColumns();
+    if (selectionColumnCache_.size() == 0 && indices.size() == 0 && remoteSelections.size() == 0) return;
     selectionColumnCache_ = indices;
     ColumnSelectionEvent event(this, selectionColumnCache_);
     propagateEvent(&event, nullptr);


### PR DESCRIPTION
…run if the local selection cache was empty, but the remote set with selected indices was not. This lead to that if an index was selected from another processor the isColumnSelected(index) would return true, but when a sendColumnSelectionEvent({ }) was called to deselect it nothing happened.

Perhaps this should be done for sendSelectionEvent() and sendFilterEvent() as well?