### PR TITLE
Observable fix

### DIFF
--- a/include/inviwo/core/properties/tfpropertyconcept.h
+++ b/include/inviwo/core/properties/tfpropertyconcept.h
@@ -47,7 +47,7 @@ namespace util {
  * \class TFPropertyConcept
  * \brief property interface used by the TF dialog to support different TF properties
  */
-struct TFPropertyConcept {
+struct IVW_CORE_API TFPropertyConcept {
     virtual ~TFPropertyConcept() = default;
     virtual Property* getProperty() const = 0;
 

--- a/include/inviwo/core/util/observer.h
+++ b/include/inviwo/core/util/observer.h
@@ -184,7 +184,7 @@ public:
     Observable() = default;
 
     /**
-     * This operation does nothing. We will not touch the observers of other
+     * This operation does nothing. We will not touch the observers of other.
      */
     Observable(const Observable<T>& other);
 
@@ -194,14 +194,13 @@ public:
     Observable(Observable<T>&& other);
 
     /**
-     * This operation does nothing. We will not touch the observers of other
+     * This operation does nothing. We will not touch the observers of other.
      */
-
     Observable<T>& operator=(const Observable<T>& other);
 
     /**
-     * This operation will remove all observers of this, amek make all observers of other observe this
-     * instead
+     * This operation will remove all observers of this, and make all observers of other observe this
+     * instead.
      */
     Observable<T>& operator=(Observable<T>&& other);
     virtual ~Observable();

--- a/include/inviwo/core/util/observer.h
+++ b/include/inviwo/core/util/observer.h
@@ -182,10 +182,28 @@ template <typename T>
 class Observable : public ObservableInterface {
 public:
     Observable() = default;
+
+    /**
+     * This operation does nothing. We will not touch the observers of other
+     */
     Observable(const Observable<T>& other);
+
+    /**
+     * This operation will remove all observers from other and add them to this.
+     */
     Observable(Observable<T>&& other);
-    Observable<T>& operator=(Observable<T>&& other);
+
+    /**
+     * This operation does nothing. We will not touch the observers of other
+     */
+
     Observable<T>& operator=(const Observable<T>& other);
+
+    /**
+     * This operation will remove all observers of this, amek make all observers of other observe this
+     * instead
+     */
+    Observable<T>& operator=(Observable<T>&& other);
     virtual ~Observable();
 
     void addObserver(T* observer);
@@ -218,9 +236,7 @@ private:
 };
 
 template <typename T>
-Observable<T>::Observable(const Observable<T>& rhs) {
-    for (auto& elem : rhs.observers_) addObserver(elem);
-}
+Observable<T>::Observable(const Observable<T>&) {}
 
 template <typename T>
 Observable<T>::Observable(Observable<T>&& rhs) {
@@ -229,11 +245,7 @@ Observable<T>::Observable(Observable<T>&& rhs) {
 }
 
 template <typename T>
-Observable<T>& inviwo::Observable<T>::operator=(const Observable<T>& that) {
-    if (this != &that) {
-        removeObservers();
-        for (auto& elem : that.observers_) addObserver(elem);
-    }
+Observable<T>& inviwo::Observable<T>::operator=(const Observable<T>&) {
     return *this;
 }
 

--- a/modules/pvm/src/pvmvolumereader.cpp
+++ b/modules/pvm/src/pvmvolumereader.cpp
@@ -113,7 +113,6 @@ std::shared_ptr<Volume> PVMVolumeReader::readPVMData(std::string filePath) {
                 throw DataReaderException(
                     "Error: Unsupported format (bytes per voxel) in .pvm file: " + filePath,
                     IVW_CONTEXT_CUSTOM("PVMVolumeReader"));
-                return nullptr;
         }
     }();
 

--- a/src/core/datastructures/tfprimitiveset.cpp
+++ b/src/core/datastructures/tfprimitiveset.cpp
@@ -413,7 +413,7 @@ void TFPrimitiveSet::interpolateAndStoreColors(vec4* dataArray, const size_t dat
 }
 
 void TFPrimitiveSet::flipPositions(const std::vector<TFPrimitive*>& primitives) {
-    dvec2 range;
+    dvec2 range{};
     std::vector<TFPrimitive*> selection;
 
     if (primitives.empty()) {
@@ -440,7 +440,7 @@ void TFPrimitiveSet::flipPositions(const std::vector<TFPrimitive*>& primitives) 
 }
 
 void TFPrimitiveSet::interpolateAlpha(const std::vector<TFPrimitive*>& primitives) {
-    dvec2 range;
+    dvec2 range{};
     vec2 alpha{0.0f, 1.0f};
     std::vector<TFPrimitive*> selection;
 


### PR DESCRIPTION
Observable no longer makes it observers observe its copies

i.e. if widget w observes property a and one creates a clone of a called b. The widget w will not anymore automatically observe both a and b as was previously the case. 

closes #585