### PR TITLE
QtEditor: Use system locale to format the eval count in the processor graphics item

### DIFF
--- a/src/qt/editor/processorgraphicsitem.cpp
+++ b/src/qt/editor/processorgraphicsitem.cpp
@@ -49,6 +49,8 @@
 #include <modules/qtwidgets/propertylistwidget.h>
 #include <modules/qtwidgets/processors/processorwidgetqt.h>
 #include <modules/qtwidgets/inviwoqtutils.h>
+#include <modules/qtwidgets/qstringhelper.h>
+
 
 #include <warn/push>
 #include <warn/ignore/all>
@@ -443,7 +445,9 @@ void ProcessorGraphicsItem::onProcessorPortRemoved(Processor*, Port* port) {
 #if IVW_PROFILING
 void ProcessorGraphicsItem::onProcessorAboutToProcess(Processor*) {
     processCount_++;
-    countLabel_->setText(QString::number(processCount_));
+    auto str =
+        QStringHelper<decltype(processCount_)>::toLocaleString(QLocale::system(), processCount_);
+    countLabel_->setText(str);
     clock_.reset();
     clock_.start();
 }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/534670/60162863-ad805e00-97fa-11e9-9661-34ab356e6bbe.png)
