### PR TITLE
CMake: Fix in ivw_private_get_ivw_module_name for cmake incorrectly treating s as whitespace

### DIFF
--- a/cmake/globalutils.cmake
+++ b/cmake/globalutils.cmake
@@ -563,7 +563,7 @@ function(ivw_private_get_ivw_module_name path retval)
      string(REPLACE "\n" ";" lines "${contents}")
      foreach(line ${lines})
         #\s*ivw_module\(\s*(\w+)\s*\)\s*
-        string(REGEX MATCH "\\s*ivw_module\\(\\s*([A-Za-z0-9_-]+)\\s*\\)\\s*" found_item ${line})
+        string(REGEX MATCH "[ ]*ivw_module\\([ ]*([A-Za-z0-9_-]+)[ ]*\\)[ ]*" found_item ${line})
         if(CMAKE_MATCH_1)
             set(${retval} ${CMAKE_MATCH_1} PARENT_SCOPE)
             return()


### PR DESCRIPTION
See #580 

Seems cmake is treating a regular s in regexp mathcing as whitespace when using \\s for searching. changing \\s in to just a regular whitespace or putting the whitespace into brackets [ ] fixes the issue. 

