### PR TITLE
Fix/tf selector

### DIFF
--- a/modules/base/src/processors/tfselector.cpp
+++ b/modules/base/src/processors/tfselector.cpp
@@ -55,26 +55,28 @@ TFSelector::TFSelector()
     , tfPresets_("presets", "Presets",
                  std::make_unique<TransferFunctionProperty>("tfPreset1", "TF 1"))
     , interactions_("interactions", "Interactions")
-    , nextTF_("nextTF", "Next TF",
-              [this](Event* e) {
-                  size_t next = selectedTF_.getSelectedIndex() + 1;
-                  if (cycle_.get()) {
-                      next = next % selectedTF_.size();
-                  }
-                  selectedTF_.setSelectedIndex(next);
-                  e->markAsUsed();
-              },
-              IvwKey::Period, KeyState::Press)
-    , previousTF_("previousTF", "Previous TF",
-                  [this](Event* e) {
-                      if (auto index = selectedTF_.getSelectedIndex()) {
-                          selectedTF_.setSelectedIndex(index - 1);
-                      } else if (cycle_.get()) {
-                          selectedTF_.setSelectedIndex(selectedTF_.size() - 1);
-                      }
-                      e->markAsUsed();
-                  },
-                  IvwKey::Comma, KeyState::Press) {
+    , nextTF_(
+          "nextTF", "Next TF",
+          [this](Event* e) {
+              size_t next = selectedTF_.getSelectedIndex() + 1;
+              if (cycle_.get()) {
+                  next = next % selectedTF_.size();
+              }
+              selectedTF_.setSelectedIndex(next);
+              e->markAsUsed();
+          },
+          IvwKey::Period, KeyState::Press)
+    , previousTF_(
+          "previousTF", "Previous TF",
+          [this](Event* e) {
+              if (auto index = selectedTF_.getSelectedIndex()) {
+                  selectedTF_.setSelectedIndex(index - 1);
+              } else if (cycle_.get()) {
+                  selectedTF_.setSelectedIndex(selectedTF_.size() - 1);
+              }
+              e->markAsUsed();
+          },
+          IvwKey::Comma, KeyState::Press) {
 
     addPort(inport_);
     addPort(outport_);

--- a/modules/base/src/processors/tfselector.cpp
+++ b/modules/base/src/processors/tfselector.cpp
@@ -103,7 +103,11 @@ TFSelector::TFSelector()
                 tfPresets_.getPropertyByIdentifier(selectedTF_.getSelectedIdentifier()));
             tfOut_.set(p->get());
             // ensure that if the TF is modified, the output is in sync
-            p->onChange([this, p]() { tfOut_.set(p->get()); });
+            p->onChange([this, p]() {
+                if (p->getIdentifier() == selectedTF_.getSelectedIdentifier()) {
+                    tfOut_.set(p->get());
+                }
+            });
         }
     });
 


### PR DESCRIPTION
Added a check for preventing the processor from changing selected TF when an unselected TF is modified. Previously it changed the selected TF to the modified even though it wasn't the chosen TF in the OptionProperty.