### PR TITLE
Feature/add port unique ptr return ref

### DIFF
--- a/include/inviwo/core/processors/processor.h
+++ b/include/inviwo/core/processors/processor.h
@@ -336,11 +336,23 @@ public:
     virtual void serialize(Serializer& s) const override;
     virtual void deserialize(Deserializer& d) override;
 
-    // Assume ownership of port, needed for dynamic ports
+    /**
+     * Add port to processor and pass ownership to processor.
+     * @note Port group is a concept for event propagation. Currently only used for
+     * ResizeEvents, which only propagate from outports to inports in the same port group
+     * @param port to add
+     * @param portGroup name of group to propagate events through (defaults to "default")
+     */
     template <typename T, typename std::enable_if_t<std::is_base_of<Inport, T>::value, int> = 0>
     T& addPort(std::unique_ptr<T> port, const std::string& portGroup = "default");
 
-    // Assume ownership of port, needed for dynamic ports
+    /**
+     * Add port to processor and pass ownership to processor.
+     * @note Port group is a concept for event propagation. Currently only used for
+     * ResizeEvents, which only propagate from outports to inports in the same port group
+     * @param port to add
+     * @param portGroup name of group to propagate events through (defaults to "default")
+     */
     template <typename T, typename std::enable_if_t<std::is_base_of<Outport, T>::value, int> = 0>
     T& addPort(std::unique_ptr<T> port, const std::string& portGroup = "default");
 
@@ -395,7 +407,6 @@ private:
 
 inline ProcessorNetwork* Processor::getNetwork() const { return network_; }
 
