### PR TITLE
Core: NetworkEvaluator: Added a separate try/catch around port onchange for better error messages

### DIFF
--- a/include/inviwo/core/network/evaluationerrorhandler.h
+++ b/include/inviwo/core/network/evaluationerrorhandler.h
@@ -39,7 +39,7 @@ namespace inviwo {
 
 class Processor;
 
-enum class EvaluationType { InitResource, Process, NotReady };
+enum class EvaluationType { InitResource, PortOnChange, Process, NotReady };
 
 using EvaluationErrorHandler = std::function<void(Processor*, EvaluationType, ExceptionContext)>;
 

--- a/src/core/network/evaluationerrorhandler.cpp
+++ b/src/core/network/evaluationerrorhandler.cpp
@@ -39,6 +39,8 @@ void StandardEvaluationErrorHandler::operator()(Processor* processor, Evaluation
         switch (type) {
             case EvaluationType::InitResource:
                 return "InitializeResources";
+            case EvaluationType::PortOnChange:
+                return "PortOnChange";
             case EvaluationType::Process:
                 return "Process";
             case EvaluationType::NotReady:

--- a/src/core/network/processornetworkevaluator.cpp
+++ b/src/core/network/processornetworkevaluator.cpp
@@ -109,12 +109,20 @@ void ProcessorNetworkEvaluator::evaluate() {
                     if (processor->getInvalidationLevel() >= InvalidationLevel::InvalidResources) {
                         processor->initializeResources();
                     }
+
+                } catch (...) {
+                    exceptionHandler_(processor, EvaluationType::InitResource, IVW_CONTEXT);
+                    processor->setValid();
+                    continue;
+                }
+
+                try {
                     // call onChange for all invalid inports
                     for (auto inport : processor->getInports()) {
                         inport->callOnChangeIfChanged();
                     }
                 } catch (...) {
-                    exceptionHandler_(processor, EvaluationType::InitResource, IVW_CONTEXT);
+                    exceptionHandler_(processor, EvaluationType::PortOnChange, IVW_CONTEXT);
                     processor->setValid();
                     continue;
                 }


### PR DESCRIPTION
Added a separate try/catch around port on change for better error messages.

Before this PR it was possible to get an error message in the log saying an excetion was thrown while Initializing Resousources of a processor while the exception actually was thrown in a port on change. 
