### PR TITLE
Feature/tf transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 Here we document changes that affect the public API or changes that needs to be communicated to other developers. 
 
+## 2019-07-16 Transfer Function Editing
+
+Added some utility functions for editing transfer functions: 
+
+ * **flip positions** - swap the positions of all TF primitives with respect to their range
+ * **interpolate alpha** - interpolates the alpha values of all TF primitives in between the left-most and right-most TF primitive
+ * **equalize alpha** - averages the alpha value of all selected TF primitives
+
+These functions are accessible under `Transform` in the context menus of both TF editor and respective TF properties. All functions are applied to the current selection or the entire TF, if nothing is selected.
+
 ## 2019-07-05 Plotting Improvements
 We added a `AxisStyleProperty` for simplifying the setup of multiple axes in plots. Multiple axis properties can be registered with this new style property (`AxisStyleProperty::registerProperty()`). Changes to any of the style properties (line and text color, font size, tick length, etc.) are propagated to all registered axes, i.e. all axis share the same style. Note: this modifications can be overwritten in the individual axis.
 
@@ -8,11 +18,13 @@ There is now also an `Image Plot Processor` which allows to plot a 2D image with
 ## 2019-07-04 New Inviwo version
 We are releasing a new Inviwo version 0.9.10. 
 Major change since the last relase include:
+
  * Embedded web browser support
  * Get Started widget
  * Python processors
  * New module structure
  * New meta tool for adding new modules/processors
+
 Moreover this will be that last version to not require c++17.
 
 ## 2019-06-11 Webbrowser property synchronization

--- a/include/inviwo/core/datastructures/tfprimitiveset.h
+++ b/include/inviwo/core/datastructures/tfprimitiveset.h
@@ -229,6 +229,29 @@ public:
      */
     void interpolateAndStoreColors(vec4* dataArray, const size_t size) const;
 
+    /**
+     * flip the positions of the \p primitives with respect to the respective range, i.e.
+     *      p' = range.max - (p - range.min)
+     * with range.min/max corresponding to the lowest/highest position in \p primitives. If
+     * \p primitives is empty, the entire TFPrimitiveSet is flipped using
+     * TFPrimitiveSet::getRange().
+     *
+     * @param primitives   list of primitives to be flipped. If empty, the entire primitive set
+     *                     is flipped.
+     */
+    void flipPositions(const std::vector<TFPrimitive*>& primitives = {});
+    /**
+     * interpolate the alpha values of all primitives in between the first and the last primitive
+     * based on their relative position. If \p primitives is empty, the alpha of the entire
+     * TFPrimitiveSet will be adjusted.
+     */
+    void interpolateAlpha(const std::vector<TFPrimitive*>& primitives = {});
+    /**
+     * set the alphas value of all primitives to the average alpha value. If \p primitives is empty,
+     * the entire TFPrimitiveSet is equalized.
+     */
+    void equalizeAlpha(const std::vector<TFPrimitive*>& primitives = {});
+
 protected:
     void add(std::unique_ptr<TFPrimitive> primitive);
     bool remove(std::vector<std::unique_ptr<TFPrimitive>>::iterator it);

