### PR TITLE
Property assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Here we document changes that affect the public API or changes that needs to be communicated to other developers. 
 
+## 2019-08-16
+We decided to remove the assignment operator from Property and related classes. The reason being that it is hard to understand what is does and hard to implement. Hence if you have implemented your own properties in your code you will have to remove the assignment operators from them. And given that we couldn't find any uses of it we decided to remove it. If you want to assign the "value" of a property to an other property the Property::set(const Property* src) function should be used.
+
 ## 2019-08-05 New version requirements
 We now require a C++17 compatible compiler, and CMake version of at least 3.12 
 

--- a/include/inviwo/core/interaction/trackball.h
+++ b/include/inviwo/core/interaction/trackball.h
@@ -59,7 +59,7 @@ public:
      */
     Trackball(TrackballObject* object);
     Trackball(const Trackball& rhs);
-    Trackball& operator=(const Trackball& that);
+    virtual Trackball* clone() const override;
     virtual ~Trackball();
 
     virtual void invokeEvent(Event* event) override;

--- a/include/inviwo/core/properties/advancedmaterialproperty.h
+++ b/include/inviwo/core/properties/advancedmaterialproperty.h
@@ -67,7 +67,7 @@ public:
                              PropertySemantics semantics = PropertySemantics::Default);
 
     AdvancedMaterialProperty(const AdvancedMaterialProperty& rhs);
-    AdvancedMaterialProperty& operator=(const AdvancedMaterialProperty& that);
+    
     virtual AdvancedMaterialProperty* clone() const override;
     virtual ~AdvancedMaterialProperty();
 

--- a/include/inviwo/core/properties/boolcompositeproperty.h
+++ b/include/inviwo/core/properties/boolcompositeproperty.h
@@ -51,7 +51,6 @@ public:
                           PropertySemantics semantics = PropertySemantics::Default);
 
     BoolCompositeProperty(const BoolCompositeProperty& rhs);
-    BoolCompositeProperty& operator=(const BoolCompositeProperty& that) = default;
 
     virtual BoolCompositeProperty* clone() const override;
     virtual ~BoolCompositeProperty();

--- a/include/inviwo/core/properties/boolproperty.h
+++ b/include/inviwo/core/properties/boolproperty.h
@@ -53,7 +53,6 @@ public:
                  PropertySemantics semantics = PropertySemantics::Default);
 
     BoolProperty(const BoolProperty& rhs);
-    BoolProperty& operator=(const BoolProperty& that);
     BoolProperty& operator=(const bool& value);
     virtual BoolProperty* clone() const override;
     virtual ~BoolProperty();

--- a/include/inviwo/core/properties/buttonproperty.h
+++ b/include/inviwo/core/properties/buttonproperty.h
@@ -58,7 +58,6 @@ public:
                    PropertySemantics semantics = PropertySemantics::Default);
 
     ButtonProperty(const ButtonProperty& rhs);
-    ButtonProperty& operator=(const ButtonProperty& that);
     virtual ButtonProperty* clone() const override;
     virtual ~ButtonProperty();
 

--- a/include/inviwo/core/properties/cameraproperty.h
+++ b/include/inviwo/core/properties/cameraproperty.h
@@ -64,7 +64,6 @@ public:
                    PropertySemantics semantics = PropertySemantics::Default);
 
     CameraProperty(const CameraProperty& rhs);
-    CameraProperty& operator=(const CameraProperty& that);
 
     operator const Camera&() const;
 

--- a/include/inviwo/core/properties/compositeproperty.h
+++ b/include/inviwo/core/properties/compositeproperty.h
@@ -56,7 +56,7 @@ public:
                       PropertySemantics semantics = PropertySemantics::Default);
 
     CompositeProperty(const CompositeProperty& rhs) = default;
-    CompositeProperty& operator=(const CompositeProperty& that) = default;
+
     virtual CompositeProperty* clone() const override;
     virtual ~CompositeProperty() = default;
     virtual std::string getClassIdentifierForWidget() const override;

--- a/include/inviwo/core/properties/directoryproperty.h
+++ b/include/inviwo/core/properties/directoryproperty.h
@@ -52,7 +52,6 @@ public:
                       PropertySemantics semantics = PropertySemantics::Default);
 
     DirectoryProperty(const DirectoryProperty& rhs);
-    DirectoryProperty& operator=(const DirectoryProperty& that);
     virtual DirectoryProperty* clone() const override;
 
     virtual ~DirectoryProperty();

--- a/include/inviwo/core/properties/eventproperty.h
+++ b/include/inviwo/core/properties/eventproperty.h
@@ -83,7 +83,6 @@ public:
                   PropertySemantics semantics = PropertySemantics::Default);
 
     EventProperty(const EventProperty& rhs);
-    EventProperty& operator=(const EventProperty& that);
     virtual EventProperty* clone() const override;
     virtual ~EventProperty() = default;
 

--- a/include/inviwo/core/properties/filepatternproperty.h
+++ b/include/inviwo/core/properties/filepatternproperty.h
@@ -70,7 +70,6 @@ public:
                         PropertySemantics semantics = PropertySemantics::Default);
 
     FilePatternProperty(const FilePatternProperty& rhs);
-    FilePatternProperty& operator=(const FilePatternProperty& that);
 
     virtual FilePatternProperty* clone() const override;
     virtual ~FilePatternProperty();

--- a/include/inviwo/core/properties/fileproperty.h
+++ b/include/inviwo/core/properties/fileproperty.h
@@ -77,7 +77,7 @@ public:
                  PropertySemantics semantics = PropertySemantics::Default);
 
     FileProperty(const FileProperty& rhs) = default;
-    FileProperty& operator=(const FileProperty& that) = default;
+
     FileProperty& operator=(const std::string& value);
     virtual FileProperty* clone() const override;
     virtual ~FileProperty() = default;

--- a/include/inviwo/core/properties/imageeditorproperty.h
+++ b/include/inviwo/core/properties/imageeditorproperty.h
@@ -69,7 +69,7 @@ public:
                         PropertySemantics semantics = PropertySemantics::Default);
 
     ImageEditorProperty(const ImageEditorProperty& rhs);
-    ImageEditorProperty& operator=(const ImageEditorProperty& that);
+
     virtual ImageEditorProperty* clone() const override;
     virtual ~ImageEditorProperty();
 

--- a/include/inviwo/core/properties/isotfproperty.h
+++ b/include/inviwo/core/properties/isotfproperty.h
@@ -70,7 +70,6 @@ public:
     IsoTFProperty(const IsoTFProperty& rhs);
     virtual ~IsoTFProperty() = default;
 
-    IsoTFProperty& operator=(const IsoTFProperty& rhs) = default;
     virtual IsoTFProperty* clone() const override;
 
     virtual std::string getClassIdentifierForWidget() const override;

--- a/include/inviwo/core/properties/isovalueproperty.h
+++ b/include/inviwo/core/properties/isovalueproperty.h
@@ -69,7 +69,6 @@ public:
     IsoValueProperty(const IsoValueProperty& rhs);
     virtual ~IsoValueProperty();
 
-    IsoValueProperty& operator=(const IsoValueProperty& rhs);
     virtual IsoValueProperty* clone() const override;
 
     void setZoomH(double zoomHMin, double zoomHMax);

--- a/include/inviwo/core/properties/listproperty.h
+++ b/include/inviwo/core/properties/listproperty.h
@@ -117,7 +117,7 @@ public:
                  InvalidationLevel invalidationLevel = InvalidationLevel::InvalidResources,
                  PropertySemantics semantics = PropertySemantics::Default);
     ListProperty(const ListProperty& rhs);
-    ListProperty& operator=(const ListProperty& that);
+
     virtual ListProperty* clone() const override;
     virtual ~ListProperty() = default;
 

--- a/include/inviwo/core/properties/minmaxproperty.h
+++ b/include/inviwo/core/properties/minmaxproperty.h
@@ -58,7 +58,6 @@ public:
                    PropertySemantics semantics = PropertySemantics::Default);
 
     MinMaxProperty(const MinMaxProperty& rhs) = default;
-    MinMaxProperty& operator=(const MinMaxProperty& that) = default;
     MinMaxProperty& operator=(const range_type& value);
 
     virtual MinMaxProperty<T>* clone() const override;

--- a/include/inviwo/core/properties/multifileproperty.h
+++ b/include/inviwo/core/properties/multifileproperty.h
@@ -70,7 +70,6 @@ public:
                       PropertySemantics semantics = PropertySemantics::Default);
 
     MultiFileProperty(const MultiFileProperty& rhs);
-    MultiFileProperty& operator=(const MultiFileProperty& that);
     MultiFileProperty& operator=(const std::vector<std::string>& value);
     virtual MultiFileProperty* clone() const override;
     virtual ~MultiFileProperty() = default;

