### PR TITLE
Core: IndexMapper: Fix for incorrect operand order when converting 1D linear-index to 2D coords

### DIFF
--- a/include/inviwo/core/util/indexmapper.h
+++ b/include/inviwo/core/util/indexmapper.h
@@ -50,7 +50,7 @@ struct IndexMapper<2, IndexType> {
         return pos.x + pos.y * dimx;
     }
     constexpr Vector<2, IndexType> operator()(const IndexType index) const noexcept {
-        return Vector<2, IndexType>(index / dimx, index % dimx);
+        return Vector<2, IndexType>(index % dimx, index / dimx);
     }
 
 private:


### PR DESCRIPTION
Fix for incorrect operand order when converting 1D linear-index to 2D coords

Commit bc502d8201b9f52c63a4b1825b89cb1f116469b8 accidentally put them in the wrong order. 
