### PR TITLE
fix sigar not building on linux

### DIFF
--- a/cmake/modules/FindTIRPC.cmake
+++ b/cmake/modules/FindTIRPC.cmake
@@ -1,6 +1,8 @@
 # FindTIRPC
 # ---------
 #
+# From https://raw.githubusercontent.com/snort3/snort3/master/cmake/FindTIRPC.cmake
+#
 # Find the native TIRPC includes and library.
 #
 # Result Variables

--- a/cmake/modules/FindTIRPC.cmake
+++ b/cmake/modules/FindTIRPC.cmake
@@ -1,0 +1,44 @@
+# FindTIRPC
+# ---------
+#
+# Find the native TIRPC includes and library.
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module will set the following variables in your project:
+#
+# ``TIRPC_INCLUDE_DIRS``
+#   where to find rpc.h, etc.
+# ``TIRPC_LIBRARIES``
+#   the libraries to link against to use TIRPC.
+# ``TIRPC_VERSION``
+#   the version of TIRPC found.
+# ``TIRPC_FOUND``
+#   true if the TIRPC headers and libraries were found.
+#
+
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_TIRPC REQUIRED libtirpc)
+
+find_path(TIRPC_INCLUDE_DIRS
+    NAMES netconfig.h
+    PATH_SUFFIXES tirpc
+    HINTS ${PC_TIRPC_INCLUDE_DIRS}
+)
+
+find_library(TIRPC_LIBRARIES
+    NAMES tirpc
+    HINTS ${PC_TIRPC_LIBRARY_DIRS}
+)
+
+set(TIRPC_VERSION ${PC_TIRPC_VERSION})
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(TIRPC
+    REQUIRED_VARS TIRPC_LIBRARIES TIRPC_INCLUDE_DIRS
+    VERSION_VAR TIRPC_VERSION
+)
+
+mark_as_advanced(TIRPC_INCLUDE_DIRS TIRPC_LIBRARIES)