--- a/include/inviwo/core/properties/optionproperty.h
+++ b/include/inviwo/core/properties/optionproperty.h
@@ -52,7 +52,7 @@ public:
                        PropertySemantics semantics = PropertySemantics::Default);
 
     BaseOptionProperty(const BaseOptionProperty& rhs);
-    BaseOptionProperty& operator=(const BaseOptionProperty&);
+
     virtual ~BaseOptionProperty();
 
     virtual std::string getClassIdentifier() const override = 0;
@@ -132,7 +132,7 @@ public:
                            PropertySemantics semantics = PropertySemantics::Default);
 
     TemplateOptionProperty(const TemplateOptionProperty<T>& rhs);
-    TemplateOptionProperty<T>& operator=(const TemplateOptionProperty<T>& that);
+
     virtual TemplateOptionProperty<T>* clone() const override;
     virtual ~TemplateOptionProperty();
 
@@ -369,10 +369,6 @@ TemplateOptionProperty<T>::TemplateOptionProperty(
 
 template <typename T>
 TemplateOptionProperty<T>::TemplateOptionProperty(const TemplateOptionProperty<T>& rhs) = default;
-
-template <typename T>
-TemplateOptionProperty<T>& TemplateOptionProperty<T>::operator=(
-    const TemplateOptionProperty<T>& that) = default;
 
 template <typename T>
 TemplateOptionProperty<T>::~TemplateOptionProperty() = default;

--- a/include/inviwo/core/properties/ordinalproperty.h
+++ b/include/inviwo/core/properties/ordinalproperty.h
@@ -54,7 +54,6 @@ public:
                     PropertySemantics semantics = PropertySemantics::Default);
 
     OrdinalProperty(const OrdinalProperty<T>& rhs);
-    OrdinalProperty<T>& operator=(const OrdinalProperty<T>& that);
     OrdinalProperty<T>& operator=(const T& value);
     virtual OrdinalProperty<T>* clone() const override;
     virtual ~OrdinalProperty();
@@ -163,9 +162,6 @@ OrdinalProperty<T>::OrdinalProperty(const std::string& identifier, const std::st
 
 template <typename T>
 OrdinalProperty<T>::OrdinalProperty(const OrdinalProperty<T>& rhs) = default;
-
-template <typename T>
-OrdinalProperty<T>& OrdinalProperty<T>::operator=(const OrdinalProperty<T>& that) = default;
 
 template <typename T>
 OrdinalProperty<T>& OrdinalProperty<T>::operator=(const T& value) {

--- a/include/inviwo/core/properties/planeproperty.h
+++ b/include/inviwo/core/properties/planeproperty.h
@@ -61,7 +61,6 @@ public:
                   PropertySemantics semantics = PropertySemantics::Default);
 
     PlaneProperty(const PlaneProperty& rhs);
-    PlaneProperty& operator=(const PlaneProperty& that);
     virtual PlaneProperty* clone() const override;
     virtual ~PlaneProperty();
 

--- a/include/inviwo/core/properties/positionproperty.h
+++ b/include/inviwo/core/properties/positionproperty.h
@@ -63,7 +63,6 @@ public:
                      InvalidationLevel = InvalidationLevel::InvalidResources,
                      PropertySemantics semantics = PropertySemantics::Default);
     PositionProperty(const PositionProperty& rhs);
-    PositionProperty& operator=(const PositionProperty& that);
     virtual PositionProperty* clone() const override;
     virtual ~PositionProperty() {}
 

--- a/include/inviwo/core/properties/property.h
+++ b/include/inviwo/core/properties/property.h
@@ -131,6 +131,12 @@ public:
     Property(const std::string& identifier = "", const std::string& displayName = "",
              InvalidationLevel invalidationLevel = InvalidationLevel::InvalidOutput,
              PropertySemantics semantics = PropertySemantics::Default);
+
+    /**
+     * Creates a clone of this property. The clone will have the same identifier, hence the
+     * identifier must be changed if the clone should be added to the same owner as this. The new
+     * clone does not have any owner set.
+     */
     virtual Property* clone() const = 0;
     /**
      * \brief Removes itself from its PropertyOwner.
@@ -240,6 +246,12 @@ public:
     virtual void setValid();
     virtual Property& setModified();
     virtual bool isModified() const;
+
+    /**
+     * Set the value of this to that of src. The "value" is in this case considered to be for
+     * example the string in a StringProperty or the float value in a FloatProperty. But not things
+     * like the identifier of display name.
+     */
     virtual void set(const Property* src);
 
     virtual void serialize(Serializer& s) const override;
@@ -356,7 +368,19 @@ public:
     };
 
 protected:
+    /**
+     * Since property is a polymorphic class the copy constructor should only be used internally to
+     * implement the clone functionality
+     * @see clone
+     */
     Property(const Property& rhs);
+
+    /**
+     * Properties do not support copy assignment.
+     * To assign the "value" of a property to an other property the Property::set(const Property*
+     * src) function should be used
+     * @see set
+     */
     Property& operator=(const Property& that) = delete;
 
     void updateWidgets();

--- a/include/inviwo/core/properties/property.h
+++ b/include/inviwo/core/properties/property.h
@@ -357,7 +357,7 @@ public:
 
 protected:
     Property(const Property& rhs);
-    Property& operator=(const Property& that);
+    Property& operator=(const Property& that) = delete;
 
     void updateWidgets();
     void notifyAboutChange();

--- a/include/inviwo/core/properties/propertyowner.h
+++ b/include/inviwo/core/properties/propertyowner.h
@@ -51,9 +51,6 @@ public:
     using iterator = std::vector<Property*>::iterator;
     using const_iterator = std::vector<Property*>::const_iterator;
 
-    PropertyOwner();
-    PropertyOwner(const PropertyOwner& rhs);
-    PropertyOwner& operator=(const PropertyOwner& that);
     /**
      * \brief Removes all properties and notifies its observers of the removal.
      */
@@ -137,7 +134,12 @@ public:
     virtual InviwoApplication* getInviwoApplication();
 
 protected:
-    // Add the properties belonging the the property owner
+    PropertyOwner();
+    PropertyOwner(const PropertyOwner& rhs);
+    PropertyOwner& operator=(const PropertyOwner& that) = delete;
+
+
+    // Add the properties belonging the property owner
     // PropertyOwner do not assume owner ship here since in the most common case these are
     // pointers to members of derived classes.
     std::vector<Property*> properties_;

--- a/include/inviwo/core/properties/raycastingproperty.h
+++ b/include/inviwo/core/properties/raycastingproperty.h
@@ -73,7 +73,6 @@ public:
                        PropertySemantics semantics = PropertySemantics::Default);
 
     RaycastingProperty(const RaycastingProperty& rhs);
-    RaycastingProperty& operator=(const RaycastingProperty& rhs);
     virtual ~RaycastingProperty() = default;
 
     virtual RaycastingProperty* clone() const override;

--- a/include/inviwo/core/properties/simplelightingproperty.h
+++ b/include/inviwo/core/properties/simplelightingproperty.h
@@ -70,7 +70,6 @@ public:
                            PropertySemantics semantics = PropertySemantics::Default);
 
     SimpleLightingProperty(const SimpleLightingProperty& rhs);
-    SimpleLightingProperty& operator=(const SimpleLightingProperty& that);
     virtual SimpleLightingProperty* clone() const override;
     virtual ~SimpleLightingProperty();
 

--- a/include/inviwo/core/properties/simpleraycastingproperty.h
+++ b/include/inviwo/core/properties/simpleraycastingproperty.h
@@ -51,7 +51,6 @@ public:
                              PropertySemantics semantics = PropertySemantics::Default);
 
     SimpleRaycastingProperty(const SimpleRaycastingProperty& rhs);
-    SimpleRaycastingProperty& operator=(const SimpleRaycastingProperty& that);
     virtual SimpleRaycastingProperty* clone() const override;
     virtual ~SimpleRaycastingProperty() = default;
 

--- a/include/inviwo/core/properties/stipplingproperty.h
+++ b/include/inviwo/core/properties/stipplingproperty.h
@@ -50,7 +50,6 @@ public:
                       InvalidationLevel invalidationLevel = InvalidationLevel::InvalidResources,
                       PropertySemantics semantics = PropertySemantics::Default);
     StipplingProperty(const StipplingProperty& rhs);
-    StipplingProperty& operator=(const StipplingProperty& rhs) = default;
     virtual StipplingProperty* clone() const override;
     virtual ~StipplingProperty() = default;
 

--- a/include/inviwo/core/properties/stringproperty.h
+++ b/include/inviwo/core/properties/stringproperty.h
@@ -62,7 +62,6 @@ public:
                    PropertySemantics semantics = PropertySemantics::Default);
 
     StringProperty(const StringProperty& rhs);
