### PR TITLE
Chaining API

### DIFF
--- a/include/inviwo/core/processors/processor.h
+++ b/include/inviwo/core/processors/processor.h
@@ -337,21 +337,20 @@ public:
     virtual void deserialize(Deserializer& d) override;
 
     /**
-     * Add inport to processor.
+     * Add port to processor.
      * @note Port group is a concept for event propagation. Currently only used for
      * ResizeEvents, which only propagate from outports to inports in the same port group
      * @param port to add
      * @param portGroup name of group to propagate events through (defaults to "default")
      */
-    void addPort(Inport& port, const std::string& portGroup = "default");
-    /**
-     * Add outport to processor.
-     * @note Port group is a concept for event propagation. Currently only used for
-     * ResizeEvents, which only propagate from outports to inports in the same port group
-     * @param port to add
-     * @param portGroup name of group to propagate events through (defaults to "default")
-     */
-    void addPort(Outport& port, const std::string& portGroup = "default");
+    template <typename T>
+    T& addPort(T& port, const std::string& portGroup = "default"){
+        static_assert(std::is_base_of<Inport,  T>::value ||
+                      std::is_base_of<Outport, T>::value,
+                      "T must be an Inport or Outport");
+        addPortInternal(&port, portGroup);
+        return port;
+    }
 
     // Assume ownership of port, needed for dynamic ports
     void addPort(std::unique_ptr<Inport> port, const std::string& portGroup = "default");

--- a/include/inviwo/core/properties/buttonproperty.h
+++ b/include/inviwo/core/properties/buttonproperty.h
@@ -79,10 +79,10 @@ public:
      */
     virtual void pressButton();
 
-    virtual void propertyModified() override;  // override for custom onChange behavior
+    virtual ButtonProperty& propertyModified() override;  // override for custom onChange behavior
 
     // Override Property::resetToDefaultState, to avoid calling propertyModified  on reset.
-    virtual void resetToDefaultState() override;
+    virtual ButtonProperty& resetToDefaultState() override;
 
 private:
     bool buttonPressed_ = false;

--- a/include/inviwo/core/properties/compositeproperty.h
+++ b/include/inviwo/core/properties/compositeproperty.h
@@ -72,9 +72,9 @@ public:
     virtual void setValid() override;
     virtual InvalidationLevel getInvalidationLevel() const override;
 
