### PR TITLE
Feature/volumereader

### DIFF
--- a/include/inviwo/core/io/rawvolumereader.h
+++ b/include/inviwo/core/io/rawvolumereader.h
@@ -54,7 +54,7 @@ public:
     virtual ~RawVolumeReader() = default;
 
     virtual void setParameters(const DataFormatBase* format, ivec3 dimensions, bool littleEndian,
-                               DataMapper dataMapper, size_t dataOffset = 0u);
+                               DataMapper dataMapper, size_t byteOffset = 0u);
 
     virtual std::shared_ptr<Volume> readData(const std::string& filePath) override;
     virtual std::shared_ptr<Volume> readData(const std::string& filePath,
@@ -70,7 +70,7 @@ private:
     vec3 spacing_;
     const DataFormatBase* format_;
     DataMapper dataMapper_;
-    size_t dataOffset_;
+    size_t byteOffset_;
     bool parametersSet_;
 };
 

--- a/include/inviwo/core/io/volumedatareaderdialog.h
+++ b/include/inviwo/core/io/volumedatareaderdialog.h
@@ -49,14 +49,14 @@ public:
     virtual dvec3 getSpacing() const = 0;
     virtual bool getEndianess() const = 0;
     virtual DataMapper getDataMapper() const = 0;
-    virtual size_t getDataOffset() const = 0;
+    virtual size_t getByteOffset() const = 0;
 
     virtual void setFormat(const DataFormatBase* format) = 0;
     virtual void setDimensions(uvec3 dim) = 0;
     virtual void setSpacing(dvec3 spacing) = 0;
     virtual void setEndianess(bool endian) = 0;
     virtual void setDataMapper(const DataMapper& datamapper) = 0;
-    virtual void setDataOffset(size_t offset) = 0;
+    virtual void setByteOffset(size_t offset) = 0;
 };
 
 }  // namespace inviwo