-    StringProperty& operator=(const StringProperty& that);
     StringProperty& operator=(const std::string& value);
     virtual StringProperty* clone() const override;
     virtual ~StringProperty() = default;

--- a/include/inviwo/core/properties/templateproperty.h
+++ b/include/inviwo/core/properties/templateproperty.h
@@ -72,7 +72,6 @@ public:
 
 protected:
     TemplateProperty(const TemplateProperty& rhs) = default;
-    TemplateProperty<T>& operator=(const TemplateProperty<T>& that) = default;
     ValueWrapper<T> value_;
 };
 

--- a/include/inviwo/core/properties/transferfunctionproperty.h
+++ b/include/inviwo/core/properties/transferfunctionproperty.h
@@ -84,7 +84,6 @@ public:
                              PropertySemantics semantics = PropertySemantics::Default);
 
     TransferFunctionProperty(const TransferFunctionProperty& rhs);
-    TransferFunctionProperty& operator=(const TransferFunctionProperty& that);
     virtual TransferFunctionProperty* clone() const override;
     virtual ~TransferFunctionProperty();
 

--- a/include/inviwo/core/properties/volumeindicatorproperty.h
+++ b/include/inviwo/core/properties/volumeindicatorproperty.h
@@ -56,7 +56,6 @@ public:
         PropertySemantics semantics = PropertySemantics::Default);
 
     VolumeIndicatorProperty(const VolumeIndicatorProperty& rhs);
-    VolumeIndicatorProperty& operator=(const VolumeIndicatorProperty& that);
     virtual VolumeIndicatorProperty* clone() const override;
     virtual ~VolumeIndicatorProperty();
 

--- a/modules/abuffergl/abufferglhelpers/abuffergl.cpp
+++ b/modules/abuffergl/abufferglhelpers/abuffergl.cpp
@@ -86,20 +86,6 @@ ABufferGLCompositeProperty::ABufferGLCompositeProperty(const ABufferGLCompositeP
     setAllPropertiesCurrentStateAsDefault();
 }
 
-ABufferGLCompositeProperty& ABufferGLCompositeProperty::operator=(
-    const ABufferGLCompositeProperty& that) {
-    if (this != &that) {
-        CompositeProperty::operator=(that);
-        abufferEnable_ = that.abufferEnable_;
-        abufferPageSize_ = that.abufferPageSize_;
-        abufferLocalMemorySize_ = that.abufferLocalMemorySize_;
-        abufferReSize_ = that.abufferReSize_;
-        abufferWriteABufferInfoToFile_ = that.abufferWriteABufferInfoToFile_;
-        verboseLogging_ = that.verboseLogging_;
-    }
-    return *this;
-}
-
 ABufferGLCompositeProperty* ABufferGLCompositeProperty::clone() const {
     return new ABufferGLCompositeProperty(*this);
 }

--- a/modules/abuffergl/abufferglhelpers/abuffergl.h
+++ b/modules/abuffergl/abufferglhelpers/abuffergl.h
@@ -78,7 +78,6 @@ public:
         PropertySemantics semantics = PropertySemantics::Default);
 
     ABufferGLCompositeProperty(const ABufferGLCompositeProperty& rhs);
-    ABufferGLCompositeProperty& operator=(const ABufferGLCompositeProperty& that);
     virtual ABufferGLCompositeProperty* clone() const override;
     virtual ~ABufferGLCompositeProperty();
     virtual std::string getClassIdentifierForWidget() const override;

--- a/modules/base/include/modules/base/properties/basisproperty.h
+++ b/modules/base/include/modules/base/properties/basisproperty.h
@@ -63,7 +63,6 @@ public:
     void onResetOverride();
 
     BasisProperty(const BasisProperty& rhs);
-    BasisProperty& operator=(const BasisProperty& that);
     virtual BasisProperty* clone() const override;
     virtual ~BasisProperty() = default;
 

--- a/modules/base/include/modules/base/properties/bufferinformationproperty.h
+++ b/modules/base/include/modules/base/properties/bufferinformationproperty.h
@@ -53,7 +53,6 @@ public:
         InvalidationLevel invalidationLevel = InvalidationLevel::InvalidResources,
         PropertySemantics semantics = PropertySemantics::Default);
     BufferInformationProperty(const BufferInformationProperty& rhs);
-    BufferInformationProperty& operator=(const BufferInformationProperty& that);
     virtual BufferInformationProperty* clone() const override;
     virtual ~BufferInformationProperty() = default;
 
@@ -79,7 +78,6 @@ public:
         InvalidationLevel invalidationLevel = InvalidationLevel::InvalidResources,
         PropertySemantics semantics = PropertySemantics::Default);
     MeshBufferInformationProperty(const MeshBufferInformationProperty& rhs);
-    MeshBufferInformationProperty& operator=(const MeshBufferInformationProperty& that);
     virtual MeshBufferInformationProperty* clone() const override;
     virtual ~MeshBufferInformationProperty() = default;
 
@@ -103,7 +101,6 @@ public:
         InvalidationLevel invalidationLevel = InvalidationLevel::InvalidResources,
         PropertySemantics semantics = PropertySemantics::Default);
     IndexBufferInformationProperty(const IndexBufferInformationProperty& rhs);
-    IndexBufferInformationProperty& operator=(const IndexBufferInformationProperty& that);
     virtual IndexBufferInformationProperty* clone() const override;
     virtual ~IndexBufferInformationProperty() = default;
 

--- a/modules/base/include/modules/base/properties/gaussianproperty.h
+++ b/modules/base/include/modules/base/properties/gaussianproperty.h
@@ -64,7 +64,6 @@ public:
         addProperty(sigma_);
         addProperty(center_);
     }
-    GaussianProperty &operator=(const GaussianProperty &that) = default;
 
     virtual GaussianProperty<T> *clone() const override { return new GaussianProperty<T>(*this); }
 

--- a/modules/base/include/modules/base/properties/imageinformationproperty.h
+++ b/modules/base/include/modules/base/properties/imageinformationproperty.h
@@ -53,7 +53,6 @@ public:
         InvalidationLevel invalidationLevel = InvalidationLevel::InvalidResources,
         PropertySemantics semantics = PropertySemantics::Default);
     ImageInformationProperty(const ImageInformationProperty& rhs);
-    ImageInformationProperty& operator=(const ImageInformationProperty& that);
     virtual ImageInformationProperty* clone() const override;
     virtual ~ImageInformationProperty() = default;
 

--- a/modules/base/include/modules/base/properties/layerinformationproperty.h
+++ b/modules/base/include/modules/base/properties/layerinformationproperty.h
@@ -52,7 +52,6 @@ public:
         InvalidationLevel invalidationLevel = InvalidationLevel::InvalidResources,
         PropertySemantics semantics = PropertySemantics::Default);
     LayerInformationProperty(const LayerInformationProperty& rhs);
-    LayerInformationProperty& operator=(const LayerInformationProperty& that);
     virtual LayerInformationProperty* clone() const override;
     virtual ~LayerInformationProperty() = default;
 

--- a/modules/base/include/modules/base/properties/meshinformationproperty.h
+++ b/modules/base/include/modules/base/properties/meshinformationproperty.h
@@ -53,7 +53,6 @@ public:
         InvalidationLevel invalidationLevel = InvalidationLevel::InvalidResources,
         PropertySemantics semantics = PropertySemantics::Default);
     MeshInformationProperty(const MeshInformationProperty& rhs);
-    MeshInformationProperty& operator=(const MeshInformationProperty& that);
     virtual MeshInformationProperty* clone() const override;
     virtual ~MeshInformationProperty() = default;
 

--- a/modules/base/include/modules/base/properties/sequencetimerproperty.h
+++ b/modules/base/include/modules/base/properties/sequencetimerproperty.h
@@ -53,7 +53,6 @@ public:
                           InvalidationLevel invalidationLevel = InvalidationLevel::InvalidResources,
                           PropertySemantics semantics = PropertySemantics::Default);
     SequenceTimerProperty(const SequenceTimerProperty& rhs);
-    SequenceTimerProperty& operator=(const SequenceTimerProperty& that);
     virtual SequenceTimerProperty* clone() const override;
     virtual ~SequenceTimerProperty() = default;
 

--- a/modules/base/include/modules/base/properties/volumeinformationproperty.h
+++ b/modules/base/include/modules/base/properties/volumeinformationproperty.h
@@ -53,7 +53,6 @@ public:
         InvalidationLevel invalidationLevel = InvalidationLevel::InvalidResources,
         PropertySemantics semantics = PropertySemantics::Default);
     VolumeInformationProperty(const VolumeInformationProperty& rhs);
-    VolumeInformationProperty& operator=(const VolumeInformationProperty& that);
     virtual VolumeInformationProperty* clone() const override;
     virtual ~VolumeInformationProperty() = default;
 

