### PR TITLE
General: fixed typo `util::PrecsionType`/`util::PrecsionValueType`

### DIFF
--- a/include/inviwo/core/datastructures/buffer/bufferram.h
+++ b/include/inviwo/core/datastructures/buffer/bufferram.h
@@ -88,8 +88,8 @@ public:
      * ```{.cpp}
      * BufferRam* bufferram = ...; // of some glm vector type.
      * auto count = bufferram->dispatch<size_t, dispatching::filter::Vecs>([](auto brprecision) {
-     *     using BufferType = util::PrecsionType<decltype(brprecision)>;
-     *     using ValueType = util::PrecsionValueType<decltype(brprecision)>;
+     *     using BufferType = util::PrecisionType<decltype(brprecision)>;
+     *     using ValueType = util::PrecisionValueType<decltype(brprecision)>;
      *
      *     std::vector<ValueType>& data = brprecision->getDataContainer();
      *     return std::count_if(data.begin(), data.end(), [](auto x){return x > ValueType{0};});

--- a/include/inviwo/core/datastructures/image/layerram.h
+++ b/include/inviwo/core/datastructures/image/layerram.h
@@ -96,8 +96,8 @@ public:
      * ```{.cpp}
      * LayerRam* layerram = ...; // of some glm vector type.
      * auto count = layerram->dispatch<size_t, dispatching::filter::Vecs>([](auto lrprecision) {
-     *     using LayerType = util::PrecsionType<decltype(lrprecision)>;
-     *     using ValueType = util::PrecsionValueType<decltype(lrprecision)>;
+     *     using LayerType = util::PrecisionType<decltype(lrprecision)>;
+     *     using ValueType = util::PrecisionValueType<decltype(lrprecision)>;
      *
      *     T* data = lrprecision->getDataTyped();
      *     auto dim = lrprecision->getDimensions();

--- a/include/inviwo/core/datastructures/volume/volumeram.h
+++ b/include/inviwo/core/datastructures/volume/volumeram.h
@@ -120,8 +120,8 @@ public:
      * ```{.cpp}
      * VolumeRam* volumeram = ...; // of some glm vector type.
      * auto count = volumeram->dispatch<size_t, dispatching::filter::Vecs>([](auto vrprecision) {
-     *     using VolumeType = util::PrecsionType<decltype(vrprecision)>;
-     *     using ValueType = util::PrecsionValueType<decltype(vrprecision)>;
+     *     using VolumeType = util::PrecisionType<decltype(vrprecision)>;
+     *     using ValueType = util::PrecisionValueType<decltype(vrprecision)>;
      *
      *     T* data = vrprecision->getDataTyped();
      *     auto dim = vrprecision->getDimensions();

--- a/include/inviwo/core/util/formatdispatching.h
+++ b/include/inviwo/core/util/formatdispatching.h
@@ -257,13 +257,17 @@ namespace util {
  * ```{.cpp}
  * VolumeRam* volumeram = ...; // of some glm vector type.
  * auto count = volumeram->dispatch<size_t, dispatching::filter::Vecs>([](auto vrprecision) {
- *     using VolumeType = util::PrecsionType<decltype(vrprecision)>;
+ *     using VolumeType = util::PrecisionType<decltype(vrprecision)>;
  *     ....
  * ```
  * VolumeType will then be for example VolumeRamPrecision<vec3>
  */
 template <typename T>
-using PrecsionType = typename std::remove_pointer<typename std::remove_const<T>::type>::type;
+using PrecisionType = typename std::remove_pointer<typename std::remove_const<T>::type>::type;
+
+template <typename T>
+using PrecsionType[[deprecated("Use `PrecisionType` instead")]] =
+    typename std::remove_pointer<typename std::remove_const<T>::type>::type;
 
 /**
  * Utility for retrieving the type of a (Buffer/Layer/Volume)RamPrecision pointer variable.
@@ -271,13 +275,17 @@ using PrecsionType = typename std::remove_pointer<typename std::remove_const<T>:
  * ```{.cpp}
  * VolumeRam* volumeram = ...; // of some glm vector type.
  * auto count = volumeram->dispatch<size_t, dispatching::filter::Vecs>([](auto vrprecision) {
- *     using ValueType = util::PrecsionValueType<decltype(vrprecision)>;
+ *     using ValueType = util::PrecisionValueType<decltype(vrprecision)>;
  *     ....
  * ```
  * ValueType will then be for example vec3
  */
 template <typename T>
-using PrecsionValueType = typename PrecsionType<T>::type;
+using PrecisionValueType = typename PrecisionType<T>::type;
+
+template <typename T>
+using PrecsionValueType[[deprecated("Use `PrecisionValueType` instead")]] =
+    typename PrecisionType<T>::type;
 
 }  // namespace util
 

--- a/modules/base/include/modules/base/algorithm/image/layerramdistancetransform.h
+++ b/modules/base/include/modules/base/algorithm/image/layerramdistancetransform.h
@@ -257,7 +257,7 @@ void util::layerDistanceTransform(const Layer *inLayer, LayerRAMPrecision<U> *ou
 
     const auto inputLayerRep = inLayer->getRepresentation<LayerRAM>();
     inputLayerRep->dispatch<void, dispatching::filter::Scalars>([&](const auto lrprecision) {
-        using ValueType = util::PrecsionValueType<decltype(lrprecision)>;
+        using ValueType = util::PrecisionValueType<decltype(lrprecision)>;
 
         const auto predicateIn = [threshold](const ValueType &val) { return val < threshold; };
         const auto predicateOut = [threshold](const ValueType &val) { return val > threshold; };

--- a/modules/base/include/modules/base/algorithm/image/layerramsubset.h
+++ b/modules/base/include/modules/base/algorithm/image/layerramsubset.h
@@ -142,7 +142,7 @@ std::shared_ptr<LayerRAMPrecision<T>> util::layerSubSet(const Layer* in, ivec2 o
 
     return in->getRepresentation<LayerRAM>()->dispatch<std::shared_ptr<LayerRAMPrecision<T>>>(
         [offset, extent, clampBorderOutsideImage](auto layerpr) {
-            using ValueType = util::PrecsionValueType<decltype(layerpr)>;
+            using ValueType = util::PrecisionValueType<decltype(layerpr)>;
 
             return util::detail::extractLayerSubSet<ValueType, T>(layerpr, offset, extent,
                                                                   clampBorderOutsideImage);

--- a/modules/base/include/modules/base/algorithm/volume/volumeramdistancetransform.h
+++ b/modules/base/include/modules/base/algorithm/volume/volumeramdistancetransform.h
@@ -297,7 +297,7 @@ void util::volumeDistanceTransform(const Volume *inVolume, VolumeRAMPrecision<U>
 
     const auto inputVolumeRep = inVolume->getRepresentation<VolumeRAM>();
     inputVolumeRep->dispatch<void, dispatching::filter::Scalars>([&](const auto vrprecision) {
-        using ValueType = util::PrecsionValueType<decltype(vrprecision)>;
+        using ValueType = util::PrecisionValueType<decltype(vrprecision)>;
 
         const auto predicateIn = [threshold](const ValueType &val) { return val < threshold; };
         const auto predicateOut = [threshold](const ValueType &val) { return val > threshold; };

--- a/modules/base/src/algorithm/image/layerramsubset.cpp
+++ b/modules/base/src/algorithm/image/layerramsubset.cpp
@@ -38,7 +38,7 @@ std::shared_ptr<LayerRAM> layerSubSet(const Layer *in, ivec2 offset, size2_t ext
 
     return in->getRepresentation<LayerRAM>()->dispatch<std::shared_ptr<LayerRAM>>(
         [offset, extent, clampBorderOutsideImage](auto layerpr) {
-            using ValueType = util::PrecsionValueType<decltype(layerpr)>;
+            using ValueType = util::PrecisionValueType<decltype(layerpr)>;
 
             return detail::extractLayerSubSet<ValueType>(layerpr, offset, extent,
                                                          clampBorderOutsideImage);

--- a/modules/base/src/algorithm/volume/marchingcubes.cpp
+++ b/modules/base/src/algorithm/volume/marchingcubes.cpp
@@ -577,7 +577,7 @@ std::shared_ptr<Mesh> marchingcubes(std::shared_ptr<const Volume> volume, double
                                     std::function<bool(const size3_t &)> maskingCallback) {
 
     return volume->getRepresentation<VolumeRAM>()->dispatch<std::shared_ptr<Mesh>>([&](auto ram) {
-        using T = util::PrecsionValueType<decltype(ram)>;
+        using T = util::PrecisionValueType<decltype(ram)>;
         if (progressCallback) progressCallback(0.0f);
 
         if (!maskingCallback) {

--- a/modules/base/src/algorithm/volume/marchingcubesopt.cpp
+++ b/modules/base/src/algorithm/volume/marchingcubesopt.cpp
@@ -453,7 +453,7 @@ std::shared_ptr<Mesh> marchingCubesOpt(std::shared_ptr<const Volume> volume, dou
     if (progressCallback) progressCallback(0.0f);
 
     const auto mc = [&](auto ram, auto isoTest, auto mapValue) {
-        using T = util::PrecsionValueType<decltype(ram)>;
+        using T = util::PrecisionValueType<decltype(ram)>;
         static const marching::Config cube{};
 
         const T *src = ram->getDataTyped();
@@ -543,7 +543,7 @@ std::shared_ptr<Mesh> marchingCubesOpt(std::shared_ptr<const Volume> volume, dou
     if (invert) {
         volume->getRepresentation<VolumeRAM>()->dispatch<void, dispatching::filter::Scalars>(
             [&](auto ram) {
-                using ValueType = util::PrecsionValueType<decltype(ram)>;
+                using ValueType = util::PrecisionValueType<decltype(ram)>;
                 mc(ram,
                    [tiso = util::glm_convert<ValueType>(iso)](auto &&val) { return val > tiso; },
                    [iso](auto &&val) { return util::glm_convert<double>(val) - iso; });
@@ -551,7 +551,7 @@ std::shared_ptr<Mesh> marchingCubesOpt(std::shared_ptr<const Volume> volume, dou
     } else {
         volume->getRepresentation<VolumeRAM>()->dispatch<void, dispatching::filter::Scalars>(
             [&](auto ram) {
-                using ValueType = util::PrecsionValueType<decltype(ram)>;
+                using ValueType = util::PrecisionValueType<decltype(ram)>;
                 mc(ram,
                    [tiso = util::glm_convert<ValueType>(iso)](auto &&val) { return val < tiso; },
                    [iso](auto &&val) { return -(util::glm_convert<double>(val) - iso); });

--- a/modules/base/src/algorithm/volume/marchingtetrahedron.cpp
+++ b/modules/base/src/algorithm/volume/marchingtetrahedron.cpp
@@ -160,7 +160,7 @@ std::shared_ptr<Mesh> marchingtetrahedron(std::shared_ptr<const Volume> volume, 
                                           std::function<bool(const size3_t &)> maskingCallback) {
 
     return volume->getRepresentation<VolumeRAM>()->dispatch<std::shared_ptr<Mesh>>([&](auto ram) {
-        using T = util::PrecsionValueType<decltype(ram)>;
+        using T = util::PrecisionValueType<decltype(ram)>;
         if (progressCallback) progressCallback(0.0f);
 
         if (!maskingCallback) {

--- a/modules/base/src/algorithm/volume/volumecurl.cpp
+++ b/modules/base/src/algorithm/volume/volumecurl.cpp
@@ -62,7 +62,7 @@ std::unique_ptr<Volume> curlVolume(const Volume& volume) {
 
     volume.getRepresentation<VolumeRAM>()->dispatch<void, dispatching::filter::Vec3s>(
         [&](auto vol) {
-            using ValueType = util::PrecsionValueType<decltype(vol)>;
+            using ValueType = util::PrecisionValueType<decltype(vol)>;
             using ComponentType = typename ValueType::value_type;
 
             util::IndexMapper3D index(volume.getDimensions());

--- a/modules/base/src/algorithm/volume/volumedivergence.cpp
+++ b/modules/base/src/algorithm/volume/volumedivergence.cpp
@@ -62,7 +62,7 @@ std::unique_ptr<Volume> divergenceVolume(const Volume& volume) {
 
     volume.getRepresentation<VolumeRAM>()->dispatch<void, dispatching::filter::Vec3s>(
         [&](auto vol) {
-            using ValueType = util::PrecsionValueType<decltype(vol)>;
+            using ValueType = util::PrecisionValueType<decltype(vol)>;
             using ComponentType = typename ValueType::value_type;
 
             util::IndexMapper3D index(volume.getDimensions());

--- a/modules/base/src/algorithm/volume/volumeramsubsample.cpp
+++ b/modules/base/src/algorithm/volume/volumeramsubsample.cpp
@@ -37,7 +37,7 @@ namespace inviwo {
 std::shared_ptr<VolumeRAM> util::volumeSubSample(const VolumeRAM* volume, size3_t f) {
     return volume->dispatch<std::shared_ptr<VolumeRAM>>(
         [&f](auto srcVol) -> std::shared_ptr<VolumeRAM> {
-            using ValueType = util::PrecsionValueType<decltype(srcVol)>;
+            using ValueType = util::PrecisionValueType<decltype(srcVol)>;
 
             // use a double type to perform the summation
             using P = typename util::same_extent<ValueType, double>::type;

--- a/modules/base/src/algorithm/volume/volumesignificantvoxels.cpp
+++ b/modules/base/src/algorithm/volume/volumesignificantvoxels.cpp
@@ -37,7 +37,7 @@ namespace inviwo {
 
 size_t util::volumeSignificantVoxels(const VolumeRAM* volume, IgnoreSpecialValues ignore) {
     return volume->dispatch<size_t>([&ignore](auto vr) -> size_t {
-        using ValueType = util::PrecsionValueType<decltype(vr)>;
+        using ValueType = util::PrecisionValueType<decltype(vr)>;
 
         const auto data = vr->getDataTyped();
         const auto dim = vr->getDimensions();

--- a/modules/base/src/processors/imagestackvolumesource.cpp
+++ b/modules/base/src/processors/imagestackvolumesource.cpp
@@ -191,7 +191,7 @@ std::shared_ptr<Volume> ImageStackVolumeSource::load() {
 
     return referenceRAM->dispatch<std::shared_ptr<Volume>, FloatOrIntMax32>(
         [&](auto reflayerprecision) {
-            using ValueType = util::PrecsionValueType<decltype(reflayerprecision)>;
+            using ValueType = util::PrecisionValueType<decltype(reflayerprecision)>;
             using PrimitiveType = typename DataFormat<ValueType>::primitive;
 
             const size2_t layerDims = reflayerprecision->getDimensions();

--- a/modules/base/src/processors/volumeslice.cpp
+++ b/modules/base/src/processors/volumeslice.cpp
@@ -141,7 +141,7 @@ void VolumeSlice::process() {
                 [axis = static_cast<CartesianCoordinateAxis>(sliceAlongAxis_.get()),
                  slice = static_cast<size_t>(sliceNumber_.get() - 1),
                  &cache = imageCache_](const auto vrprecision) {
-                    using T = util::PrecsionValueType<decltype(vrprecision)>;
+                    using T = util::PrecisionValueType<decltype(vrprecision)>;
 
                     const T* voldata = vrprecision->getDataTyped();
                     const auto voldim = vrprecision->getDimensions();

--- a/modules/hdf5/src/datastructures/hdf5handle.cpp
+++ b/modules/hdf5/src/datastructures/hdf5handle.cpp
@@ -193,7 +193,7 @@ std::shared_ptr<Volume> Handle::getVolumeAtPathAsType(const Path& path,
 
     auto minmax = volumeram->dispatch<std::pair<dvec4, dvec4>, dispatching::filter::Scalars>(
         [&](auto vrprecision) {
-            using ValueType = ::inviwo::util::PrecsionValueType<decltype(vrprecision)>;
+            using ValueType = ::inviwo::util::PrecisionValueType<decltype(vrprecision)>;
 
             ValueType* data = vrprecision->getDataTyped();
 

--- a/modules/plotting/src/datastructures/dataframe.cpp
+++ b/modules/plotting/src/datastructures/dataframe.cpp
@@ -56,7 +56,7 @@ std::shared_ptr<Column> DataFrame::addColumnFromBuffer(const std::string &identi
                                                        std::shared_ptr<const BufferBase> buffer) {
     return buffer->getRepresentation<BufferRAM>()
         ->dispatch<std::shared_ptr<Column>, dispatching::filter::Scalars>([&](auto buf) {
-            using ValueType = util::PrecsionValueType<decltype(buf)>;
+            using ValueType = util::PrecisionValueType<decltype(buf)>;
             auto col = this->addColumn<ValueType>(identifier);
             auto newBuf = col->getTypedBuffer();
             auto &newVec = newBuf->getEditableRAMRepresentation()->getDataContainer();

--- a/modules/plotting/src/datastructures/dataframeutil.cpp
+++ b/modules/plotting/src/datastructures/dataframeutil.cpp
@@ -42,7 +42,7 @@ std::shared_ptr<BufferBase> cloneBufferRange(std::shared_ptr<const BufferBase> b
 
     return buffer->getRepresentation<BufferRAM>()->dispatch<std::shared_ptr<BufferBase>>(
         [&](auto typed) {
-            using ValueType = util::PrecsionValueType<decltype(typed)>;
+            using ValueType = util::PrecisionValueType<decltype(typed)>;
             auto newBuffer = std::make_shared<Buffer<ValueType>>();
             auto &vecOut = newBuffer->getEditableRAMRepresentation()->getDataContainer();
             auto &vecIn = typed->getDataContainer();
@@ -60,7 +60,7 @@ void copyBufferRange(std::shared_ptr<const BufferBase> src, std::shared_ptr<Buff
 
     if (src->getDataFormat()->getId() == dst->getDataFormat()->getId()) {
         dst->getEditableRepresentation<BufferRAM>()->dispatch<void>([&](auto typed) {
-            using ValueType = util::PrecsionValueType<decltype(typed)>;
+            using ValueType = util::PrecisionValueType<decltype(typed)>;
             auto typedInBuf = static_cast<const Buffer<ValueType> *>(src.get());
             auto &vecIn = typedInBuf->getRAMRepresentation()->getDataContainer();
             auto &vecOut = typed->getDataContainer();
@@ -139,7 +139,7 @@ std::shared_ptr<plot::DataFrame> combineDataFrames(
             ->getRepresentation<BufferRAM>()
             ->dispatch<void, dispatching::filter::Scalars>([&](auto typedBuf) {
                 IVW_UNUSED_PARAM(typedBuf);
-                using ValueType = util::PrecsionValueType<decltype(typedBuf)>;
+                using ValueType = util::PrecisionValueType<decltype(typedBuf)>;
                 columns[col->getHeader()] = newDataFrame->addColumn<ValueType>(col->getHeader());
             });
     }
@@ -151,7 +151,7 @@ std::shared_ptr<plot::DataFrame> combineDataFrames(
                 ->getBuffer()
                 ->getEditableRepresentation<BufferRAM>()
                 ->dispatch<void>([&](auto typedBuf) {
-                    using ValueType = util::PrecsionValueType<decltype(typedBuf)>;
+                    using ValueType = util::PrecisionValueType<decltype(typedBuf)>;
 
                     auto typedBuffer =
                         static_cast<const Buffer<ValueType> *>(col->getBuffer().get());

--- a/modules/plotting/src/processors/dataframeexporter.cpp
+++ b/modules/plotting/src/processors/dataframeexporter.cpp
@@ -162,7 +162,7 @@ void DataFrameExporter::exportAsCSV(bool separateVectorTypesIntoColumns) {
             col->getBuffer()
                 ->getRepresentation<BufferRAM>()
                 ->dispatch<void, dispatching::filter::Vecs>([&printers, delimiter](auto br) {
-                    using ValueType = util::PrecsionValueType<decltype(br)>;
+                    using ValueType = util::PrecisionValueType<decltype(br)>;
                     printers.push_back([br, delimiter](std::ostream& os, size_t index) {
                         auto oj = util::make_ostream_joiner(os, delimiter);
                         for (size_t i = 0; i < util::flat_extent<ValueType>::value; ++i) {

--- a/modules/plotting/src/processors/imagetodataframe.cpp
+++ b/modules/plotting/src/processors/imagetodataframe.cpp
@@ -165,7 +165,7 @@ void ImageToDataFrame::process() {
             static const vec3 avgLum(1.0f / 3.0f);
 
             layer->dispatch<void>([&](const auto lr) {
-                using ValueType = util::PrecsionValueType<decltype(lr)>;
+                using ValueType = util::PrecisionValueType<decltype(lr)>;
                 const auto im = util::IndexMapper2D(dims);
                 const auto data = lr->getDataTyped();
 
@@ -206,7 +206,7 @@ void ImageToDataFrame::process() {
         case Mode::Rows: {
             auto dataFrame = std::make_shared<plot::DataFrame>(static_cast<glm::u32>(dims.x));
             layer->dispatch<void>([&](const auto lr) {
-                using ValueType = util::PrecsionValueType<decltype(lr)>;
+                using ValueType = util::PrecisionValueType<decltype(lr)>;
                 const auto im = util::IndexMapper2D(dims);
                 const auto data = lr->getDataTyped();
                 for (size_t j = range_.getStart(); j < range_.getEnd(); ++j) {
@@ -227,7 +227,7 @@ void ImageToDataFrame::process() {
         case Mode::Columns: {
             auto dataFrame = std::make_shared<plot::DataFrame>(static_cast<glm::u32>(dims.y));
             layer->dispatch<void>([&](const auto lr) {
-                using ValueType = util::PrecsionValueType<decltype(lr)>;
+                using ValueType = util::PrecisionValueType<decltype(lr)>;
                 const auto im = util::IndexMapper2D(dims);
                 const auto data = lr->getDataTyped();
                 for (size_t i = range_.getStart(); i < range_.getEnd(); ++i) {

--- a/modules/plotting/src/processors/volumetodataframe.cpp
+++ b/modules/plotting/src/processors/volumetodataframe.cpp
@@ -127,7 +127,7 @@ void VolumeToDataFrame::process() {
 
             volume->getRepresentation<VolumeRAM>()->dispatch<void>([&](auto vr) {
                 const auto im = util::IndexMapper3D(vr->getDimensions());
-                using ValueType = util::PrecsionValueType<decltype(vr)>;
+                using ValueType = util::PrecisionValueType<decltype(vr)>;
                 const auto data = vr->getDataTyped();
                 auto i = 0;
                 size3_t ind;
@@ -165,7 +165,7 @@ void VolumeToDataFrame::process() {
 
             volume->getRepresentation<VolumeRAM>()->dispatch<void>([this, dataFrame,
                                                                     size](const auto vr) {
-                using ValueType = util::PrecsionValueType<decltype(vr)>;
+                using ValueType = util::PrecisionValueType<decltype(vr)>;
                 const auto im = util::IndexMapper3D(vr->getDimensions());
                 const auto data = vr->getDataTyped();
                 size3_t ind;
@@ -193,7 +193,7 @@ void VolumeToDataFrame::process() {
 
             volume->getRepresentation<VolumeRAM>()->dispatch<void>(
                 [this, dataFrame, size](const auto vr) {
-                    using ValueType = util::PrecsionValueType<decltype(vr)>;
+                    using ValueType = util::PrecisionValueType<decltype(vr)>;
                     const auto im = util::IndexMapper3D(vr->getDimensions());
                     const auto data = vr->getDataTyped();
                     size3_t ind;
@@ -221,7 +221,7 @@ void VolumeToDataFrame::process() {
 
             volume->getRepresentation<VolumeRAM>()->dispatch<void>(
                 [this, dataFrame, size](const auto vr) {
-                    using ValueType = util::PrecsionValueType<decltype(vr)>;
+                    using ValueType = util::PrecisionValueType<decltype(vr)>;
                     const auto im = util::IndexMapper3D(vr->getDimensions());
                     const auto data = vr->getDataTyped();
                     size3_t ind;

--- a/src/core/datastructures/buffer/bufferram.cpp
+++ b/src/core/datastructures/buffer/bufferram.cpp
@@ -78,7 +78,7 @@ bool operator==(const BufferBase &bufA, const BufferBase &bufB) {
     }
 
     return bufA.getRepresentation<BufferRAM>()->dispatch<bool>([&](const auto buffer) {
-        using ValueType = util::PrecsionValueType<decltype(buffer)>;
+        using ValueType = util::PrecisionValueType<decltype(buffer)>;
 
         auto containerA = buffer->getDataContainer();
         auto bufBRAM = bufB.getRepresentation<BufferRAM>();


### PR DESCRIPTION
* deprecated misspelled types `util::PrecsionType` and `util::PrecsionValueType` for backward compatibility
