### PR TITLE
Core: Make PropertyOwner remove all its properties before destruction…

### DIFF
--- a/include/inviwo/core/processors/canvasprocessor.h
+++ b/include/inviwo/core/processors/canvasprocessor.h
@@ -92,6 +92,7 @@ protected:
 public:
     ImageInport inport_;
 
+    CompositeProperty inputSize_;
     IntVec2Property dimensions_;
     BoolProperty enableCustomInputDimensions_;
     IntVec2Property customInputDimensions_;
@@ -104,7 +105,6 @@ public:
     DirectoryProperty saveLayerDirectory_;
     ButtonProperty saveLayerButton_;
     ButtonProperty saveLayerToFileButton_;
-    CompositeProperty inputSize_;
     BoolProperty fullScreen_;
     EventProperty fullScreenEvent_;
     EventProperty saveLayerEvent_;

--- a/include/inviwo/core/properties/property.h
+++ b/include/inviwo/core/properties/property.h
@@ -132,7 +132,10 @@ public:
              InvalidationLevel invalidationLevel = InvalidationLevel::InvalidOutput,
              PropertySemantics semantics = PropertySemantics::Default);
     virtual Property* clone() const = 0;
-    virtual ~Property() = default;
+    /**
+     * \brief Removes itself from its PropertyOwner.
+     */
+    virtual ~Property();
 
     /**
      * Property identifier has to be unique within the scope

--- a/include/inviwo/core/properties/propertyowner.h
+++ b/include/inviwo/core/properties/propertyowner.h
@@ -54,6 +54,9 @@ public:
     PropertyOwner();
     PropertyOwner(const PropertyOwner& rhs);
     PropertyOwner& operator=(const PropertyOwner& that);
+    /**
+     * \brief Removes all properties and notifies its observers of the removal.
+     */
     virtual ~PropertyOwner();
 
     virtual void addProperty(Property* property, bool owner = true);
@@ -139,14 +142,14 @@ protected:
     // pointers to members of derived classes.
     std::vector<Property*> properties_;
 
+    // Cached lists of certain property types
+    std::vector<EventProperty*> eventProperties_;          //< non-owning references.
+    std::vector<CompositeProperty*> compositeProperties_;  //< non-owning references.
+
     // An additional list of properties for which PropertyOwner assumes ownership.
     // I.e. PropertyOwner will take care of deleting them. Usually used for dynamic properties
     // allocated on the heap.
     std::vector<std::unique_ptr<Property>> ownedProperties_;
-
-    // Cached lists of certain property types
-    std::vector<EventProperty*> eventProperties_;          //< non-owning references.
-    std::vector<CompositeProperty*> compositeProperties_;  //< non-owning references.
 
 private:
     Property* removeProperty(std::vector<Property*>::iterator it);

--- a/include/inviwo/core/properties/propertyowner.h
+++ b/include/inviwo/core/properties/propertyowner.h
@@ -54,7 +54,7 @@ public:
     PropertyOwner();
     PropertyOwner(const PropertyOwner& rhs);
     PropertyOwner& operator=(const PropertyOwner& that);
-    virtual ~PropertyOwner() = default;
+    virtual ~PropertyOwner();
 
     virtual void addProperty(Property* property, bool owner = true);
     virtual void addProperty(Property& property);

--- a/modules/basegl/include/modules/basegl/processors/multichannelraycaster.h
+++ b/modules/basegl/include/modules/basegl/processors/multichannelraycaster.h
@@ -71,7 +71,7 @@ public:
     static const ProcessorInfo processorInfo_;
 
     MultichannelRaycaster();
-    virtual ~MultichannelRaycaster();
+    virtual ~MultichannelRaycaster() = default;
 
     virtual void initializeResources() override;
     virtual void process() override;

--- a/modules/basegl/src/processors/multichannelraycaster.cpp
+++ b/modules/basegl/src/processors/multichannelraycaster.cpp
@@ -62,13 +62,13 @@ MultichannelRaycaster::MultichannelRaycaster()
     , lighting_("lighting", "Lighting", &camera_)
     , positionIndicator_("positionindicator", "Position Indicator") {
     transferFunctions_.addProperty(
-        new TransferFunctionProperty("transferFunction1", "Channel 1", &volumePort_), false);
+        new TransferFunctionProperty("transferFunction1", "Channel 1", &volumePort_), true);
     transferFunctions_.addProperty(
-        new TransferFunctionProperty("transferFunction2", "Channel 2", &volumePort_), false);
+        new TransferFunctionProperty("transferFunction2", "Channel 2", &volumePort_), true);
     transferFunctions_.addProperty(
-        new TransferFunctionProperty("transferFunction3", "Channel 3", &volumePort_), false);
+        new TransferFunctionProperty("transferFunction3", "Channel 3", &volumePort_), true);
     transferFunctions_.addProperty(
-        new TransferFunctionProperty("transferFunction4", "Channel 4", &volumePort_), false);
+        new TransferFunctionProperty("transferFunction4", "Channel 4", &volumePort_), true);
 
     shader_.onReload([this]() { invalidate(InvalidationLevel::InvalidResources); });
 
@@ -90,12 +90,6 @@ MultichannelRaycaster::MultichannelRaycaster()
 
     backgroundPort_.onConnect([&]() { this->invalidate(InvalidationLevel::InvalidResources); });
     backgroundPort_.onDisconnect([&]() { this->invalidate(InvalidationLevel::InvalidResources); });