--- a/modules/base/src/properties/basisproperty.cpp
+++ b/modules/base/src/properties/basisproperty.cpp
@@ -111,14 +111,6 @@ BasisProperty::BasisProperty(const BasisProperty& rhs)
                             size_, a_, b_, c_, offset_);
 }
 
-BasisProperty& BasisProperty::operator=(const BasisProperty& that) {
-    if (this != &that) {
-        CompositeProperty::operator=(that);
-        util::for_each_in_tuple([](auto& dst, auto& src) { dst = src; }, props(), that.props());
-    }
-    return *this;
-}
-
 BasisProperty* BasisProperty::clone() const { return new BasisProperty(*this); }
 
 void BasisProperty::updateForNewEntity(const StructuredGridEntity<3>& volume, bool deserialize) {

--- a/modules/base/src/properties/bufferinformationproperty.cpp
+++ b/modules/base/src/properties/bufferinformationproperty.cpp
@@ -76,15 +76,6 @@ BufferInformationProperty::BufferInformationProperty(const BufferInformationProp
     util::for_each_in_tuple([&](auto& e) { this->addProperty(e); }, props());
 }
 
-BufferInformationProperty& BufferInformationProperty::operator=(
-    const BufferInformationProperty& that) {
-    if (this != &that) {
-        CompositeProperty::operator=(that);
-        util::for_each_in_tuple([](auto& dst, auto& src) { dst = src; }, props(), that.props());
-    }
-    return *this;
-}
-
 BufferInformationProperty* BufferInformationProperty::clone() const {
     return new BufferInformationProperty(*this);
 }
@@ -124,15 +115,6 @@ MeshBufferInformationProperty::MeshBufferInformationProperty(
     util::for_each_in_tuple([&, i = 0](auto& e) mutable { this->insertProperty(i++, e); }, props());
 }
 
-MeshBufferInformationProperty& MeshBufferInformationProperty::operator=(
-    const MeshBufferInformationProperty& that) {
-    if (this != &that) {
-        BufferInformationProperty::operator=(that);
-        util::for_each_in_tuple([](auto& dst, auto& src) { dst = src; }, props(), that.props());
-    }
-    return *this;
-}
-
 MeshBufferInformationProperty* MeshBufferInformationProperty::clone() const {
     return new MeshBufferInformationProperty(*this);
 }
@@ -170,15 +152,6 @@ IndexBufferInformationProperty::IndexBufferInformationProperty(
     const IndexBufferInformationProperty& rhs)
     : BufferInformationProperty(rhs), drawType_(rhs.drawType_), connectivity_(rhs.connectivity_) {
     util::for_each_in_tuple([&, i = 0](auto& e) mutable { this->insertProperty(i++, e); }, props());
-}
-
-IndexBufferInformationProperty& IndexBufferInformationProperty::operator=(
-    const IndexBufferInformationProperty& that) {
-    if (this != &that) {
-        BufferInformationProperty::operator=(that);
-        util::for_each_in_tuple([](auto& dst, auto& src) { dst = src; }, props(), that.props());
-    }
-    return *this;
 }
 
 IndexBufferInformationProperty* IndexBufferInformationProperty::clone() const {

--- a/modules/base/src/properties/imageinformationproperty.cpp
+++ b/modules/base/src/properties/imageinformationproperty.cpp
@@ -75,15 +75,6 @@ ImageInformationProperty::ImageInformationProperty(const ImageInformationPropert
     addProperty(layers_);
 }
 
-ImageInformationProperty& ImageInformationProperty::operator=(
-    const ImageInformationProperty& that) {
-    if (this != &that) {
-        CompositeProperty::operator=(that);
-        util::for_each_in_tuple([](auto& dst, auto& src) { dst = src; }, props(), that.props());
-    }
-    return *this;
-}
-
 ImageInformationProperty* ImageInformationProperty::clone() const {
     return new ImageInformationProperty(*this);
 }

--- a/modules/base/src/properties/layerinformationproperty.cpp
+++ b/modules/base/src/properties/layerinformationproperty.cpp
@@ -66,18 +66,6 @@ LayerInformationProperty::LayerInformationProperty(const LayerInformationPropert
                             std::tie(layerType_, format_, channels_, swizzleMask_));
 }
 
-LayerInformationProperty& LayerInformationProperty::operator=(
-    const LayerInformationProperty& that) {
-    if (this != &that) {
-        CompositeProperty::operator=(that);
-        layerType_ = that.layerType_;
-        format_ = that.format_;
-        channels_ = that.channels_;
-        swizzleMask_ = that.swizzleMask_;
-    }
-    return *this;
-}
-
 LayerInformationProperty* LayerInformationProperty::clone() const {
     return new LayerInformationProperty(*this);
 }

--- a/modules/base/src/properties/meshinformationproperty.cpp
+++ b/modules/base/src/properties/meshinformationproperty.cpp
@@ -130,16 +130,6 @@ MeshInformationProperty::MeshInformationProperty(const MeshInformationProperty& 
                   meshProperties_, buffers_, indexBuffers_);
 }
 
-MeshInformationProperty& MeshInformationProperty::operator=(const MeshInformationProperty& that) {
-    if (this != &that) {
-        CompositeProperty::operator=(that);
-        util::for_each_in_tuple([](auto& dst, auto& src) { dst = src; }, props(), that.props());
-        util::for_each_in_tuple([](auto& dst, auto& src) { dst = src; }, compositeProps(),
-                                that.compositeProps());
-    }
-    return *this;
-}
-
 MeshInformationProperty* MeshInformationProperty::clone() const {
     return new MeshInformationProperty(*this);
 }

--- a/modules/base/src/properties/sequencetimerproperty.cpp
+++ b/modules/base/src/properties/sequencetimerproperty.cpp
@@ -76,17 +76,6 @@ SequenceTimerProperty::SequenceTimerProperty(const SequenceTimerProperty& rhs)
     addProperty(playPause_);
 }
 
-SequenceTimerProperty& SequenceTimerProperty::operator=(const SequenceTimerProperty& that) {
-    if (this != &that) {
-        CompositeProperty::operator=(that);
-        index_ = that.index_;
-        play_ = that.play_;
-        framesPerSecond_ = that.framesPerSecond_;
-        playPause_ = that.playPause_;
-    }
-    return *this;
-}
-
 SequenceTimerProperty* SequenceTimerProperty::clone() const {
     return new SequenceTimerProperty(*this);
 }

--- a/modules/base/src/properties/volumeinformationproperty.cpp
+++ b/modules/base/src/properties/volumeinformationproperty.cpp
@@ -95,21 +95,6 @@ VolumeInformationProperty::VolumeInformationProperty(const VolumeInformationProp
     addProperty(valueUnit_);
 }
 
-VolumeInformationProperty& VolumeInformationProperty::operator=(
-    const VolumeInformationProperty& that) {
-    if (this != &that) {
-        CompositeProperty::operator=(that);
-        dimensions_ = that.dimensions_;
-        format_ = that.format_;
-        channels_ = that.channels_;
-        numVoxels_ = that.numVoxels_;
-        dataRange_ = that.dataRange_;
-        valueRange_ = that.valueRange_;
-        valueUnit_ = that.valueUnit_;
-    }
-    return *this;
-}
-
 VolumeInformationProperty* VolumeInformationProperty::clone() const {
     return new VolumeInformationProperty(*this);
 }

--- a/modules/dataframe/include/inviwo/dataframe/properties/dataframeproperty.h
+++ b/modules/dataframe/include/inviwo/dataframe/properties/dataframeproperty.h
@@ -49,7 +49,6 @@ public:
                             size_t firstIndex = 0);
 
     DataFrameColumnProperty(const DataFrameColumnProperty& rhs);
-    DataFrameColumnProperty& operator=(const DataFrameColumnProperty& that);
     virtual DataFrameColumnProperty* clone() const override;
 
     virtual ~DataFrameColumnProperty() = default;

--- a/modules/dataframe/src/properties/dataframeproperty.cpp
+++ b/modules/dataframe/src/properties/dataframeproperty.cpp
@@ -66,8 +66,6 @@ DataFrameColumnProperty::DataFrameColumnProperty(const DataFrameColumnProperty& 
     , allowNone_{rhs.allowNone_}
     , firstIndex_{rhs.firstIndex_} {}
 
-DataFrameColumnProperty& DataFrameColumnProperty::operator=(const DataFrameColumnProperty& that) =
-    default;
 
 DataFrameColumnProperty* DataFrameColumnProperty::clone() const {
     return new DataFrameColumnProperty(*this);

--- a/modules/plotting/include/modules/plotting/properties/axisproperty.h
+++ b/modules/plotting/include/modules/plotting/properties/axisproperty.h
@@ -59,7 +59,6 @@ public:
                  InvalidationLevel invalidationLevel = InvalidationLevel::InvalidOutput,
                  PropertySemantics semantics = PropertySemantics::Default);
     AxisProperty(const AxisProperty& rhs);
-    AxisProperty& operator=(const AxisProperty& rhs) = default;
     virtual AxisProperty* clone() const override;
     virtual ~AxisProperty() = default;
 

--- a/modules/plotting/include/modules/plotting/properties/axisstyleproperty.h
+++ b/modules/plotting/include/modules/plotting/properties/axisstyleproperty.h
@@ -55,7 +55,6 @@ public:
                       InvalidationLevel invalidationLevel = InvalidationLevel::InvalidOutput,
                       PropertySemantics semantics = PropertySemantics::Default);
     AxisStyleProperty(const AxisStyleProperty& rhs);
