### PR TITLE
Feature/pcp colormaps

### DIFF
--- a/include/inviwo/core/properties/optionproperty.h
+++ b/include/inviwo/core/properties/optionproperty.h
@@ -188,6 +188,10 @@ public:
                                                    const std::vector<T>& values);
     virtual TemplateOptionProperty& replaceOptions(std::vector<OptionPropertyOption<T>> options);
 
+    template <typename U = T,
+              class = typename std::enable_if<util::is_stream_insertable<U>::value, void>::type>
+    TemplateOptionProperty& replaceOptions(const std::vector<T>& options);
+
     virtual bool isSelectedIndex(size_t index) const override;
     virtual bool isSelectedIdentifier(const std::string& identifier) const override;
     virtual bool isSelectedDisplayName(const std::string& name) const override;
@@ -601,6 +605,27 @@ TemplateOptionProperty<T>& TemplateOptionProperty<T>::replaceOptions(
     if (!options_.empty()) selectId = getSelectedIdentifier();
 
     options_ = std::move(options);
+    auto it = util::find_if(options_, [&](auto& opt) { return opt.id_ == selectId; });
+    if (it != options_.end()) {
+        selectedIndex_ = std::distance(options_.begin(), it);
+    } else {
+        selectedIndex_ = 0;
+    }
+    propertyModified();
+    return *this;
+}
+
+template <typename T>
+template <typename U, class>
+TemplateOptionProperty<T>& TemplateOptionProperty<T>::replaceOptions(
+    const std::vector<T>& options) {
+
+    std::string selectId{};
+    if (!options_.empty()) selectId = getSelectedIdentifier();
+
+    options_.clear();
+    for (size_t i = 0; i < options.size(); i++) options_.emplace_back(options[i]);
+
     auto it = util::find_if(options_, [&](auto& opt) { return opt.id_ == selectId; });
     if (it != options_.end()) {
         selectedIndex_ = std::distance(options_.begin(), it);

--- a/include/inviwo/core/util/colorbrewer.h
+++ b/include/inviwo/core/util/colorbrewer.h
@@ -32,8 +32,7 @@ This complete file is auto-generated with python script
 tools/codegen/colorbrewer/colorbrewer.py
 */
 
-#ifndef IWW_COLORBREWER_H
-#define IWW_COLORBREWER_H
+#pragma once
 
 #include <inviwo/core/common/inviwocoredefine.h>
 #include <inviwo/core/common/inviwo.h>
@@ -68,7 +67,6 @@ public:
         : Exception(message, context) {}
     virtual ~ColorBrewerTooManyException() throw() {}
 };
-
 // clang-format off
 enum class Colormap {
     Accent_3, Accent_4, Accent_5, Accent_6, Accent_7, Accent_8, 
@@ -108,7 +106,6 @@ enum class Colormap {
     YlOrRd_3, YlOrRd_4, YlOrRd_5, YlOrRd_6, YlOrRd_7, YlOrRd_8, 
     FirstMap=Accent_3, LastMap=YlOrRd_8
 };
-// clang-format on
 
 enum class Category { Diverging, Qualitative, Sequential, NumberOfColormapCategories, Undefined };
 
@@ -151,7 +148,7 @@ enum class Family {
     NumberOfColormapFamilies,
     Undefined
 };
-
+// clang-format on
 template <class Elem, class Traits>
 std::basic_ostream<Elem, Traits> &operator<<(std::basic_ostream<Elem, Traits> &os,
                                              Colormap colormap) {
@@ -421,6 +418,7 @@ std::basic_ostream<Elem, Traits> &operator<<(std::basic_ostream<Elem, Traits> &o
     case Colormap::YlOrRd_6: os << "YlOrRd_6"; break;
     case Colormap::YlOrRd_7: os << "YlOrRd_7"; break;
     case Colormap::YlOrRd_8: os << "YlOrRd_8"; break;
+
     }
     // clang-format on
     return os;
@@ -446,7 +444,6 @@ std::basic_ostream<Elem, Traits> &operator<<(std::basic_ostream<Elem, Traits> &o
             os << "Undefined";
             break;
     }
-
     return os;
 }
 
@@ -491,6 +488,7 @@ std::basic_ostream<Elem, Traits> &operator<<(std::basic_ostream<Elem, Traits> &o
     case Family::YlOrRd: os << "YlOrRd"; break;
     case Family::NumberOfColormapFamilies: os << "NumberOfColormapFamilies"; break;
     case Family::Undefined: os << "Undefined"; break;
+
     }
     // clang-format on
     return os;
@@ -545,16 +543,16 @@ IVW_CORE_API glm::uint8 getMaxNumberOfColorsForFamily(const Family &family);
 IVW_CORE_API std::vector<Family> getFamiliesForCategory(const Category &category);
 
 /**
- * Returns a transfer function for the given parameters. 
- * 
+ * Returns a transfer function for the given parameters.
+ *
  * @param category according to ColorBrewer2
  * @param family color scheme name
  * @param discrete will make each color constant instead of linearly varying inbetween colors.
- * @param divergenceMidpoint in [0 1]. Only used when category is Diverging 
+ * @param divergenceMidpoint in [0 1]. Only used when category is Diverging
  **/
-IVW_CORE_API TransferFunction getTransferfunction(const Category &category, const Family &family, glm::uint8 nColors, bool discrete, double divergenceMidPoint);
+IVW_CORE_API TransferFunction getTransferFunction(const Category &category, const Family &family,
+                                                  glm::uint8 nColors, bool discrete,
+                                                  double divergenceMidPoint);
 
 }  // namespace colorbrewer
 }  // namespace inviwo
-
-#endif  // COLORBREWER_H

--- a/include/inviwo/core/util/colorbrewer.h
+++ b/include/inviwo/core/util/colorbrewer.h
@@ -37,6 +37,7 @@ tools/codegen/colorbrewer/colorbrewer.py
 
 #include <inviwo/core/common/inviwocoredefine.h>
 #include <inviwo/core/common/inviwo.h>
+#include <inviwo/core/datastructures/transferfunction.h>
 #include <vector>
 #include <ostream>
 
@@ -542,6 +543,16 @@ IVW_CORE_API glm::uint8 getMaxNumberOfColorsForFamily(const Family &family);
  * Returns all families contained in the specified category.
  **/
 IVW_CORE_API std::vector<Family> getFamiliesForCategory(const Category &category);
+
+/**
+ * Returns a transfer function for the given parameters. 
+ * 
+ * @param category according to ColorBrewer2
+ * @param family color scheme name
+ * @param discrete will make each color constant instead of linearly varying inbetween colors.
+ * @param divergenceMidpoint in [0 1]. Only used when category is Diverging 
+ **/
+IVW_CORE_API TransferFunction getTransferfunction(const Category &category, const Family &family, glm::uint8 nColors, bool discrete, double divergenceMidPoint);
 
 }  // namespace colorbrewer
 }  // namespace inviwo

--- a/modules/dataframe/CMakeLists.txt
+++ b/modules/dataframe/CMakeLists.txt
@@ -22,6 +22,7 @@ set(HEADER_FILES
 	include/inviwo/dataframe/processors/syntheticdataframe.h
 	include/inviwo/dataframe/processors/volumesequencetodataframe.h
 	include/inviwo/dataframe/processors/volumetodataframe.h
+	include/inviwo/dataframe/properties/colormapproperty.h
 	include/inviwo/dataframe/properties/dataframeproperty.h
 )
 ivw_group("Header Files" ${HEADER_FILES})
@@ -44,6 +45,7 @@ set(SOURCE_FILES
 	src/processors/syntheticdataframe.cpp
 	src/processors/volumesequencetodataframe.cpp
 	src/processors/volumetodataframe.cpp
+	src/properties/colormapproperty.cpp
 	src/properties/dataframeproperty.cpp
 )
 ivw_group("Source Files" ${SOURCE_FILES})

