### PR TITLE
BaseGL: Added property for changing indicator size

### DIFF
--- a/modules/basegl/include/modules/basegl/processors/volumeslicegl.h
+++ b/modules/basegl/include/modules/basegl/processors/volumeslicegl.h
@@ -180,6 +180,7 @@ private:
     BoolProperty posPicking_;
     BoolProperty showIndicator_;
     FloatVec4Property indicatorColor_;
+    FloatProperty indicatorSize_;
 
     BoolProperty tfMappingEnabled_;
     TransferFunctionProperty transferFunction_;

--- a/modules/basegl/src/processors/volumeslicegl.cpp
+++ b/modules/basegl/src/processors/volumeslicegl.cpp
@@ -478,7 +478,6 @@ void VolumeSliceGL::renderPositionIndicator() {
 
     utilgl::GlBoolState smooth(GL_LINE_SMOOTH, true);
     utilgl::BlendModeState blend(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    //utilgl::LineWidthState linewidth(2.5f); // Doesn't seem to make a difference
 
     indicatorShader_.activate();
     indicatorShader_.setUniform("dataToClip", mat4(1.0f));

--- a/modules/opengl/include/modules/opengl/openglutils.h
+++ b/modules/opengl/include/modules/opengl/openglutils.h
@@ -588,7 +588,9 @@ using DepthMaskState =
  *
  * \see glLineWidth, GL_LINE_WIDTH
  */
-using LineWidthState =
+
+using LineWidthState [[deprecated(
+    "glLineWidth is not supported by all OpenGL implementations for widths different from 1.0")]] =
     SimpleState<GLfloat, GLfloat, GL_LINE_WIDTH, glGetFloatv, glLineWidth, validateLineWidth>;
 
 /**


### PR DESCRIPTION
Added property to change indicator size in VolumeSliceGL since the size was previously determined on the size of the input volume.

Also wanted to create a property for changing the linewidth as it also is depending on ratio between input size and output image size, but it seems that the glLineWidth function call does not change anything and the lines are always 1 pixel wide with respect to the volume resolution.

(Also did some clang formatting)