-    AxisStyleProperty& operator=(const AxisStyleProperty& rhs);
     virtual AxisStyleProperty* clone() const override;
     virtual ~AxisStyleProperty() = default;
 

--- a/modules/plotting/include/modules/plotting/properties/categoricalaxisproperty.h
+++ b/modules/plotting/include/modules/plotting/properties/categoricalaxisproperty.h
@@ -66,7 +66,6 @@ public:
                             InvalidationLevel invalidationLevel = InvalidationLevel::InvalidOutput,
                             PropertySemantics semantics = PropertySemantics::Default);
     CategoricalAxisProperty(const CategoricalAxisProperty& rhs);
-    CategoricalAxisProperty& operator=(const CategoricalAxisProperty& rhs) = default;
     virtual CategoricalAxisProperty* clone() const override;
     virtual ~CategoricalAxisProperty() = default;
 

--- a/modules/plotting/include/modules/plotting/properties/marginproperty.h
+++ b/modules/plotting/include/modules/plotting/properties/marginproperty.h
@@ -57,7 +57,6 @@ public:
                    PropertySemantics semantics = PropertySemantics::Default);
 
     MarginProperty(const MarginProperty &rhs);
-    MarginProperty &operator=(const MarginProperty &that);
     virtual MarginProperty *clone() const override;
 
     virtual ~MarginProperty() = default;

--- a/modules/plotting/include/modules/plotting/properties/plottextproperty.h
+++ b/modules/plotting/include/modules/plotting/properties/plottextproperty.h
@@ -55,7 +55,6 @@ public:
                      InvalidationLevel invalidationLevel = InvalidationLevel::InvalidOutput,
                      PropertySemantics semantics = PropertySemantics::Default);
     PlotTextProperty(const PlotTextProperty& rhs);
-    PlotTextProperty& operator=(const PlotTextProperty& rhs) = default;
     virtual PlotTextProperty* clone() const override;
     virtual ~PlotTextProperty() = default;
 

--- a/modules/plotting/include/modules/plotting/properties/tickproperty.h
+++ b/modules/plotting/include/modules/plotting/properties/tickproperty.h
@@ -55,7 +55,6 @@ public:
                       InvalidationLevel invalidationLevel = InvalidationLevel::InvalidOutput,
                       PropertySemantics semantics = PropertySemantics::Default);
     MajorTickProperty(const MajorTickProperty& rhs);
-    MajorTickProperty& operator=(const MajorTickProperty& rhs) = default;
     virtual MajorTickProperty* clone() const override;
     virtual ~MajorTickProperty() = default;
 
@@ -85,7 +84,6 @@ public:
                       InvalidationLevel invalidationLevel = InvalidationLevel::InvalidOutput,
                       PropertySemantics semantics = PropertySemantics::Default);
     MinorTickProperty(const MinorTickProperty& rhs);
-    MinorTickProperty& operator=(const MinorTickProperty& rhs) = default;
     virtual MinorTickProperty* clone() const override;
     virtual ~MinorTickProperty() = default;
 
@@ -114,7 +112,6 @@ public:
                  InvalidationLevel invalidationLevel = InvalidationLevel::InvalidOutput,
                  PropertySemantics semantics = PropertySemantics::Default);
     TickProperty(const TickProperty& rhs);
-    TickProperty& operator=(const TickProperty& rhs) = default;
     virtual TickProperty* clone() const override;
     virtual ~TickProperty() = default;
 

--- a/modules/plotting/src/properties/axisstyleproperty.cpp
+++ b/modules/plotting/src/properties/axisstyleproperty.cpp
@@ -115,15 +115,6 @@ AxisStyleProperty::AxisStyleProperty(const AxisStyleProperty& rhs)
     util::for_each_in_tuple([&](auto& e) { this->addProperty(e); }, props());
 }
 
-AxisStyleProperty& AxisStyleProperty::operator=(const AxisStyleProperty& rhs) {
-    if (this != &rhs) {
-        CompositeProperty::operator=(rhs);
-        util::for_each_in_tuple([](auto& dst, auto& src) { dst = src; }, props(), rhs.props());
-        axes_ = rhs.axes_;
-    }
-    return *this;
-}
-
 AxisStyleProperty* AxisStyleProperty::clone() const { return new AxisStyleProperty(*this); }
 
 void AxisStyleProperty::registerProperty(AxisProperty& p) {

--- a/modules/plotting/src/properties/marginproperty.cpp
+++ b/modules/plotting/src/properties/marginproperty.cpp
@@ -64,16 +64,7 @@ MarginProperty::MarginProperty(const MarginProperty& rhs)
     addProperty(bottom_);
     addProperty(left_);
 }
-MarginProperty& MarginProperty::operator=(const MarginProperty& that) {
-    if (this != &that) {
-        CompositeProperty::operator=(that);
-        top_ = that.top_;
-        right_ = that.right_;
-        bottom_ = that.bottom_;
-        left_ = that.left_;
-    }
-    return *this;
-}
+
 MarginProperty* MarginProperty::clone() const { return new MarginProperty(*this); }
 
 void MarginProperty::setMargins(float top, float right, float bottom, float left) {

--- a/modules/plottinggl/include/modules/plottinggl/plotters/persistencediagramplotgl.h
+++ b/modules/plottinggl/include/modules/plottinggl/plotters/persistencediagramplotgl.h
@@ -74,7 +74,6 @@ public:
                    PropertySemantics semantics = PropertySemantics::Default);
 
         Properties(const Properties &rhs);
-        Properties &operator=(const Properties &that);
         virtual Properties *clone() const override;
         virtual ~Properties() = default;
 

--- a/modules/plottinggl/include/modules/plottinggl/plotters/scatterplotgl.h
+++ b/modules/plottinggl/include/modules/plottinggl/plotters/scatterplotgl.h
@@ -68,7 +68,6 @@ public:
                    PropertySemantics semantics = PropertySemantics::Default);
 
         Properties(const Properties &rhs);
-        Properties &operator=(const Properties &that);
         virtual Properties *clone() const override;
         virtual ~Properties() = default;
 

--- a/modules/plottinggl/include/modules/plottinggl/processors/parallelcoordinates/pcpaxissettings.h
+++ b/modules/plottinggl/include/modules/plottinggl/processors/parallelcoordinates/pcpaxissettings.h
@@ -123,7 +123,6 @@ public:
 
     PCPAxisSettings(std::string identifier, std::string displayName, size_t columnId = 0);
     PCPAxisSettings(const PCPAxisSettings& rhs);
-    PCPAxisSettings& operator=(const PCPAxisSettings& that);
     virtual PCPAxisSettings* clone() const override;
 
     virtual ~PCPAxisSettings() = default;

--- a/modules/plottinggl/src/plotters/persistencediagramplotgl.cpp
+++ b/modules/plottinggl/src/plotters/persistencediagramplotgl.cpp
@@ -121,17 +121,6 @@ PersistenceDiagramPlotGL::Properties::Properties(const PersistenceDiagramPlotGL:
     axisStyle_.registerProperties(xAxis_, yAxis_);
 }
 
-PersistenceDiagramPlotGL::Properties &PersistenceDiagramPlotGL::Properties::operator=(
-    const PersistenceDiagramPlotGL::Properties &that) {
-    if (this != &that) {
-        CompositeProperty::operator=(that);
-        util::for_each_in_tuple([](auto &dst, auto &src) { dst = src; }, props(), that.props());
-        axisStyle_.unregisterAll();
-        axisStyle_.registerProperties(xAxis_, yAxis_);
-    }
-    return *this;
-}
-
 PersistenceDiagramPlotGL::Properties *PersistenceDiagramPlotGL::Properties::clone() const {
     return new Properties(*this);
 }

--- a/modules/plottinggl/src/plotters/scatterplotgl.cpp
+++ b/modules/plottinggl/src/plotters/scatterplotgl.cpp
@@ -113,17 +113,6 @@ ScatterPlotGL::Properties *ScatterPlotGL::Properties::clone() const {
     return new Properties(*this);
 }
 