--- a/modules/dataframe/CMakeLists.txt
+++ b/modules/dataframe/CMakeLists.txt
@@ -5,48 +5,50 @@ ivw_module(DataFrame)
 #--------------------------------------------------------------------
 # Add header files
 set(HEADER_FILES
-	include/inviwo/dataframe/dataframemodule.h
-	include/inviwo/dataframe/dataframemoduledefine.h
-	include/inviwo/dataframe/jsondataframeconversion.h
-	include/inviwo/dataframe/datastructures/column.h
-	include/inviwo/dataframe/datastructures/dataframe.h
-	include/inviwo/dataframe/datastructures/dataframeutil.h
-	include/inviwo/dataframe/datastructures/datapoint.h
-	include/inviwo/dataframe/io/csvreader.h
-	include/inviwo/dataframe/io/jsonreader.h
-	include/inviwo/dataframe/io/json/dataframepropertyjsonconverter.h
-	include/inviwo/dataframe/processors/csvsource.h
-	include/inviwo/dataframe/processors/dataframesource.h
-	include/inviwo/dataframe/processors/dataframeexporter.h
-	include/inviwo/dataframe/processors/imagetodataframe.h
-	include/inviwo/dataframe/processors/syntheticdataframe.h
-	include/inviwo/dataframe/processors/volumesequencetodataframe.h
-	include/inviwo/dataframe/processors/volumetodataframe.h
-	include/inviwo/dataframe/properties/colormapproperty.h
-	include/inviwo/dataframe/properties/dataframeproperty.h
+    include/inviwo/dataframe/dataframemodule.h
+    include/inviwo/dataframe/dataframemoduledefine.h
+    include/inviwo/dataframe/datastructures/column.h
+    include/inviwo/dataframe/datastructures/dataframe.h
+    include/inviwo/dataframe/datastructures/dataframeutil.h
+    include/inviwo/dataframe/datastructures/datapoint.h
+    include/inviwo/dataframe/io/csvreader.h
+    include/inviwo/dataframe/io/json/dataframepropertyjsonconverter.h
+    include/inviwo/dataframe/io/jsonreader.h
+    include/inviwo/dataframe/jsondataframeconversion.h
+    include/inviwo/dataframe/processors/csvsource.h
+    include/inviwo/dataframe/processors/dataframeexporter.h
+    include/inviwo/dataframe/processors/dataframesource.h
+    include/inviwo/dataframe/processors/imagetodataframe.h
+    include/inviwo/dataframe/processors/syntheticdataframe.h
+    include/inviwo/dataframe/processors/volumesequencetodataframe.h
+    include/inviwo/dataframe/processors/volumetodataframe.h
+    include/inviwo/dataframe/properties/colormapproperty.h
+    include/inviwo/dataframe/properties/dataframecolormapproperty.h
+    include/inviwo/dataframe/properties/dataframeproperty.h
 )
 ivw_group("Header Files" ${HEADER_FILES})
 
 #--------------------------------------------------------------------
 # Add source files
 set(SOURCE_FILES
-	src/dataframemodule.cpp
-	src/jsondataframeconversion.cpp
-	src/datastructures/column.cpp
-	src/datastructures/dataframe.cpp
-	src/datastructures/dataframeutil.cpp
-	src/io/csvreader.cpp
-	src/io/jsonreader.cpp
-	src/io/json/dataframepropertyjsonconverter.cpp
-	src/processors/csvsource.cpp
-	src/processors/dataframeexporter.cpp
-	src/processors/dataframesource.cpp
-	src/processors/imagetodataframe.cpp
-	src/processors/syntheticdataframe.cpp
-	src/processors/volumesequencetodataframe.cpp
-	src/processors/volumetodataframe.cpp
-	src/properties/colormapproperty.cpp
-	src/properties/dataframeproperty.cpp
+    src/dataframemodule.cpp
+    src/datastructures/column.cpp
+    src/datastructures/dataframe.cpp
+    src/datastructures/dataframeutil.cpp
+    src/io/csvreader.cpp
+    src/io/json/dataframepropertyjsonconverter.cpp
+    src/io/jsonreader.cpp
+    src/jsondataframeconversion.cpp
+    src/processors/csvsource.cpp
+    src/processors/dataframeexporter.cpp
+    src/processors/dataframesource.cpp
+    src/processors/imagetodataframe.cpp
+    src/processors/syntheticdataframe.cpp
+    src/processors/volumesequencetodataframe.cpp
+    src/processors/volumetodataframe.cpp
+    src/properties/colormapproperty.cpp
+    src/properties/dataframecolormapproperty.cpp
+    src/properties/dataframeproperty.cpp
 )
 ivw_group("Source Files" ${SOURCE_FILES})
 

--- a/modules/dataframe/include/inviwo/dataframe/properties/colormapproperty.h
+++ b/modules/dataframe/include/inviwo/dataframe/properties/colormapproperty.h
@@ -34,6 +34,7 @@
 #include <inviwo/core/datastructures/transferfunction.h>
 #include <inviwo/core/common/inviwo.h>
 #include <inviwo/core/properties/compositeproperty.h>
+#include <inviwo/core/properties/ordinalproperty.h>
 #include <inviwo/core/properties/optionproperty.h>
 #include <inviwo/core/util/colorbrewer.h>
 

--- a/modules/dataframe/include/inviwo/dataframe/properties/colormapproperty.h
+++ b/modules/dataframe/include/inviwo/dataframe/properties/colormapproperty.h
@@ -33,6 +33,7 @@
 #include <inviwo/dataframe/datastructures/dataframe.h>
 #include <inviwo/core/datastructures/transferfunction.h>
 #include <inviwo/core/common/inviwo.h>
+#include <inviwo/core/properties/boolproperty.h>
 #include <inviwo/core/properties/compositeproperty.h>
 #include <inviwo/core/properties/ordinalproperty.h>
 #include <inviwo/core/properties/optionproperty.h>

--- a/modules/dataframe/include/inviwo/dataframe/properties/colormapproperty.h
+++ b/modules/dataframe/include/inviwo/dataframe/properties/colormapproperty.h
@@ -117,6 +117,7 @@ public:
 
 
 private:
+    void updateColormaps();
 };
 
 }  // namespace inviwo

--- a/modules/dataframe/include/inviwo/dataframe/properties/colormapproperty.h
+++ b/modules/dataframe/include/inviwo/dataframe/properties/colormapproperty.h
@@ -1,0 +1,78 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2016-2019 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#pragma once
+
+#include <inviwo/dataframe/dataframemoduledefine.h>
+#include <inviwo/dataframe/datastructures/dataframe.h>
+#include <inviwo/core/datastructures/transferfunction.h>
+#include <inviwo/core/common/inviwo.h>
+#include <inviwo/core/properties/compositeproperty.h>
+#include <inviwo/core/properties/optionproperty.h>
+#include <inviwo/core/util/colorbrewer.h>
+
+namespace inviwo {
+
+class IVW_MODULE_DATAFRAME_API ColorMapProperty : public CompositeProperty {
+public:
+    virtual std::string getClassIdentifier() const override;
+    static const std::string classIdentifier;
+
+    ColorMapProperty(std::string identifier,
+                     std::string displayName,
+                     colorbrewer::Category category = colorbrewer::Category::Sequential,
+                     colorbrewer::Family family = colorbrewer::Family::Blues,
+                     size_t numColors = getMinNumberOfColorsForFamily(colorbrewer::Family::Blues), 
+                     InvalidationLevel invalidationLevel = InvalidationLevel::InvalidOutput,
+                     PropertySemantics semantics = PropertySemantics::Default);
+
+    ColorMapProperty(const ColorMapProperty& rhs);
+    virtual ColorMapProperty* clone() const override;
+
+    virtual ~ColorMapProperty() = default;
+
+    virtual std::string getClassIdentifierForWidget() const override {
+        return CompositeProperty::classIdentifier;
+    }
+
+    //virtual void set(const Property* p) override;
+    TransferFunction get() const;
+
+    TemplateOptionProperty<colorbrewer::Category> category;
+    TemplateOptionProperty<colorbrewer::Family> colormap;
+    IntSizeTProperty nColors;
+    BoolProperty discrete_;
+    DoubleProperty divergenceMidPoint_;
+
+private:
+
+};
+
+}  // namespace inviwo
+

