### PR TITLE
Meta: Possible compile fix for MSVC 2019

### DIFF
--- a/tools/meta/include/inviwo/meta/cmake/cmakefile.hpp
+++ b/tools/meta/include/inviwo/meta/cmake/cmakefile.hpp
@@ -83,13 +83,13 @@ struct INVIWO_META_API Command {
     Range<const_iterator> args() const;
 
 private:
-    static inline const filter_t filter = [](const ArgElement& elem) -> bool {
+    static inline constexpr filter_t filter = [](const ArgElement& elem) -> bool {
         return std::holds_alternative<Argument>(elem);
     };
-    static inline const transform_t transform = [](ArgElement& elem) -> Argument& {
+    static inline constexpr transform_t transform = [](ArgElement& elem) -> Argument& {
         return std::get<Argument>(elem);
     };
-    static inline const const_transform_t const_transform =
+    static inline constexpr const_transform_t const_transform =
         [](const ArgElement& elem) -> const Argument& { return std::get<Argument>(elem); };
 };
 
@@ -123,13 +123,13 @@ public:
 
     std::vector<FileElement> items;
 private:
-    static inline const filter_t filter = [](const FileElement& elem) -> bool {
+    static inline constexpr filter_t filter = [](const FileElement& elem) -> bool {
         return std::holds_alternative<Command>(elem);
     };
-    static inline const transform_t transform = [](FileElement& elem) -> Command& {
+    static inline constexpr transform_t transform = [](FileElement& elem) -> Command& {
         return std::get<Command>(elem);
     };
-    static inline const const_transform_t const_transform =
+    static inline constexpr const_transform_t const_transform =
         [](const FileElement& elem) -> const Command& { return std::get<Command>(elem); };
 };
 

--- a/tools/meta/include/inviwo/meta/inviwomodule.hpp
+++ b/tools/meta/include/inviwo/meta/inviwomodule.hpp
@@ -95,11 +95,11 @@ public:
                                                           std::vector<std::filesystem::path> bases);
 
 private:
-    static inline const std::string_view headerGroup{"HEADER_FILES"};
-    static inline const std::string_view sourceGroup{"SOURCE_FILES"};
-    static inline const std::string_view shaderGroup{"SHADER_FILES"};
-    static inline const std::string_view testGroup{"TEST_FILES"};
-    static inline const std::string_view moduleCmd{"ivw_module"};
+    static inline constexpr std::string_view headerGroup{"HEADER_FILES"};
+    static inline constexpr std::string_view sourceGroup{"SOURCE_FILES"};
+    static inline constexpr std::string_view shaderGroup{"SHADER_FILES"};
+    static inline constexpr std::string_view testGroup{"TEST_FILES"};
+    static inline constexpr std::string_view moduleCmd{"ivw_module"};
 
     static void sortArgs(cmake::Command& cmd);
     static void addArg(std::vector<cmake::ArgElement>& args, std::string_view arg);

--- a/tools/meta/include/inviwo/meta/inviwomoduleconf.hpp
+++ b/tools/meta/include/inviwo/meta/inviwomoduleconf.hpp
@@ -56,7 +56,7 @@ public:
     path includePrefix() const { return fmt("{org}{lname}"); }
 
 protected:
-    static inline const path cmlists{"CMakeLists.txt"};
+    const path cmlists{"CMakeLists.txt"};
     std::string fmt(std::string_view str) const {
         using namespace fmt::literals;
         return fmt::format(str, "name"_a = name_, "uname"_a = util::toUpper(name_),

--- a/tools/meta/src/paths.cpp
+++ b/tools/meta/src/paths.cpp
@@ -33,6 +33,7 @@
 #include <array>
 #include <algorithm>
 #include <fstream>
+#include <string>
 
 namespace inviwo::meta {
 


### PR DESCRIPTION
When updating from MSVC 2017 to 2019 meta failed to build (see #620). 
There is a bug in MSVC 2019 with DLL export/import and static inline const. 
Changing the `static inline const` to  `static inline constexpr` removes the ICE