### PR TITLE
Core: Removed deprecated methods from TransferFunction

### DIFF
--- a/include/inviwo/core/datastructures/transferfunction.h
+++ b/include/inviwo/core/datastructures/transferfunction.h
@@ -61,37 +61,6 @@ public:
     const Layer* getData() const;
     size_t getTextureSize() const;
 
-    // clang-format off
-    [[deprecated("was declared deprecated (20180418). Use `size()` instead")]]
-    size_t getNumPoints() const;
-
-    [[deprecated("was declared deprecated (20180418). Use `get(size_t i)` instead")]]
-    TFPrimitive* getPoint(size_t i);
-    [[deprecated("was declared deprecated (20180418). Use `get(size_t i) const` instead")]]
-    const TFPrimitive* getPoint(size_t i) const;
-
-    [[deprecated("was declared deprecated (20180418). Use `add(const double& pos, const vec4& color)` instead")]]
-    void addPoint(const float& pos, const vec4& color);
-
-    [[deprecated("was declared deprecated (20180418). Use `add(const TFPrimitiveData& data)` instead")]]
-    void addPoint(const TFPrimitiveData& point);
-
-    [[deprecated("was declared deprecated (20180418). Use `add(const dvec2& pos)` instead")]]
-    void addPoint(const vec2& pos);
-
-    [[deprecated("was declared deprecated (20180418). Use `add(const std::vector<TFPrimitiveData>& primitives)` instead")]]
-    void addPoints(const std::vector<TFPrimitiveData>& points);
-
-    [[deprecated("was declared deprecated (20180418). Use `add(const double& pos, const vec4& color)` instead")]]
-    void addPoint(const vec2& pos, const vec4& color);
-
-    [[deprecated("was declared deprecated (20180418). Use `remove(TFPrimitive* primitive)` instead")]]
-    void removePoint(TFPrimitive* dataPoint);
-
-    [[deprecated("was declared deprecated (20180418). Use `clear()` instead")]]
-    void clearPoints();
-    // clang-format on
-
     void setMaskMin(double maskMin);
     double getMaskMin() const;
     void setMaskMax(double maskMax);

--- a/src/core/datastructures/transferfunction.cpp
+++ b/src/core/datastructures/transferfunction.cpp
@@ -97,30 +97,6 @@ const Layer* TransferFunction::getData() const {
 
 size_t TransferFunction::getTextureSize() const { return dataRepr_->getDimensions().x; }
 
-size_t TransferFunction::getNumPoints() const { return size(); }
-
-const TFPrimitive* TransferFunction::getPoint(size_t i) const { return &get(i); }
-
-TFPrimitive* TransferFunction::getPoint(size_t i) { return &get(i); }
-
-void TransferFunction::addPoint(const vec2& pos) { add(pos); }
-
-void TransferFunction::addPoint(const vec2& pos, const vec4& color) {
-    add(TFPrimitiveData({pos.x, color}));
-}
-
-void TransferFunction::addPoint(const float& pos, const vec4& color) {
-    add(TFPrimitiveData({pos, color}));
-}
-
-void TransferFunction::addPoint(const TFPrimitiveData& point) { add(point); }
-
-void TransferFunction::addPoints(const std::vector<TFPrimitiveData>& points) { add(points); }
-
-void TransferFunction::removePoint(TFPrimitive* dataPoint) { remove(*dataPoint); }
-
-void TransferFunction::clearPoints() { clear(); }
-
 void TransferFunction::setMaskMin(double maskMin) {
     maskMin_ = maskMin;
     invalidate();


### PR DESCRIPTION
Various method in the TransferFunction class has been marked as deprecated for way over a year now. I keep getting annoyed when IntelliSense suggests them in the completion menu for TF objects. 