-// Assume ownership of port, needed for dynamic ports
 template <typename T, typename std::enable_if_t<std::is_base_of<Inport, T>::value, int>>
 T& Processor::addPort(std::unique_ptr<T> port, const std::string& portGroup) {
     T& ret = *port;
@@ -404,7 +415,6 @@ T& Processor::addPort(std::unique_ptr<T> port, const std::string& portGroup) {
     return ret;
 }
 
-// Assume ownership of port, needed for dynamic ports
 template <typename T, typename std::enable_if_t<std::is_base_of<Outport, T>::value, int>>
 T& Processor::addPort(std::unique_ptr<T> port, const std::string& portGroup) {
     T& ret = *port;
@@ -413,13 +423,6 @@ T& Processor::addPort(std::unique_ptr<T> port, const std::string& portGroup) {
     return ret;
 }
 
-/**
- * Add port to processor.
- * @note Port group is a concept for event propagation. Currently only used for
- * ResizeEvents, which only propagate from outports to inports in the same port group
- * @param port to add
- * @param portGroup name of group to propagate events through (defaults to "default")
- */
 template <typename T>
 T& Processor::addPort(T& port, const std::string& portGroup) {
     static_assert(std::is_base_of<Inport, T>::value || std::is_base_of<Outport, T>::value,

--- a/include/inviwo/core/processors/processor.h
+++ b/include/inviwo/core/processors/processor.h
@@ -336,6 +336,14 @@ public:
     virtual void serialize(Serializer& s) const override;
     virtual void deserialize(Deserializer& d) override;
 
+    // Assume ownership of port, needed for dynamic ports
+    template <typename T, typename std::enable_if_t<std::is_base_of<Inport, T>::value, int> = 0>
+    T& addPort(std::unique_ptr<T> port, const std::string& portGroup = "default");
+
+    // Assume ownership of port, needed for dynamic ports
+    template <typename T, typename std::enable_if_t<std::is_base_of<Outport, T>::value, int> = 0>
+    T& addPort(std::unique_ptr<T> port, const std::string& portGroup = "default");
+
     /**
      * Add port to processor.
      * @note Port group is a concept for event propagation. Currently only used for
@@ -344,17 +352,7 @@ public:
      * @param portGroup name of group to propagate events through (defaults to "default")
      */
     template <typename T>
-    T& addPort(T& port, const std::string& portGroup = "default") {
-        static_assert(std::is_base_of<Inport, T>::value || std::is_base_of<Outport, T>::value,
-                      "T must be an Inport or Outport");
-        addPortInternal(&port, portGroup);
-        return port;
-    }
-
-    // Assume ownership of port, needed for dynamic ports
-    void addPort(std::unique_ptr<Inport> port, const std::string& portGroup = "default");
-    // Assume ownership of port, needed for dynamic ports
-    void addPort(std::unique_ptr<Outport> port, const std::string& portGroup = "default");
+    T& addPort(T& port, const std::string& portGroup = "default");
 
     Port* removePort(const std::string& identifier);
     Inport* removePort(Inport* port);
@@ -396,6 +394,39 @@ private:
 };
 
 inline ProcessorNetwork* Processor::getNetwork() const { return network_; }
+
+// Assume ownership of port, needed for dynamic ports
+template <typename T, typename std::enable_if_t<std::is_base_of<Inport, T>::value, int>>
+T& Processor::addPort(std::unique_ptr<T> port, const std::string& portGroup) {
+    T& ret = *port;
+    addPortInternal(port.get(), portGroup);
+    ownedInports_.push_back(std::move(port));
+    return ret;
+}
+
+// Assume ownership of port, needed for dynamic ports
+template <typename T, typename std::enable_if_t<std::is_base_of<Outport, T>::value, int>>
+T& Processor::addPort(std::unique_ptr<T> port, const std::string& portGroup) {
+    T& ret = *port;
+    addPortInternal(port.get(), portGroup);
+    ownedOutports_.push_back(std::move(port));
+    return ret;
+}
+
+/**
+ * Add port to processor.
+ * @note Port group is a concept for event propagation. Currently only used for
+ * ResizeEvents, which only propagate from outports to inports in the same port group
+ * @param port to add
+ * @param portGroup name of group to propagate events through (defaults to "default")
+ */
+template <typename T>
+T& Processor::addPort(T& port, const std::string& portGroup) {
+    static_assert(std::is_base_of<Inport, T>::value || std::is_base_of<Outport, T>::value,
+                  "T must be an Inport or Outport");
+    addPortInternal(&port, portGroup);
+    return port;
+}
 
 }  // namespace inviwo
 

--- a/src/core/common/inviwocore.cpp
+++ b/src/core/common/inviwocore.cpp
@@ -246,6 +246,7 @@ InviwoCore::InviwoCore(InviwoApplication* app)
 
     registerDefaultsForDataType<Mesh>();
     registerDefaultsForDataType<Volume>();
+    registerDefaultsForDataType<VolumeSequence>();
     registerDefaultsForDataType<BufferBase>();
     registerDefaultsForDataType<LightSource>();
 

--- a/src/core/processors/processor.cpp
+++ b/src/core/processors/processor.cpp
@@ -82,11 +82,6 @@ void Processor::addPortInternal(Inport* port, const std::string& portGroup) {
     isReady_.update();
 }
 
-void Processor::addPort(std::unique_ptr<Inport> port, const std::string& portGroup) {
-    addPortInternal(port.get(), portGroup);
-    ownedInports_.push_back(std::move(port));
-}
-
 void Processor::addPortInternal(Outport* port, const std::string& portGroup) {
     if (getPort(port->getIdentifier()) != nullptr) {
         throw Exception("Processor \"" + getIdentifier() + "\" Can't add outport, identifier \"" +
@@ -105,11 +100,6 @@ void Processor::addPortInternal(Outport* port, const std::string& portGroup) {
     notifyObserversProcessorPortAdded(this, port);
     isSink_.update();
     isReady_.update();
-}
-
-void Processor::addPort(std::unique_ptr<Outport> port, const std::string& portGroup) {
-    addPortInternal(port.get(), portGroup);
-    ownedOutports_.push_back(std::move(port));
 }
 
 Port* Processor::removePort(const std::string& identifier) {


### PR DESCRIPTION
Made the addPort(std::unique_ptr<Inport|Outport>) return a reference, now it can be used as addPort(T&)