### PR TITLE
QT: Fix qt deprecation warnings (using windows qt 5.13.0)

### DIFF
--- a/modules/python3qt/src/pythoneditorwidget.cpp
+++ b/modules/python3qt/src/pythoneditorwidget.cpp
@@ -286,7 +286,8 @@ void PythonEditorWidget::saveAs() {
 
     saveFileDialog.setFileMode(FileMode::AnyFile);
     saveFileDialog.setAcceptMode(AcceptMode::Save);
-    saveFileDialog.setConfirmOverwrite(true);
+    saveFileDialog.setOption(QFileDialog::Option::DontConfirmOverwrite, false);
+
     saveFileDialog.addSidebarPath(PathType::Scripts);
     saveFileDialog.addExtension("py", "Python Script");
 

--- a/modules/python3qt/src/pythonmenu.cpp
+++ b/modules/python3qt/src/pythonmenu.cpp
@@ -93,7 +93,7 @@ PythonMenu::PythonMenu(InviwoModule* pymodule, InviwoApplication* app) {
             InviwoFileDialog saveFileDialog(nullptr, "Create Python Processor", "PythonProcessor");
             saveFileDialog.setFileMode(FileMode::AnyFile);
             saveFileDialog.setAcceptMode(AcceptMode::Save);
-            saveFileDialog.setConfirmOverwrite(true);
+            saveFileDialog.setOption(QFileDialog::Option::DontConfirmOverwrite,false);
             saveFileDialog.addExtension("py", "Python file");
             const auto dir = app->getPath(PathType::Settings) + "/python_processors";
             filesystem::createDirectoryRecursively(dir);

--- a/modules/qtwidgets/src/angleradiuswidget.cpp
+++ b/modules/qtwidgets/src/angleradiuswidget.cpp
@@ -118,7 +118,11 @@ void AngleRadiusWidget::paintEvent(QPaintEvent*) {
     int anglePosY = -10;
     QFontMetrics fm(painter.font());
     QString angleText = QString::fromStdString(angleStream.str()) + QChar(0260);
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
     int angleTextWidth = fm.width(angleText);
+#else
+    int angleTextWidth = fm.horizontalAdvance(angleText);
+#endif
     if (anglePosX + angleTextWidth > referenceRadius) {
         anglePosX = referenceRadius + 2;
         anglePosY = -2;

--- a/modules/qtwidgets/src/codeedit.cpp
+++ b/modules/qtwidgets/src/codeedit.cpp
@@ -74,7 +74,11 @@ void CodeEdit::setSyntax(SyntaxType type) {
         setStyleSheet(ss.str().c_str());
 
         QFontMetrics metrics(QFont(utilqt::toQString(family), size));
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
         setTabStopWidth(4 * metrics.width(' '));
+#else
+        setTabStopDistance(static_cast<qreal>(4 * metrics.horizontalAdvance(' ')));
+#endif
     };
     auto app = util::getInviwoApplication();
     auto settings = app->getSettingsByType<QtWidgetsSettings>();
@@ -161,7 +165,12 @@ int CodeEdit::lineNumberAreaWidth() {
         ++digits;
     }
 
-    return (annotationSpace_(digits) + 2) * fontMetrics().width(' ');
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
+    const int w = fontMetrics().width(' ');
+#else
+    const int w = fontMetrics().horizontalAdvance(' ');
+#endif
+    return (annotationSpace_(digits) + 2) * w;
 }
 
 void CodeEdit::updateLineNumberAreaWidth(int /* newBlockCount */) {
@@ -212,7 +221,12 @@ void CodeEdit::lineNumberAreaPaintEvent(QPaintEvent *event) {
     int blockNumber = block.blockNumber();
     int top = static_cast<int>(blockBoundingGeometry(block).translated(contentOffset()).top());
     int bottom = top + static_cast<int>(blockBoundingRect(block).height());
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
     const int offset = fontMetrics().width(' ');
+#else
+    const int offset = fontMetrics().horizontalAdvance(' ');
+#endif
+    
     const int height = fontMetrics().height();
     const int width = lineNumberArea_->width() - offset;
 

--- a/modules/qtwidgets/src/inviwoqtutils.cpp
+++ b/modules/qtwidgets/src/inviwoqtutils.cpp
@@ -56,6 +56,7 @@
 #include <QBuffer>
 #include <QByteArray>
 #include <QStyle>
+#include <QScreen>
 #include <warn/pop>
 
 #include <ios>
@@ -381,7 +382,6 @@ QPoint movePointOntoDesktop(const QPoint& point, const QSize& /*size*/,
 #endif
 
     QPoint pos(point);
-    QDesktopWidget* desktop = QApplication::desktop();
 
     if (decorationOffset) {
         QPoint offset = windowDecorationOffset;
@@ -394,8 +394,9 @@ QPoint movePointOntoDesktop(const QPoint& point, const QSize& /*size*/,
     static constexpr int rightPadding = 10;
     static constexpr int bottomPadding = 10;
     const bool withinAnyDesktop = [&]() {
-        for (int i = 0; i < desktop->screenCount(); i++) {
-            auto geom = desktop->screenGeometry(i).marginsRemoved(
+        QList<QScreen*> screens = QGuiApplication::screens();
+        for (QScreen* screen : screens) {
+            auto geom = screen->geometry().marginsRemoved(
                 {leftPadding, topPadding, rightPadding, bottomPadding});
             if (geom.contains(pos)) {
                 return true;

--- a/modules/qtwidgets/src/properties/texteditorwidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/texteditorwidgetqt.cpp
@@ -115,7 +115,7 @@ TextEditorDockWidget::TextEditorDockWidget(Property* property)
 
             saveFileDialog.setFileMode(FileMode::AnyFile);
             saveFileDialog.setAcceptMode(AcceptMode::Save);
-            saveFileDialog.setConfirmOverwrite(true);
+            saveFileDialog.setOption(QFileDialog::Option::DontConfirmOverwrite, false);
 
             for (const auto& filter : fileProperty_->getNameFilters()) {
                 saveFileDialog.addExtension(filter);

--- a/src/qt/editor/fileassociations.cpp
+++ b/src/qt/editor/fileassociations.cpp
@@ -273,7 +273,7 @@ private:
      * then.
      */
     bool SetHkcrUserRegKey(QString key, const QString& value,
-                           const QString& valueName = QString::null) {
+                           const QString& valueName = QString()) {
         HKEY hKey;
         key.prepend("Software\\Classes\\");
 

--- a/src/qt/editor/inviwomainwindow.cpp
+++ b/src/qt/editor/inviwomainwindow.cpp
@@ -451,7 +451,7 @@ void InviwoMainWindow::addActions() {
                 InviwoFileDialog saveFileDialog(this, "Export Network ...", "image");
                 saveFileDialog.setFileMode(FileMode::AnyFile);
                 saveFileDialog.setAcceptMode(AcceptMode::Save);
-                saveFileDialog.setConfirmOverwrite(true);
+                saveFileDialog.setOption(QFileDialog::Option::DontConfirmOverwrite, false);
 
                 saveFileDialog.addSidebarPath(PathType::Workspaces);
                 saveFileDialog.addSidebarPath(workspaceFileDir_);
@@ -1085,7 +1085,7 @@ void InviwoMainWindow::saveWorkspaceAs() {
     InviwoFileDialog saveFileDialog(this, "Save Workspace ...", "workspace");
     saveFileDialog.setFileMode(FileMode::AnyFile);
     saveFileDialog.setAcceptMode(AcceptMode::Save);
-    saveFileDialog.setConfirmOverwrite(true);
+    saveFileDialog.setOption(QFileDialog::Option::DontConfirmOverwrite, false);
 
     saveFileDialog.addSidebarPath(PathType::Workspaces);
     saveFileDialog.addSidebarPath(workspaceFileDir_);
@@ -1107,7 +1107,7 @@ void InviwoMainWindow::saveWorkspaceAsCopy() {
     InviwoFileDialog saveFileDialog(this, "Save Workspace ...", "workspace");
     saveFileDialog.setFileMode(FileMode::AnyFile);
     saveFileDialog.setAcceptMode(AcceptMode::Save);
-    saveFileDialog.setConfirmOverwrite(true);
+    saveFileDialog.setOption(QFileDialog::Option::DontConfirmOverwrite, false);
 
     saveFileDialog.addSidebarPath(PathType::Workspaces);
     saveFileDialog.addSidebarPath(workspaceFileDir_);

--- a/src/qt/editor/processorlistwidget.cpp
+++ b/src/qt/editor/processorlistwidget.cpp
@@ -333,7 +333,7 @@ QTreeWidgetItem* ProcessorTreeWidget::addToplevelItemTo(QString title, const std
         newItem->setToolTip(0, utilqt::toLocalQString(desc));
     }
     processorTree_->addTopLevelItem(newItem);
-    processorTree_->setFirstItemColumnSpanned(newItem, true);
+    newItem->setFirstColumnSpanned(true);
 
     return newItem;
 }
@@ -546,7 +546,7 @@ void ProcessorTreeWidget::extractInfoAndAddProcessor(ProcessorFactoryObject* pro
         processorTree_->addTopLevelItem(newItem);
     }
     if (!hasTags) {
-        processorTree_->setFirstItemColumnSpanned(newItem, true);
+        newItem->setFirstColumnSpanned(true);
     }
 }
 
@@ -569,7 +569,7 @@ ProcessorDragObject::ProcessorDragObject(QWidget* source, std::unique_ptr<Proces
     auto mime = new ProcessorMimeData(std::move(processor));
     setMimeData(mime);
     setHotSpot(QPoint(img.width() / 2, img.height() / 2));
-    start(Qt::MoveAction);
+    exec(Qt::MoveAction);
 }
 
 bool ProcessorTreeItem::operator<(const QTreeWidgetItem& other) const {

--- a/src/qt/editor/processorstatusgraphicsitem.cpp
+++ b/src/qt/editor/processorstatusgraphicsitem.cpp
@@ -65,7 +65,7 @@ void ProcessorStatusGraphicsItem::setRunning(bool running) {
 
 void ProcessorStatusGraphicsItem::paint(QPainter* p, const QStyleOptionGraphicsItem*, QWidget*) {
     qreal ledRadius = size_ / 2.0f;
-    QColor baseColor = QColor(0, 170, 0).light(200);
+    QColor baseColor = QColor(0, 170, 0).lighter(200);
 
     QColor ledColor;
     QColor borderColor(124, 124, 124);
@@ -78,7 +78,7 @@ void ProcessorStatusGraphicsItem::paint(QPainter* p, const QStyleOptionGraphicsI
             ledColor = QColor(255, 221, 85);
             break;
         case State::Invalid:
-            ledColor = baseColor.dark(400);
+            ledColor = baseColor.darker(400);
             break;
     }
     current_ = state_;

--- a/src/qt/editor/toolsmetamenu.cpp
+++ b/src/qt/editor/toolsmetamenu.cpp
@@ -52,7 +52,7 @@ void addInviwoMetaAction(QMenu* menu) {
         InviwoFileDialog saveFileDialog(nullptr, "Create " + name, "source");
         saveFileDialog.setFileMode(FileMode::AnyFile);
         saveFileDialog.setAcceptMode(AcceptMode::Save);
-        saveFileDialog.setConfirmOverwrite(true);
+        saveFileDialog.setOption(QFileDialog::Option::DontConfirmOverwrite, false);
 
         if (saveFileDialog.exec()) {
             QString qpath = saveFileDialog.selectedFiles().at(0);

--- a/src/qt/editor/welcomewidget.cpp
+++ b/src/qt/editor/welcomewidget.cpp
@@ -138,7 +138,11 @@ WelcomeWidget::WelcomeWidget(InviwoMainWindow *window, QWidget *parent)
         }
 
         const auto dateformat = "yyyy-MM-dd hh:mm:ss";
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
         auto createdStr = utilqt::fromQString(info.created().toString(dateformat));
+#else
+        auto createdStr = utilqt::fromQString(info.birthTime().toString(dateformat));
+#endif
         auto modifiedStr = utilqt::fromQString(info.lastModified().toString(dateformat));
 
         const bool hasTitle = !annotations.getTitle().empty();


### PR DESCRIPTION
Just updated to qt 15.3.0 and got a bunch of new warnings (depreciation of qt methods) 