### PR TITLE
jenkins fix for multiple external modules

### DIFF
--- a/tools/jenkins/util.groovy
+++ b/tools/jenkins/util.groovy
@@ -261,7 +261,7 @@ def cmake(Map args = [:]) {
     return "cmake -G Ninja " +
         (args.printCMakeVars ? " -LA " : "") +
         (args.opts?.collect{" -D${it.key}=${it.value}"}?.join('') ?: "") + 
-        (args.modulePaths ? " -DIVW_EXTERNAL_MODULES=" + args.modulePaths.join(";") : "" ) +
+        (args.modulePaths ? " -DIVW_EXTERNAL_MODULES=\"" + args.modulePaths.join(";") + "\"" : "" ) +
         (args.onModules?.collect{" -DIVW_MODULE_${it.toUpperCase()}=ON"}?.join('') ?: "") +
         (args.offModules?.collect{" -DIVW_MODULE_${it.toUpperCase()}=OFF"}?.join('') ?: "") +
         " ../inviwo"


### PR DESCRIPTION
Need to put IVW_EXTERNAL_MODULES inside citation marks to be able to include semi-colons.

Noticed in failing commit  https://github.com/inviwo/modules/commit/982169cb492f3cfafece2a6413c2fc35635bfb60 with [jenkins build](http://jenkins.inviwo.org:8080/job/modules/job/feature%252Fgenericvtkreader/)

This was tested in the modules repo with https://github.com/inviwo/modules/commit/47058216c550b396fd9861e0e71a51394959921a and [jenkins build](http://jenkins.inviwo.org:8080/job/modules/job/fix%252Fjenkins-multiple-external-modules/ ) 