-    virtual void setCurrentStateAsDefault() override;
-    virtual void resetToDefaultState() override;
-    virtual void setReadOnly(bool value) override;
+    virtual CompositeProperty& setCurrentStateAsDefault() override;
+    virtual CompositeProperty& resetToDefaultState() override;
+    virtual CompositeProperty& setReadOnly(bool value) override;
 
     // Override from the PropertyOwner
     virtual void invalidate(InvalidationLevel invalidationLevel,

--- a/include/inviwo/core/properties/eventproperty.h
+++ b/include/inviwo/core/properties/eventproperty.h
@@ -98,8 +98,8 @@ public:
     bool isEnabled() const;
     void setEnabled(bool enabled);
 
-    virtual void setCurrentStateAsDefault() override;
-    virtual void resetToDefaultState() override;
+    virtual EventProperty& setCurrentStateAsDefault() override;
+    virtual EventProperty& resetToDefaultState() override;
 
     virtual void serialize(Serializer& s) const override;
     virtual void deserialize(Deserializer& d) override;

--- a/include/inviwo/core/properties/isovalueproperty.h
+++ b/include/inviwo/core/properties/isovalueproperty.h
@@ -83,8 +83,8 @@ public:
 
     VolumeInport* getVolumeInport();
 
-    virtual void setCurrentStateAsDefault() override;
-    virtual void resetToDefaultState() override;
+    virtual IsoValueProperty& setCurrentStateAsDefault() override;
+    virtual IsoValueProperty& resetToDefaultState() override;
 
     virtual void serialize(Serializer& s) const override;
     virtual void deserialize(Deserializer& d) override;

--- a/include/inviwo/core/properties/minmaxproperty.h
+++ b/include/inviwo/core/properties/minmaxproperty.h
@@ -77,15 +77,15 @@ public:
     virtual void set(const range_type& value) override;
     virtual void set(const Property* srcProperty) override;
 
-    void setStart(const T& value);
-    void setEnd(const T& value);
+    MinMaxProperty<T>& setStart(const T& value);
+    MinMaxProperty<T>& setEnd(const T& value);
 
-    void setRangeMin(const T& value);
-    void setRangeMax(const T& value);
-    void setIncrement(const T& value);
-    void setMinSeparation(const T& value);
+    MinMaxProperty<T>& setRangeMin(const T& value);
+    MinMaxProperty<T>& setRangeMax(const T& value);
+    MinMaxProperty<T>& setIncrement(const T& value);
+    MinMaxProperty<T>& setMinSeparation(const T& value);
 
-    void setRange(const range_type& value);
+    MinMaxProperty<T>& setRange(const range_type& value);
 
     /**
      * \brief set all parameters of the range property at the same time with only a
@@ -98,13 +98,13 @@ public:
              const T& minSep);
 
     // set a new range, and maintains the same relative values as before.
-    void setRangeNormalized(const range_type& newRange);
+    MinMaxProperty<T>& setRangeNormalized(const range_type& newRange);
 
     const BaseCallBack* onRangeChange(std::function<void()> callback);
     void removeOnRangeChange(const BaseCallBack* callback);
 
-    virtual void setCurrentStateAsDefault() override;
-    virtual void resetToDefaultState() override;
+    virtual MinMaxProperty<T>& setCurrentStateAsDefault() override;
+    virtual MinMaxProperty<T>& resetToDefaultState() override;
 
     virtual void serialize(Serializer& s) const override;
     virtual void deserialize(Deserializer& s) override;
@@ -228,17 +228,19 @@ void MinMaxProperty<T>::set(const range_type& value) {
 }
 
 template <typename T>
-void MinMaxProperty<T>::setStart(const T& value) {
+MinMaxProperty<T>& MinMaxProperty<T>::setStart(const T& value) {
     auto val = TemplateProperty<range_type>::value_.value;
     val.x = value;
     set(val);
+    return *this;
 }
 
 template <typename T>
-void MinMaxProperty<T>::setEnd(const T& value) {
+MinMaxProperty<T>& MinMaxProperty<T>::setEnd(const T& value) {
     auto val = TemplateProperty<range_type>::value_.value;
     val.y = value;
     set(val);
+    return *this;
 }
 
 template <typename T>
@@ -259,8 +261,8 @@ void MinMaxProperty<T>::set(const Property* srcProperty) {
 }
 
 template <typename T>
-void MinMaxProperty<T>::setRangeMin(const T& value) {
-    if (range_.value.x == value) return;
+MinMaxProperty<T>& MinMaxProperty<T>::setRangeMin(const T& value) {
+    if (range_.value.x == value) return *this;
 
     range_.value.x = value;
     // ensure that rangeMax is greater equal than rangeMin
@@ -269,11 +271,12 @@ void MinMaxProperty<T>::setRangeMin(const T& value) {
     value_.value = validateValues(value_.value).second;
     MinMaxProperty<T>::propertyModified();
     onRangeChangeCallback_.invokeAll();
+    return *this;
 }
 
 template <typename T>
-void MinMaxProperty<T>::setRangeMax(const T& value) {
-    if (range_.value.y == value) return;
+MinMaxProperty<T>& MinMaxProperty<T>::setRangeMax(const T& value) {
+    if (range_.value.y == value) return *this;
 
     range_.value.y = value;
     // ensure that rangeMin is less equal than rangeMax
@@ -282,18 +285,20 @@ void MinMaxProperty<T>::setRangeMax(const T& value) {
     value_.value = validateValues(value_.value).second;
     MinMaxProperty<T>::propertyModified();
     onRangeChangeCallback_.invokeAll();
+    return *this;
 }
 
 template <typename T>
-void MinMaxProperty<T>::setIncrement(const T& value) {
-    if (increment_ == value) return;
+MinMaxProperty<T>& MinMaxProperty<T>::setIncrement(const T& value) {
+    if (increment_ == value) return *this;
     increment_ = value;
     MinMaxProperty<T>::propertyModified();
+    return *this;
 }
 
 template <typename T>
-void MinMaxProperty<T>::setMinSeparation(const T& value) {
-    if (minSeparation_ == value) return;
+MinMaxProperty<T>& MinMaxProperty<T>::setMinSeparation(const T& value) {
+    if (minSeparation_ == value) return *this;
     minSeparation_ = value;
 
     // ensure that min separation is not larger than the entire range
@@ -303,11 +308,12 @@ void MinMaxProperty<T>::setMinSeparation(const T& value) {
 
     value_.value = validateValues(value_.value).second;
     MinMaxProperty<T>::propertyModified();
+    return *this;
 }
 
 template <typename T>
-void MinMaxProperty<T>::setRange(const range_type& value) {
-    if (value == range_.value) return;
+MinMaxProperty<T>& MinMaxProperty<T>::setRange(const range_type& value) {
+    if (value == range_.value) return *this;
 
     if (value.x < value.y) {
         range_.value = value;
@@ -318,6 +324,7 @@ void MinMaxProperty<T>::setRange(const range_type& value) {
     value_.value = validateValues(value_.value).second;
     MinMaxProperty<T>::propertyModified();
     onRangeChangeCallback_.invokeAll();
+    return *this;
 }
 
 template <typename T>
@@ -363,7 +370,7 @@ void MinMaxProperty<T>::set(const T& start, const T& end, const T& rangeMin, con
 }
 
 template <typename T>
-void MinMaxProperty<T>::setRangeNormalized(const range_type& newRange) {
+MinMaxProperty<T>& MinMaxProperty<T>::setRangeNormalized(const range_type& newRange) {
     dvec2 val = this->get();
 
     val = (val - static_cast<double>(range_.value.x)) /
@@ -375,14 +382,16 @@ void MinMaxProperty<T>::setRangeNormalized(const range_type& newRange) {
         static_cast<double>(range_.value.x);
 
     this->set(newVal);
+    return *this;
 }
 
 template <typename T>
-void MinMaxProperty<T>::resetToDefaultState() {
+MinMaxProperty<T>& MinMaxProperty<T>::resetToDefaultState() {
     range_.reset();
     increment_.reset();
     minSeparation_.reset();
     TemplateProperty<range_type>::resetToDefaultState();
+    return *this;
 }
 
 template <typename T>
@@ -396,11 +405,12 @@ void MinMaxProperty<T>::removeOnRangeChange(const BaseCallBack* callback) {
 }
 
 template <typename T>
-void MinMaxProperty<T>::setCurrentStateAsDefault() {
+MinMaxProperty<T>& MinMaxProperty<T>::setCurrentStateAsDefault() {
     TemplateProperty<range_type>::setCurrentStateAsDefault();
     range_.setAsDefault();
     increment_.setAsDefault();
     minSeparation_.setAsDefault();
+    return *this;
 }
 
 template <typename T>

--- a/include/inviwo/core/properties/optionproperty.h
+++ b/include/inviwo/core/properties/optionproperty.h
@@ -6,7 +6,7 @@
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * modification, are permitted provided that thvoide following conditions are met:
  *
  * 1. Redistributions of source code must retain the above copyright notice, this
  * list of conditions and the following disclaimer.
@@ -57,7 +57,7 @@ public:
 
     virtual std::string getClassIdentifier() const override = 0;
 
-    virtual void clearOptions() = 0;
+    virtual BaseOptionProperty& clearOptions() = 0;
 
     virtual size_t size() const = 0;
     virtual size_t getSelectedIndex() const = 0;
@@ -150,16 +150,18 @@ public:
      * Adds a option to the property and stores it as a struct in the options_
      * The option name is the name of the option that will be displayed in the widget.
      */
-    void addOption(const std::string& identifier, const std::string& displayName, const T& value);
+    TemplateOptionProperty& addOption(const std::string& identifier, const std::string& displayName, const T& value);
     template <typename U = T,
               class = typename std::enable_if<std::is_same<U, std::string>::value, void>::type>
-    void addOption(const std::string& identifier, const std::string& displayName) {
+    TemplateOptionProperty& addOption(const std::string& identifier,
+                                      const std::string& displayName) {
         addOption(identifier, displayName, identifier);
+        return *this;
     }
 
-    virtual void removeOption(const std::string& identifier);
-    virtual void removeOption(size_t index);
-    virtual void clearOptions() override;
+    virtual TemplateOptionProperty& removeOption(const std::string& identifier);
+    virtual TemplateOptionProperty& removeOption(size_t index);
+    virtual TemplateOptionProperty& clearOptions() override;
 
     virtual size_t size() const override;
     virtual size_t getSelectedIndex() const override;
@@ -180,10 +182,10 @@ public:
     virtual bool setSelectedIdentifier(const std::string& identifier) override;
     virtual bool setSelectedDisplayName(const std::string& name) override;
     bool setSelectedValue(const T& val);
-    virtual void replaceOptions(const std::vector<std::string>& ids,
+    virtual TemplateOptionProperty& replaceOptions(const std::vector<std::string>& ids,
                                 const std::vector<std::string>& displayNames,
                                 const std::vector<T>& values);
-    virtual void replaceOptions(std::vector<OptionPropertyOption<T>> options);
+    virtual TemplateOptionProperty& replaceOptions(std::vector<OptionPropertyOption<T>> options);
 
     virtual bool isSelectedIndex(size_t index) const override;
     virtual bool isSelectedIdentifier(const std::string& identifier) const override;
@@ -199,8 +201,8 @@ public:
      * function after adding all the default options, usually in the processor constructor.
      * @see Property::setCurrentStateAsDefault()
      */
-    virtual void setCurrentStateAsDefault() override;
-    virtual void resetToDefaultState() override;
+    virtual TemplateOptionProperty& setCurrentStateAsDefault() override;
+    virtual TemplateOptionProperty& resetToDefaultState() override;
 
     virtual std::string getClassIdentifierForWidget() const override;
     virtual void serialize(Serializer& s) const override;
@@ -386,8 +388,9 @@ template <typename T>
 TemplateOptionProperty<T>::~TemplateOptionProperty() = default;
 
 template <typename T>
-void TemplateOptionProperty<T>::addOption(const std::string& identifier,
-                                          const std::string& displayName, const T& value) {
+TemplateOptionProperty<T>& TemplateOptionProperty<T>::addOption(const std::string& identifier,
+                                                             const std::string& displayName,
+                                                             const T& value) {
     options_.push_back(OptionPropertyOption<T>(identifier, displayName, value));
 
     // in case we add the first option, we also select it
@@ -396,22 +399,24 @@ void TemplateOptionProperty<T>::addOption(const std::string& identifier,
     }
 
     propertyModified();
+    return *this;
 }
 
 template <typename T>
-void TemplateOptionProperty<T>::removeOption(size_t index) {
-    if (options_.empty()) return;
+TemplateOptionProperty<T>& TemplateOptionProperty<T>::removeOption(size_t index) {
+    if (options_.empty()) return *this;
     std::string id = getSelectedIdentifier();
     options_.erase(options_.begin() + index);
     if (!setSelectedIdentifier(id)) {
         selectedIndex_ = 0;
     }
     propertyModified();
+    return *this;
 }
 
 template <typename T>
-void TemplateOptionProperty<T>::removeOption(const std::string& identifier) {
-    if (options_.empty()) return;
+TemplateOptionProperty<T>& TemplateOptionProperty<T>::removeOption(const std::string& identifier) {
+    if (options_.empty()) return *this;
     std::string id = getSelectedIdentifier();
     util::erase_remove_if(
         options_, [&](const OptionPropertyOption<T>& opt) { return opt.id_ == identifier; });
@@ -419,12 +424,14 @@ void TemplateOptionProperty<T>::removeOption(const std::string& identifier) {
         selectedIndex_ = 0;
     }
     propertyModified();
+    return *this;
 }
 
 template <typename T>
-void TemplateOptionProperty<T>::clearOptions() {
+TemplateOptionProperty<T>& TemplateOptionProperty<T>::clearOptions() {
     options_.clear();
     selectedIndex_ = 0;
+    return *this;
 }
 
 // Getters
@@ -579,9 +586,9 @@ bool TemplateOptionProperty<T>::setSelectedValue(const T& val) {
 }
 
 template <typename T>
-void TemplateOptionProperty<T>::replaceOptions(const std::vector<std::string>& ids,
-                                               const std::vector<std::string>& displayNames,
-                                               const std::vector<T>& values) {
+TemplateOptionProperty<T>& TemplateOptionProperty<T>::replaceOptions(
+    const std::vector<std::string>& ids, const std::vector<std::string>& displayNames,
+    const std::vector<T>& values) {
     std::string selectId{};
     if (!options_.empty()) selectId = getSelectedIdentifier();
 
@@ -596,10 +603,12 @@ void TemplateOptionProperty<T>::replaceOptions(const std::vector<std::string>& i
         selectedIndex_ = 0;
     }
     propertyModified();
+    return *this;
 }
 
 template <typename T>
-void TemplateOptionProperty<T>::replaceOptions(std::vector<OptionPropertyOption<T>> options) {
+TemplateOptionProperty<T>& TemplateOptionProperty<T>::replaceOptions(
+    std::vector<OptionPropertyOption<T>> options) {
     std::string selectId{};
     if (!options_.empty()) selectId = getSelectedIdentifier();
 
@@ -611,6 +620,7 @@ void TemplateOptionProperty<T>::replaceOptions(std::vector<OptionPropertyOption<
         selectedIndex_ = 0;
     }
     propertyModified();
+    return *this;
 }
 
 // Is...
@@ -651,7 +661,7 @@ void TemplateOptionProperty<T>::set(const Property* srcProperty) {
 }
 
 template <typename T>
-void TemplateOptionProperty<T>::resetToDefaultState() {
+TemplateOptionProperty<T>& TemplateOptionProperty<T>::resetToDefaultState() {
     options_ = defaultOptions_;
     selectedIndex_ = defaultSelectedIndex_;
 
@@ -662,13 +672,15 @@ void TemplateOptionProperty<T>::resetToDefaultState() {
     }
 
     Property::resetToDefaultState();
+    return *this;
 }
 
 template <typename T>
-void TemplateOptionProperty<T>::setCurrentStateAsDefault() {
+TemplateOptionProperty<T>& TemplateOptionProperty<T>::setCurrentStateAsDefault() {
     Property::setCurrentStateAsDefault();
     defaultSelectedIndex_ = selectedIndex_;
     defaultOptions_ = options_;
+    return *this;
 }
 
 template <typename T>

--- a/include/inviwo/core/properties/optionproperty.h
+++ b/include/inviwo/core/properties/optionproperty.h
@@ -6,7 +6,7 @@
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that thvoide following conditions are met:
+ * modification, are permitted provided that the following conditions are met:
  *
  * 1. Redistributions of source code must retain the above copyright notice, this
  * list of conditions and the following disclaimer.

--- a/include/inviwo/core/properties/ordinalproperty.h
+++ b/include/inviwo/core/properties/ordinalproperty.h
@@ -78,8 +78,8 @@ public:
      */
     void set(const T& value, const T& minVal, const T& maxVal, const T& increment);
 
-    virtual void setCurrentStateAsDefault() override;
-    virtual void resetToDefaultState() override;
+    virtual OrdinalProperty<T>& setCurrentStateAsDefault() override;
+    virtual OrdinalProperty<T>& resetToDefaultState() override;
 
     virtual void serialize(Serializer& s) const override;
     virtual void deserialize(Deserializer& d) override;
@@ -290,19 +290,21 @@ void OrdinalProperty<T>::set(const T& value, const T& minVal, const T& maxVal, c
 }
 
 template <typename T>
-void OrdinalProperty<T>::resetToDefaultState() {
+OrdinalProperty<T>& OrdinalProperty<T>::resetToDefaultState() {
     minValue_.reset();
     maxValue_.reset();
     increment_.reset();
     TemplateProperty<T>::resetToDefaultState();
+    return *this;
 }
 
 template <typename T>
-void OrdinalProperty<T>::setCurrentStateAsDefault() {
+OrdinalProperty<T>& OrdinalProperty<T>::setCurrentStateAsDefault() {
     TemplateProperty<T>::setCurrentStateAsDefault();
     minValue_.setAsDefault();
     maxValue_.setAsDefault();
     increment_.setAsDefault();
+    return *this;
 }
 
 template <typename T>

--- a/include/inviwo/core/properties/property.h
+++ b/include/inviwo/core/properties/property.h
@@ -137,14 +137,14 @@ public:
      * of a PropertyOwner. Property identifiers should only contain alpha numeric
      * characters, "-" and "_".
      */
-    virtual void setIdentifier(const std::string& identifier);
+    virtual Property& setIdentifier(const std::string& identifier);
     virtual std::string getIdentifier() const;
     virtual std::vector<std::string> getPath() const;
 
     /**
      * \brief A property's name displayed to the user
      */
-    virtual void setDisplayName(const std::string& displayName);
+    virtual Property& setDisplayName(const std::string& displayName);
     virtual std::string getDisplayName() const;
 
     /**
@@ -155,16 +155,16 @@ public:
      */
     virtual std::string getClassIdentifierForWidget() const;
 
-    virtual void setSemantics(const PropertySemantics& semantics);
+    virtual Property& setSemantics(const PropertySemantics& semantics);
     virtual PropertySemantics getSemantics() const;
 
     /**
      * \brief Enable or disable editing of property
      */
-    virtual void setReadOnly(bool value);
+    virtual Property& setReadOnly(bool value);
     virtual bool getReadOnly() const;
 
-    virtual void setInvalidationLevel(InvalidationLevel invalidationLevel);
+    virtual Property& setInvalidationLevel(InvalidationLevel invalidationLevel);
     virtual InvalidationLevel getInvalidationLevel() const;
 
     virtual void setOwner(PropertyOwner* owner);
@@ -222,18 +222,18 @@ public:
      * It is important that all overriding properties make sure to call the base class
      * implementation.
      */
-    virtual void setCurrentStateAsDefault();
+    virtual Property& setCurrentStateAsDefault();
 
     /**
      * Reset the state of the property back to it's default value.
      * It is important that all overriding properties make sure to call the base class
      * implementation.
      */
-    virtual void resetToDefaultState();
+    virtual Property& resetToDefaultState();
 
-    virtual void propertyModified();
+    virtual Property& propertyModified();
     virtual void setValid();
-    virtual void setModified();
+    virtual Property& setModified();
     virtual bool isModified() const;
     virtual void set(const Property* src);
 
@@ -273,13 +273,13 @@ public:
     void removeOnChange(T* object);
     // clang-format on
 
-    virtual void setUsageMode(UsageMode usageMode);
+    virtual Property& setUsageMode(UsageMode usageMode);
     virtual UsageMode getUsageMode() const;
 
     virtual void setSerializationMode(PropertySerializationMode mode);
     virtual PropertySerializationMode getSerializationMode() const;
 
-    virtual void setVisible(bool val);
+    virtual Property& setVisible(bool val);
     virtual bool getVisible() const;
 
     /* \brief sets visibility depending another property `prop`, according to `callback`
@@ -291,15 +291,16 @@ public:
      * might result in poor performance when `prop` is a very frequently changed property.
      */
     template<typename P, typename DecisionFunc>
-    const BaseCallBack* visibilityDependsOn(P& prop, DecisionFunc callback) {
+    Property& visibilityDependsOn(P& prop, DecisionFunc callback) {
         typename std::result_of<DecisionFunc(P&)>::type b = true;
         static_assert(std::is_same<decltype(b), bool>::value, "The visibility callback must return a boolean!");
         static_assert(std::is_base_of<Property, P>::value, "P must be a Property!");
         this->setVisible(callback(prop));
-        return prop.onChange([callback, &prop, this](){
+        prop.onChange([callback, &prop, this](){
             bool visible = callback(prop);
             this->setVisible(visible);
         });
+        return *this;
     }
 
     /* \brief sets readonly depending another property `prop`, according to `callback`
@@ -311,15 +312,16 @@ public:
      * might result in poor performance when `prop` is a very frequently changed property.
      */
     template<typename P, typename DecisionFunc>
-    const BaseCallBack* readonlyDependsOn(P& prop, DecisionFunc callback) {
+    Property& readonlyDependsOn(P& prop, DecisionFunc callback) {
         typename std::result_of<DecisionFunc(P&)>::type b = true;
         static_assert(std::is_same<decltype(b), bool>::value, "The readonly callback must return a boolean!");
         static_assert(std::is_base_of<Property, P>::value, "P must be a Property!");
         this->setReadOnly(callback(prop));
-        return prop.onChange([callback, &prop, this](){
+        prop.onChange([callback, &prop, this](){
             bool readonly = callback(prop);
             this->setReadOnly(readonly);
         });
+        return *this;
     }
 
     virtual Document getDescription() const;
@@ -328,7 +330,7 @@ public:
     static void setStateAsDefault(T& property, const U& state);
 
     template <typename P>
-    void autoLinkToProperty(const std::string& propertyPath);
+    Property& autoLinkToProperty(const std::string& propertyPath);
     const std::vector<std::pair<std::string, std::string>>& getAutoLinkToProperty() const;
 
     class IVW_CORE_API OnChangeBlocker {
@@ -399,9 +401,10 @@ void Property::setStateAsDefault(T& property, const U& state) {
 }
 
 template <typename P>
-void Property::autoLinkToProperty(const std::string& propertyPath) {
+Property& Property::autoLinkToProperty(const std::string& propertyPath) {
     autoLinkTo_.push_back(
         std::make_pair(ProcessorTraits<P>::getProcessorInfo().classIdentifier, propertyPath));
+    return *this;
 }
 
 }  // namespace inviwo

--- a/include/inviwo/core/properties/propertyconverter.h
+++ b/include/inviwo/core/properties/propertyconverter.h
@@ -35,6 +35,7 @@
 
 #include <inviwo/core/properties/templateproperty.h>
 #include <inviwo/core/properties/stringproperty.h>
+#include <inviwo/core/properties/directoryproperty.h>
 #include <inviwo/core/properties/fileproperty.h>
 #include <inviwo/core/properties/optionproperty.h>
 #include <inviwo/core/properties/ordinalproperty.h>
@@ -137,6 +138,7 @@ protected:
     }
 };
 
+// conversion between String and File/Directory properties
 class FileToStringConverter : public TemplatePropertyConverter<FileProperty, StringProperty> {
 protected:
     virtual void convertimpl(const FileProperty* src, StringProperty* dst) const override {
@@ -147,6 +149,20 @@ protected:
 class StringToFileConverter : public TemplatePropertyConverter<StringProperty, FileProperty> {
 protected:
     virtual void convertimpl(const StringProperty* src, FileProperty* dst) const override {
+        dst->set(src->get());
+    }
+};
+
+class DirectoryToStringConverter : public TemplatePropertyConverter<DirectoryProperty, StringProperty> {
+protected:
+    virtual void convertimpl(const DirectoryProperty* src, StringProperty* dst) const override {
+        dst->set(src->get());
+    }
+};
+
+class StringToDirectoryConverter : public TemplatePropertyConverter<StringProperty, DirectoryProperty> {
+protected:
+    virtual void convertimpl(const StringProperty* src, DirectoryProperty* dst) const override {
         dst->set(src->get());
     }
 };

--- a/include/inviwo/core/properties/templateproperty.h
+++ b/include/inviwo/core/properties/templateproperty.h
@@ -64,8 +64,8 @@ public:
     void set(const TemplateProperty<T>* srcProperty);
     virtual void set(const Property* srcProperty) override;
 
-    virtual void setCurrentStateAsDefault() override;
-    virtual void resetToDefaultState() override;
+    virtual TemplateProperty& setCurrentStateAsDefault() override;
+    virtual TemplateProperty& resetToDefaultState() override;
 
     virtual void serialize(Serializer& s) const override;
     virtual void deserialize(Deserializer& d) override;
@@ -108,15 +108,17 @@ TemplateProperty<T>::operator const T&() const {
 }
 
 template <typename T>
-void inviwo::TemplateProperty<T>::resetToDefaultState() {
+TemplateProperty<T>& inviwo::TemplateProperty<T>::resetToDefaultState() {
     value_.reset();
     Property::resetToDefaultState();
+    return *this;
 }
 
 template <typename T>
-void inviwo::TemplateProperty<T>::setCurrentStateAsDefault() {
+TemplateProperty<T>& inviwo::TemplateProperty<T>::setCurrentStateAsDefault() {
     Property::setCurrentStateAsDefault();
     value_.setAsDefault();
+    return *this;
 }
 
 template <typename T>

--- a/include/inviwo/core/properties/transferfunctionproperty.h
+++ b/include/inviwo/core/properties/transferfunctionproperty.h
@@ -88,22 +88,22 @@ public:
     virtual TransferFunctionProperty* clone() const override;
     virtual ~TransferFunctionProperty();
 
-    void setMask(double maskMin, double maskMax);
+    TransferFunctionProperty& setMask(double maskMin, double maskMax);
     const dvec2 getMask() const;
-    void clearMask();
+    TransferFunctionProperty& clearMask();
 
-    void setZoomH(double zoomHMin, double zoomHMax);
+    TransferFunctionProperty& setZoomH(double zoomHMin, double zoomHMax);
     const dvec2& getZoomH() const;
 
-    void setZoomV(double zoomVMin, double zoomVMax);
+    TransferFunctionProperty& setZoomV(double zoomVMin, double zoomVMax);
     const dvec2& getZoomV() const;
 
-    void setHistogramMode(HistogramMode type);
+    TransferFunctionProperty& setHistogramMode(HistogramMode type);
     HistogramMode getHistogramMode();
     VolumeInport* getVolumeInport();
 
-    virtual void setCurrentStateAsDefault() override;
-    virtual void resetToDefaultState() override;
+    virtual TransferFunctionProperty& setCurrentStateAsDefault() override;
+    virtual TransferFunctionProperty& resetToDefaultState() override;
 
     virtual void serialize(Serializer& s) const override;
     virtual void deserialize(Deserializer& d) override;

--- a/modules/assimp/src/assimpreader.cpp
+++ b/modules/assimp/src/assimpreader.cpp
@@ -61,19 +61,24 @@ namespace inviwo {
  */
 class InviwoAssimpLogStream : public Assimp::LogStream {
 private:
-    LogLevel loglevel;
+    LogLevel loglevel_;
+    const std::string fileName_;
 
 public:
-    InviwoAssimpLogStream(LogLevel ploglevel) { loglevel = ploglevel; }
-
+    InviwoAssimpLogStream(LogLevel ploglevel, const std::string filename = "")
+        : loglevel_{ploglevel}, fileName_{filename} {}
     virtual ~InviwoAssimpLogStream() = default;
 
     void write(const char* message) {
+        if (strlen(message) == 0) return;
         std::string tmp(message);
         while ('\n' == tmp.back()) tmp.pop_back();
+        if (fileName_.size() > 0) {
+            tmp += " (" + fileName_ + ")";
+        }
 
-        inviwo::LogCentral::getPtr()->log("Assimp Geometry Importer", loglevel, LogAudience::User,
-                                          "<Assimp Bibliothek>", "<Funktion>", 0, tmp);
+        inviwo::LogCentral::getPtr()->log("AssimpReader", loglevel_, LogAudience::User, __FILE__,
+                                          "inviwo::AssimpReader::readData", 0, tmp);
     }
 };
 
@@ -81,7 +86,7 @@ AssimpReader::AssimpReader()
     : DataReaderType<Mesh>()
     , logLevel_(AssimpLogLevel::Warn)
     , verboseLog_(false)
-    , fixInvalidData_(true) {
+    , fixInvalidData_(false) {
     aiString str{};
     Assimp::Importer importer{};
 
@@ -123,19 +128,23 @@ std::shared_ptr<Mesh> AssimpReader::readData(const std::string& filePath) {
                                                               : Assimp::Logger::LogSeverity::NORMAL;
         Assimp::DefaultLogger::create("AssimpImportLog.txt", logSeverity, 0);
         // if logging is enabled, errors will always be logged
-        Assimp::DefaultLogger::get()->attachStream(new InviwoAssimpLogStream(LogLevel::Error),
-                                                   Assimp::Logger::ErrorSeverity::Err);
+        Assimp::DefaultLogger::get()->attachStream(
+            new InviwoAssimpLogStream(LogLevel::Error, filePath),
+            Assimp::Logger::ErrorSeverity::Err);
         if (logLevel_ >= AssimpLogLevel::Warn) {
-            Assimp::DefaultLogger::get()->attachStream(new InviwoAssimpLogStream(LogLevel::Warn),
-                                                       Assimp::Logger::ErrorSeverity::Warn);
+            Assimp::DefaultLogger::get()->attachStream(
+                new InviwoAssimpLogStream(LogLevel::Warn, filePath),
+                Assimp::Logger::ErrorSeverity::Warn);
         }
         if (logLevel_ >= AssimpLogLevel::Info) {
-            Assimp::DefaultLogger::get()->attachStream(new InviwoAssimpLogStream(LogLevel::Info),
-                                                       Assimp::Logger::ErrorSeverity::Info);
+            Assimp::DefaultLogger::get()->attachStream(
+                new InviwoAssimpLogStream(LogLevel::Info, filePath),
+                Assimp::Logger::ErrorSeverity::Info);
         }
         if (logLevel_ >= AssimpLogLevel::Debug) {
-            Assimp::DefaultLogger::get()->attachStream(new InviwoAssimpLogStream(LogLevel::Info),
-                                                       Assimp::Logger::ErrorSeverity::Debugging);
+            Assimp::DefaultLogger::get()->attachStream(
+                new InviwoAssimpLogStream(LogLevel::Info, filePath),
+                Assimp::Logger::ErrorSeverity::Debugging);
         }
     }
 

--- a/modules/base/include/modules/base/properties/basisproperty.h
+++ b/modules/base/include/modules/base/properties/basisproperty.h
@@ -77,8 +77,8 @@ public:
     virtual void serialize(Serializer& s) const override;
     virtual void deserialize(Deserializer& d) override;
 
-    virtual void setCurrentStateAsDefault() override;
-    virtual void resetToDefaultState() override;
+    virtual BasisProperty& setCurrentStateAsDefault() override;
+    virtual BasisProperty& resetToDefaultState() override;
 
     TemplateOptionProperty<BasisPropertyMode> mode_;
     TemplateOptionProperty<BasisPropertyReference> reference_;

--- a/modules/base/src/processors/heightfieldmapper.cpp
+++ b/modules/base/src/processors/heightfieldmapper.cpp
@@ -46,36 +46,29 @@ HeightFieldMapper::HeightFieldMapper()
     : Processor()
     , inport_("image", true)
     , outport_("heightfield", DataFloat32::get())
-    , scalingModeProp_("scalingmode", "Scaling Mode")
+    , scalingModeProp_("scalingmode", "Scaling Mode",
+                       {{"scaleFixed", "Fixed Range [0:1]", HeightFieldScaling::FixedRange},
+                        {"scaleRange", "Data Range", HeightFieldScaling::DataRange},
+                        {"scaleSeaLevel", "Sea Level", HeightFieldScaling::SeaLevel}},
+                       0)
     , heightRange_("heightrange", "Height Range", 0.0f, 1.0f, -1.0e1f, 1.0e1f)
     , maxHeight_("maxheight", "Maximum Height", 1.0f, 0.0f, 1.0e1f)
     , seaLevel_("sealevel", "Sea Level", 0.0f, -1.0e1f, 1.0e1f) {
     addPort(inport_);
     addPort(outport_);
 
-    scalingModeProp_.addOption("scaleFixed", "Fixed Range [0:1]", HeightFieldScaling::FixedRange);
-    scalingModeProp_.addOption("scaleRange", "Data Range", HeightFieldScaling::DataRange);
-    scalingModeProp_.addOption("scaleSeaLevel", "Sea Level", HeightFieldScaling::SeaLevel);
-    scalingModeProp_.set(HeightFieldScaling::FixedRange);
+    heightRange_.visibilityDependsOn(scalingModeProp_, [](const OptionPropertyInt &opt) {
+        return opt == HeightFieldScaling::DataRange;
+    });
+    maxHeight_.visibilityDependsOn(scalingModeProp_, [](const OptionPropertyInt &opt) {
+        return opt == HeightFieldScaling::SeaLevel;
+    });
+    seaLevel_.visibilityDependsOn(scalingModeProp_, [](const OptionPropertyInt &opt) {
+        return opt == HeightFieldScaling::SeaLevel;
+    });
 
-    auto scalingModeChanged = [this]() {
-        int mode = scalingModeProp_.get();
-        heightRange_.setVisible(mode == HeightFieldScaling::DataRange);
-        maxHeight_.setVisible(mode == HeightFieldScaling::SeaLevel);
-        seaLevel_.setVisible(mode == HeightFieldScaling::SeaLevel);
-    };
-
-    scalingModeProp_.onChange(scalingModeChanged);
-
-    addProperty(scalingModeProp_);
-    addProperty(heightRange_);
-    addProperty(maxHeight_);
-    addProperty(seaLevel_);
-
+    addProperties(scalingModeProp_, heightRange_, maxHeight_, seaLevel_);
     setAllPropertiesCurrentStateAsDefault();
-
-    // update UI state
-    scalingModeChanged();
 }
 
 HeightFieldMapper::~HeightFieldMapper() {}

--- a/modules/base/src/properties/basisproperty.cpp
+++ b/modules/base/src/properties/basisproperty.cpp
@@ -298,15 +298,17 @@ void BasisProperty::deserialize(Deserializer& d) {
     if (modified) propertyModified();
 }
 
-void BasisProperty::setCurrentStateAsDefault() {
+BasisProperty& BasisProperty::setCurrentStateAsDefault() {
     CompositeProperty::setCurrentStateAsDefault();
     overrideModel_.setAsDefault();
+    return *this;
 }
 
-void BasisProperty::resetToDefaultState() {
+BasisProperty& BasisProperty::resetToDefaultState() {
     CompositeProperty::resetToDefaultState();
     overrideModel_.reset();
     load();
+    return *this;
 }
 
 void BasisProperty::updateEntity(SpatialEntity<3>& volume) {

--- a/src/core/common/inviwocore.cpp
+++ b/src/core/common/inviwocore.cpp
@@ -355,6 +355,8 @@ InviwoCore::InviwoCore(InviwoApplication* app)
 
     registerPropertyConverter(std::make_unique<FileToStringConverter>());
     registerPropertyConverter(std::make_unique<StringToFileConverter>());
+    registerPropertyConverter(std::make_unique<DirectoryToStringConverter>());
+    registerPropertyConverter(std::make_unique<StringToDirectoryConverter>());
 
     registerPropertyConverter(std::make_unique<TransferfunctionToIsoTFConverter>());
     registerPropertyConverter(std::make_unique<IsoTFToTransferfunctionConverter>());

--- a/src/core/processors/processor.cpp
+++ b/src/core/processors/processor.cpp
@@ -82,9 +82,6 @@ void Processor::addPortInternal(Inport* port, const std::string& portGroup) {
     isReady_.update();
 }
 
-void Processor::addPort(Inport& port, const std::string& portGroup) {
-    addPortInternal(&port, portGroup);
-}
 void Processor::addPort(std::unique_ptr<Inport> port, const std::string& portGroup) {
     addPortInternal(port.get(), portGroup);
     ownedInports_.push_back(std::move(port));
@@ -108,10 +105,6 @@ void Processor::addPortInternal(Outport* port, const std::string& portGroup) {
     notifyObserversProcessorPortAdded(this, port);
     isSink_.update();
     isReady_.update();
-}
-
-void Processor::addPort(Outport& port, const std::string& portDependencySet) {
-    addPortInternal(&port, portDependencySet);
 }
 
 void Processor::addPort(std::unique_ptr<Outport> port, const std::string& portGroup) {

--- a/src/core/properties/buttonproperty.cpp
+++ b/src/core/properties/buttonproperty.cpp
@@ -70,11 +70,12 @@ void ButtonProperty::pressButton() {
     propertyModified();
 }
 
-void ButtonProperty::propertyModified() {
-    if (!buttonPressed_) return;
+ButtonProperty& ButtonProperty::propertyModified() {
+    if (!buttonPressed_) return *this;
     Property::propertyModified();
+    return *this;
 }
 
-void ButtonProperty::resetToDefaultState() {}
+ButtonProperty& ButtonProperty::resetToDefaultState() { return *this;}
 
 }  // namespace inviwo

--- a/src/core/properties/compositeproperty.cpp
+++ b/src/core/properties/compositeproperty.cpp
@@ -96,26 +96,29 @@ void CompositeProperty::setValid() {
     subPropertyInvalidationLevel_ = InvalidationLevel::Valid;
 }
 
-void CompositeProperty::setCurrentStateAsDefault() {
+CompositeProperty& CompositeProperty::setCurrentStateAsDefault() {
     Property::setCurrentStateAsDefault();
     for (auto& elem : properties_) {
         elem->setCurrentStateAsDefault();
     }
+    return *this;
 }
 
-void CompositeProperty::resetToDefaultState() {
+CompositeProperty& CompositeProperty::resetToDefaultState() {
     NetworkLock lock(this);
     for (auto& elem : properties_) {
         elem->resetToDefaultState();
     }
     Property::resetToDefaultState();
+    return *this;
 }
 
-void CompositeProperty::setReadOnly(bool value) {
+CompositeProperty& CompositeProperty::setReadOnly(bool value) {
     Property::setReadOnly(value);
     for (auto& elem : properties_) {
         elem->setReadOnly(value);
     }
+    return *this;
 }
 
 void CompositeProperty::serialize(Serializer& s) const {

--- a/src/core/properties/eventproperty.cpp
+++ b/src/core/properties/eventproperty.cpp
@@ -96,12 +96,14 @@ void EventProperty::setEventMatcher(std::unique_ptr<EventMatcher> matcher) {
 
 void EventProperty::setAction(Action action) { action_ = std::move(action); }
 
-void EventProperty::setCurrentStateAsDefault() {
+EventProperty& EventProperty::setCurrentStateAsDefault() {
     if (matcher_) matcher_->setCurrentStateAsDefault();
+    return *this;
 }
 
-void EventProperty::resetToDefaultState() {
+EventProperty& EventProperty::resetToDefaultState() {
     if (matcher_) matcher_->resetToDefaultState();
+    return *this;
 }
 
 void EventProperty::serialize(Serializer& s) const {

--- a/src/core/properties/isovalueproperty.cpp
+++ b/src/core/properties/isovalueproperty.cpp
@@ -120,19 +120,21 @@ HistogramMode IsoValueProperty::getHistogramMode() { return histogramMode_; }
 
 VolumeInport* IsoValueProperty::getVolumeInport() { return volumeInport_; }
 
-void IsoValueProperty::setCurrentStateAsDefault() {
+IsoValueProperty& IsoValueProperty::setCurrentStateAsDefault() {
     TemplateProperty<IsoValueCollection>::setCurrentStateAsDefault();
     zoomH_.setAsDefault();
     zoomV_.setAsDefault();
     histogramMode_.setAsDefault();
+    return *this;
 }
 
-void IsoValueProperty::resetToDefaultState() {
+IsoValueProperty& IsoValueProperty::resetToDefaultState() {
     NetworkLock lock(this);
     zoomH_.reset();
     zoomV_.reset();
     histogramMode_.reset();
     TemplateProperty<IsoValueCollection>::resetToDefaultState();
+    return *this;
 }
 
 void IsoValueProperty::serialize(Serializer& s) const {

--- a/src/core/properties/property.cpp
+++ b/src/core/properties/property.cpp
@@ -93,7 +93,7 @@ Property& Property::operator=(const Property& that) {
 }
 
 std::string Property::getIdentifier() const { return identifier_; }
-void Property::setIdentifier(const std::string& identifier) {
+Property& Property::setIdentifier(const std::string& identifier) {
     if (identifier_ != identifier) {
         identifier_ = identifier;
 
@@ -102,6 +102,7 @@ void Property::setIdentifier(const std::string& identifier) {
         notifyObserversOnSetIdentifier(this, identifier_);
         notifyAboutChange();
     }
+    return *this;
 }
 std::vector<std::string> Property::getPath() const {
     std::vector<std::string> path;
@@ -114,38 +115,42 @@ std::vector<std::string> Property::getPath() const {
 
 std::string Property::getDisplayName() const { return displayName_; }
 
-void Property::setDisplayName(const std::string& displayName) {
+Property& Property::setDisplayName(const std::string& displayName) {
     if (displayName_ != displayName) {
         displayName_ = displayName;
         notifyObserversOnSetDisplayName(this, displayName_);
         notifyAboutChange();
     }
+    return *this;
 }
 
 PropertySemantics Property::getSemantics() const { return semantics_; }
 
-void Property::setSemantics(const PropertySemantics& semantics) {
+Property& Property::setSemantics(const PropertySemantics& semantics) {
     if (semantics_ != semantics) {
         semantics_ = semantics;
         notifyObserversOnSetSemantics(this, semantics_);
         notifyAboutChange();
     }
+    return *this;
 }
 
 std::string Property::getClassIdentifierForWidget() const { return getClassIdentifier(); }
 
 bool Property::getReadOnly() const { return readOnly_; }
-void Property::setReadOnly(bool readOnly) {
+Property& Property::setReadOnly(bool readOnly) {
     if (readOnly_ != readOnly) {
         readOnly_ = readOnly;
         notifyObserversOnSetReadOnly(this, readOnly_);
         notifyAboutChange();
     }
+    return *this;
 }
 
 InvalidationLevel Property::getInvalidationLevel() const { return invalidationLevel_; }
-void Property::setInvalidationLevel(InvalidationLevel invalidationLevel) {
+Property& Property::setInvalidationLevel(InvalidationLevel invalidationLevel) {
     invalidationLevel_ = invalidationLevel;
+    return *this;
 }
 
 PropertyOwner* Property::getOwner() { return owner_; }
@@ -176,7 +181,7 @@ void Property::updateWidgets() {
 
 bool Property::hasWidgets() const { return !propertyWidgets_.empty(); }
 
-void Property::propertyModified() {
+Property& Property::propertyModified() {
     NetworkLock lock(this);
     onChangeCallback_.invokeAll();
     setModified();
@@ -194,11 +199,12 @@ void Property::propertyModified() {
     }
 
     updateWidgets();
+    return *this;
 }
 
 void Property::setValid() { propertyModified_ = false; }
 
-void Property::setModified() { propertyModified_ = true; }
+Property& Property::setModified() { propertyModified_ = true; return *this;}
 
 bool Property::isModified() const { return propertyModified_; }
 
@@ -251,21 +257,23 @@ void Property::deserialize(Deserializer& d) {
 }
 
 inviwo::UsageMode Property::getUsageMode() const { return usageMode_; }
-void Property::setUsageMode(UsageMode usageMode) {
+Property& Property::setUsageMode(UsageMode usageMode) {
     if (usageMode_ != usageMode) {
         usageMode_ = usageMode;
         notifyObserversOnSetUsageMode(this, usageMode_);
         notifyAboutChange();
     }
+    return *this;
 }
 
 bool Property::getVisible() const { return visible_; }
-void Property::setVisible(bool visible) {
+Property& Property::setVisible(bool visible) {
     if (visible_ != visible) {
         visible_ = visible;
         notifyObserversOnSetVisible(this, visible_);
         notifyAboutChange();
     }
+    return *this;
 }
 
 Document Property::getDescription() const {
@@ -305,15 +313,16 @@ void Property::notifyAboutChange() {
     }
 }
 
-void Property::setCurrentStateAsDefault() {
+Property& Property::setCurrentStateAsDefault() {
     displayName_.setAsDefault();
     readOnly_.setAsDefault();
     semantics_.setAsDefault();
     visible_.setAsDefault();
     usageMode_.setAsDefault();
+    return *this;
 }
 
-void Property::resetToDefaultState() { propertyModified(); }
+Property& Property::resetToDefaultState() { propertyModified(); return *this; }
 
 void Property::set(const Property* /*src*/) { propertyModified(); }
 

--- a/src/core/properties/raycastingproperty.cpp
+++ b/src/core/properties/raycastingproperty.cpp
@@ -71,11 +71,7 @@ RaycastingProperty::RaycastingProperty(std::string identifier, std::string displ
           3, InvalidationLevel::InvalidResources)
     , samplingRate_("samplingRate", "Sampling rate", 2.0f, 1.0f, 20.0f) {
 
-    addProperty(renderingType_);
-    addProperty(classification_);
-    addProperty(compositing_);
-    addProperty(gradientComputation_);
-    addProperty(samplingRate_);
+    addProperties(renderingType_, classification_, compositing_, gradientComputation_, samplingRate_);
 }
 
 RaycastingProperty::RaycastingProperty(const RaycastingProperty& rhs)

--- a/src/core/properties/simplelightingproperty.cpp
+++ b/src/core/properties/simplelightingproperty.cpp
@@ -40,27 +40,29 @@ SimpleLightingProperty::SimpleLightingProperty(std::string identifier, std::stri
                                                InvalidationLevel invalidationLevel,
                                                PropertySemantics semantics)
     : CompositeProperty(identifier, displayName, invalidationLevel, semantics)
-    , shadingMode_("shadingMode", "Shading", InvalidationLevel::InvalidResources)
+    , shadingMode_("shadingMode", "Shading",
+                   {{"none", "No Shading", ShadingMode::None},
+                    {"ambient", "Ambient", ShadingMode::Ambient},
+                    {"diffuse", "Diffuse", ShadingMode::Diffuse},
+                    {"specular", "Specular", ShadingMode::Specular},
+                    {"blinnphong", "Blinn Phong", ShadingMode::BlinnPhong},
+                    {"phong", "Phong", ShadingMode::Phong}},
+                   5, InvalidationLevel::InvalidResources)
     , referenceFrame_("referenceFrame", "Space")
     , lightPosition_("lightPosition", "Position", vec3(0.0f, 5.0f, 5.0f), vec3(-10, -10, -10),
-                     vec3(10, 10, 10))
+                     vec3(10, 10, 10), vec3(0.1), InvalidationLevel::InvalidOutput,
+                     PropertySemantics::LightPosition)
     , lightAttenuation_("lightAttenuation", "Attenuation", vec3(1.0f, 0.0f, 0.0f))
     , applyLightAttenuation_("applyLightAttenuation", "Enable Light Attenuation", false)
 
-    , ambientColor_("lightColorAmbient", "Ambient color", vec3(0.15f))
-    , diffuseColor_("lightColorDiffuse", "Diffuse color", vec3(0.6f))
-    , specularColor_("lightColorSpecular", "Specular color", vec3(0.4f))
+    , ambientColor_("lightColorAmbient", "Ambient color", vec3(0.15f), vec3(0), vec3(1), vec3(0.1),
+                    InvalidationLevel::InvalidOutput, PropertySemantics::Color)
+    , diffuseColor_("lightColorDiffuse", "Diffuse color", vec3(0.6f), vec3(0), vec3(1), vec3(0.1),
+                    InvalidationLevel::InvalidOutput, PropertySemantics::Color)
+    , specularColor_("lightColorSpecular", "Specular color", vec3(0.4f), vec3(0), vec3(1),
+                     vec3(0.1), InvalidationLevel::InvalidOutput, PropertySemantics::Color)
     , specularExponent_("materialShininess", "Shininess", 60.0f, 1.0f, 180.0f)
     , camera_(camera) {
-
-    shadingMode_.addOption("none", "No Shading", ShadingMode::None);
-    shadingMode_.addOption("ambient", "Ambient", ShadingMode::Ambient);
-    shadingMode_.addOption("diffuse", "Diffuse", ShadingMode::Diffuse);
-    shadingMode_.addOption("specular", "Specular", ShadingMode::Specular);
-    shadingMode_.addOption("blinnphong", "Blinn Phong", ShadingMode::BlinnPhong);
-    shadingMode_.addOption("phong", "Phong", ShadingMode::Phong);
-    shadingMode_.setSelectedValue(ShadingMode::Phong);
-    shadingMode_.setCurrentStateAsDefault();
 
     referenceFrame_.addOption("world", "World", static_cast<int>(Space::WORLD));
     referenceFrame_.setSelectedValue(static_cast<int>(Space::WORLD));
@@ -68,24 +70,11 @@ SimpleLightingProperty::SimpleLightingProperty(std::string identifier, std::stri
         referenceFrame_.addOption("view", "View", static_cast<int>(Space::VIEW));
         referenceFrame_.setSelectedValue(static_cast<int>(Space::VIEW));
     }
-
     referenceFrame_.setCurrentStateAsDefault();
 
-    lightPosition_.setSemantics(PropertySemantics("Spherical"));
-    ambientColor_.setSemantics(PropertySemantics::Color);
-    diffuseColor_.setSemantics(PropertySemantics::Color);
-    specularColor_.setSemantics(PropertySemantics::Color);
-
-    // add properties
-    addProperty(shadingMode_);
-    addProperty(referenceFrame_);
-    addProperty(lightPosition_);
-    addProperty(ambientColor_);
-    addProperty(diffuseColor_);
-    addProperty(specularColor_);
-    addProperty(specularExponent_);
-    addProperty(applyLightAttenuation_);
-    addProperty(lightAttenuation_);
+    addProperties(shadingMode_, referenceFrame_, lightPosition_);
+    addProperties(ambientColor_, diffuseColor_, specularColor_);
+    addProperties(specularExponent_, applyLightAttenuation_, lightAttenuation_);
 }
 
 SimpleLightingProperty::SimpleLightingProperty(const SimpleLightingProperty& rhs)

--- a/src/core/properties/transferfunctionproperty.cpp
+++ b/src/core/properties/transferfunctionproperty.cpp
@@ -116,29 +116,33 @@ TransferFunctionProperty* TransferFunctionProperty::clone() const {
 
 TransferFunctionProperty::~TransferFunctionProperty() { volumeInport_ = nullptr; }
 
-void TransferFunctionProperty::setHistogramMode(HistogramMode mode) {
+TransferFunctionProperty& TransferFunctionProperty::setHistogramMode(HistogramMode mode) {
     if (histogramMode_ != mode) {
         histogramMode_ = mode;
         notifyHistogramModeChange(histogramMode_);
     }
+    return *this;
 }
 
 auto TransferFunctionProperty::getHistogramMode() -> HistogramMode { return histogramMode_; }
 
 VolumeInport* TransferFunctionProperty::getVolumeInport() { return volumeInport_; }
 
-void TransferFunctionProperty::resetToDefaultState() {
+TransferFunctionProperty& TransferFunctionProperty::resetToDefaultState() {
     NetworkLock lock(this);
     zoomH_.reset();
     zoomV_.reset();
     histogramMode_.reset();
     TemplateProperty<TransferFunction>::resetToDefaultState();
+    return *this;
 }
-void TransferFunctionProperty::setCurrentStateAsDefault() {
+
+TransferFunctionProperty& TransferFunctionProperty::setCurrentStateAsDefault() {
     TemplateProperty<TransferFunction>::setCurrentStateAsDefault();
     zoomH_.setAsDefault();
     zoomV_.setAsDefault();
     histogramMode_.setAsDefault();
+    return *this;
 }
 
 void TransferFunctionProperty::serialize(Serializer& s) const {
@@ -161,7 +165,7 @@ void TransferFunctionProperty::deserialize(Deserializer& d) {
     if (modified) propertyModified();
 }
 
-void TransferFunctionProperty::setMask(double maskMin, double maskMax) {
+TransferFunctionProperty& TransferFunctionProperty::setMask(double maskMin, double maskMax) {
     if (maskMax < maskMin) {
         maskMax = maskMin;
     }
@@ -174,9 +178,10 @@ void TransferFunctionProperty::setMask(double maskMin, double maskMax) {
 
         propertyModified();
     }
+    return *this;
 }
 
-void TransferFunctionProperty::clearMask() {
+TransferFunctionProperty& TransferFunctionProperty::clearMask() {
     auto prevMask = getMask();
 
     this->value_.value.clearMask();
@@ -184,6 +189,7 @@ void TransferFunctionProperty::clearMask() {
         notifyMaskChange(getMask());
     }
     propertyModified();
+    return *this;
 }
 
 const dvec2 TransferFunctionProperty::getMask() const {
@@ -192,7 +198,7 @@ const dvec2 TransferFunctionProperty::getMask() const {
 
 const dvec2& TransferFunctionProperty::getZoomH() const { return zoomH_; }
 
-void TransferFunctionProperty::setZoomH(double zoomHMin, double zoomHMax) {
+TransferFunctionProperty& TransferFunctionProperty::setZoomH(double zoomHMin, double zoomHMax) {
     if (zoomHMax < zoomHMin) {
         zoomHMax = zoomHMin;
     }
@@ -202,11 +208,12 @@ void TransferFunctionProperty::setZoomH(double zoomHMin, double zoomHMax) {
         zoomH_ = newZoomH;
         notifyZoomHChange(zoomH_);
     }
+    return *this;
 }
 
 const dvec2& TransferFunctionProperty::getZoomV() const { return zoomV_; }
 
-void TransferFunctionProperty::setZoomV(double zoomVMin, double zoomVMax) {
+TransferFunctionProperty& TransferFunctionProperty::setZoomV(double zoomVMin, double zoomVMax) {
     if (zoomVMax < zoomVMin) {
         zoomVMax = zoomVMin;
     }
@@ -216,6 +223,7 @@ void TransferFunctionProperty::setZoomV(double zoomVMin, double zoomVMax) {
         zoomV_ = newZoomV;
         notifyZoomVChange(zoomV_);
     }
+    return *this;
 }
 
 void TransferFunctionProperty::set(const TransferFunction& value) {


### PR DESCRIPTION
Solves Issue #461.
I split my commits into two. The first commit implements the chaining for the properties and for the `addPort()` and the second uses the new apis in a few processors and properties in order to test and demonstrate. Despite the size increase of this PR, I left the second commit in there so reviewers can actually test the first commits functionality quickly.