--- a/modules/dataframe/include/inviwo/dataframe/properties/colormapproperty.h
+++ b/modules/dataframe/include/inviwo/dataframe/properties/colormapproperty.h
@@ -43,14 +43,14 @@ namespace inviwo {
  * Categorical is suitable for data where there should be no magnitude difference between classes,
  * such as volvo and audi.
  */
-enum class ColormapType { Continous, Categorical };
+enum class ColormapType { Continuous, Categorical };
 
 template <class Elem, class Traits>
 std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& os,
                                              ColormapType colormap) {
     // clang-format off
     switch (colormap) {
-        case ColormapType::Continous: os << "Continous"; break;
+        case ColormapType::Continuous: os << "Continuous"; break;
         case ColormapType::Categorical: os << "Categorical"; break;
     }
     // clang-format on
@@ -61,8 +61,8 @@ std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& o
  * \brief Selection of pre-defined color maps based on data type.
  *
  * The following data types are supported:
- * Continous: Ordered/Sequential data progressing from low to high
- * Continous discrete: Constant inbetween colors to emphasize differences in the scale.
+ * Continuous: Ordered/Sequential data progressing from low to high
+ * Continuous discrete: Constant inbetween colors to emphasize differences in the scale.
  * Continuous diverging: Emphasis on mid-point or critical values. Break in the middle.
  *
  * Categorical: Suitable for categorical/nominal data where there should be no magnitude difference
@@ -74,7 +74,7 @@ public:
     static const std::string classIdentifier;
 
     ColormapProperty(std::string identifier, std::string displayName,
-                     ColormapType type = ColormapType::Continous,
+                     ColormapType type = ColormapType::Continuous,
                      colorbrewer::Family family = colorbrewer::Family::Blues,
                      size_t numColors = getMinNumberOfColorsForFamily(colorbrewer::Family::Blues),
                      InvalidationLevel invalidationLevel = InvalidationLevel::InvalidOutput,
@@ -95,8 +95,11 @@ public:
 
     /**
      * Update settings based on Column.
-     * Uses ColormapType::Categorical for CategoricalColumn and ColormapType::Continous otherwise.
-     * Divergence mid point and rawill be computed 
+     * Uses ColormapType::Categorical for CategoricalColumn and ColormapType::Continuous otherwise.
+     * Divergence mid-point and its min-max range will be updated based on the Column values.
+     * The mid-point will be set to the average of the column,
+     * unless the min value is negative and the max value is positive in which case it 
+     * will be set to 0.
      */
     void setupForColumn(const Column& col);
     void setupForColumn(const Column& col, double minVal, double maxVal);
@@ -113,8 +116,6 @@ public:
     DoubleProperty divergenceMidPoint;
     BoolProperty discrete;
     IntSizeTProperty nColors;
-
-
 
 private:
     void updateColormaps();

--- a/modules/dataframe/include/inviwo/dataframe/properties/dataframecolormapproperty.h
+++ b/modules/dataframe/include/inviwo/dataframe/properties/dataframecolormapproperty.h
@@ -26,49 +26,46 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  *********************************************************************************/
+#pragma once
 
-#include <inviwo/dataframe/dataframemodule.h>
-#include <inviwo/dataframe/io/json/dataframepropertyjsonconverter.h>
-#include <inviwo/dataframe/processors/csvsource.h>
-#include <inviwo/dataframe/processors/dataframesource.h>
-#include <inviwo/dataframe/processors/dataframeexporter.h>
-#include <inviwo/dataframe/processors/imagetodataframe.h>
-#include <inviwo/dataframe/processors/syntheticdataframe.h>
-#include <inviwo/dataframe/processors/volumetodataframe.h>
-#include <inviwo/dataframe/processors/volumesequencetodataframe.h>
-
+#include <inviwo/dataframe/dataframemoduledefine.h>
+#include <inviwo/dataframe/properties/dataframeproperty.h>
 #include <inviwo/dataframe/properties/colormapproperty.h>
-
-#include <inviwo/dataframe/io/csvreader.h>
-#include <inviwo/dataframe/io/jsonreader.h>
-
-#include <modules/json/jsonmodule.h>
+#include <inviwo/core/properties/boolproperty.h>
+#include <inviwo/core/properties/compositeproperty.h>
+#include <inviwo/core/properties/transferfunctionproperty.h>
+#include <inviwo/core/common/inviwo.h>
 
 namespace inviwo {
 
-DataFrameModule::DataFrameModule(InviwoApplication* app) : InviwoModule(app, "DataFrame") {
-    // Register objects that can be shared with the rest of inviwo here:
+/**
+ * \brief Property for selecting which column to apply colormapping to.
+ * Allows the user to select a column and options for the color map.
+ * A ColormapProperty for each column will be added to this property, but only the 
+ * one corresponding to the selected axis will be visible. 
+ *
+ * It is possible to override the ColormapProperty
+ *
+ */
+class IVW_MODULE_DATAFRAME_API DataFrameColormapProperty : public CompositeProperty {
+public:
+    virtual std::string getClassIdentifier() const override;
+    static const std::string classIdentifier;
 
-    // Processors
-    registerProcessor<CSVSource>();
-    registerProcessor<DataFrameSource>();
-    registerProcessor<DataFrameExporter>();
-    registerProcessor<ImageToDataFrame>();
-    registerProcessor<SyntheticDataFrame>();
-    registerProcessor<VolumeToDataFrame>();
-    registerProcessor<VolumeSequenceToDataFrame>();
+    DataFrameColormapProperty(std::string identifier, std::string displayName, DataInport<DataFrame>& port);
+    virtual ~DataFrameColormapProperty() = default;
 
-    registerDefaultsForDataType<DataFrame>();
-    // Properties
-    registerProperty<ColormapProperty>();
-    registerProperty<DataFrameColumnProperty>();
+    void createOrUpdateProperties(std::shared_ptr<const DataFrame> dataframe);
 
-    // Readers and writes
-    registerDataReader(std::make_unique<CSVReader>());
-    registerDataReader(std::make_unique<JSONDataFrameReader>());
+    DataFrameColumnProperty selectedColorAxis;
+    BoolProperty overrideColormap;
+    TransferFunctionProperty tf;
 
-    // Data converters
-    app->getModuleByType<JSONModule>()->registerPropertyJSONConverter<DataFrameColumnProperty>();
-}
+protected:
+
+    std::vector<ColormapProperty*> colormaps_;
+    std::shared_ptr<const DataFrame> dataframe_;
+    std::shared_ptr<std::function<void()>> colormapChanged_;
+};
 
 }  // namespace inviwo

--- a/modules/dataframe/include/inviwo/dataframe/properties/dataframecolormapproperty.h
+++ b/modules/dataframe/include/inviwo/dataframe/properties/dataframecolormapproperty.h
@@ -52,7 +52,9 @@ public:
     virtual std::string getClassIdentifier() const override;
     static const std::string classIdentifier;
 
-    DataFrameColormapProperty(std::string identifier, std::string displayName, DataInport<DataFrame>& port);
+    DataFrameColormapProperty(std::string identifier, std::string displayName, DataInport<DataFrame>& port,
+                              InvalidationLevel invalidationLevel = InvalidationLevel::InvalidOutput,
+                              PropertySemantics semantics = PropertySemantics::Default);
     virtual ~DataFrameColormapProperty() = default;
 
     void createOrUpdateProperties(std::shared_ptr<const DataFrame> dataframe);

--- a/modules/dataframe/src/dataframemodule.cpp
+++ b/modules/dataframe/src/dataframemodule.cpp
@@ -37,6 +37,8 @@
 #include <inviwo/dataframe/processors/volumetodataframe.h>
 #include <inviwo/dataframe/processors/volumesequencetodataframe.h>
 
+#include <inviwo/dataframe/properties/colormapproperty.h>
+
 #include <inviwo/dataframe/io/csvreader.h>
 #include <inviwo/dataframe/io/jsonreader.h>
 
@@ -58,6 +60,7 @@ DataFrameModule::DataFrameModule(InviwoApplication* app) : InviwoModule(app, "Da
 
     registerDefaultsForDataType<DataFrame>();
     // Properties
+    registerProperty<ColorMapProperty>();
     registerProperty<DataFrameColumnProperty>();
 
     // Readers and writes

--- a/modules/dataframe/src/properties/colormapproperty.cpp
+++ b/modules/dataframe/src/properties/colormapproperty.cpp
@@ -1,0 +1,169 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2016-2019 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/dataframe/properties/colormapproperty.h>
+
+namespace inviwo {
+
+const std::string ColorMapProperty::classIdentifier = "org.inviwo.ColorMapProperty";
+std::string ColorMapProperty::getClassIdentifier() const { return classIdentifier; }
+
+ColorMapProperty::ColorMapProperty(std::string identifier, std::string displayName,
+                                   colorbrewer::Category selectedCategory,
+                                   colorbrewer::Family selectedFamily, size_t numColors,
+                                   InvalidationLevel invalidationLevel, PropertySemantics semantics)
+    : CompositeProperty(identifier, displayName, invalidationLevel, semantics)
+    , category("category", "Category")
+    , colormap("colormap", "Colormap")
+    , nColors("nColors", "Number of classes")
+    , discrete_("discrete", "Discrete")
+    , divergenceMidPoint_("midPoint", "Mid point", 0.5, 0., 1.) {
+    using namespace colorbrewer;
+    auto categories = {Category::Diverging, Category::Qualitative, Category::Sequential};
+    for (auto cat : categories) {
+        auto name = toString(cat);
+        category.addOption(name, name, cat);
+    }
+    category.onChange([&]() {
+        colormap.clearOptions();
+        for (const auto& family : getFamiliesForCategory(
+                 static_cast<colorbrewer::Category>(category.getSelectedValue()))) {
+            auto familyName = toString(family);
+            colormap.addOption(familyName, familyName, static_cast<colorbrewer::Family>(family));
+        }
+    });
+
+    colormap.onChange([&]() {
+        nColors.set(*nColors, getMinNumberOfColorsForFamily(*colormap),
+                    getMaxNumberOfColorsForFamily(*colormap), 1);
+    });
+    category.setSelectedValue(selectedCategory);
+    colormap.setSelectedValue(selectedFamily);
+    nColors.set(numColors);
+    category.setCurrentStateAsDefault();
+    colormap.setCurrentStateAsDefault();
+
+    divergenceMidPoint_.visibilityDependsOn(
+        category, [](auto prop) -> bool { return *prop == Category::Diverging; });
+
+    addProperty(category);
+    addProperty(colormap);
+    addProperty(nColors);
+    addProperty(discrete_);
+    addProperty(divergenceMidPoint_);
+}
+
+ColorMapProperty::ColorMapProperty(const ColorMapProperty& rhs)
+    : CompositeProperty(rhs)
+    , category(rhs.category)
+    , colormap(rhs.colormap)
+    , nColors(rhs.nColors)
+    , discrete_(rhs.discrete_)
+    , divergenceMidPoint_(rhs.divergenceMidPoint_) {
+    addProperty(category);
+    addProperty(colormap);
+    addProperty(nColors);
+    addProperty(discrete_);
+    addProperty(divergenceMidPoint_);
+}
+
+ColorMapProperty* ColorMapProperty::clone() const { return new ColorMapProperty(*this); }
+
+TransferFunction ColorMapProperty::get() const {
+    TransferFunction tf;
+    auto colors = colorbrewer::getColormap(*colormap, static_cast<glm::uint8>(*nColors));
+
+    if (*category == colorbrewer::Category::Diverging) {
+        // Mid point in [0 1]
+        auto midPoint = (*divergenceMidPoint_ - divergenceMidPoint_.getMinValue()) /
+                        (divergenceMidPoint_.getMaxValue() - divergenceMidPoint_.getMinValue());
+
+        if (*discrete_) {
+            auto dt = midPoint / (0.5 * (colors.size()));
+            double start = 0, end = std::max(dt - std::numeric_limits<double>::epsilon(), 0.);
+            for (auto i = 0; i < colors.size() / 2; i++) {
+                tf.add(start, vec4(colors[i]));
+                tf.add(end, vec4(colors[i]));
+                start += dt;
+                end += dt;
+            }
+            tf.add(start, vec4(colors[colors.size() / 2]));
+            if (midPoint < 1.0) {
+                dt = (1.0 - midPoint) / (0.5 * (colors.size()));
+                tf.add(start + dt - std::numeric_limits<double>::epsilon(),
+                       vec4(colors[colors.size() / 2]));
+                start = start + dt;
+                end = start + dt - std::numeric_limits<double>::epsilon();
+                for (auto i = colors.size() / 2 + 1; i < colors.size(); i++) {
+                    // Avoid numerical issues with min
+                    tf.add(std::min(start, 1.0), vec4(colors[i]));
+                    tf.add(std::min(end, 1.0), vec4(colors[i]));
+                    start += dt;
+                    end += dt;
+                }
+            }
+        } else {
+            auto dt = midPoint / (0.5 * (colors.size() - 1.0));
+            for (auto i = 0; i < colors.size() / 2; i++) {
+                tf.add(i * dt, vec4(colors[i]));
+            }
+            tf.add(midPoint, vec4(colors[colors.size() / 2]));
+            if (midPoint < 1.0) {
+                dt = (1.0 - midPoint) / (0.5 * (colors.size() - 1.0));
+                auto t = midPoint + dt;
+                for (auto i = colors.size() / 2 + 1; i < colors.size(); i++) {
+                    // Avoid numerical issues with min
+                    tf.add(std::min(t, 1.0), vec4(colors[i]));
+                    t += dt;
+                }
+            }
+        }
+
+    } else {
+        if (*discrete_) {
+            double dt = 1.0 / (colors.size());
+            double start = 0, end = dt - std::numeric_limits<double>::epsilon();
+            for (const auto& c : colors) {
+                tf.add(start, vec4(c));
+                tf.add(end, vec4(c));
+                start += dt;
+                end += dt;
+            }
+        } else {
+            auto dt = 1.0 / (colors.size() - 1.0);
+            size_t idx = 0;
+            for (const auto& c : colors) {
+                tf.add(idx++ * dt, vec4(c));
+            }
+        }
+    }
+    return tf;
+}  // namespace inviwo
+
+}  // namespace inviwo

--- a/modules/dataframe/src/properties/colormapproperty.cpp
+++ b/modules/dataframe/src/properties/colormapproperty.cpp
@@ -120,12 +120,12 @@ ColormapProperty* ColormapProperty::clone() const { return new ColormapProperty(
 colorbrewer::Category ColormapProperty::getCategory() const {
     colorbrewer::Category cat;
     switch (type) {
-        case ColormapType::Continuous:
-            cat = diverging ? colorbrewer::Category::Diverging : colorbrewer::Category::Sequential;
-            break;
         case ColormapType::Categorical:
             cat = colorbrewer::Category::Qualitative;
             break;
+        case ColormapType::Continuous:
+            [[fallthrough]];
+        default: cat = diverging ? colorbrewer::Category::Diverging : colorbrewer::Category::Sequential;
     }
     return cat;
 }

--- a/modules/dataframe/src/properties/colormapproperty.cpp
+++ b/modules/dataframe/src/properties/colormapproperty.cpp
@@ -43,7 +43,7 @@ ColormapProperty::ColormapProperty(std::string identifier, std::string displayNa
                                    InvalidationLevel invalidationLevel, PropertySemantics semantics)
     : CompositeProperty(identifier, displayName, invalidationLevel, semantics)
     , type("type", "Type",
-           {{"continous", "Continous", ColormapType::Continous},
+           {{"continous", "Continuous", ColormapType::Continuous},
             {"categorical", "Categorical", ColormapType::Categorical}})
     , colormap("colormap", "Colormap")
     , diverging("diverging", "Diverging", false)
@@ -68,10 +68,10 @@ ColormapProperty::ColormapProperty(std::string identifier, std::string displayNa
     colormap.setCurrentStateAsDefault();
 
     diverging.visibilityDependsOn(
-        type, [](auto prop) -> bool { return prop == ColormapType::Continous; });
+        type, [](auto prop) -> bool { return prop == ColormapType::Continuous; });
     divergenceMidPoint.visibilityDependsOn(diverging, [](auto prop) -> bool { return prop; });
     // Always discrete for categorical data
-    discrete.visibilityDependsOn(type, [](auto prop) { return prop == ColormapType::Continous; });
+    discrete.visibilityDependsOn(type, [](auto prop) { return prop == ColormapType::Continuous; });
 
     addProperty(type);
     addProperty(colormap);
@@ -101,10 +101,10 @@ ColormapProperty::ColormapProperty(const ColormapProperty& rhs)
     });
 
     diverging.visibilityDependsOn(
-        type, [](auto prop) -> bool { return prop == ColormapType::Continous; });
+        type, [](auto prop) -> bool { return prop == ColormapType::Continuous; });
     divergenceMidPoint.visibilityDependsOn(diverging, [](auto prop) -> bool { return prop; });
     // Always discrete for categorical data
-    discrete.visibilityDependsOn(type, [](auto prop) { return prop == ColormapType::Continous; });
+    discrete.visibilityDependsOn(type, [](auto prop) { return prop == ColormapType::Continuous; });
 
     addProperty(type);
     addProperty(colormap);
@@ -120,7 +120,7 @@ ColormapProperty* ColormapProperty::clone() const { return new ColormapProperty(
 colorbrewer::Category ColormapProperty::getCategory() const {
     colorbrewer::Category cat;
     switch (type) {
-        case ColormapType::Continous:
+        case ColormapType::Continuous:
             cat = diverging ? colorbrewer::Category::Diverging : colorbrewer::Category::Sequential;
             break;
         case ColormapType::Categorical:
@@ -156,12 +156,17 @@ void ColormapProperty::setupForColumn(const Column& col, double minVal, double m
         nColors = numCategories;
         discrete = true;
     } else {
-        type.set(ColormapType::Continous);
+        type.set(ColormapType::Continuous);
         // Better contrast when using many classes
         nColors = getMaxNumberOfColorsForFamily(colormap);
         discrete = false;
     }
-    divergenceMidPoint.set(0.5 * (minVal + maxVal), minVal, maxVal, 0.1 * (maxVal - minVal));
+    if (minVal < 0 && maxVal > 0) {
+        divergenceMidPoint.set(0, minVal, maxVal, 0.01 * (maxVal - minVal));
+    } else {
+        divergenceMidPoint.set(0.5 * (minVal + maxVal), minVal, maxVal, 0.01 * (maxVal - minVal));
+    }
+    
 }
 
 TransferFunction ColormapProperty::getTransferFunction() const {

--- a/modules/dataframe/src/properties/colormapproperty.cpp
+++ b/modules/dataframe/src/properties/colormapproperty.cpp
@@ -56,7 +56,10 @@ ColormapProperty::ColormapProperty(std::string identifier, std::string displayNa
     }
     auto updateColormaps = [&]() {
         colormap.replaceOptions(getFamiliesForCategory(getCategory()));
-        if (type == ColormapType::Categorical) diverging = false;
+        if (type == ColormapType::Categorical) {
+            diverging = false;
+            discrete = true;
+        }
     };
     updateColormaps();
     type.onChange(updateColormaps);
@@ -68,8 +71,8 @@ ColormapProperty::ColormapProperty(std::string identifier, std::string displayNa
     });
     type.setSelectedValue(selectedCategory);
     colormap.setSelectedValue(selectedFamily);
-    nColors.set(numColors,getMinNumberOfColorsForFamily(colormap),
-                    getMaxNumberOfColorsForFamily(colormap), 1);
+    nColors.set(numColors, getMinNumberOfColorsForFamily(colormap),
+                getMaxNumberOfColorsForFamily(colormap), 1);
     type.setCurrentStateAsDefault();
     colormap.setCurrentStateAsDefault();
 

--- a/modules/dataframe/src/properties/colormapproperty.cpp
+++ b/modules/dataframe/src/properties/colormapproperty.cpp
@@ -135,7 +135,6 @@ colorbrewer::Family ColormapProperty::getFamily() const { return *colormap; }
 void ColormapProperty::setupForColumn(const Column& col) {
     col.getBuffer()->getRepresentation<BufferRAM>()->dispatch<void, dispatching::filter::Scalars>(
         [&](auto ram) -> void {
-            using T = typename util::PrecisionValueType<decltype(ram)>;
             auto minMax = util::bufferMinMax(ram, IgnoreSpecialValues::Yes);
             setupForColumn(col, minMax.first.x, minMax.second.x);
         });

--- a/modules/dataframe/src/properties/dataframecolormapproperty.cpp
+++ b/modules/dataframe/src/properties/dataframecolormapproperty.cpp
@@ -28,6 +28,7 @@
  *********************************************************************************/
 
 #include <inviwo/dataframe/properties/dataframecolormapproperty.h>
+#include <inviwo/core/util/utilities.h>
 
 namespace inviwo {
 
@@ -57,14 +58,14 @@ DataFrameColormapProperty::DataFrameColormapProperty(std::string identifier,
 
 
     selectedColorAxis.onChange([&]() {
-        if (colormaps_.size() <= selectedColorAxis || overrideColormap) return;
+        if (colormaps_.size() <= static_cast<size_t>(*selectedColorAxis) || overrideColormap) return;
 
-        for (auto i = 0; i < colormaps_.size(); i++) {
-            colormaps_[i]->setVisible(i == selectedColorAxis);
+        for (auto i = 0u; i < colormaps_.size(); i++) {
+            colormaps_[i]->setVisible(i == static_cast<size_t>(*selectedColorAxis));
         }
 
         auto updateColormap = [&]() {
-            if (colormaps_.size() <= selectedColorAxis) return;
+            if (colormaps_.size() <= static_cast<size_t>(*selectedColorAxis)) return;
             auto cm = dynamic_cast<const ColormapProperty*>(colormaps_[selectedColorAxis]);
             if (cm) *tf = cm->getTransferFunction();
         };

--- a/modules/dataframe/src/properties/dataframecolormapproperty.cpp
+++ b/modules/dataframe/src/properties/dataframecolormapproperty.cpp
@@ -37,8 +37,10 @@ std::string DataFrameColormapProperty::getClassIdentifier() const { return class
 
 DataFrameColormapProperty::DataFrameColormapProperty(std::string identifier,
                                                      std::string displayName,
-                                                     DataInport<DataFrame>& port)
-    : CompositeProperty(identifier, displayName)
+                                                     DataInport<DataFrame>& port,
+                                                     InvalidationLevel invalidationLevel,
+                                                     PropertySemantics semantics)
+    : CompositeProperty(identifier, displayName, invalidationLevel, semantics)
     , selectedColorAxis{"selectedColorAxis", "Column", port, false, 1}
     , overrideColormap("overrideColormap", "Override", false)
     , tf{"tf", "Colormap"}
@@ -58,7 +60,7 @@ DataFrameColormapProperty::DataFrameColormapProperty(std::string identifier,
 
 
     selectedColorAxis.onChange([&]() {
-        if (colormaps_.size() <= static_cast<size_t>(*selectedColorAxis) || overrideColormap) return;
+        if (selectedColorAxis.size() == 0 || colormaps_.size() != selectedColorAxis.size() || overrideColormap) return;
 
         for (auto i = 0u; i < colormaps_.size(); i++) {
             colormaps_[i]->setVisible(i == static_cast<size_t>(*selectedColorAxis));
@@ -117,8 +119,8 @@ void DataFrameColormapProperty::createOrUpdateProperties(
             removeProperty(p);
         }
     }
-    selectedColorAxis.propertyModified();
     setCurrentStateAsDefault();
+    selectedColorAxis.propertyModified();
 }
 
 }  // namespace inviwo

--- a/modules/dataframe/src/properties/dataframecolormapproperty.cpp
+++ b/modules/dataframe/src/properties/dataframecolormapproperty.cpp
@@ -1,0 +1,123 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2019 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/dataframe/properties/dataframecolormapproperty.h>
+
+namespace inviwo {
+
+const std::string DataFrameColormapProperty::classIdentifier = "org.inviwo.DataFrameColormapProperty";
+std::string DataFrameColormapProperty::getClassIdentifier() const { return classIdentifier; }
+
+DataFrameColormapProperty::DataFrameColormapProperty(std::string identifier,
+                                                     std::string displayName,
+                                                     DataInport<DataFrame>& port)
+    : CompositeProperty(identifier, displayName)
+    , selectedColorAxis{"selectedColorAxis", "Column", port, false, 1}
+    , overrideColormap("overrideColormap", "Override", false)
+    , tf{"tf", "Colormap"}
+    , dataframe_(port.getData()) {
+
+    overrideColormap.onChange([&]() {
+        if (*overrideColormap) {
+            colormapChanged_.reset();
+            for (auto p : colormaps_) {
+                p->setVisible(false);
+            }
+        } else {
+            selectedColorAxis.propertyModified();
+        }
+        tf.setReadOnly(!*overrideColormap);
+    });
+
+
+    selectedColorAxis.onChange([&]() {
+        if (colormaps_.size() <= selectedColorAxis || overrideColormap) return;
+
+        for (auto i = 0; i < colormaps_.size(); i++) {
+            colormaps_[i]->setVisible(i == selectedColorAxis);
+        }
+
+        auto updateColormap = [&]() {
+            if (colormaps_.size() <= selectedColorAxis) return;
+            auto cm = dynamic_cast<const ColormapProperty*>(colormaps_[selectedColorAxis]);
+            if (cm) *tf = cm->getTransferFunction();
+        };
+        colormapChanged_ = dynamic_cast<ColormapProperty*>(colormaps_[selectedColorAxis])
+                               ->onChangeScoped(updateColormap);
+        updateColormap();
+    });
+
+    addProperties(selectedColorAxis, overrideColormap, tf);
+
+    port.onChange([this, portPtr = &port]() {
+        if (portPtr->hasData()) {
+            createOrUpdateProperties(portPtr->getData());
+        }
+    });
+}
+
+void DataFrameColormapProperty::createOrUpdateProperties(
+    std::shared_ptr<const DataFrame> dataframe) {
+    if (!dataframe || dataframe->getNumberOfColumns() <= 1) return;
+    dataframe_ = dataframe;
+    auto oldColormapProperties = colormaps_;
+    colormaps_.clear();
+    for (size_t i = 0; i < dataframe_->getNumberOfColumns(); i++) {
+        auto c = dataframe_->getColumn(i);
+        std::string displayName = "Settings";
+        std::string identifier = util::stripIdentifier(c->getHeader());
+
+        auto colormapProp = [&]() -> ColormapProperty* {
+            if (auto p = getPropertyByIdentifier(identifier)) {
+                if (auto prop = dynamic_cast<ColormapProperty*>(p)) {
+                    return prop;
+                }
+                removeProperty(identifier);
+            }
+            auto newProp = std::make_unique<ColormapProperty>(identifier, displayName);
+            auto ptr = newProp.get();
+            newProp->setVisible(false);
+            newProp->setSerializationMode(PropertySerializationMode::All);
+            insertProperty(1, newProp.release());
+            return ptr;
+        }();
+        colormaps_.push_back(colormapProp);
+        colormapProp->setupForColumn(*c);
+    }
+    // Remove properties that were not reused
+    for (auto p : oldColormapProperties) {
+        if (util::find(colormaps_, p) == colormaps_.end()) { 
+            removeProperty(p);
+        }
+    }
+    selectedColorAxis.propertyModified();
+    setCurrentStateAsDefault();
+}
+
+}  // namespace inviwo

--- a/modules/plottinggl/include/modules/plottinggl/processors/parallelcoordinates/parallelcoordinates.h
+++ b/modules/plottinggl/include/modules/plottinggl/processors/parallelcoordinates/parallelcoordinates.h
@@ -43,7 +43,6 @@
 #include <inviwo/core/properties/ordinalproperty.h>
 #include <inviwo/core/properties/stringproperty.h>
 #include <inviwo/core/properties/buttonproperty.h>
-#include <inviwo/core/properties/transferfunctionproperty.h>
 #include <modules/brushingandlinking/ports/brushingandlinkingports.h>
 #include <inviwo/dataframe/datastructures/dataframe.h>
 #include <modules/opengl/shader/shader.h>
@@ -54,6 +53,7 @@
 
 #include <modules/plotting/properties/categoricalaxisproperty.h>
 #include <inviwo/dataframe/properties/dataframeproperty.h>
+#include <inviwo/dataframe/properties/dataframecolormapproperty.h>
 #include <modules/plotting/properties/marginproperty.h>
 
 #include <modules/plottinggl/utils/axisrenderer.h>
@@ -102,8 +102,7 @@ public:
 
     CompositeProperty axisProperties_;
 
-    DataFrameColumnProperty selectedColorAxis_;
-    TransferFunctionProperty tf_;
+    DataFrameColormapProperty colormap_;
 
     TemplateOptionProperty<AxisSelection> axisSelection_;
 
@@ -180,7 +179,6 @@ private:
 
     glui::Renderer sliderWidgetRenderer_;
     std::vector<ColumnAxis> axes_;
-    std::shared_ptr<std::function<void()>> colormapChanged_;
 
     bool enabledAxesModified_ = false;
     std::vector<size_t> enabledAxes_;

--- a/modules/plottinggl/include/modules/plottinggl/processors/parallelcoordinates/parallelcoordinates.h
+++ b/modules/plottinggl/include/modules/plottinggl/processors/parallelcoordinates/parallelcoordinates.h
@@ -180,6 +180,7 @@ private:
 
     glui::Renderer sliderWidgetRenderer_;
     std::vector<ColumnAxis> axes_;
+    std::shared_ptr<std::function<void()>> colormapChanged_;
 
     bool enabledAxesModified_ = false;
     std::vector<size_t> enabledAxes_;

--- a/modules/plottinggl/include/modules/plottinggl/processors/parallelcoordinates/pcpaxissettings.h
+++ b/modules/plottinggl/include/modules/plottinggl/processors/parallelcoordinates/pcpaxissettings.h
@@ -190,7 +190,6 @@ public:
     virtual const MajorTickSettings& getMajorTicks() const override;
     virtual const MinorTickSettings& getMinorTicks() const override;
 
-    ColorMapProperty colormap;
     BoolProperty usePercentiles;
     BoolProperty invertRange;
     DoubleMinMaxProperty range;

--- a/modules/plottinggl/include/modules/plottinggl/processors/parallelcoordinates/pcpaxissettings.h
+++ b/modules/plottinggl/include/modules/plottinggl/processors/parallelcoordinates/pcpaxissettings.h
@@ -35,6 +35,7 @@
 #include <inviwo/core/properties/boolproperty.h>
 #include <modules/opengl/texture/texture2d.h>
 
+#include <inviwo/dataframe/properties/colormapproperty.h>
 #include <modules/plotting/datastructures/axissettings.h>
 
 namespace inviwo {
@@ -189,6 +190,7 @@ public:
     virtual const MajorTickSettings& getMajorTicks() const override;
     virtual const MinorTickSettings& getMinorTicks() const override;
 
+    ColorMapProperty colormap;
     BoolProperty usePercentiles;
     BoolProperty invertRange;
     DoubleMinMaxProperty range;

--- a/modules/plottinggl/include/modules/plottinggl/processors/parallelcoordinates/pcpaxissettings.h
+++ b/modules/plottinggl/include/modules/plottinggl/processors/parallelcoordinates/pcpaxissettings.h
@@ -35,7 +35,6 @@
 #include <inviwo/core/properties/boolproperty.h>
 #include <modules/opengl/texture/texture2d.h>
 
-#include <inviwo/dataframe/properties/colormapproperty.h>
 #include <modules/plotting/datastructures/axissettings.h>
 
 namespace inviwo {

--- a/modules/plottinggl/src/plottingglmodule.cpp
+++ b/modules/plottinggl/src/plottingglmodule.cpp
@@ -65,7 +65,7 @@ PlottingGLModule::PlottingGLModule(InviwoApplication* app) : InviwoModule(app, "
     registerDataVisualizer(std::make_unique<PCPDataFrameVisualizer>(app));
 }
 
-int PlottingGLModule::getVersion() const { return 1; }
+int PlottingGLModule::getVersion() const { return 2; }
 
 std::unique_ptr<VersionConverter> PlottingGLModule::getConverter(int version) const {
     return std::make_unique<Converter>(version);
@@ -97,11 +97,54 @@ bool PlottingGLModule::Converter::convert(TxElement* root) {
                     props->InsertEndChild(*color);
                 }
 
-                res = true;
                 return true;
             }};
 
-            conv.convert(root);
+            res |= conv.convert(root);
+            [[fallthrough]];
+        }
+        case 1: {
+            TraversingVersionConverter conv{[&](TxElement* node) -> bool {
+                std::string key;
+                node->GetValue(&key);
+                if (key != "Processor") return true;
+                const auto type = node->GetAttributeOrDefault("type", "");
+                if (type != "org.inviwo.ParallelCoordinates") return true;
+
+                auto props = xml::getElement(node, "Properties");
+                TxElement compNode{"Property"};
+                compNode.SetAttribute("type", "org.inviwo.DataFrameColormapProperty");
+                compNode.SetAttribute("identifier", "colormap");
+
+                TxElement propNode{"Properties"};
+                // Move old TF and selected color into new DataFrameColormapProperty
+                if (auto tf = xml::getElement(props,
+                                              "Property&identifier=tf")) {
+                    propNode.InsertEndChild(*tf);
+                }
+
+                if (auto color = xml::getElement(props,
+                                                 "Property&identifier=selectedColorAxis")) {
+                    propNode.InsertEndChild(*color);
+                }
+
+                // Override colormap so that the old one is used
+                TxElement boolNode{"Property"};
+                boolNode.SetAttribute("type", "org.inviwo.BoolProperty");
+                boolNode.SetAttribute("identifier", "overrideColormap");
+
+                TxElement valNode{"value"};
+                valNode.SetAttribute("content", "1");
+
+                boolNode.InsertEndChild(valNode);
+                propNode.InsertEndChild(boolNode);
+                compNode.InsertEndChild(propNode);
+                props->InsertEndChild(compNode);
+
+                return true;
+            }};
+            res |= conv.convert(root);
+
             return res;
         }
 

--- a/modules/plottinggl/src/processors/parallelcoordinates/parallelcoordinates.cpp
+++ b/modules/plottinggl/src/processors/parallelcoordinates/parallelcoordinates.cpp
@@ -382,7 +382,7 @@ void ParallelCoordinates::createOrUpdateProperties() {
         // initialize corresponding flipped flag for the line shader
         lines_.axisFlipped[i] = static_cast<int>(prop->invertRange);
 
-        axes_.push_back({prop, std::move(renderer), std::move(slider)});        
+        axes_.push_back({prop, std::move(renderer), std::move(slider)});
     }
 
     for (auto& axis : axes_) {

--- a/modules/plottinggl/src/processors/parallelcoordinates/parallelcoordinates.cpp
+++ b/modules/plottinggl/src/processors/parallelcoordinates/parallelcoordinates.cpp
@@ -158,6 +158,14 @@ ParallelCoordinates::ParallelCoordinates()
 
     addProperty(axisProperties_);
     addProperty(selectedColorAxis_);
+    selectedColorAxis_.onChange([&]() {
+        if (axes_.empty()) return;
+        auto& colormap =
+            axes_[glm::clamp(*selectedColorAxis_, 0, static_cast<int>(axes_.size()) - 1)]
+                .pcp->colormap;
+        *tf_ = colormap.get();
+        colormapChanged_ = colormap.onChangeScoped([&]() { *tf_ = colormap.get(); });
+    });
     addProperty(tf_);
 
     addProperty(axisSelection_);

--- a/modules/plottinggl/src/processors/parallelcoordinates/pcpaxissettings.cpp
+++ b/modules/plottinggl/src/processors/parallelcoordinates/pcpaxissettings.cpp
@@ -69,13 +69,11 @@ std::string PCPAxisSettings::getClassIdentifier() const { return classIdentifier
 
 PCPAxisSettings::PCPAxisSettings(std::string identifier, std::string displayName, size_t columnId)
     : BoolCompositeProperty(identifier, displayName, true)
-    , colormap("colormap", "Colormap")
     , usePercentiles("usePercentiles", "Use Percentiles", false)
     , invertRange("invertRange", "Invert Range")
     , range("range", "Axis Range")
     , columnId_{columnId} {
 
-    addProperty(colormap);
     addProperty(range);
     addProperty(invertRange);
     addProperty(usePercentiles);
@@ -94,13 +92,11 @@ PCPAxisSettings::PCPAxisSettings(std::string identifier, std::string displayName
 
 PCPAxisSettings::PCPAxisSettings(const PCPAxisSettings& rhs)
     : BoolCompositeProperty(rhs)
-    , colormap(rhs.colormap)
     , usePercentiles{rhs.usePercentiles}
     , invertRange(rhs.invertRange)
     , range{rhs.range}
     , columnId_{rhs.columnId_} {
 
-    addProperty(colormap);
     addProperty(range);
     addProperty(invertRange);
     addProperty(usePercentiles);
@@ -116,12 +112,7 @@ PCPAxisSettings* PCPAxisSettings::clone() const { return new PCPAxisSettings(*th
 void PCPAxisSettings::updateFromColumn(std::shared_ptr<const Column> col) {
     col_ = col;
     catCol_ = dynamic_cast<const CategoricalColumn*>(col.get());
-    if (catCol_) {
-        colormap.category.set(colorbrewer::Category::Qualitative);
-        colormap.colormap.set(colorbrewer::Family::Paired);
-        colormap.nColors.set(catCol_->getCategories().size());
-        colormap.discrete_.set(true);
-    }
+
     col->getBuffer()->getRepresentation<BufferRAM>()->dispatch<void, dispatching::filter::Scalars>(
         [&](auto ram) -> void {
             using T = typename util::PrecisionValueType<decltype(ram)>;
@@ -156,7 +147,6 @@ void PCPAxisSettings::updateFromColumn(std::shared_ptr<const Column> col) {
             p100_ = static_cast<double>(pecentiles[3]);
             at = [vec = &dataVector](size_t idx) { return static_cast<double>(vec->at(idx)); };
 
-            colormap.divergenceMidPoint_.set(0.5 * (minV + maxV), minV, maxV, 0.1*(maxV - minV));
         });
 
     range.propertyModified();

--- a/src/core/util/colorbrewer.cpp
+++ b/src/core/util/colorbrewer.cpp
@@ -2951,7 +2951,7 @@ TransferFunction getTransferFunction(const Category &category, const Family &fam
         if (discrete) {
             auto dt = midPoint / (0.5 * (colors.size()));
             double start = 0, end = std::max(dt - std::numeric_limits<double>::epsilon(), 0.);
-            for (auto i = 0; i < colors.size() / 2; i++) {
+            for (auto i = 0u; i < colors.size() / 2; i++) {
                 tf.add(start, vec4(colors[i]));
                 tf.add(end, vec4(colors[i]));
                 start += dt;
@@ -2974,7 +2974,7 @@ TransferFunction getTransferFunction(const Category &category, const Family &fam
             }
         } else {
             auto dt = midPoint / (0.5 * (colors.size() - 1.0));
-            for (auto i = 0; i < colors.size() / 2; i++) {
+            for (auto i = 0u; i < colors.size() / 2; i++) {
                 tf.add(i * dt, vec4(colors[i]));
             }
             tf.add(midPoint, vec4(colors[colors.size() / 2]));

--- a/src/core/util/colorbrewer.cpp
+++ b/src/core/util/colorbrewer.cpp
@@ -2942,7 +2942,7 @@ std::vector<Family> getFamiliesForCategory(const Category &category) {
     return v;
 }
 
-TransferFunction getTransferfunction(const Category &category, const Family &family,
+TransferFunction getTransferFunction(const Category &category, const Family &family,
                                      glm::uint8 nColors, bool discrete, double midPoint) {
     TransferFunction tf;
     auto colors = colorbrewer::getColormap(family, nColors);

--- a/src/core/util/colorbrewer.cpp
+++ b/src/core/util/colorbrewer.cpp
@@ -2942,6 +2942,74 @@ std::vector<Family> getFamiliesForCategory(const Category &category) {
     return v;
 }
 
+TransferFunction getTransferfunction(const Category &category, const Family &family,
+                                     glm::uint8 nColors, bool discrete, double midPoint) {
+    TransferFunction tf;
+    auto colors = colorbrewer::getColormap(family, nColors);
+
+    if (category == colorbrewer::Category::Diverging) {
+        if (discrete) {
+            auto dt = midPoint / (0.5 * (colors.size()));
+            double start = 0, end = std::max(dt - std::numeric_limits<double>::epsilon(), 0.);
+            for (auto i = 0; i < colors.size() / 2; i++) {
+                tf.add(start, vec4(colors[i]));
+                tf.add(end, vec4(colors[i]));
+                start += dt;
+                end += dt;
+            }
+            tf.add(start, vec4(colors[colors.size() / 2]));
+            if (midPoint < 1.0) {
+                dt = (1.0 - midPoint) / (0.5 * (colors.size()));
+                tf.add(start + dt - std::numeric_limits<double>::epsilon(),
+                       vec4(colors[colors.size() / 2]));
+                start = start + dt;
+                end = start + dt - std::numeric_limits<double>::epsilon();
+                for (auto i = colors.size() / 2 + 1; i < colors.size(); i++) {
+                    // Avoid numerical issues with min
+                    tf.add(std::min(start, 1.0), vec4(colors[i]));
+                    tf.add(std::min(end, 1.0), vec4(colors[i]));
+                    start += dt;
+                    end += dt;
+                }
+            }
+        } else {
+            auto dt = midPoint / (0.5 * (colors.size() - 1.0));
+            for (auto i = 0; i < colors.size() / 2; i++) {
+                tf.add(i * dt, vec4(colors[i]));
+            }
+            tf.add(midPoint, vec4(colors[colors.size() / 2]));
+            if (midPoint < 1.0) {
+                dt = (1.0 - midPoint) / (0.5 * (colors.size() - 1.0));
+                auto t = midPoint + dt;
+                for (auto i = colors.size() / 2 + 1; i < colors.size(); i++) {
+                    // Avoid numerical issues with min
+                    tf.add(std::min(t, 1.0), vec4(colors[i]));
+                    t += dt;
+                }
+            }
+        }
+
+    } else {
+        if (discrete) {
+            double dt = 1.0 / (colors.size());
+            double start = 0, end = dt - std::numeric_limits<double>::epsilon();
+            for (const auto &c : colors) {
+                tf.add(start, vec4(c));
+                tf.add(end, vec4(c));
+                start += dt;
+                end += dt;
+            }
+        } else {
+            auto dt = 1.0 / (colors.size() - 1.0);
+            size_t idx = 0;
+            for (const auto &c : colors) {
+                tf.add(idx++ * dt, vec4(c));
+            }
+        }
+    }
+    return tf;
+}
+
 }  // namespace colorbrewer
 
 }  // namespace inviwo

--- a/tools/codegen/colorbrewer/colorbrewer_tmpl.cpp
+++ b/tools/codegen/colorbrewer/colorbrewer_tmpl.cpp
@@ -49,7 +49,7 @@ const std::vector<dvec4> &getColormap(const Family &family, glm::uint8 numberOfC
     if (getMinNumberOfColorsForFamily(family) > numberOfColors){
         throw ColorBrewerTooFewException();
     } 
-    if(getMaxNumberOfColorsForFamily(family) < numberOfColors) {
+    if (getMaxNumberOfColorsForFamily(family) < numberOfColors) {
         throw ColorBrewerTooManyException();
     }
 
@@ -136,7 +136,7 @@ std::map<Family, std::vector<dvec4>> getColormaps(const Category &category,
     return v;
 }
 
-glm::uint8 getMinNumberOfColorsForFamily(const Family &family) { return 3; }
+glm::uint8 getMinNumberOfColorsForFamily(const Family &) { return 3; }
 
 glm::uint8 getMaxNumberOfColorsForFamily(const Family &family) {
 ##GETMAXIMPL##
@@ -150,6 +150,74 @@ std::vector<Family> getFamiliesForCategory(const Category &category) {
     }
 
     return v;
+}
+
+TransferFunction getTransferFunction(const Category &category, const Family &family,
+                                     glm::uint8 nColors, bool discrete, double midPoint) {
+    TransferFunction tf;
+    auto colors = colorbrewer::getColormap(family, nColors);
+
+    if (category == colorbrewer::Category::Diverging) {
+        if (discrete) {
+            auto dt = midPoint / (0.5 * (colors.size()));
+            double start = 0, end = std::max(dt - std::numeric_limits<double>::epsilon(), 0.);
+            for (auto i = 0; i < colors.size() / 2; i++) {
+                tf.add(start, vec4(colors[i]));
+                tf.add(end, vec4(colors[i]));
+                start += dt;
+                end += dt;
+            }
+            tf.add(start, vec4(colors[colors.size() / 2]));
+            if (midPoint < 1.0) {
+                dt = (1.0 - midPoint) / (0.5 * (colors.size()));
+                tf.add(start + dt - std::numeric_limits<double>::epsilon(),
+                       vec4(colors[colors.size() / 2]));
+                start = start + dt;
+                end = start + dt - std::numeric_limits<double>::epsilon();
+                for (auto i = colors.size() / 2 + 1; i < colors.size(); i++) {
+                    // Avoid numerical issues with min
+                    tf.add(std::min(start, 1.0), vec4(colors[i]));
+                    tf.add(std::min(end, 1.0), vec4(colors[i]));
+                    start += dt;
+                    end += dt;
+                }
+            }
+        } else {
+            auto dt = midPoint / (0.5 * (colors.size() - 1.0));
+            for (auto i = 0; i < colors.size() / 2; i++) {
+                tf.add(i * dt, vec4(colors[i]));
+            }
+            tf.add(midPoint, vec4(colors[colors.size() / 2]));
+            if (midPoint < 1.0) {
+                dt = (1.0 - midPoint) / (0.5 * (colors.size() - 1.0));
+                auto t = midPoint + dt;
+                for (auto i = colors.size() / 2 + 1; i < colors.size(); i++) {
+                    // Avoid numerical issues with min
+                    tf.add(std::min(t, 1.0), vec4(colors[i]));
+                    t += dt;
+                }
+            }
+        }
+
+    } else {
+        if (discrete) {
+            double dt = 1.0 / (colors.size());
+            double start = 0, end = dt - std::numeric_limits<double>::epsilon();
+            for (const auto &c : colors) {
+                tf.add(start, vec4(c));
+                tf.add(end, vec4(c));
+                start += dt;
+                end += dt;
+            }
+        } else {
+            auto dt = 1.0 / (colors.size() - 1.0);
+            size_t idx = 0;
+            for (const auto &c : colors) {
+                tf.add(idx++ * dt, vec4(c));
+            }
+        }
+    }
+    return tf;
 }
 
 }  // namespace colorbrewer

--- a/tools/codegen/colorbrewer/colorbrewer_tmpl.cpp
+++ b/tools/codegen/colorbrewer/colorbrewer_tmpl.cpp
@@ -161,7 +161,7 @@ TransferFunction getTransferFunction(const Category &category, const Family &fam
         if (discrete) {
             auto dt = midPoint / (0.5 * (colors.size()));
             double start = 0, end = std::max(dt - std::numeric_limits<double>::epsilon(), 0.);
-            for (auto i = 0; i < colors.size() / 2; i++) {
+            for (auto i = 0u; i < colors.size() / 2; i++) {
                 tf.add(start, vec4(colors[i]));
                 tf.add(end, vec4(colors[i]));
                 start += dt;
@@ -184,7 +184,7 @@ TransferFunction getTransferFunction(const Category &category, const Family &fam
             }
         } else {
             auto dt = midPoint / (0.5 * (colors.size() - 1.0));
-            for (auto i = 0; i < colors.size() / 2; i++) {
+            for (auto i = 0u; i < colors.size() / 2; i++) {
                 tf.add(i * dt, vec4(colors[i]));
             }
             tf.add(midPoint, vec4(colors[colors.size() / 2]));

--- a/tools/codegen/colorbrewer/colorbrewer_tmpl.h
+++ b/tools/codegen/colorbrewer/colorbrewer_tmpl.h
@@ -32,11 +32,11 @@ This complete file is auto-generated with python script
 tools/codegen/colorbrewer/colorbrewer.py
 */
 
-#ifndef IWW_COLORBREWER_H
-#define IWW_COLORBREWER_H
+#pragma once
 
 #include <inviwo/core/common/inviwocoredefine.h>
 #include <inviwo/core/common/inviwo.h>
+#include <inviwo/core/datastructures/transferfunction.h>
 #include <vector>
 #include <ostream>
 
@@ -52,28 +52,32 @@ public:
 };
 class IVW_CORE_API ColorBrewerTooFewException : public Exception {
 public:
-    ColorBrewerTooFewException(const std::string &message = "Requested colormap does not support selected number of colors.",
-        ExceptionContext context = ExceptionContext())
+    ColorBrewerTooFewException(const std::string &message =
+                                   "Requested colormap does not support selected number of colors.",
+                               ExceptionContext context = ExceptionContext())
         : Exception(message, context) {}
     virtual ~ColorBrewerTooFewException() throw() {}
 };
 class IVW_CORE_API ColorBrewerTooManyException : public Exception {
 public:
-    ColorBrewerTooManyException(const std::string &message = "Requested colormap does not support selected number of colors.",
+    ColorBrewerTooManyException(
+        const std::string &message =
+            "Requested colormap does not support selected number of colors.",
         ExceptionContext context = ExceptionContext())
         : Exception(message, context) {}
     virtual ~ColorBrewerTooManyException() throw() {}
 };
-
+// clang-format off
 ##PLACEHOLDER##
-
+// clang-format on
 template <class Elem, class Traits>
 std::basic_ostream<Elem, Traits> &operator<<(std::basic_ostream<Elem, Traits> &os,
-                                             Colormap colormap) {
+                                                 Colormap colormap) {
+    // clang-format off
     switch (colormap) {
 ##PLACEHOLDER_NAMES##
     }
-
+    // clang-format on
     return os;
 }
 
@@ -83,17 +87,16 @@ std::basic_ostream<Elem, Traits> &operator<<(std::basic_ostream<Elem, Traits> &o
     switch (category) {
 ##PLACEHOLDER_CATEGORIES##
     }
-
     return os;
 }
 
 template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits> &operator<<(std::basic_ostream<Elem, Traits> &os,
-                                             Family family) {
+std::basic_ostream<Elem, Traits> &operator<<(std::basic_ostream<Elem, Traits> &os, Family family) {
+    // clang-format off
     switch (family) {
 ##PLACEHOLDER_FAMILIES##
     }
-
+    // clang-format on
     return os;
 }
 
@@ -145,9 +148,18 @@ IVW_CORE_API glm::uint8 getMaxNumberOfColorsForFamily(const Family &family);
  **/
 IVW_CORE_API std::vector<Family> getFamiliesForCategory(const Category &category);
 
+/**
+ * Returns a transfer function for the given parameters.
+ *
+ * @param category according to ColorBrewer2
+ * @param family color scheme name
+ * @param discrete will make each color constant instead of linearly varying inbetween colors.
+ * @param divergenceMidpoint in [0 1]. Only used when category is Diverging
+ **/
+IVW_CORE_API TransferFunction getTransferFunction(const Category &category, const Family &family,
+                                                  glm::uint8 nColors, bool discrete,
+                                                  double divergenceMidPoint);
+
 }  // namespace colorbrewer
 }  // namespace inviwo
-
-#endif  // COLORBREWER_H
-
 


### PR DESCRIPTION
Added DataFrameColormapProperty and ColormapProperty to select predefined colormaps for a column.

* Categorical columns automatically use appropriate colormap
* Old workspaces will use previously defined transfer function. Disable "Override" in the new Colormap property

Roughly how it looked before:
![image](https://user-images.githubusercontent.com/8738140/63592750-ab483f00-c5b2-11e9-9fa4-1c59d2299c9f.png)

New 
![image](https://user-images.githubusercontent.com/8738140/63592802-cdda5800-c5b2-11e9-92c1-8c7bad6021cd.png)