-ScatterPlotGL::Properties &ScatterPlotGL::Properties::operator=(
-    const ScatterPlotGL::Properties &that) {
-    if (this != &that) {
-        CompositeProperty::operator=(that);
-        util::for_each_in_tuple([](auto &dst, auto &src) { dst = src; }, props(), that.props());
-        axisStyle_.unregisterAll();
-        axisStyle_.registerProperties(xAxis_, yAxis_);
-    }
-    return *this;
-}
-
 ScatterPlotGL::ScatterPlotGL(Processor *processor)
     : properties_("scatterplot", "Scatterplot")
     , shader_("scatterplot.vert", "scatterplot.geom", "scatterplot.frag")

--- a/modules/plottinggl/src/processors/parallelcoordinates/pcpaxissettings.cpp
+++ b/modules/plottinggl/src/processors/parallelcoordinates/pcpaxissettings.cpp
@@ -107,8 +107,6 @@ PCPAxisSettings::PCPAxisSettings(const PCPAxisSettings& rhs)
     });
 }
 
-PCPAxisSettings& PCPAxisSettings::operator=(const PCPAxisSettings& that) = default;
-
 PCPAxisSettings* PCPAxisSettings::clone() const { return new PCPAxisSettings(*this); }
 
 void PCPAxisSettings::updateFromColumn(std::shared_ptr<const Column> col) {

--- a/modules/vectorfieldvisualization/include/modules/vectorfieldvisualization/processors/integrallinevectortomesh.h
+++ b/modules/vectorfieldvisualization/include/modules/vectorfieldvisualization/processors/integrallinevectortomesh.h
@@ -67,7 +67,6 @@ public:
 
         ColorByProperty(const ColorByProperty& rhs);
 
-        ColorByProperty& operator=(const ColorByProperty& that);
         virtual ColorByProperty* clone() const override;
         virtual ~ColorByProperty();
 

--- a/modules/vectorfieldvisualization/include/modules/vectorfieldvisualization/properties/integrallineproperties.h
+++ b/modules/vectorfieldvisualization/include/modules/vectorfieldvisualization/properties/integrallineproperties.h
@@ -49,7 +49,6 @@ public:
 
     IntegralLineProperties(std::string identifier, std::string displayName);
     IntegralLineProperties(const IntegralLineProperties& rhs);
-    IntegralLineProperties& operator=(const IntegralLineProperties& that);
     virtual IntegralLineProperties* clone() const override;
     virtual ~IntegralLineProperties();
 

--- a/modules/vectorfieldvisualization/include/modules/vectorfieldvisualization/properties/pathlineproperties.h
+++ b/modules/vectorfieldvisualization/include/modules/vectorfieldvisualization/properties/pathlineproperties.h
@@ -45,7 +45,6 @@ public:
 
     PathLineProperties(std::string identifier, std::string displayName);
     PathLineProperties(const PathLineProperties& rhs);
-    PathLineProperties& operator=(const PathLineProperties& that);
     virtual PathLineProperties* clone() const override;
     virtual ~PathLineProperties();
 

--- a/modules/vectorfieldvisualization/include/modules/vectorfieldvisualization/properties/streamlineproperties.h
+++ b/modules/vectorfieldvisualization/include/modules/vectorfieldvisualization/properties/streamlineproperties.h
@@ -44,7 +44,6 @@ public:
 
     StreamLineProperties(std::string identifier, std::string displayName);
     StreamLineProperties(const StreamLineProperties& rhs);
-    StreamLineProperties& operator=(const StreamLineProperties& that);
     virtual StreamLineProperties* clone() const override;
     virtual ~StreamLineProperties();
 };

--- a/modules/vectorfieldvisualization/src/processors/integrallinevectortomesh.cpp
+++ b/modules/vectorfieldvisualization/src/processors/integrallinevectortomesh.cpp
@@ -86,18 +86,6 @@ IntegralLineVectorToMesh::ColorByProperty::ColorByProperty(const ColorByProperty
     addProperties();
 }
 
-IntegralLineVectorToMesh::ColorByProperty &IntegralLineVectorToMesh::ColorByProperty::operator=(
-    const ColorByProperty &that) {
-    if (this != &that) {
-        scaleBy_ = that.scaleBy_;
-        loopTF_ = that.loopTF_;
-        minValue_ = that.minValue_;
-        maxValue_ = that.maxValue_;
-        tf_ = that.tf_;
-    }
-    return *this;
-}
-
 IntegralLineVectorToMesh::ColorByProperty *IntegralLineVectorToMesh::ColorByProperty::clone()
     const {
     return new ColorByProperty(*this);

--- a/modules/vectorfieldvisualization/src/properties/integrallineproperties.cpp
+++ b/modules/vectorfieldvisualization/src/properties/integrallineproperties.cpp
@@ -53,19 +53,6 @@ IntegralLineProperties::IntegralLineProperties(const IntegralLineProperties& rhs
     setUpProperties();
 }
 
-IntegralLineProperties& IntegralLineProperties::operator=(const IntegralLineProperties& that) {
-    if (this != &that) {
-        CompositeProperty::operator=(that);
-        numberOfSteps_ = that.numberOfSteps_;
-        stepSize_ = that.stepSize_;
-        normalizeSamples_ = that.normalizeSamples_;
-        stepDirection_ = that.stepDirection_;
-        integrationScheme_ = that.integrationScheme_;
-        seedPointsSpace_ = that.seedPointsSpace_;
-    }
-    return *this;
-}
-
 IntegralLineProperties* IntegralLineProperties::clone() const {
     return new IntegralLineProperties(*this);
 }

--- a/modules/vectorfieldvisualization/src/properties/pathlineproperties.cpp
+++ b/modules/vectorfieldvisualization/src/properties/pathlineproperties.cpp
@@ -45,14 +45,6 @@ PathLineProperties::PathLineProperties(const PathLineProperties& rhs)
     setUpProperties();
 }
 
-PathLineProperties& PathLineProperties::operator=(const PathLineProperties& that) {
-    if (this != &that) {
-        PathLineProperties::operator=(that);
-        startT_ = that.startT_;
-    }
-    return *this;
-}
-
 PathLineProperties* PathLineProperties::clone() const { return new PathLineProperties(*this); }
 
 PathLineProperties::~PathLineProperties() {}

--- a/modules/vectorfieldvisualization/src/properties/streamlineproperties.cpp
+++ b/modules/vectorfieldvisualization/src/properties/streamlineproperties.cpp
@@ -44,13 +44,6 @@ StreamLineProperties* StreamLineProperties::clone() const {
     return new StreamLineProperties(*this);
 }
 
-StreamLineProperties::~StreamLineProperties() {}
-
-StreamLineProperties& StreamLineProperties::operator=(const StreamLineProperties& that) {
-    if (this != &that) {
-        IntegralLineProperties::operator=(that);
-    }
-    return *this;
-}
+StreamLineProperties::~StreamLineProperties() = default;
 
 }  // namespace inviwo

--- a/src/core/interaction/trackball.cpp
+++ b/src/core/interaction/trackball.cpp
@@ -192,20 +192,7 @@ Trackball::Trackball(const Trackball& rhs)
     setCollapsed(true);
 }
 
-Trackball& Trackball::operator=(const Trackball& that) {
-    if (this != &that) {
-        CompositeProperty::operator=(that);
-        object_ = that.object_;
-        isMouseBeingPressedAndHold_ = false;
-        lastNDC_ = vec3(0.0);
-        gestureStartNDCDepth_ = -1;
-
-        util::for_each_in_tuple([](auto& dst, auto& src) { dst = src; }, props(), that.props());
-        util::for_each_in_tuple([](auto& dst, auto& src) { dst = src; }, eventprops(),
-                                that.eventprops());
-    }
-    return *this;
-}
+Trackball* Trackball::clone() const { return new Trackball(*this); }
 
 Trackball::~Trackball() = default;
 

--- a/src/core/properties/advancedmaterialproperty.cpp
+++ b/src/core/properties/advancedmaterialproperty.cpp
@@ -81,19 +81,6 @@ AdvancedMaterialProperty::AdvancedMaterialProperty(const AdvancedMaterialPropert
     addProperty(anisotropyProp);
 }
 
-AdvancedMaterialProperty& AdvancedMaterialProperty::operator=(
-    const AdvancedMaterialProperty& that) {
-    if (this != &that) {
-        CompositeProperty::operator=(that);
-        phaseFunctionProp = that.phaseFunctionProp;
-        indexOfRefractionProp = that.indexOfRefractionProp;
-        roughnessProp = that.roughnessProp;
-        specularColorProp = that.specularColorProp;
-        anisotropyProp = that.anisotropyProp;
-    }
-    return *this;
-}
-
 AdvancedMaterialProperty* AdvancedMaterialProperty::clone() const {
     return new AdvancedMaterialProperty(*this);
 }

