### PR TITLE
Core: warning fix

### DIFF
--- a/src/core/properties/property.cpp
+++ b/src/core/properties/property.cpp
@@ -39,7 +39,6 @@ namespace inviwo {
 Property::Property(const std::string& identifier, const std::string& displayName,
                    InvalidationLevel invalidationLevel, PropertySemantics semantics)
     : PropertyObservable()
-    , Serializable()
     , MetaDataOwner()
     , serializationMode_(PropertySerializationMode::Default)
     , identifier_(identifier)
@@ -58,7 +57,6 @@ Property::Property(const std::string& identifier, const std::string& displayName
 
 Property::Property(const Property& rhs)
     : PropertyObservable(rhs)
-    , Serializable(rhs)
     , MetaDataOwner(rhs)
     , serializationMode_(rhs.serializationMode_)
     , identifier_(rhs.identifier_)

--- a/src/core/properties/simplelightingproperty.cpp
+++ b/src/core/properties/simplelightingproperty.cpp
@@ -50,17 +50,17 @@ SimpleLightingProperty::SimpleLightingProperty(std::string identifier, std::stri
                    5, InvalidationLevel::InvalidResources)
     , referenceFrame_("referenceFrame", "Space")
     , lightPosition_("lightPosition", "Position", vec3(0.0f, 5.0f, 5.0f), vec3(-10, -10, -10),
-                     vec3(10, 10, 10), vec3(0.1), InvalidationLevel::InvalidOutput,
+                     vec3(10, 10, 10), vec3(0.1f), InvalidationLevel::InvalidOutput,
                      PropertySemantics::LightPosition)
     , lightAttenuation_("lightAttenuation", "Attenuation", vec3(1.0f, 0.0f, 0.0f))
     , applyLightAttenuation_("applyLightAttenuation", "Enable Light Attenuation", false)
 
-    , ambientColor_("lightColorAmbient", "Ambient color", vec3(0.15f), vec3(0), vec3(1), vec3(0.1),
+    , ambientColor_("lightColorAmbient", "Ambient color", vec3(0.15f), vec3(0), vec3(1), vec3(0.1f),
                     InvalidationLevel::InvalidOutput, PropertySemantics::Color)
-    , diffuseColor_("lightColorDiffuse", "Diffuse color", vec3(0.6f), vec3(0), vec3(1), vec3(0.1),
+    , diffuseColor_("lightColorDiffuse", "Diffuse color", vec3(0.6f), vec3(0), vec3(1), vec3(0.1f),
                     InvalidationLevel::InvalidOutput, PropertySemantics::Color)
     , specularColor_("lightColorSpecular", "Specular color", vec3(0.4f), vec3(0), vec3(1),
-                     vec3(0.1), InvalidationLevel::InvalidOutput, PropertySemantics::Color)
+                     vec3(0.1f), InvalidationLevel::InvalidOutput, PropertySemantics::Color)
     , specularExponent_("materialShininess", "Shininess", 60.0f, 1.0f, 180.0f)
     , camera_(camera) {
 


### PR DESCRIPTION
Fixed warning introduced by virtual inheritance in 7848184acafab416a6e407e028a037e7f13e20b5

```
property.cpp(42): warning C4589: Constructor of abstract class 'inviwo::Property' ignores initializer for virtual base class 'inviwo::Serializable'
property.cpp(42): note: virtual base classes are only initialized by the most-derived type
property.cpp(41): warning C5038: base class 'PropertyObservable' will be initialized after base class 'Serializable'
```