--- a/modules/base/include/modules/base/io/datvolumesequencereader.h
+++ b/modules/base/include/modules/base/io/datvolumesequencereader.h
@@ -45,12 +45,14 @@ namespace inviwo {
  *   - __Rawfile__ The name of the raw data file, should be in the same directory (Mandatory).
  *   - __ByteOrder__ the byte order in the raw data file. (Optional, LittleEndian|BigEndian,
  *     default: LittleEndian).
+ *   - __DataOffset__  offset in byte to where the data starts
  *   - __Resolution | Dimension__ The size of the data grid: nx,ny,nz (Mandatory).
  *   - __Format__ The type of values in the raw file. (Mandatory)
  *   - __Spacing | SliceThickness__ The size of the voxels in the data. (Optional)
  *   - __BasisVector(1|2|3)__ Defines a coordinate system for the data. (Optional, overides spacing,
  *     default: 2*IdentityMatrix);
- *   - __Offset__ Offsets the basisvecors in space. (Optional, defaults to center the data on origo)
+ *   - __Offset__ Offsets the basisvecors in space. (Optional, defaults to center the data at the
+ *     origin)
  *   - __WorldVector(1|2|3|4)__ Defines a world transformation matrix that is applied last to orient
  *     the data in world space. (Optional, default: IdentityMatrix)
  *   - __DatFile__ Relative path to other file to create a VolumeSequence from
@@ -59,10 +61,11 @@ namespace inviwo {
  *
  * Supports reading VolumeSequence (for example time-varying volume data) by specifying multiple
  *.dat files.
+ *
  * Example:
- *     Datfile: sequence0.dat
- *     Datfile: sequence1.dat
- *     Datfile: sequence2.dat
+ *     + Datfile: sequence0.dat
+ *     + Datfile: sequence1.dat
+ *     + Datfile: sequence2.dat
  */
 class IVW_MODULE_BASE_API DatVolumeSequenceReader
     : public DataReaderType<std::vector<std::shared_ptr<Volume>>> {
@@ -78,11 +81,6 @@ public:
     virtual std::shared_ptr<VolumeSequence> readData(const std::string& filePath) override;
 
 private:
-    std::string rawFile_;
-    size_t filePos_;
-    bool littleEndian_;
-    size3_t dimensions_;
-    const DataFormatBase* format_;
     bool enableLogOutput_;
 };
 

--- a/modules/base/include/modules/base/io/datvolumesequencereader.h
+++ b/modules/base/include/modules/base/io/datvolumesequencereader.h
@@ -51,7 +51,7 @@ namespace inviwo {
  *   - __Spacing | SliceThickness__ The size of the voxels in the data. (Optional)
  *   - __BasisVector(1|2|3)__ Defines a coordinate system for the data. (Optional, overides spacing,
  *     default: 2*IdentityMatrix);
- *   - __Offset__ Offsets the basisvecors in space. (Optional, defaults to center the data at the
+ *   - __Offset__ Offsets the basis vectors in space. (Optional, defaults to center the data at the
  *     origin)
  *   - __WorldVector(1|2|3|4)__ Defines a world transformation matrix that is applied last to orient
  *     the data in world space. (Optional, default: IdentityMatrix)

--- a/modules/base/include/modules/base/io/ivfsequencevolumereader.h
+++ b/modules/base/include/modules/base/io/ivfsequencevolumereader.h
@@ -41,7 +41,7 @@ namespace inviwo {
  * \ingroup dataio
  * \brief Reader for *.ivfs sequnce files
  *
- * Supports reader a volume sequence from disk.
+ * Supports reading a volume sequence from disk.
  *
  * The expected structure of the ivfs sequence files is:
  * \verbatim

--- a/modules/base/include/modules/base/io/ivfvolumereader.h
+++ b/modules/base/include/modules/base/io/ivfvolumereader.h
@@ -48,13 +48,6 @@ public:
     virtual ~IvfVolumeReader() = default;
 
     virtual std::shared_ptr<Volume> readData(const std::string& filePath) override;
-
-private:
-    std::string rawFile_;
-    size_t filePos_;
-    bool littleEndian_;
-    size3_t dimensions_;
-    const DataFormatBase* format_;
 };
 
 }  // namespace inviwo

--- a/modules/base/src/io/datvolumesequencereader.cpp
+++ b/modules/base/src/io/datvolumesequencereader.cpp
@@ -88,7 +88,7 @@ std::shared_ptr<DatVolumeSequenceReader::VolumeSequence> DatVolumeSequenceReader
 
     std::string rawFile;
     size3_t dimensions{0u};
-    size_t dataOffset = 0u;
+    size_t byteOffset = 0u;
     const DataFormatBase* format = nullptr;
     bool littleEndian = true;
 
@@ -135,8 +135,8 @@ std::shared_ptr<DatVolumeSequenceReader::VolumeSequence> DatVolumeSequenceReader
             if (toLower(value) == "bigendian") {
                 littleEndian = false;
             }
-        } else if (key == "dataoffset") {
-            ss >> dataOffset;
+        } else if (key == "byteoffset") {
+            ss >> byteOffset;
         } else if (key == "sequences") {
             ss >> sequences;
         } else if (key == "resolution" || key == "dimensions") {
@@ -299,7 +299,7 @@ std::shared_ptr<DatVolumeSequenceReader::VolumeSequence> DatVolumeSequenceReader
             else
                 volumes->push_back(std::shared_ptr<Volume>(volumes->front()->clone()));
             auto diskRepr = std::make_shared<VolumeDisk>(fileName, dimensions, format);
-            size_t filePos = t * bytes + dataOffset;
+            size_t filePos = t * bytes + byteOffset;
 
             auto loader = std::make_unique<RawVolumeRAMLoader>(rawFile, filePos, dimensions,
                                                                littleEndian, format);

--- a/modules/base/src/io/datvolumewriter.cpp
+++ b/modules/base/src/io/datvolumewriter.cpp
@@ -69,7 +69,7 @@ void DatVolumeWriter::writeData(const Volume* data, const std::string filePath) 
     writeKeyToString(ss, "RawFile", fileName + ".raw");
     writeKeyToString(ss, "Resolution", vr->getDimensions());
     writeKeyToString(ss, "Format", vr->getDataFormatString());
-    writeKeyToString(ss, "DataOffset", 0);
+    writeKeyToString(ss, "ByteOffset", 0);
     writeKeyToString(ss, "BasisVector1", basis[0]);
     writeKeyToString(ss, "BasisVector2", basis[1]);
     writeKeyToString(ss, "BasisVector3", basis[2]);

--- a/modules/base/src/io/datvolumewriter.cpp
+++ b/modules/base/src/io/datvolumewriter.cpp
@@ -69,6 +69,7 @@ void DatVolumeWriter::writeData(const Volume* data, const std::string filePath) 
     writeKeyToString(ss, "RawFile", fileName + ".raw");
     writeKeyToString(ss, "Resolution", vr->getDimensions());
     writeKeyToString(ss, "Format", vr->getDataFormatString());
+    writeKeyToString(ss, "DataOffset", 0);
     writeKeyToString(ss, "BasisVector1", basis[0]);
     writeKeyToString(ss, "BasisVector2", basis[1]);
     writeKeyToString(ss, "BasisVector3", basis[2]);

--- a/modules/base/src/io/ivfvolumereader.cpp
+++ b/modules/base/src/io/ivfvolumereader.cpp
@@ -54,14 +54,14 @@ std::shared_ptr<Volume> IvfVolumeReader::readData(const std::string& filePath) {
 
     std::string rawFile;
     size3_t dimensions{0u};
-    size_t dataOffset = 0u;
+    size_t byteOffset = 0u;
     const DataFormatBase* format = nullptr;
     bool littleEndian = true;
 
     d.registerFactory(InviwoApplication::getPtr()->getMetaDataFactory());
     d.deserialize("RawFile", rawFile);
     rawFile = fileDirectory + "/" + rawFile;
-    d.deserialize("DataOffset", dataOffset);
+    d.deserialize("ByteOffset", byteOffset);
     std::string formatFlag;
     d.deserialize("Format", formatFlag);
     format = DataFormatBase::get(formatFlag);
@@ -84,7 +84,7 @@ std::shared_ptr<Volume> IvfVolumeReader::readData(const std::string& filePath) {
     auto vd = std::make_shared<VolumeDisk>(filePath, dimensions, format);
 
     auto loader =
-        std::make_unique<RawVolumeRAMLoader>(rawFile, dataOffset, dimensions, littleEndian, format);
+        std::make_unique<RawVolumeRAMLoader>(rawFile, byteOffset, dimensions, littleEndian, format);
     vd->setLoader(loader.release());
 
     volume->addRepresentation(vd);

--- a/modules/base/src/io/ivfvolumewriter.cpp
+++ b/modules/base/src/io/ivfvolumewriter.cpp
@@ -64,6 +64,7 @@ void IvfVolumeWriter::writeData(const Volume* volume, const std::string filePath
     Serializer s(filePath);
     s.serialize("RawFile", fileName + ".raw");
     s.serialize("Format", vr->getDataFormatString());
+    s.serialize("DataOffset", 0u);
     s.serialize("BasisAndOffset", volume->getModelMatrix());
     s.serialize("WorldTransform", volume->getWorldMatrix());
     s.serialize("Dimension", volume->getDimensions());
@@ -73,7 +74,7 @@ void IvfVolumeWriter::writeData(const Volume* volume, const std::string filePath
 
     volume->getMetaDataMap()->serialize(s);
     s.writeFile();
-    std::fstream fout(rawPath.c_str(), std::ios::out | std::ios::binary);
+    std::ofstream fout = filesystem::ofstream(rawPath, std::ios::out | std::ios::binary);
 
     if (fout.good()) {
         fout.write((char*)vr->getData(), vr->getDimensions().x * vr->getDimensions().y *

--- a/modules/base/src/io/ivfvolumewriter.cpp
+++ b/modules/base/src/io/ivfvolumewriter.cpp
@@ -64,7 +64,7 @@ void IvfVolumeWriter::writeData(const Volume* volume, const std::string filePath
     Serializer s(filePath);
     s.serialize("RawFile", fileName + ".raw");
     s.serialize("Format", vr->getDataFormatString());
-    s.serialize("DataOffset", 0u);
+    s.serialize("ByteOffset", 0u);
     s.serialize("BasisAndOffset", volume->getModelMatrix());
     s.serialize("WorldTransform", volume->getWorldMatrix());
     s.serialize("Dimension", volume->getDimensions());

--- a/modules/qtwidgets/include/modules/qtwidgets/rawdatareaderdialogqt.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/rawdatareaderdialogqt.h
@@ -56,14 +56,14 @@ public:
     virtual dvec3 getSpacing() const override;
     virtual bool getEndianess() const override;
     virtual DataMapper getDataMapper() const override;
-    virtual size_t getDataOffset() const override;
+    virtual size_t getByteOffset() const override;
 
     virtual void setFormat(const DataFormatBase* format) override;
     virtual void setDimensions(uvec3 dim) override;
     virtual void setSpacing(dvec3 spacing) override;
     virtual void setEndianess(bool endian) override;
     virtual void setDataMapper(const DataMapper& datamapper) override;
-    virtual void setDataOffset(size_t offset) override;
+    virtual void setByteOffset(size_t offset) override;
 
 private:
     QLabel* fileName_;
@@ -82,7 +82,7 @@ private:
     QLineEdit* spaceY_;
     QLineEdit* spaceZ_;
 
-    QSpinBox* dataOffset_;
+    QSpinBox* byteOffset_;
     /*
     QSpinBox* timeSteps_;
     QSpinBox* timeStepOffset_;

--- a/modules/qtwidgets/src/rawdatareaderdialogqt.cpp
+++ b/modules/qtwidgets/src/rawdatareaderdialogqt.cpp
@@ -175,11 +175,11 @@ RawDataReaderDialogQt::RawDataReaderDialogQt() {
     dataSizeBox->setLayout(dataSizeLayout);
 
     QGridLayout* readOptionsLayout = new QGridLayout();
-    QLabel* dataOffsetLabel = new QLabel("Data offset");
-    dataOffset_ = new QSpinBox();
-    dataOffset_->setRange(0, 4096);
-    dataOffset_->setValue(0);
-    dataOffset_->setSuffix(" Byte");
+    QLabel* byteOffsetLabel = new QLabel("Byte offset");
+    byteOffset_ = new QSpinBox();
+    byteOffset_->setRange(0, 4096);
+    byteOffset_->setValue(0);
+    byteOffset_->setSuffix(" Byte");
     /*
     QLabel* timeStepOffsetLabel = new QLabel("Time step offset");
     timeStepOffset_ = new QSpinBox();
@@ -191,8 +191,8 @@ RawDataReaderDialogQt::RawDataReaderDialogQt() {
     endianess_ = new QComboBox();
     endianess_->addItem("Little Endian");
     endianess_->addItem("Big Endian");
-    readOptionsLayout->addWidget(dataOffsetLabel, 0, 0);
-    readOptionsLayout->addWidget(dataOffset_, 0, 1);
+    readOptionsLayout->addWidget(byteOffsetLabel, 0, 0);
+    readOptionsLayout->addWidget(byteOffset_, 0, 1);
     /*
     readOptionsLayout->addWidget(timeStepOffsetLabel, 1, 0);
     readOptionsLayout->addWidget(timeStepOffset_, 1, 1);
@@ -304,12 +304,12 @@ void RawDataReaderDialogQt::setDataMapper(const DataMapper& datamapper) {
     valueUnit_->setText(utilqt::toLocalQString(datamapper.valueUnit));
 }
 
-size_t RawDataReaderDialogQt::getDataOffset() const {
-    return static_cast<size_t>(dataOffset_->value());
+size_t RawDataReaderDialogQt::getByteOffset() const {
+    return static_cast<size_t>(byteOffset_->value());
 }
 
-void RawDataReaderDialogQt::setDataOffset(size_t offset) {
-    dataOffset_->setValue(static_cast<int>(offset));
+void RawDataReaderDialogQt::setByteOffset(size_t offset) {
+    byteOffset_->setValue(static_cast<int>(offset));
 }
 
 void RawDataReaderDialogQt::selectedDataTypeChanged(int index) {


### PR DESCRIPTION
Some fixes in the dat-raw and ivf volume readers/writers
* exposed byte offset for data (`DataOffset`) in dat and ivf file (previously only in Raw import dialog)
* ivf writer fix to handle unicode filenames
* ticpp fix for unicode filenames
* minor clean-up