### PR TITLE
Add world up dropdown for fixUp in trackball 

### DIFF
--- a/include/inviwo/core/interaction/trackball.h
+++ b/include/inviwo/core/interaction/trackball.h
@@ -116,6 +116,7 @@ protected:
     void moveForward(Event* event);
     void moveBackward(Event* event);
 
+    const vec3 getWorldUp() const;
     mat4 roll(const float radians) const;
     mat4 pitch(const float radians) const;
     mat4 yaw(const float radians) const;
@@ -164,6 +165,7 @@ protected:
                                          /// when fixUp is True
     FloatProperty movementSpeed_;
     BoolProperty fixUp_;  /// Fixes the up vector to world_up in all rotation methods
+    OptionPropertyInt worldUp_; /// Defines which axis is considered up in world space
 
     // Interaction restrictions
     BoolProperty handleInteractionEvents_;

--- a/include/inviwo/core/interaction/trackball.h
+++ b/include/inviwo/core/interaction/trackball.h
@@ -122,7 +122,7 @@ protected:
     mat4 yaw(const float radians) const;
 
     void stepRotate(Direction dir);
-    void stepZoom(Direction dir, const int numSteps=1);
+    void stepZoom(Direction dir, const int numSteps = 1);
     void stepPan(Direction dir);
 
     void rotateLeft(Event* event);
@@ -136,8 +136,8 @@ protected:
     void panDown(Event* event);
 
     void zoomWheel(Event* event);
-    void zoomIn(Event* event, const int numSteps=1);
-    void zoomOut(Event* event, const int numSteps=1);
+    void zoomIn(Event* event, const int numSteps = 1);
+    void zoomOut(Event* event, const int numSteps = 1);
 
     void recenterFocusPoint(Event* event);
 
@@ -164,8 +164,9 @@ protected:
     FloatProperty verticalAngleLimit_;   /// Limits the angle between world up and view direction
                                          /// when fixUp is True
     FloatProperty movementSpeed_;
-    BoolProperty fixUp_;  /// Fixes the up vector to world_up in all rotation methods
-    OptionPropertyInt worldUp_; /// Defines which axis is considered up in world space
+    BoolProperty fixUp_;               /// Fixes the up vector to world_up in all rotation methods
+    OptionPropertyInt worldUp_;        /// Defines which axis is considered up in world space
+    FloatVec3Property customWorldUp_;  /// The custom world up direction (normalized)
 
     // Interaction restrictions
     BoolProperty handleInteractionEvents_;

--- a/src/core/interaction/trackball.cpp
+++ b/src/core/interaction/trackball.cpp
@@ -52,14 +52,24 @@ Trackball::Trackball(TrackballObject* object)
     , isMouseBeingPressedAndHold_(false)
     , lastNDC_(vec3(0.0))
     , gestureStartNDCDepth_(-1)
-    , trackballMethod_("trackballMethod", "Trackball Method")
+    , trackballMethod_("trackballMethod", "Trackball Method",
+                       {{"tb_vt", "Virtual Trackball", 0},
+                        {"tb_tav", "Two Axis Valuator Trackball", 1},
+                        {"tb_fps", "First Person Camera", 2},
+                        {"tb_fodr", "Object follows Cursor", 3}},
+                       0)
     , sensitivity_("sensitivity", "Sensitivity", 3.0f, 0.0f, 10.0f, 0.25f)
     , verticalAngleLimit_("verticalAngleLimit", "Vertical Angle Limit", 0.125f, 0.0f,
                           glm::pi<float>() / 2.0f, 0.05f)
     , movementSpeed_("movementSpeed", "Movement Speed", 0.025, 0.0f, 1.0f)
     , fixUp_("fixUp", "Fix Up Vector", false)
     , worldUp_("worldUp", "World Up",
-               {{"xAxis", "X Axis", 0}, {"yAxis", "Y Axis", 1}, {"zAxis", "Z Axis", 2}})
+               {{"xAxis", "X Axis", 0},
+                {"yAxis", "Y Axis", 1},
+                {"zAxis", "Z Axis", 2},
+                {"custom", "Custom", 3}},
+               1)
+    , customWorldUp_("customWup", "Custom World Up", vec3(0, 1, 0), vec3(-1, -1, -1), vec3(1, 1, 1))
     , handleInteractionEvents_("handleEvents", "Handle interaction events", true,
                                InvalidationLevel::Valid)
     , allowHorizontalPanning_("allowHorizontalPanning", "Horizontal panning enabled", true)
