### PR TITLE
Core: linking between TF and IsoValue properties

### DIFF
--- a/include/inviwo/core/properties/isotfproperty.h
+++ b/include/inviwo/core/properties/isotfproperty.h
@@ -76,7 +76,15 @@ public:
     virtual std::string getClassIdentifierForWidget() const override;
 
     virtual void set(const Property* property) override;
+    /**
+     * \brief sets only the isovalue property to \p p. The transfer function property remains
+     * unchanged.
+     */
     void set(const IsoValueProperty& p);
+    /**
+     * \brief sets only the transfer function property to \p p. The isovalue property remains
+     * unchanged.
+     */
     void set(const TransferFunctionProperty& p);
 
     void setMask(double maskMin, double maskMax);

--- a/include/inviwo/core/properties/isotfproperty.h
+++ b/include/inviwo/core/properties/isotfproperty.h
@@ -75,6 +75,10 @@ public:
 
     virtual std::string getClassIdentifierForWidget() const override;
 
+    virtual void set(const Property* property) override;
+    void set(const IsoValueProperty& p);
+    void set(const TransferFunctionProperty& p);
+
     void setMask(double maskMin, double maskMax);
     const dvec2 getMask() const;
     void clearMask();

--- a/include/inviwo/core/properties/isovalueproperty.h
+++ b/include/inviwo/core/properties/isovalueproperty.h
@@ -42,6 +42,8 @@
 
 namespace inviwo {
 
+class IsoTFProperty;
+
 /**
  * \ingroup properties
  * \class IsoValueProperty
@@ -89,6 +91,7 @@ public:
 
     // Overrides
     virtual void set(const IsoValueCollection& c) override;
+    void set(const IsoTFProperty& p);
     virtual void set(const Property* property) override;
 
     // Overrides TFPrimitiveSetObserver

--- a/include/inviwo/core/properties/transferfunctionproperty.h
+++ b/include/inviwo/core/properties/transferfunctionproperty.h
@@ -41,6 +41,8 @@
 
 namespace inviwo {
 
+class IsoTFProperty;
+
 class IVW_CORE_API TFPropertyObserver : public Observer {
 public:
     virtual void onMaskChange(const dvec2& mask);
@@ -108,6 +110,7 @@ public:
 
     // Override
     virtual void set(const TransferFunction& property) override;
+    void set(const IsoTFProperty& p);
     virtual void set(const Property* property) override;
 
     // Override TFPrimitiveSetObserver

--- a/modules/qtwidgets/src/properties/isotfpropertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/isotfpropertywidgetqt.cpp
@@ -93,7 +93,7 @@ std::unique_ptr<QMenu> IsoTFPropertyWidgetQt::getContextMenu() {
 
     util::addTFPresetsMenu(this, menu.get(), &static_cast<IsoTFProperty*>(property_)->tf_);
 
-    auto clearTF = menu->addAction("&Clear TF & Isovalues");
+    auto clearTF = menu->addAction("&Clear TF && Isovalues");
     clearTF->setEnabled(!property_->getReadOnly());
 
     connect(clearTF, &QAction::triggered, this, [this]() {

--- a/modules/qtwidgets/src/tf/tfeditorisovalue.cpp
+++ b/modules/qtwidgets/src/tf/tfeditorisovalue.cpp
@@ -69,11 +69,7 @@ QPainterPath TFEditorIsovalue::shape() const {
     const auto width = getSize() + 3.0;  //<! consider size of pen;
     path.addRect(QRectF(QPointF(-0.5 * width, -0.5 * width), QSizeF(width, width)));
 
-    // add box of vertical line
-    double verticalScaling = getVerticalSceneScaling();
-    QRectF rect = scene()->sceneRect();
-    path.moveTo(QPointF(0.0, -rect.height() * verticalScaling));
-    path.lineTo(QPointF(0.0, rect.height() * verticalScaling));
+    // do not add the vertical line to the shape in order to make only the square box selectable
 
     return path;
 }

--- a/src/core/common/inviwocore.cpp
+++ b/src/core/common/inviwocore.cpp
@@ -356,6 +356,11 @@ InviwoCore::InviwoCore(InviwoApplication* app)
     registerPropertyConverter(std::make_unique<FileToStringConverter>());
     registerPropertyConverter(std::make_unique<StringToFileConverter>());
 
+    registerPropertyConverter(std::make_unique<TransferfunctionToIsoTFConverter>());
+    registerPropertyConverter(std::make_unique<IsoTFToTransferfunctionConverter>());
+    registerPropertyConverter(std::make_unique<IsovalueToIsoTFConverter>());
+    registerPropertyConverter(std::make_unique<IsoTFToIsovalueConverter>());
+
     // for_each_type_pair will call the functor with all permutation of types, and supplied
     // arguments like: ConverterRegFunctor<float, float>(registerPC), ConverterRegFunctor<float,
     // double>(registerPC), ...

--- a/src/core/properties/isotfproperty.cpp
+++ b/src/core/properties/isotfproperty.cpp
@@ -74,7 +74,7 @@ std::string IsoTFProperty::getClassIdentifierForWidget() const {
 
 void IsoTFProperty::set(const Property* property) {
     if (const auto isotfprop = dynamic_cast<const CompositeProperty*>(property)) {
-        set(isotfprop);
+        CompositeProperty::set(isotfprop);
     } else if (auto isoprop = dynamic_cast<const IsoValueProperty*>(property)) {
         isovalues_.set(isoprop);
     } else if (auto tfprop = dynamic_cast<const TransferFunctionProperty*>(property)) {

--- a/src/core/properties/isotfproperty.cpp
+++ b/src/core/properties/isotfproperty.cpp
@@ -72,6 +72,20 @@ std::string IsoTFProperty::getClassIdentifierForWidget() const {
     return IsoTFProperty::classIdentifier;
 }
 
+void IsoTFProperty::set(const Property* property) {
+    if (const auto isotfprop = dynamic_cast<const CompositeProperty*>(property)) {
+        set(isotfprop);
+    } else if (auto isoprop = dynamic_cast<const IsoValueProperty*>(property)) {
+        isovalues_.set(isoprop);
+    } else if (auto tfprop = dynamic_cast<const TransferFunctionProperty*>(property)) {
+        tf_.set(tfprop);
+    }
+}
+
+void IsoTFProperty::set(const IsoValueProperty& p) { isovalues_.set(p); }
+
+void IsoTFProperty::set(const TransferFunctionProperty& p) { tf_.set(p); }
+
 void IsoTFProperty::setMask(double maskMin, double maskMax) { tf_.setMask(maskMin, maskMax); }
 
 const dvec2 IsoTFProperty::getMask() const { return tf_.getMask(); }

--- a/src/core/properties/isovalueproperty.cpp
+++ b/src/core/properties/isovalueproperty.cpp
@@ -29,6 +29,7 @@
 
 #include <inviwo/core/properties/isovalueproperty.h>
 #include <inviwo/core/network/networklock.h>
+#include <inviwo/core/properties/isotfproperty.h>
 
 namespace inviwo {
 
@@ -161,9 +162,13 @@ void IsoValueProperty::set(const IsoValueCollection& c) {
     this->value_.value.addObserver(this);
 }
 
+void IsoValueProperty::set(const IsoTFProperty& p) { set(p.isovalues_.get()); }
+
 void IsoValueProperty::set(const Property* property) {
-    if (auto tfp = dynamic_cast<const IsoValueProperty*>(property)) {
-        TemplateProperty<IsoValueCollection>::set(tfp);
+    if (auto isoprop = dynamic_cast<const IsoValueProperty*>(property)) {
+        TemplateProperty<IsoValueCollection>::set(isoprop);
+    } else if (auto isotfprop = dynamic_cast<const IsoTFProperty*>(property)) {
+        TemplateProperty<IsoValueCollection>::set(&isotfprop->isovalues_);
     }
 }
 

--- a/src/core/properties/transferfunctionproperty.cpp
+++ b/src/core/properties/transferfunctionproperty.cpp
@@ -223,9 +223,13 @@ void TransferFunctionProperty::set(const TransferFunction& value) {
     this->value_.value.addObserver(this);
 }
 
+void TransferFunctionProperty::set(const IsoTFProperty& p) { set(p.tf_.get()); }
+
 void TransferFunctionProperty::set(const Property* property) {
     if (auto tfp = dynamic_cast<const TransferFunctionProperty*>(property)) {
         TemplateProperty<TransferFunction>::set(tfp);
+    } else if (auto isotfprop = dynamic_cast<const IsoTFProperty*>(property)) {
+        TemplateProperty<TransferFunction>::set(&isotfprop->tf_);
     }
 }
 

--- a/src/core/properties/transferfunctionproperty.cpp
+++ b/src/core/properties/transferfunctionproperty.cpp
@@ -30,6 +30,7 @@
 #include <inviwo/core/properties/transferfunctionproperty.h>
 #include <inviwo/core/network/processornetwork.h>
 #include <inviwo/core/network/networklock.h>
+#include <inviwo/core/properties/isotfproperty.h>
 
 namespace inviwo {
 


### PR DESCRIPTION
allows direct linking between `IsoTFProperty` and `TransferfunctionProperty` as well as `IsoTFProperty` and `IsoValueProperty`. Only the respective parts, i.e. either the TF or the isovalues, are linked. Everything else is left intact.