### PR TITLE
Webbrowser: Suppress warnings

### DIFF
--- a/modules/webbrowser/include/modules/webbrowser/processors/propertysyncexampleprocessor.h
+++ b/modules/webbrowser/include/modules/webbrowser/processors/propertysyncexampleprocessor.h
@@ -70,6 +70,8 @@ namespace inviwo {
  * 2. Javascript functions must be added to the html page, see
  * /data/workspaces/web_property_sync.html
  */
+#include <warn/push>
+#include <warn/ignore/dll-interface-base>  // Fine if dependent libs use the same CEF lib binaries
 class IVW_MODULE_WEBBROWSER_API PropertySyncExampleProcessor : public Processor,
                                                                public CefLoadHandler {
 public:
@@ -111,7 +113,7 @@ private:
 
     IMPLEMENT_REFCOUNTING(PropertySyncExampleProcessor)
 };
-
+#include <warn/pop>
 }  // namespace inviwo
 
 #endif  // IVW_PROPERTYSYNCEXAMPLEPROCESSOR_H

--- a/modules/webbrowser/include/modules/webbrowser/processors/webbrowserprocessor.h
+++ b/modules/webbrowser/include/modules/webbrowser/processors/webbrowserprocessor.h
@@ -93,6 +93,8 @@ namespace inviwo {
  * \class WebBrowser
  * \brief Render webpage into the color and picking layers (OpenGL).
  */
+#include <warn/push>
+#include <warn/ignore/dll-interface-base>  // Fine if dependent libs use the same CEF lib binaries
 class IVW_MODULE_WEBBROWSER_API WebBrowserProcessor : public Processor, public CefLoadHandler {
 public:
     WebBrowserProcessor();
@@ -144,7 +146,7 @@ protected:
 
     IMPLEMENT_REFCOUNTING(WebBrowserProcessor)
 };
-
+#include <warn/pop>
 }  // namespace inviwo
 
 #endif  // IVW_WEBBROWSERPROCESSOR_H

--- a/modules/webbrowser/include/modules/webbrowser/properties/propertycefsynchronizer.h
+++ b/modules/webbrowser/include/modules/webbrowser/properties/propertycefsynchronizer.h
@@ -66,6 +66,8 @@ namespace inviwo {
  *
  *
  */
+#include <warn/push>
+#include <warn/ignore/dll-interface-base>  // Fine if dependent libs use the same CEF lib binaries
 class IVW_MODULE_WEBBROWSER_API PropertyCefSynchronizer
     : public CefMessageRouterBrowserSide::Handler,
       public CefLoadHandler {
@@ -122,6 +124,7 @@ private:
     std::vector<std::unique_ptr<PropertyWidgetCEF>> widgets_;
     IMPLEMENT_REFCOUNTING(PropertyCefSynchronizer)
 };
+#include <warn/pop>
 
 template <typename T, typename P>
 void PropertyCefSynchronizer::registerPropertyWidget(PropertySemantics semantics) {

--- a/modules/webbrowser/include/modules/webbrowser/renderhandlergl.h
+++ b/modules/webbrowser/include/modules/webbrowser/renderhandlergl.h
@@ -44,6 +44,8 @@ namespace inviwo {
  * Copies web page into a Texture2D each time it has been painted by the browser and calls
  * onWebPageCopiedCallback afterwards.
  */
+#include <warn/push>
+#include <warn/ignore/dll-interface-base> // Fine if dependent libs use the same CEF lib binaries
 class IVW_MODULE_WEBBROWSER_API RenderHandlerGL : public CefRenderHandler {
 public:
     RenderHandlerGL(std::function<void()> onWebPageCopiedCallback);
@@ -80,7 +82,7 @@ private:
 public:
     IMPLEMENT_REFCOUNTING(RenderHandlerGL)
 };
-
+#include <warn/pop>
 };  // namespace inviwo
 
 #endif  // IVW_RENDERHANDLERGL_H

--- a/modules/webbrowser/include/modules/webbrowser/webbrowserapp.h
+++ b/modules/webbrowser/include/modules/webbrowser/webbrowserapp.h
@@ -44,6 +44,8 @@ namespace inviwo {
 /**
  * App to be used in the browser thread.
  */
+#include <warn/push>
+#include <warn/ignore/dll-interface-base>  // Fine if dependent libs use the same CEF lib binaries
 class IVW_MODULE_WEBBROWSER_API WebBrowserApp : public CefApp, public CefBrowserProcessHandler {
 public:
     WebBrowserApp();
@@ -53,6 +55,7 @@ public:
 private:
     IMPLEMENT_REFCOUNTING(WebBrowserApp)
 };
+#include <warn/pop>
 
 };      // namespace inviwo
 #endif  // IVW_WEBBROWSERAPP_H

--- a/modules/webbrowser/include/modules/webbrowser/webbrowserclient.h
+++ b/modules/webbrowser/include/modules/webbrowser/webbrowserclient.h
@@ -50,6 +50,8 @@ namespace inviwo {
 /* \class WebBrowserClient
  * CefClient with custom render handler
  */
+#include <warn/push>
+#include <warn/ignore/dll-interface-base>  // Fine if dependent libs use the same CEF lib binaries
 class IVW_MODULE_WEBBROWSER_API WebBrowserClient : public CefClient,
                                                    public CefLifeSpanHandler,
                                                    public CefRequestHandler,
@@ -138,7 +140,7 @@ private:
     IMPLEMENT_REFCOUNTING(WebBrowserClient)
     DISALLOW_COPY_AND_ASSIGN(WebBrowserClient);
 };
-
+#include <warn/pop>
 }  // namespace inviwo
 
 #endif  // IVW_WEBBROWSERCLIENT_H


### PR DESCRIPTION
Suppress warnings about deriving from classes that are not exported. Since the classes we derive from mostly have virtual functions we can still call them. The same (binary compatible) CEF-library need to be linked by dependent modules, which we require anyway.

Now there are only two c++17-related deprecation warnings left in this module.


