### PR TITLE
Python3: pybind fix for TFPrimitiveSet

### DIFF
--- a/modules/python3/bindings/src/pytfprimitiveset.cpp
+++ b/modules/python3/bindings/src/pytfprimitiveset.cpp
@@ -147,7 +147,7 @@ void exposeTFPrimitiveSet(pybind11::module &m) {
         .def("__getitem__",
              [](const TFPrimitiveSet &ps, size_t i) {
                  if (i >= ps.size()) throw py::index_error();
-                 return ps[i];
+                 return &ps[i];
              },
              py::return_value_policy::reference_internal)
         .def("__setitem__",


### PR DESCRIPTION
* getter for TFPrimitiveSet returns reference to TF primitive instead of a copy
