### PR TITLE
Python: CMake: Check IVW_UNITTESTS instead of IVW_UNITTESTS_RUN_ON_BU…

### DIFF
--- a/modules/python3/CMakeLists.txt
+++ b/modules/python3/CMakeLists.txt
@@ -91,7 +91,7 @@ target_include_directories(inviwo-module-python3 PUBLIC
 
 add_subdirectory(bindings)
 
-if(IVW_UNITTESTS_RUN_ON_BUILD)
+if(IVW_UNITTESTS)
     add_dependencies(inviwo-unittests-python3 inviwopy)
 endif()
 


### PR DESCRIPTION
Check `IVW_UNITTESTS` instead of `IVW_UNITTESTS_RUN_ON_BUILD` since the later can be true while the former is false and the unit test target depend only on the former. 

CMake failed if `IVW_UNITTESTS` was set to false while `IVW_UNITTESTS_RUN_ON_BUILD` was untuched (set to true) 