### PR TITLE
Qt: Fix for Processor eval time not being reseted

### DIFF
--- a/src/qt/editor/processorgraphicsitem.cpp
+++ b/src/qt/editor/processorgraphicsitem.cpp
@@ -444,6 +444,7 @@ void ProcessorGraphicsItem::onProcessorPortRemoved(Processor*, Port* port) {
 void ProcessorGraphicsItem::onProcessorAboutToProcess(Processor*) {
     processCount_++;
     countLabel_->setText(QString::number(processCount_));
+    clock_.reset();
     clock_.start();
 }
 


### PR DESCRIPTION
A while ago the clock behavior changed to accumulate time between start/stops and one need to call reset to start from zero again. This resulted in the eval time in the tooltips to accumulate. (Screenshot is taken after the fix) 
![image](https://user-images.githubusercontent.com/534670/54357680-d96a4000-465e-11e9-8987-4bbcea4b7341.png)