--- a/src/core/properties/boolproperty.cpp
+++ b/src/core/properties/boolproperty.cpp
@@ -40,13 +40,6 @@ BoolProperty::BoolProperty(std::string identifier, std::string displayName, bool
 
 BoolProperty::BoolProperty(const BoolProperty& rhs) : TemplateProperty<bool>(rhs) {}
 
-BoolProperty& BoolProperty::operator=(const BoolProperty& that) {
-    if (this != &that) {
-        TemplateProperty<bool>::operator=(that);
-    }
-    return *this;
-}
-
 BoolProperty& BoolProperty::operator=(const bool& value) {
     TemplateProperty<bool>::operator=(value);
     return *this;

--- a/src/core/properties/buttonproperty.cpp
+++ b/src/core/properties/buttonproperty.cpp
@@ -45,13 +45,6 @@ ButtonProperty::ButtonProperty(
 
 ButtonProperty::ButtonProperty(const ButtonProperty& rhs) : Property(rhs) {}
 
-ButtonProperty& ButtonProperty::operator=(const ButtonProperty& that) {
-    if (this != &that) {
-        Property::operator=(that);
-    }
-    return *this;
-}
-
 ButtonProperty* ButtonProperty::clone() const { return new ButtonProperty(*this); }
 
 ButtonProperty::~ButtonProperty() {}

--- a/src/core/properties/cameraproperty.cpp
+++ b/src/core/properties/cameraproperty.cpp
@@ -171,28 +171,6 @@ void CameraProperty::changeCamera(std::unique_ptr<Camera> newCamera) {
     camera_->configureProperties(this);
 }
 
-CameraProperty& CameraProperty::operator=(const CameraProperty& that) {
-    if (this != &that) {
-        CompositeProperty::operator=(that);
-        changeCamera(std::unique_ptr<Camera>(that.camera_->clone()));
-
-        if (inport_) {
-            inport_->removeOnChange(callbackInportOnChange_);
-            callbackInportOnChange_ = nullptr;
-        }
-        inport_ = that.inport_;
-        if (inport_) {
-            callbackInportOnChange_ = inport_->onChange([this]() { inportChanged(); });
-        }
-        data_ = nullptr;
-        prevDataToWorldMatrix_ = mat4(0);
-        updatePropertyFromValue();
-
-        inportChanged();
-    }
-    return *this;
-}
-
 const Camera& CameraProperty::get() const { return *camera_; }
 Camera& CameraProperty::get() { return *camera_; }
 

--- a/src/core/properties/directoryproperty.cpp
+++ b/src/core/properties/directoryproperty.cpp
@@ -45,7 +45,6 @@ DirectoryProperty::DirectoryProperty(std::string identifier, std::string display
 }
 
 DirectoryProperty::DirectoryProperty(const DirectoryProperty& rhs) = default;
-DirectoryProperty& DirectoryProperty::operator=(const DirectoryProperty& that) = default;
 DirectoryProperty* DirectoryProperty::clone() const { return new DirectoryProperty(*this); }
 
 DirectoryProperty::~DirectoryProperty() = default;

--- a/src/core/properties/eventproperty.cpp
+++ b/src/core/properties/eventproperty.cpp
@@ -62,20 +62,6 @@ EventProperty::EventProperty(const EventProperty& rhs)
     , action_{rhs.action_}
     , enabled_{rhs.enabled_} {}
 
-EventProperty& EventProperty::operator=(const EventProperty& that) {
-    if (this != &that) {
-        Property::operator=(that);
-        std::unique_ptr<EventMatcher> e{that.matcher_ ? that.matcher_->clone() : nullptr};
-        Action a{that.action_};
-
-        std::swap(matcher_, e);
-        std::swap(action_, a);
-
-        enabled_ = that.enabled_;
-    }
-    return *this;
-}
-
 EventProperty* EventProperty::clone() const { return new EventProperty(*this); }
 
 void EventProperty::invokeEvent(Event* e) {

--- a/src/core/properties/filepatternproperty.cpp
+++ b/src/core/properties/filepatternproperty.cpp
@@ -141,8 +141,6 @@ FilePatternProperty::FilePatternProperty(const FilePatternProperty& rhs)
     }
 }
 
-FilePatternProperty& FilePatternProperty::operator=(const FilePatternProperty& that) = default;
-
 FilePatternProperty* FilePatternProperty::clone() const { return new FilePatternProperty(*this); }
 
 FilePatternProperty::~FilePatternProperty() = default;

--- a/src/core/properties/imageeditorproperty.cpp
+++ b/src/core/properties/imageeditorproperty.cpp
@@ -39,15 +39,6 @@ ImageLabel::ImageLabel(vec2 startPoint, vec2 rectSize, std::string name)
 ImageEditorProperty::ImageEditorProperty(const ImageEditorProperty& rhs)
     : FileProperty(rhs), labels_(rhs.labels_), dimensions_(rhs.dimensions_) {}
 
-ImageEditorProperty& ImageEditorProperty::operator=(const ImageEditorProperty& that) {
-    if (this != &that) {
-        FileProperty::operator=(that);
-        labels_ = that.labels_;
-        dimensions_ = that.dimensions_;
-    }
-    return *this;
-}
-
 ImageEditorProperty* ImageEditorProperty::clone() const { return new ImageEditorProperty(*this); }
 
 ImageEditorProperty::~ImageEditorProperty() = default;

--- a/src/core/properties/isovalueproperty.cpp
+++ b/src/core/properties/isovalueproperty.cpp
@@ -67,18 +67,6 @@ IsoValueProperty::IsoValueProperty(const IsoValueProperty& rhs)
 }
 IsoValueProperty::~IsoValueProperty() = default;
 
-IsoValueProperty& IsoValueProperty::operator=(const IsoValueProperty& rhs) {
-    if (this != &rhs) {
-        value_.value.removeObserver(this);
-        TemplateProperty<IsoValueCollection>::operator=(rhs);
-        value_.value.addObserver(this);
-        zoomH_ = rhs.zoomH_;
-        zoomV_ = rhs.zoomV_;
-        histogramMode_ = rhs.histogramMode_;
-        volumeInport_ = rhs.volumeInport_;
-    }
-    return *this;
-}
 IsoValueProperty* IsoValueProperty::clone() const { return new IsoValueProperty(*this); }
 
 void IsoValueProperty::setZoomH(double zoomHMin, double zoomHMax) {

--- a/src/core/properties/listproperty.cpp
+++ b/src/core/properties/listproperty.cpp
@@ -87,15 +87,6 @@ ListProperty::ListProperty(const ListProperty& rhs)
     , maxNumElements_(rhs.maxNumElements_)
     , prefabs_(detail::clonePropertyVector(rhs.prefabs_)) {}
 
-ListProperty& ListProperty::operator=(const ListProperty& that) {
-    if (this != &that) {
-        uiFlags_ = that.uiFlags_;
-        maxNumElements_ = that.maxNumElements_;
-        prefabs_ = detail::clonePropertyVector(that.prefabs_);
-    }
-    return *this;
-}
-
 ListProperty* ListProperty::clone() const { return new ListProperty(*this); }
 
 std::string ListProperty::getClassIdentifierForWidget() const {

--- a/src/core/properties/multifileproperty.cpp
+++ b/src/core/properties/multifileproperty.cpp
@@ -57,16 +57,6 @@ MultiFileProperty::MultiFileProperty(const MultiFileProperty& rhs)
     , acceptMode_(rhs.acceptMode_)
     , fileMode_(rhs.fileMode_) {}
 
-MultiFileProperty& MultiFileProperty::operator=(const MultiFileProperty& that) {
-    if (this != &that) {
-        TemplateProperty<std::vector<std::string>>::operator=(that);
-        nameFilters_ = that.nameFilters_;
-        acceptMode_ = that.acceptMode_;
-        fileMode_ = that.fileMode_;
-    }
-    return *this;
-}
-
 MultiFileProperty& MultiFileProperty::operator=(const std::vector<std::string>& value) {
     TemplateProperty<std::vector<std::string>>::operator=(value);
     return *this;

--- a/src/core/properties/optionproperty.cpp
+++ b/src/core/properties/optionproperty.cpp
@@ -38,7 +38,6 @@ BaseOptionProperty::BaseOptionProperty(const std::string& identifier,
     : Property(identifier, displayName, invalidationLevel, semantics) {}
 
 BaseOptionProperty::BaseOptionProperty(const BaseOptionProperty& rhs) = default;
-BaseOptionProperty& BaseOptionProperty::operator=(const BaseOptionProperty&) = default;
 
 BaseOptionProperty::~BaseOptionProperty() = default;
 

--- a/src/core/properties/planeproperty.cpp
+++ b/src/core/properties/planeproperty.cpp
@@ -67,8 +67,6 @@ PlaneProperty::PlaneProperty(const PlaneProperty& rhs)
     addProperty(color_);
 }
 
-PlaneProperty& PlaneProperty::operator=(const PlaneProperty& that) = default;
-
 PlaneProperty* PlaneProperty::clone() const { return new PlaneProperty(*this); }
 
 PlaneProperty::~PlaneProperty() = default;

--- a/src/core/properties/positionproperty.cpp
+++ b/src/core/properties/positionproperty.cpp
@@ -80,17 +80,6 @@ PositionProperty::PositionProperty(const PositionProperty& rhs)
     }
 }
 
-PositionProperty& PositionProperty::operator=(const PositionProperty& that) {
-    if (this != &that) {
-        CompositeProperty::operator=(that);
-        referenceFrame_ = that.referenceFrame_;
-        position_ = that.position_;
-        camera_ = that.camera_;
-        positionWorldSpace_ = that.positionWorldSpace_;
-    }
-    return *this;
-}
-
 PositionProperty* PositionProperty::clone() const { return new PositionProperty(*this); }
 
 const vec3& PositionProperty::get() const { return positionWorldSpace_; }

--- a/src/core/properties/property.cpp
+++ b/src/core/properties/property.cpp
@@ -67,33 +67,13 @@ Property::Property(const Property& rhs)
     , visible_(rhs.visible_)
     , propertyModified_(rhs.propertyModified_)
     , invalidationLevel_(rhs.invalidationLevel_)
-    , owner_(rhs.owner_)
+    , owner_(nullptr)
     , initiatingWidget_(rhs.initiatingWidget_) {}
     
 Property::~Property() {
     if (auto owner = getOwner()) {
         owner->removeProperty(this);
     }
-}
-
-Property& Property::operator=(const Property& that) {
-    if (this != &that) {
-        PropertyObservable::operator=(that);
-        Serializable::operator=(that);
-        MetaDataOwner::operator=(that);
-        serializationMode_ = that.serializationMode_;
-        identifier_ = that.identifier_;
-        displayName_ = that.displayName_;
-        readOnly_ = that.readOnly_;
-        semantics_ = that.semantics_;
-        usageMode_ = that.usageMode_;
-        visible_ = that.visible_;
-        propertyModified_ = that.propertyModified_;
-        invalidationLevel_ = that.invalidationLevel_;
-        owner_ = that.owner_;
-        initiatingWidget_ = that.initiatingWidget_;
-    }
-    return *this;
 }
 
 std::string Property::getIdentifier() const { return identifier_; }

--- a/src/core/properties/propertyowner.cpp
+++ b/src/core/properties/propertyowner.cpp
@@ -56,19 +56,6 @@ PropertyOwner::~PropertyOwner() {
     }
 }
 
-PropertyOwner& PropertyOwner::operator=(const PropertyOwner& that) {
-    if (this != &that) {
-        invalidationLevel_ = that.invalidationLevel_;
-        // PropertyOwner is only responsible for owned properties,
-        // not all, e.g. the ones in properties_.
-        while (!ownedProperties_.empty()) {
-            removeProperty(ownedProperties_.back().get());
-        }
-        for (const auto& p : that.ownedProperties_) addProperty(p->clone());
-    }
-    return *this;
-}
-
 void PropertyOwner::addProperty(Property* property, bool owner) {
     insertProperty(properties_.size(), property, owner);
 }

--- a/src/core/properties/raycastingproperty.cpp
+++ b/src/core/properties/raycastingproperty.cpp
@@ -89,18 +89,6 @@ RaycastingProperty::RaycastingProperty(const RaycastingProperty& rhs)
     addProperty(samplingRate_);
 }
 