--- a/ext/sigar/CMakeLists.txt
+++ b/ext/sigar/CMakeLists.txt
@@ -31,7 +31,13 @@ set(HEADER_FILES include/sigar.h
 ## linux
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(SIGAR_SRC src/os/linux/linux_sigar.c)
-    find_package(TIRPC REQUIRED)
+    CHECK_INCLUDE_FILE("rpc/rpc.h" HAS_RPCH)
+    if(HAS_RPCH)
+        message("Using RPC from glibc")
+    else()
+        find_package(TIRPC REQUIRED)
+        message("Using libtirpc")
+    endif()
 endif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 
 ## macosx, freebsd

--- a/ext/sigar/CMakeLists.txt
+++ b/ext/sigar/CMakeLists.txt
@@ -9,28 +9,29 @@ project(sigar)
 
 #--------------------------------------------------------------------
 # Define defintions
-if(WIN32) 
-    ## make sure we only use the smallest set of 
-    ## headers on win32. Otherwise we get clashes 
+if(WIN32)
+    ## make sure we only use the smallest set of
+    ## headers on win32. Otherwise we get clashes
     ## between winsock2.h and winsock.h
     add_definitions(-DWIN32_LEAN_AND_MEAN)
 endif()
 
 source_group("CMake Files" FILES ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt)
 
-set(HEADER_FILES include/sigar.h 
-    include/sigar_fileinfo.h 
-    include/sigar_format.h 
-    include/sigar_getline.h 
-    include/sigar_log.h 
-    include/sigar_private.h 
-    include/sigar_ptql.h 
+set(HEADER_FILES include/sigar.h
+    include/sigar_fileinfo.h
+    include/sigar_format.h
+    include/sigar_getline.h
+    include/sigar_log.h
+    include/sigar_private.h
+    include/sigar_ptql.h
     include/sigar_util.h
 )
 
 ## linux
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(SIGAR_SRC src/os/linux/linux_sigar.c)
+    find_package(TIRPC REQUIRED)
 endif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 
 ## macosx, freebsd
@@ -67,7 +68,7 @@ add_library(sigar ${SIGAR_SRC} ${HEADER_FILES})
 add_library(inviwo::sigar ALIAS sigar)
 set_target_properties(sigar PROPERTIES VERSION 1.6.4 SOVERSION 1.6)
 
-target_include_directories(sigar PUBLIC 
+target_include_directories(sigar PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include/ext/sigar>
 )
@@ -77,6 +78,7 @@ target_compile_definitions(sigar PUBLIC IVW_SIGAR)
 ## linux
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(sys_headers src/os/linux/)
+    target_link_libraries(sigar PRIVATE tirpc)
 endif()
 ## macosx, freebsd
 if(CMAKE_SYSTEM_NAME MATCHES "(Darwin|FreeBSD)")
@@ -87,14 +89,15 @@ if(WIN32)
         target_compile_definitions(sigar PUBLIC SIGAR_SHARED)
         target_compile_definitions(sigar PUBLIC SIGAR_EXPORTS)
     endif()
-    target_compile_definitions(sigar PRIVATE -D_CRT_SECURE_NO_WARNINGS 
+    target_compile_definitions(sigar PRIVATE -D_CRT_SECURE_NO_WARNINGS
                                              -D_CRT_SECURE_NO_DEPRECATE)
     target_link_libraries(sigar PRIVATE ws2_32 netapi32 version)
     set(sys_headers src/os/win32/)
 endif()
-target_include_directories(sigar PRIVATE 
+target_include_directories(sigar PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${sys_headers}>
     $<INSTALL_INTERFACE:include/ext/sigar/${sys_headers}>
+    ${TIRPC_INCLUDE_DIRS}
 )
 
 if(SIGAR_LINK_FLAGS)
@@ -111,4 +114,3 @@ ivw_default_install_comp_targets(core sigar)
 ivw_make_package(Sigar sigar)
 
 ivw_suppress_compiler_warnings(sigar)
-

--- a/ext/sigar/src/os/linux/linux_sigar.c
+++ b/ext/sigar/src/os/linux/linux_sigar.c
@@ -24,6 +24,7 @@
 #include <sys/stat.h>
 #include <sys/times.h>
 #include <sys/utsname.h>
+#include <sys/sysmacros.h>
 
 #include "sigar.h"
 #include "sigar_private.h"
@@ -171,7 +172,7 @@ int sigar_os_open(sigar_t **sigar)
     if (status != SIGAR_OK) {
         return status;
     }
-    
+
     (*sigar)->ticks = sysconf(_SC_CLK_TCK);
 
     (*sigar)->ram = -1;
@@ -289,7 +290,7 @@ static int get_ram(sigar_t *sigar, sigar_mem_t *mem)
     if (total == 0) {
         return ENOENT;
     }
- 
+
     mem->ram = sigar->ram = total;
 
     return SIGAR_OK;
@@ -651,7 +652,7 @@ static int proc_stat_read(sigar_t *sigar, sigar_pid_t pid)
 
     time_t timenow = time(NULL);
 
-    /* 
+    /*
      * short-lived cache read/parse of last /proc/pid/stat
      * as this info is spread out across a few functions.
      */
@@ -754,7 +755,7 @@ int sigar_proc_mem_get(sigar_t *sigar, sigar_pid_t pid,
     procmem->major_faults = pstat->major_faults;
     procmem->page_faults =
         procmem->minor_faults + procmem->major_faults;
-    
+
     status = SIGAR_PROC_FILE2STR(buffer, pid, "/statm");
 
     if (status != SIGAR_OK) {
@@ -1032,7 +1033,7 @@ int sigar_proc_modules_get(sigar_t *sigar, sigar_pid_t pid,
             break;
         }
     }
-    
+
     fclose(fp);
 
     return SIGAR_OK;
@@ -1342,11 +1343,11 @@ static int get_iostat_procp(sigar_t *sigar,
             ptr = sigar_skip_token(ptr); /* blocks */
             ptr = sigar_skip_token(ptr); /* name */
             disk->reads = sigar_strtoull(ptr); /* rio */
-            ptr = sigar_skip_token(ptr);  /* rmerge */ 
+            ptr = sigar_skip_token(ptr);  /* rmerge */
             disk->read_bytes  = sigar_strtoull(ptr); /* rsect */
             disk->rtime = sigar_strtoull(ptr); /* ruse */
             disk->writes = sigar_strtoull(ptr); /* wio */
-            ptr = sigar_skip_token(ptr);  /* wmerge */ 
+            ptr = sigar_skip_token(ptr);  /* wmerge */
             disk->write_bytes = sigar_strtoull(ptr); /* wsect */
             disk->wtime = sigar_strtoull(ptr); /* wuse */
             ptr = sigar_skip_token(ptr); /* running */
@@ -1723,7 +1724,7 @@ int sigar_net_route_list_get(sigar_t *sigar,
         }
 
         route->flags = flags;
-        
+
         sigar_net_address_set(route->destination, hex2int(net_addr, HEX_ENT_LEN));
         sigar_net_address_set(route->gateway, hex2int(gate_addr, HEX_ENT_LEN));
         sigar_net_address_set(route->mask, hex2int(mask_addr, HEX_ENT_LEN));
@@ -1740,7 +1741,7 @@ int sigar_net_interface_stat_get(sigar_t *sigar, const char *name,
     int found = 0;
     char buffer[BUFSIZ];
     FILE *fp = fopen(PROC_FS_ROOT "net/dev", "r");
-    
+
     if (!fp) {
         return errno;
     }
@@ -2040,7 +2041,7 @@ int sigar_net_connection_walk(sigar_net_connection_walker_t *walker)
         status = proc_net_read(walker,
                                PROC_FS_ROOT "net/raw",
                                SIGAR_NETCONN_RAW);
-        
+
         if (status != SIGAR_OK) {
             return status;
         }
@@ -2174,7 +2175,7 @@ sigar_tcp_get(sigar_t *sigar,
     fclose(fp);
 
     if (status == SIGAR_OK) {
-        /* assuming field order, same in 2.2, 2.4 and 2.6 kernels */ 
+        /* assuming field order, same in 2.2, 2.4 and 2.6 kernels */
         /* Tcp: RtoAlgorithm RtoMin RtoMax MaxConn */
         ptr = sigar_skip_multiple_token(ptr, 5);
         tcp->active_opens = sigar_strtoull(ptr);
@@ -2198,7 +2199,7 @@ static int sigar_proc_nfs_gets(char *file, char *tok,
     int status = ENOENT;
     int len = strlen(tok);
     FILE *fp = fopen(file, "r");
-    
+
     if (!fp) {
         return SIGAR_ENOTIMPL;
     }
@@ -2498,7 +2499,7 @@ int sigar_proc_port_get(sigar_t *sigar, int protocol,
         memcpy(&pid_name[len], ent->d_name, slen);
         len += slen;
         pid_name[len] = '\0';
-        
+
         if (stat(pid_name, &sb) < 0) {
             continue;
         }
@@ -2543,7 +2544,7 @@ int sigar_proc_port_get(sigar_t *sigar, int protocol,
                 *pid = strtoul(ent->d_name, NULL, 10);
                 return SIGAR_OK;
             }
-            
+
         }
 
         closedir(fd_dirp);
@@ -2558,7 +2559,7 @@ static void generic_vendor_parse(char *line, sigar_sys_info_t *info)
 {
     char *ptr;
     int len = 0;
-        
+
     while (*line) {
         SIGAR_SKIP_SPACE(line);
         if (!isdigit(*line)) {
@@ -2617,7 +2618,7 @@ static void redhat_vendor_parse(char *line, sigar_sys_info_t *info)
     }
 }
 
-#define is_quote(c) ((c == '\'') || (c == '"')) 
+#define is_quote(c) ((c == '\'') || (c == '"'))
 
 static void kv_parse(char *data, sigar_sys_info_t *info,
                      void (*func)(sigar_sys_info_t *, char *, char *))


### PR DESCRIPTION
So, as #238 describes, inviwo does not build sigar on linux (or at least on arch).
After some investigation I found that a few small changes can fix that.
First of all the `sys/sysmacros.h` include is needed to get rid of the initial error.
This then leads to `rpc/rpc.h` includes that are not found, because they are located in `/usr/include/tirpc/rpc/` instead of `/usr/include/rpc/` directly.
I added the include to the sigar's `CMakeLists.txt` and it works perfectly fine now.

The only change that should possibly affect other OS is the `sys/sysmacros.h` include, which I didn't test on windows or mac yet.

Also I'm not sure about the cmake stuff, please take a look at it @petersteneteg.