-}
-
-MultichannelRaycaster::~MultichannelRaycaster() {
-    for (auto tf : transferFunctions_.getProperties()) {
-        delete tf;
-    }
 }
 
 void MultichannelRaycaster::initializeResources() {

--- a/modules/pvm/CMakeLists.txt
+++ b/modules/pvm/CMakeLists.txt
@@ -33,8 +33,8 @@ target_link_libraries(inviwo-module-pvm PRIVATE tidds)
 
 ivw_register_license_file(NAME "Tiny DDS Package" MODULE PVM TYPE "LGPL"
     URL https://github.com/Eyescale/Equalizer
-    FILES ${CMAKE_CURRENT_SOURCE_DIR}/ext/tidds/README
-          ${CMAKE_CURRENT_SOURCE_DIR}/ext/tidds/LGPL
+    FILES ${CMAKE_CURRENT_SOURCE_DIR}/ext/tidds/tidds/README
+          ${CMAKE_CURRENT_SOURCE_DIR}/ext/tidds/tidds/LGPL
 )
 
 ivw_make_package(InviwoPVMModule inviwo-module-pvm)

--- a/src/core/processors/canvasprocessor.cpp
+++ b/src/core/processors/canvasprocessor.cpp
@@ -49,6 +49,7 @@ namespace inviwo {
 CanvasProcessor::CanvasProcessor()
     : Processor()
     , inport_("inport")
+    , inputSize_("inputSize", "Input Dimension Parameters")
     , dimensions_("dimensions", "Canvas Size", ivec2(256, 256), ivec2(128, 128), ivec2(4096, 4096),
                   ivec2(1, 1), InvalidationLevel::Valid)
     , enableCustomInputDimensions_("enableCustomInputDimensions", "Separate Image Size", false,
@@ -69,7 +70,6 @@ CanvasProcessor::CanvasProcessor()
     , saveLayerButton_("saveLayer", "Save Image Layer", InvalidationLevel::Valid)
     , saveLayerToFileButton_("saveLayerToFile", "Save Image Layer to File...",
                              InvalidationLevel::Valid)
-    , inputSize_("inputSize", "Input Dimension Parameters")
     , fullScreen_("fullscreen", "Toggle Full Screen", false)
     , fullScreenEvent_("fullscreenEvent", "FullScreen",
                        [this](Event*) { fullScreen_.set(!fullScreen_); }, IvwKey::F,

--- a/src/core/properties/property.cpp
+++ b/src/core/properties/property.cpp
@@ -69,6 +69,12 @@ Property::Property(const Property& rhs)
     , invalidationLevel_(rhs.invalidationLevel_)
     , owner_(rhs.owner_)
     , initiatingWidget_(rhs.initiatingWidget_) {}
+    
+Property::~Property() {
+    if (auto owner = getOwner()) {
+        owner->removeProperty(this);
+    }
+}
 
 Property& Property::operator=(const Property& that) {
     if (this != &that) {

--- a/src/core/properties/propertyowner.cpp
+++ b/src/core/properties/propertyowner.cpp
@@ -49,9 +49,9 @@ PropertyOwner::PropertyOwner(const PropertyOwner& rhs)
 
     for (const auto& p : rhs.ownedProperties_) addProperty(p->clone());
 }
-
+    
 PropertyOwner::~PropertyOwner() {
-    while (begin() != end()) {
+    while (size() != 0) {
         removeProperty(begin());
     }
 }

--- a/src/core/properties/propertyowner.cpp
+++ b/src/core/properties/propertyowner.cpp
@@ -50,17 +50,20 @@ PropertyOwner::PropertyOwner(const PropertyOwner& rhs)
     for (const auto& p : rhs.ownedProperties_) addProperty(p->clone());
 }
 
-PropertyOwner::~PropertyOwner() { 
+PropertyOwner::~PropertyOwner() {
     while (begin() != end()) {
-        removeProperty(begin()); 
+        removeProperty(begin());
     }
 }
 
 PropertyOwner& PropertyOwner::operator=(const PropertyOwner& that) {
     if (this != &that) {
         invalidationLevel_ = that.invalidationLevel_;
-        properties_.clear();
-        ownedProperties_.clear();
+        // PropertyOwner is only responsible for owned properties,
+        // not all, e.g. the ones in properties_.
+        while (!ownedProperties_.empty()) {
+            removeProperty(ownedProperties_.back().get());
+        }
         for (const auto& p : that.ownedProperties_) addProperty(p->clone());
     }
     return *this;

--- a/src/core/properties/propertyowner.cpp
+++ b/src/core/properties/propertyowner.cpp
@@ -50,6 +50,12 @@ PropertyOwner::PropertyOwner(const PropertyOwner& rhs)
     for (const auto& p : rhs.ownedProperties_) addProperty(p->clone());
 }
 
+PropertyOwner::~PropertyOwner() { 
+    while (begin() != end()) {
+        removeProperty(begin()); 
+    }
+}
+
 PropertyOwner& PropertyOwner::operator=(const PropertyOwner& that) {
     if (this != &that) {
         invalidationLevel_ = that.invalidationLevel_;


### PR DESCRIPTION
Make PropertyOwner remove all its properties before destruction to ensure that PropertyOwnerObserver::onWillRemoveProperty is called.

Otherwise there can be calls to onWillAddProperty but not to onWillRemoveProperty
