### PR TITLE
Webrowser: CEF_TARGET_OUT_DIR need to be set to the executable path.

### DIFF
--- a/modules/webbrowser/CMakeLists.txt
+++ b/modules/webbrowser/CMakeLists.txt
@@ -68,8 +68,7 @@ set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_TMP})
 
 # Determine the target output directory.
 # Inviwo: use module target directory as output dir$<TARGET_FILE_DIR:inviwo-module-webbrowser>
-#SET_CEF_TARGET_OUT_DIR()
-set(CEF_TARGET_OUT_DIR $<TARGET_FILE_DIR:inviwo-module-webbrowser>)
+set(CEF_TARGET_OUT_DIR ${EXECUTABLE_OUTPUT_PATH}/$<CONFIG>)
 
 # Display configuration settings.
 #PRINT_CEF_CONFIG()

--- a/modules/webbrowser/CMakeLists.txt
+++ b/modules/webbrowser/CMakeLists.txt
@@ -68,7 +68,11 @@ set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_TMP})
 
 # Determine the target output directory.
 # Inviwo: use module target directory as output dir$<TARGET_FILE_DIR:inviwo-module-webbrowser>
-set(CEF_TARGET_OUT_DIR ${EXECUTABLE_OUTPUT_PATH}/$<CONFIG>)
+if(GENERATOR_IS_MULTI_CONFIG) 
+    set(CEF_TARGET_OUT_DIR ${EXECUTABLE_OUTPUT_PATH}/$<CONFIG>)
+else()
+    set(CEF_TARGET_OUT_DIR ${EXECUTABLE_OUTPUT_PATH})
+endif()
 
 # Display configuration settings.
 #PRINT_CEF_CONFIG()


### PR DESCRIPTION
When building statically `$<TARGET_FILE_DIR:inviwo-module-webbrowser>`  will evaluate to `build/lib/{Config}` and hence the cef dlls will be copied to the lib directory instead of the bin directory. 

An option is to set it to `CMAKE_RUNTIME_OUTPUT_DIRECTORY`, which is the same. (They are both set in https://github.com/inviwo/inviwo/blob/master/cmake/globalconfig.cmake#L115-L120) 