### PR TITLE
Gcc fix

### DIFF
--- a/include/inviwo/core/util/foreach.h
+++ b/include/inviwo/core/util/foreach.h
@@ -36,41 +36,44 @@
 #include <inviwo/core/common/inviwoapplication.h>
 #include <inviwo/core/util/settings/systemsettings.h>
 #include <string>
+#include <utility>
 
 namespace inviwo {
 
 namespace util {
+    
 namespace detail {
 template <typename Callback, typename IT>
-void foreach_helper(std::false_type, IT a, IT b, Callback callback, size_t /*startIndex*/ = 0) {
-    std::for_each(a, b, callback);
+void foreach_helper(std::false_type, IT a, IT b, Callback&& callback, size_t) {
+    std::for_each(a, b, std::forward<Callback>(callback));
 }
 
 template <typename Callback, typename IT>
-void foreach_helper(std::true_type, IT a, IT b, Callback callback, size_t startIndex = 0) {
-    std::for_each(a, b, [&](auto v) { callback(v, startIndex++); });
+void foreach_helper(std::true_type, IT a, IT b, Callback&& callback, size_t startIndex) {
+    std::for_each(a, b, [&](auto&& v) { callback(v, startIndex++); });
 }
 
 template <typename Callback, typename IT, typename OnDoneCallback>
-auto foreach_helper_pool(std::true_type, IT a, IT b, Callback callback, size_t startIndex = 0,
-                         OnDoneCallback onTaskDone = []() {}) {
-    return dispatchPool([id = startIndex, a, b, c = std::move(callback),
-                         onTaskDone = std::move(onTaskDone)]() mutable {
-        std::for_each(a, b, [&](auto v) { c(v, id++); });
+auto foreach_helper_pool(std::true_type, IT a, IT b, Callback&& callback, size_t startIndex,
+                         OnDoneCallback&& onTaskDone) {
+    return dispatchPool([id = startIndex, a, b, c = std::forward<Callback>(callback),
+                         onTaskDone = std::forward<OnDoneCallback>(onTaskDone)]() mutable {
+        std::for_each(a, b, [&](auto&& v) { c(v, id++); });
         onTaskDone();
     });
 }
 
 template <typename Callback, typename IT, typename OnDoneCallback>
-auto foreach_helper_pool(std::false_type, IT a, IT b, Callback callback, size_t /*startIndex*/ = 0,
-                         OnDoneCallback onTaskDone = []() {}) {
-    return dispatchPool([a, b, c = std::move(callback), onTaskDone = std::move(onTaskDone)]() {
+auto foreach_helper_pool(std::false_type, IT a, IT b, Callback&& callback, size_t,
+                         OnDoneCallback&& onTaskDone) {
+    return dispatchPool([a, b, c = std::forward<Callback>(callback), onTaskDone = std::forward<OnDoneCallback>(onTaskDone)]() {
         std::for_each(a, b, c);
         onTaskDone();
     });
 }
 
 }  // namespace detail
+
 
 /**
  * Use multiple threads to iterate over all elements in an iterable data structure (such as
@@ -87,17 +90,22 @@ auto foreach_helper_pool(std::false_type, IT a, IT b, Callback callback, size_t 
  * @param onTaskDone callback that will be called when each job is done
  * @return a vector of futures, one for each job created.
  */
-template <typename Iterable, typename T = typename Iterable::value_type, typename Callback,
-          typename OnDoneCallback = std::function<void()>>
-std::vector<std::future<void>> forEachParallelAsync(const Iterable& iterable, Callback callback,
-                                                    size_t jobs = 0,
-                                                    OnDoneCallback onTaskDone = []() {}) {
+template <typename Iterable, typename Callback, typename OnDoneCallback>
+std::vector<std::future<void>> forEachParallelAsync(const Iterable& iterable, Callback&& callback,
+                                                    size_t jobs, OnDoneCallback&& onTaskDone) {
+
+    using std::begin;
+    using std::end;
+    
     auto settings = InviwoApplication::getPtr()->getSettingsByType<SystemSettings>();
     auto poolSize = settings->poolSize_.get();
-    using IncludeIndexType = typename std::conditional<util::is_callable_with<T, size_t>(callback),
-                                                       std::true_type, std::false_type>::type;
+    
+    using value_type = decltype(*begin(iterable));
+    using IncludeIndexType = typename util::is_invocable<Callback, value_type, size_t>::type;
+
     if (poolSize == 0) {
-        detail::foreach_helper(IncludeIndexType(), iterable.begin(), iterable.end(), callback);
+        detail::foreach_helper(IncludeIndexType{}, begin(iterable), end(iterable),
+                               std::forward<Callback>(callback), 0);
         onTaskDone();
         return {};
     }
@@ -106,17 +114,24 @@ std::vector<std::future<void>> forEachParallelAsync(const Iterable& iterable, Ca
         jobs = 4 * poolSize;
     }
 
-    auto s = iterable.size();
+    const auto s = iterable.size();
     std::vector<std::future<void>> futures;
     for (size_t job = 0; job < jobs; ++job) {
         size_t start = (s * job) / jobs;
         size_t end = (s * (job + 1)) / jobs;
-        auto a = iterable.begin() + start;
-        auto b = iterable.begin() + end;
+        auto a = begin(iterable) + start;
+        auto b = begin(iterable) + end;
         futures.push_back(
-            detail::foreach_helper_pool(IncludeIndexType(), a, b, callback, start, onTaskDone));
+            detail::foreach_helper_pool(IncludeIndexType{}, a, b, std::forward<Callback>(callback),
+                                        start, std::forward<OnDoneCallback>(onTaskDone)));
     }
     return futures;
+}
+
+template <typename Iterable, typename Callback>
+std::vector<std::future<void>> forEachParallelAsync(const Iterable& iterable, Callback&& callback,
+                                                    size_t jobs) {
+    return forEachParallelAsync(iterable, std::forward<Callback>(callback), jobs, [](){});
 }
 
 /**
@@ -132,9 +147,10 @@ std::vector<std::future<void>> forEachParallelAsync(const Iterable& iterable, Ca
  * @param jobs optional parameter specifying how many jobs to create, if jobs==0 (default) it will
  * create pool size * 4 jobs
  */
-template <typename Iterable, typename T = typename Iterable::value_type, typename Callback>
-void forEachParallel(const Iterable& iterable, Callback callback, size_t jobs = 0) {
-    auto futures = forEachParallelAsync<Iterable, T, Callback>(iterable, callback, jobs);
+template <typename Iterable, typename Callback>
+void forEachParallel(const Iterable& iterable, Callback&& callback, size_t jobs = 0) {
+    const auto futures =
+        forEachParallelAsync<Iterable, Callback>(iterable, std::forward<Callback>(callback), jobs);
 
     for (const auto& e : futures) {
         e.wait();

--- a/include/inviwo/core/util/stdextensions.h
+++ b/include/inviwo/core/util/stdextensions.h
@@ -533,6 +533,20 @@ public:
     static const bool value = decltype(check<Type>(0))::value;
 };
 
+template <typename F, typename... Args>
+struct is_invocable :
+    std::is_constructible<
+        std::function<void(Args ...)>,
+        std::reference_wrapper<typename std::remove_reference<F>::type>
+    >{};
+
+template <typename R, typename F, typename... Args>
+struct is_invocable_r :
+    std::is_constructible<
+        std::function<R(Args ...)>,
+        std::reference_wrapper<typename std::remove_reference<F>::type>
+    >{};
+
 namespace detail {
 
 // https://stackoverflow.com/a/22882504/600633

--- a/include/inviwo/core/util/utilities.h
+++ b/include/inviwo/core/util/utilities.h
@@ -101,12 +101,12 @@ struct IVW_CORE_API Hideer {
 
 template <typename... Args>
 void show(Args&&... args) {
-    util::for_each_argument(detail::Shower{}, std::forward<Args>(args)...);
+    for_each_argument(detail::Shower{}, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 void hide(Args&&... args) {
-    util::for_each_argument(detail::Hideer{}, std::forward<Args>(args)...);
+    for_each_argument(detail::Hideer{}, std::forward<Args>(args)...);
 }
 
 }  // namespace util


### PR DESCRIPTION
fixes some very cryptic errors in gcc7-4:
```
07:09:36  /var/folders/2_/ylc0my9549z15wzswhg3ht3h0000gn/T//cciPVicG.s:1249:1: error: invalid symbol redefinition
07:09:36  __ZNSt14_Function_base13_Base_managerIN6inviwo4utilUlvE1_EE10_M_managerERSt9_Any_dataRKS5_St18_Manager_operation:
07:09:36  ^
07:09:36  /var/folders/2_/ylc0my9549z15wzswhg3ht3h0000gn/T//cciPVicG.s:1267:1: error: invalid symbol redefinition
07:09:36  __ZNSt14_Function_base13_Base_managerIN6inviwo4utilUlvE1_EE10_M_managerERSt9_Any_dataRKS5_St18_Manager_operation:
07:09:36  ^
07:09:36  /var/folders/2_/ylc0my9549z15wzswhg3ht3h0000gn/T//cciPVicG.s:4931:1: error: invalid symbol redefinition
07:09:36  __ZNSt17_Function_handlerIFvvEN6inviwo4utilUlvE1_EE9_M_invokeERKSt9_Any_data:
07:09:36  ^
07:09:36  /var/folders/2_/ylc0my9549z15wzswhg3ht3h0000gn/T//cciPVicG.s:4968:1: error: invalid symbol redefinition
07:09:36  __ZNSt17_Function_handlerIFvvEN6inviwo4utilUlvE1_EE9_M_invokeERKSt9_Any_data:
```
reason was related the use of lambdas as defaulted arguments to some template parameters. 