@@ -104,20 +114,23 @@ Trackball::Trackball(TrackballObject* object)
     , timer_{std::chrono::milliseconds{30LL}, [this]() { animate(); }} {
 
     mouseReset_.setVisible(false);
-    mouseReset_.setCurrentStateAsDefault();
 
-    trackballMethod_.addOption("tb_vt", "Virtual Trackball", 0);
-    trackballMethod_.addOption("tb_tav", "Two Axis Valuator Trackball", 1);
-    trackballMethod_.addOption("tb_fps", "First Person Camera", 2);
-    trackballMethod_.addOption("tb_fodr", "Object follows Cursor", 3);
     addProperty(trackballMethod_);
     addProperty(sensitivity_);
     addProperty(movementSpeed_);
     addProperty(fixUp_);
     addProperty(worldUp_);
-    worldUp_.setSelectedIndex(1);
-    worldUp_.setCurrentStateAsDefault();
+    addProperty(customWorldUp_);
     addProperty(verticalAngleLimit_);
+    customWorldUp_.visibilityDependsOn(
+        worldUp_, [](const OptionPropertyInt& opt) { return opt == 3 && opt.getVisible(); });
+    worldUp_.visibilityDependsOn(trackballMethod_,
+                                 [](const OptionPropertyInt& opt) { return opt == 1 || opt == 2; });
+    auto isTAV = [](const OptionPropertyInt& opt) { return opt == 1; };
+    verticalAngleLimit_.visibilityDependsOn(trackballMethod_, isTAV);
+    fixUp_.visibilityDependsOn(trackballMethod_, isTAV);
+    movementSpeed_.visibilityDependsOn(trackballMethod_,
+                                       [](const OptionPropertyInt& opt) { return opt == 2; });
 
     addProperty(handleInteractionEvents_);
 
@@ -175,6 +188,7 @@ Trackball::Trackball(const Trackball& rhs)
     , movementSpeed_(rhs.movementSpeed_)
     , fixUp_(rhs.fixUp_)
     , worldUp_(rhs.worldUp_)
+    , customWorldUp_(rhs.customWorldUp_)
     , handleInteractionEvents_(rhs.handleInteractionEvents_)
     , allowHorizontalPanning_(rhs.allowHorizontalPanning_)
     , allowVerticalPanning_(rhs.allowVerticalPanning_)
@@ -218,6 +232,7 @@ Trackball::Trackball(const Trackball& rhs)
     addProperty(sensitivity_);
     addProperty(fixUp_);
     addProperty(worldUp_);
+    addProperty(customWorldUp_);
     addProperty(verticalAngleLimit_);
 
     addProperty(handleInteractionEvents_);
@@ -331,11 +346,17 @@ const vec3 Trackball::getLookRight() const {
 
 /* \brief Returns the World Up Vector according to `worldUp_` property. */
 const vec3 Trackball::getWorldUp() const {
-    switch(worldUp_){
-        case 0: return vec3(1,0,0);
-        case 1: return vec3(0,1,0);
-        case 2: return vec3(0,2,0);
-        default: return vec3(0,1,0);
+    switch (worldUp_) {
+        case 0:
+            return vec3(1, 0, 0);
+        case 1:
+            return vec3(0, 1, 0);
+        case 2:
+            return vec3(0, 0, 1);
+        case 3:
+            return glm::normalize(customWorldUp_.get());
+        default:
+            return vec3(0, 1, 0);
     }
 }
 
@@ -543,7 +564,7 @@ mat4 Trackball::pitch(const float radians) const {
 
 mat4 Trackball::yaw(const float radians) const {
     return glm::translate(getLookFrom())  // to origin
-           * glm::rotate(radians, fixUp_ ? getWorldUp(): getLookUp()) *
+           * glm::rotate(radians, fixUp_ ? getWorldUp() : getLookUp()) *
            glm::translate(-getLookFrom());  // translate back
 }
 


### PR DESCRIPTION
The trackball changes in #422 bringt the option to fix horizontal rotations around the world up axis. However I forgot a way to specify the up axis (x, y or z). This adds a dropdown to specify the axis used, defaulting to y.