-RaycastingProperty& RaycastingProperty::operator=(const RaycastingProperty& rhs) {
-    if (this != &rhs) {
-        CompositeProperty::operator=(rhs);
-        renderingType_ = rhs.renderingType_;
-        classification_ = rhs.classification_;
-        compositing_ = rhs.compositing_;
-        gradientComputation_ = rhs.gradientComputation_;
-        samplingRate_ = rhs.samplingRate_;
-    }
-    return *this;
-}
-
 RaycastingProperty* RaycastingProperty::clone() const { return new RaycastingProperty(*this); }
 
 }  // namespace inviwo

--- a/src/core/properties/simplelightingproperty.cpp
+++ b/src/core/properties/simplelightingproperty.cpp
@@ -101,22 +101,6 @@ SimpleLightingProperty::SimpleLightingProperty(const SimpleLightingProperty& rhs
     addProperty(lightAttenuation_);
 }
 
-SimpleLightingProperty& SimpleLightingProperty::operator=(const SimpleLightingProperty& that) {
-    if (this != &that) {
-        CompositeProperty::operator=(that);
-        shadingMode_ = that.shadingMode_;
-        referenceFrame_ = that.referenceFrame_;
-        lightPosition_ = that.lightPosition_;
-        lightAttenuation_ = that.lightAttenuation_;
-        applyLightAttenuation_ = that.applyLightAttenuation_;
-        ambientColor_ = that.ambientColor_;
-        diffuseColor_ = that.diffuseColor_;
-        specularColor_ = that.specularColor_;
-        specularExponent_ = that.specularExponent_;
-    }
-    return *this;
-}
-
 SimpleLightingProperty* SimpleLightingProperty::clone() const {
     return new SimpleLightingProperty(*this);
 }

--- a/src/core/properties/simpleraycastingproperty.cpp
+++ b/src/core/properties/simpleraycastingproperty.cpp
@@ -93,19 +93,6 @@ SimpleRaycastingProperty::SimpleRaycastingProperty(const SimpleRaycastingPropert
     addProperty(isoValue_);
 }
 
-SimpleRaycastingProperty& SimpleRaycastingProperty::operator=(
-    const SimpleRaycastingProperty& that) {
-    if (this != &that) {
-        CompositeProperty::operator=(that);
-        classificationMode_ = that.classificationMode_;
-        compositingMode_ = that.compositingMode_;
-        gradientComputationMode_ = that.gradientComputationMode_;
-        samplingRate_ = that.samplingRate_;
-        isoValue_ = that.isoValue_;
-    }
-    return *this;
-}
-
 SimpleRaycastingProperty* SimpleRaycastingProperty::clone() const {
     return new SimpleRaycastingProperty(*this);
 }

--- a/src/core/properties/stringproperty.cpp
+++ b/src/core/properties/stringproperty.cpp
@@ -40,13 +40,6 @@ StringProperty::StringProperty(std::string identifier, std::string displayName, 
 
 StringProperty::StringProperty(const StringProperty& rhs) : TemplateProperty<std::string>(rhs) {}
 
-StringProperty& StringProperty::operator=(const StringProperty& that) {
-    if (this != &that) {
-        TemplateProperty<std::string>::operator=(that);
-    }
-    return *this;
-}
-
 StringProperty& StringProperty::operator=(const std::string& value) {
     TemplateProperty<std::string>::operator=(value);
     return *this;

--- a/src/core/properties/transferfunctionproperty.cpp
+++ b/src/core/properties/transferfunctionproperty.cpp
@@ -96,20 +96,6 @@ TransferFunctionProperty::TransferFunctionProperty(const TransferFunctionPropert
     this->value_.value.addObserver(this);
 }
 
-TransferFunctionProperty& TransferFunctionProperty::operator=(
-    const TransferFunctionProperty& that) {
-    if (this != &that) {
-        this->value_.value.removeObserver(this);
-        TemplateProperty<TransferFunction>::operator=(that);
-        this->value_.value.addObserver(this);
-        zoomH_ = that.zoomH_;
-        zoomV_ = that.zoomV_;
-        histogramMode_ = that.histogramMode_;
-        volumeInport_ = that.volumeInport_;
-    }
-    return *this;
-}
-
 TransferFunctionProperty* TransferFunctionProperty::clone() const {
     return new TransferFunctionProperty(*this);
 }

--- a/src/core/properties/volumeindicatorproperty.cpp
+++ b/src/core/properties/volumeindicatorproperty.cpp
@@ -62,16 +62,6 @@ VolumeIndicatorProperty::VolumeIndicatorProperty(const VolumeIndicatorProperty& 
     addProperty(plane3_);
 }
 
-VolumeIndicatorProperty& VolumeIndicatorProperty::operator=(const VolumeIndicatorProperty& that) {
-    if (this != &that) {
-        BoolCompositeProperty::operator=(that);
-        plane1_ = that.plane1_;
-        plane2_ = that.plane2_;
-        plane3_ = that.plane3_;
-    }
-    return *this;
-}
-
 VolumeIndicatorProperty* VolumeIndicatorProperty::clone() const {
     return new VolumeIndicatorProperty(*this);
 }


### PR DESCRIPTION
Removes operator= from Property and PropertyOwner. The sematics is strange, it is quite hard to get right, and we never use it.