--- a/modules/qtwidgets/src/properties/isotfpropertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/isotfpropertywidgetqt.cpp
@@ -93,6 +93,31 @@ std::unique_ptr<QMenu> IsoTFPropertyWidgetQt::getContextMenu() {
 
     util::addTFPresetsMenu(this, menu.get(), &static_cast<IsoTFProperty*>(property_)->tf_);
 
+    auto transformMenu = menu->addMenu("&Transform");
+
+    auto flip = transformMenu->addAction("&Horizontal Flip");
+    auto interpolate = transformMenu->addAction("&Interpolate Alpha");
+    auto equalize = transformMenu->addAction("&Equalize Alpha");
+
+    connect(flip, &QAction::triggered, this, [this]() {
+        NetworkLock lock(property_);
+        auto p = static_cast<IsoTFProperty*>(property_);
+        p->tf_.get().flipPositions();
+        p->isovalues_.get().flipPositions();
+    });
+    connect(interpolate, &QAction::triggered, this, [this]() {
+        NetworkLock lock(property_);
+        auto p = static_cast<IsoTFProperty*>(property_);
+        p->tf_.get().interpolateAlpha();
+        p->isovalues_.get().interpolateAlpha();
+    });
+    connect(equalize, &QAction::triggered, this, [this]() {
+        NetworkLock lock(property_);
+        auto p = static_cast<IsoTFProperty*>(property_);
+        p->tf_.get().equalizeAlpha();
+        p->isovalues_.get().equalizeAlpha();
+    });
+
     auto clearTF = menu->addAction("&Clear TF && Isovalues");
     clearTF->setEnabled(!property_->getReadOnly());
 

--- a/modules/qtwidgets/src/properties/isovaluepropertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/isovaluepropertywidgetqt.cpp
@@ -88,6 +88,28 @@ std::unique_ptr<QMenu> IsoValuePropertyWidgetQt::getContextMenu() {
 
     menu->addSeparator();
 
+    auto transformMenu = menu->addMenu("&Transform");
+
+    auto flip = transformMenu->addAction("&Horizontal Flip");
+    auto interpolate = transformMenu->addAction("&Interpolate Alpha");
+    auto equalize = transformMenu->addAction("&Equalize Alpha");
+
+    connect(flip, &QAction::triggered, this, [this]() {
+        NetworkLock lock(property_);
+        auto p = static_cast<IsoValueProperty*>(property_);
+        p->get().flipPositions();
+    });
+    connect(interpolate, &QAction::triggered, this, [this]() {
+        NetworkLock lock(property_);
+        auto p = static_cast<IsoValueProperty*>(property_);
+        p->get().interpolateAlpha();
+    });
+    connect(equalize, &QAction::triggered, this, [this]() {
+        NetworkLock lock(property_);
+        auto p = static_cast<IsoValueProperty*>(property_);
+        p->get().equalizeAlpha();
+    });
+
     auto clearTF = menu->addAction("&Clear Isovalues");
     clearTF->setEnabled(!property_->getReadOnly());
 

--- a/modules/qtwidgets/src/properties/tfpropertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/tfpropertywidgetqt.cpp
@@ -108,6 +108,28 @@ std::unique_ptr<QMenu> TFPropertyWidgetQt::getContextMenu() {
 
     util::addTFPresetsMenu(this, menu.get(), static_cast<TransferFunctionProperty*>(property_));
 
+    auto transformMenu = menu->addMenu("TF &Transform");
+
+    auto flip = transformMenu->addAction("&Horizontal Flip");
+    auto interpolate = transformMenu->addAction("&Interpolate Alpha");
+    auto equalize = transformMenu->addAction("&Equalize Alpha");
+
+    connect(flip, &QAction::triggered, this, [this]() {
+        NetworkLock lock(property_);
+        auto p = static_cast<TransferFunctionProperty*>(property_);
+        p->get().flipPositions();
+    });
+    connect(interpolate, &QAction::triggered, this, [this]() {
+        NetworkLock lock(property_);
+        auto p = static_cast<TransferFunctionProperty*>(property_);
+        p->get().interpolateAlpha();
+    });
+    connect(equalize, &QAction::triggered, this, [this]() {
+        NetworkLock lock(property_);
+        auto p = static_cast<TransferFunctionProperty*>(property_);
+        p->get().equalizeAlpha();
+    });
+
     auto clearTF = menu->addAction("&Clear TF");
     clearTF->setEnabled(!property_->getReadOnly());
 

--- a/modules/qtwidgets/src/tf/tfeditor.cpp
+++ b/modules/qtwidgets/src/tf/tfeditor.cpp
@@ -496,6 +496,39 @@ void TFEditor::contextMenuEvent(QGraphicsSceneContextMenuEvent* e) {
         });
     }
 
+    auto transformMenu = menu.addMenu("Trans&form");
+    menu.addSeparator();
+
+    {
+        auto flip = transformMenu->addAction("&Horizontal Flip");
+        auto interpolate = transformMenu->addAction("&Interpolate Alpha");
+        auto equalize = transformMenu->addAction("&Equalize Alpha");
+
+        connect(flip, &QAction::triggered, this, [this]() {
+            NetworkLock lock(tfPropertyPtr_->getProperty());
+            auto selection = getSelectedPrimitives();
+            for (auto& elem : tfSets_) {
+                elem->flipPositions(selection);
+            }
+        });
+
+        connect(interpolate, &QAction::triggered, this, [this]() {
+            NetworkLock lock(tfPropertyPtr_->getProperty());
+            auto selection = getSelectedPrimitives();
+            for (auto& elem : tfSets_) {
+                elem->interpolateAlpha(selection);
+            }
+        });
+
+        connect(equalize, &QAction::triggered, this, [this]() {
+            NetworkLock lock(tfPropertyPtr_->getProperty());
+            auto selection = getSelectedPrimitives();
+            for (auto& elem : tfSets_) {
+                elem->equalizeAlpha(selection);
+            }
+        });
+    }
+
     if (tfPropertyPtr_->supportsMask()) {
         auto maskMenu = menu.addMenu("&Mask");
         // TF masking

--- a/resources/changelog.html
+++ b/resources/changelog.html
@@ -86,18 +86,28 @@
 </head>
 <body >
 <h1>Latest Changes</h1>
+<h2>2019-07-16 Transfer Function Editing</h2>
+<p>Added some utility functions for editing transfer functions: </p>
+<ul>
+<li><strong>flip positions</strong> - swap the positions of all TF primitives with respect to their range</li>
+<li><strong>interpolate alpha</strong> - interpolates the alpha values of all TF primitives in between the left-most and right-most TF primitive</li>
+<li><strong>equalize alpha</strong> - averages the alpha value of all selected TF primitives</li>
+</ul>
+<p>These functions are accessible under <code>Transform</code> in the context menus of both TF editor and respective TF properties. All functions are applied to the current selection or the entire TF, if nothing is selected.</p>
 <h2>2019-07-05 Plotting Improvements</h2>
 <p>We added a <code>AxisStyleProperty</code> for simplifying the setup of multiple axes in plots. Multiple axis properties can be registered with this new style property (<code>AxisStyleProperty::registerProperty()</code>). Changes to any of the style properties (line and text color, font size, tick length, etc.) are propagated to all registered axes, i.e. all axis share the same style. Note: this modifications can be overwritten in the individual axis.</p>
 <p>There is now also an <code>Image Plot Processor</code> which allows to plot a 2D image with matching x-y axes. Interactions are forwarded to the image port which allows, e.g., to browse through volume slices. See image plot example in <code>PlottingGL</code>.</p>
 <h2>2019-07-04 New Inviwo version</h2>
 <p>We are releasing a new Inviwo version 0.9.10. <br />
-Major change since the last relase include:<br />
- * Embedded web browser support<br />
- * Get Started widget<br />
- * Python processors<br />
- * New module structure<br />
- * New meta tool for adding new modules/processors<br />
-Moreover this will be that last version to not require c++17.</p>
+Major change since the last relase include:</p>
+<ul>
+<li>Embedded web browser support</li>
+<li>Get Started widget</li>
+<li>Python processors</li>
+<li>New module structure</li>
+<li>New meta tool for adding new modules/processors</li>
+</ul>
+<p>Moreover this will be that last version to not require c++17.</p>
 <h2>2019-06-11 Webbrowser property synchronization</h2>
 <p>Changed way of synchronizing/setting properties in javascript. Instead of adding properties to the webbrowser processor one can now set them using their path from javascript.<br />
 See web_property_sync.html in the Webbrowser module</p>

--- a/tools/changelog-to-html.py
+++ b/tools/changelog-to-html.py
@@ -161,7 +161,7 @@ htmlHeader = """<!DOCTYPE html>
 <body >
 <h1>Latest Changes</h1>
 """
-htmlBody = "</body></html>"
+htmlBody = "</body></html>\n"
 changelogBegin = "Here we document changes"
 
 def main(args):


### PR DESCRIPTION
from the changelog:
Added some utility functions for editing transfer functions: 

 * **flip positions** - swap the positions of all TF primitives with respect to their range
 * **interpolate alpha** - interpolates the alpha values of all TF primitives in between the left-most and right-most TF primitive
 * **equalize alpha** - averages the alpha value of all selected TF primitives

These functions are accessible under `Transform` in the context menus of both TF editor and respective TF properties. All functions are applied to the current selection or the entire TF, if nothing is selected.

<img width="600px" src="https://user-images.githubusercontent.com/9251300/61299882-3c244180-a7e1-11e9-885a-596bbfe0ea8d.png"/>
