### PR TITLE
Feature/shader fixes

### DIFF
--- a/modules/opengl/include/modules/opengl/shader/shader.h
+++ b/modules/opengl/include/modules/opengl/shader/shader.h
@@ -150,6 +150,7 @@ public:
 
     // Callback when the shader is reloaded. A reload can for example be triggered by a file change.
     const BaseCallBack *onReload(std::function<void()> callback);
+    std::shared_ptr<std::function<void()>> onReloadScoped(std::function<void()> callback);
     void removeOnReload(const BaseCallBack *callback);
 
 private:

--- a/modules/opengl/include/modules/opengl/shader/shader.h
+++ b/modules/opengl/include/modules/opengl/shader/shader.h
@@ -120,6 +120,7 @@ public:
     void link();
     void build();
     bool isReady() const;  // returns whether the shader has been built and linked successfully
+    bool checkLinkStatus() const;
 
     GLuint getID() const { return program_.id; }
 

--- a/modules/opengl/include/modules/opengl/shader/shader.h
+++ b/modules/opengl/include/modules/opengl/shader/shader.h
@@ -120,7 +120,6 @@ public:
     void link();
     void build();
     bool isReady() const;  // returns whether the shader has been built and linked successfully
-    bool checkLinkStatus() const;
 
     GLuint getID() const { return program_.id; }
 
@@ -162,6 +161,8 @@ private:
 
     void rebuildShader(ShaderObject *obj);
     void linkShader(bool notifyRebuild = false);
+    bool checkLinkStatus() const;
+
 
     static const transform_t transform;
     static const const_transform_t const_transform;

--- a/modules/opengl/include/modules/opengl/shader/shader.h
+++ b/modules/opengl/include/modules/opengl/shader/shader.h
@@ -163,7 +163,6 @@ private:
     void linkShader(bool notifyRebuild = false);
     bool checkLinkStatus() const;
 
-
     static const transform_t transform;
     static const const_transform_t const_transform;
 

--- a/modules/opengl/src/shader/shader.cpp
+++ b/modules/opengl/src/shader/shader.cpp
@@ -274,7 +274,7 @@ void Shader::linkShader(bool notifyRebuild) {
 
     glLinkProgram(program_.id);
 
-    if (!isReady()) {
+    if (!checkLinkStatus()) {
         throw OpenGLException("Id: " + toString(program_.id) + " " +
                                   processLog(utilgl::getProgramInfoLog(program_.id)),
                               IVW_CONTEXT);
@@ -370,7 +370,9 @@ std::string Shader::processLog(std::string log) const {
     return result.str();
 }
 
-bool Shader::isReady() const {
+bool Shader::isReady() const { return ready_ && checkLinkStatus(); }
+
+bool Shader::checkLinkStatus() const {
     GLint res;
     glGetProgramiv(program_.id, GL_LINK_STATUS, &res);
     return res == GL_TRUE;

--- a/modules/opengl/src/shader/shader.cpp
+++ b/modules/opengl/src/shader/shader.cpp
@@ -293,6 +293,12 @@ void Shader::linkShader(bool notifyRebuild) {
     if (notifyRebuild) onReloadCallback_.invokeAll();
 }
 
+bool Shader::checkLinkStatus() const {
+    GLint res;
+    glGetProgramiv(program_.id, GL_LINK_STATUS, &res);
+    return res == GL_TRUE;
+}
+
 void Shader::bindAttributes() {
     for (const auto &obj : getShaderObjects()) {
         for (const auto &item : obj.getInDeclarations()) {
@@ -370,13 +376,7 @@ std::string Shader::processLog(std::string log) const {
     return result.str();
 }
 
-bool Shader::isReady() const { return ready_ && checkLinkStatus(); }
-
-bool Shader::checkLinkStatus() const {
-    GLint res;
-    glGetProgramiv(program_.id, GL_LINK_STATUS, &res);
-    return res == GL_TRUE;
-}
+bool Shader::isReady() const { return ready_; }
 
 void Shader::activate() {
     if (!ready_)

--- a/modules/opengl/src/shader/shader.cpp
+++ b/modules/opengl/src/shader/shader.cpp
@@ -395,6 +395,10 @@ const BaseCallBack *Shader::onReload(std::function<void()> callback) {
     return onReloadCallback_.addLambdaCallback(callback);
 }
 
+std::shared_ptr<std::function<void()>> Shader::onReloadScoped(std::function<void()> callback) {
+    return onReloadCallback_.addLambdaCallbackRaii(callback);
+}
+
 void Shader::removeOnReload(const BaseCallBack *callback) { onReloadCallback_.remove(callback); }
 
 std::string Shader::shaderNames() const {


### PR DESCRIPTION
* Added onReloadScoped to Shader
* Renamed isReady to checkLinkStatus and introduced a new isReady. When Querying the GL_LINK_STATUS you get the result of the previous call to glLinkProgram, which will not have been called if a shader failed to compile.