### PR TITLE
Core//UserInterfaceGL: Treat Stationary TouchState as click on TouchP…

### DIFF
--- a/include/inviwo/core/interaction/events/touchevent.h
+++ b/include/inviwo/core/interaction/events/touchevent.h
@@ -178,7 +178,7 @@ private:
 class IVW_CORE_API TouchEvent : public InteractionEvent {
 public:
     TouchEvent();
-    TouchEvent(const std::vector<TouchPoint>& touchPoints, const TouchDevice* source);
+    TouchEvent(const std::vector<TouchPoint>& touchPoints, const TouchDevice* source, KeyModifiers modifiers);
 
     virtual TouchEvent* clone() const override;
     virtual ~TouchEvent() = default;

--- a/include/inviwo/core/interaction/events/touchevent.h
+++ b/include/inviwo/core/interaction/events/touchevent.h
@@ -178,7 +178,8 @@ private:
 class IVW_CORE_API TouchEvent : public InteractionEvent {
 public:
     TouchEvent();
-    TouchEvent(const std::vector<TouchPoint>& touchPoints, const TouchDevice* source, KeyModifiers modifiers);
+    TouchEvent(const std::vector<TouchPoint>& touchPoints, const TouchDevice* source,
+               KeyModifiers modifiers);
 
     virtual TouchEvent* clone() const override;
     virtual ~TouchEvent() = default;

--- a/include/inviwo/core/interaction/events/touchstate.h
+++ b/include/inviwo/core/interaction/events/touchstate.h
@@ -42,10 +42,10 @@ namespace inviwo {
 
 enum class TouchState {
     None = 0,
-    Started = 1 << 0,     // Pressed
-    Updated = 1 << 1,     // Moved
-    Stationary = 1 << 2,  // No movement
-    Finished = 1 << 3,    // Released
+    Started = 1 << 0,     //!< Touches the surface of the TouchDevice
+    Updated = 1 << 1,     //!< Moved
+    Stationary = 1 << 2,  //!< No movement on TouchScreen, Pressed on TouchPad
+    Finished = 1 << 3,    //!< Released
 };
 
 ALLOW_FLAGS_FOR_ENUM(TouchState)

--- a/modules/basegl/src/viewmanager.cpp
+++ b/modules/basegl/src/viewmanager.cpp
@@ -181,7 +181,7 @@ bool ViewManager::propagateTouchEvent(TouchEvent* te, Propagator propagator) {
             p.setPressedPosNormalized(scale * (p.pressedPosNormalized() - offset));
         }
 
-        TouchEvent newEvent(points, te->getDevice());
+        TouchEvent newEvent(points, te->getDevice(), te->modifiers());
 
         propagator(&newEvent, viewId);
 

--- a/modules/openglqt/include/modules/openglqt/canvasqt.h
+++ b/modules/openglqt/include/modules/openglqt/canvasqt.h
@@ -488,7 +488,7 @@ bool CanvasQtBase<T>::mapTouchEvent(QTouchEvent* touch) {
         device = &(touchDevices_[touch->device()] =
                        TouchDevice(deviceType, (touch->device()->name().toStdString())));
     }
-    TouchEvent touchEvent(touchPoints, device);
+    TouchEvent touchEvent(touchPoints, device, utilqt::getModifiers(touch));
     touch->accept();
 
     lastNumFingers_ = static_cast<int>(touch->touchPoints().size());

--- a/modules/userinterfacegl/include/modules/userinterfacegl/processors/camerawidget.h
+++ b/modules/userinterfacegl/include/modules/userinterfacegl/processors/camerawidget.h
@@ -195,7 +195,7 @@ private:
     // UI state and textures
     bool isMouseBeingPressedAndHold_;
     bool mouseWasMoved_;
-    int activeWidgetID_;
+    int currentPickingID_;
 
     // initial state of camera when an interaction is triggered to keep the rotation axis consistent
     struct InitialState {

--- a/modules/userinterfacegl/src/glui/element.cpp
+++ b/modules/userinterfacegl/src/glui/element.cpp
@@ -337,69 +337,36 @@ void Element::updateLabel() {
 void Element::handlePickingEvent(PickingEvent *e) {
     bool triggerUpdate = false;
 
-    if (e->getEvent()->hash() == MouseEvent::chash()) {
-        auto mouseEvent = e->getEventAs<MouseEvent>();
-
-        bool leftMouseBtn = (mouseEvent->button() == MouseButton::Left);
-        bool mousePress = (mouseEvent->state() == MouseState::Press);
-        bool mouseRelease = (mouseEvent->state() == MouseState::Release);
-        bool mouseMove = (mouseEvent->state() == MouseState::Move);
-
-        if (e->getState() == PickingState::Started) {
-            setHoverState(true);
-            currentPickingID_ = e->getPickedId();
+    if (e->getState() == PickingState::Started) {
+        setHoverState(true);
+        currentPickingID_ = e->getPickedId();
+        triggerUpdate = true;
+    } else if (e->getState() == PickingState::Finished) {
+        // Releasing out of screen may not trigger PickingPressState::Release,
+        // so ensure that states are reset
+        setHoverState(false);
+        setPushedState(false);
+        currentPickingID_ = 0u;
+        triggerUpdate = true;
+    }
+    if (e->getPressState() != PickingPressState::None) {
+        if (e->getPressState() == PickingPressState::Move &&
+            e->getPressItems() & PickingPressItem::Primary) {
+            auto delta = e->getDeltaPressedPosition();
+            triggerUpdate = moveAction(delta * dvec2(e->getCanvasSize()));
+        } else if (e->getPressState() == PickingPressState::Press &&
+                   e->getPressItem() & PickingPressItem::Primary) {
+            // initial activation with button press
+            setPushedState(true);
             triggerUpdate = true;
-        } else if (e->getState() == PickingState::Finished) {
-            setHoverState(false);
+        } else if (e->getPressState() == PickingPressState::Release &&
+                   (e->getPressItem() & PickingPressItem::Primary) && isPushed()) {
+            // Button is released above the active element
+            triggerAction();
             setPushedState(false);
-            currentPickingID_ = 0u;
             triggerUpdate = true;
-        } else if (e->getState() == PickingState::Updated) {
-            if (mouseMove && (mouseEvent->buttonState() & MouseButton::Left) == MouseButton::Left) {
-                auto delta = e->getDeltaPressedPosition();
-                triggerUpdate = moveAction(delta * dvec2(e->getCanvasSize()));
-            } else if (leftMouseBtn) {
-                if (mousePress) {
-                    // initial activation with mouse button press
-                    setPushedState(true);
-                    triggerUpdate = true;
-                } else if (mouseRelease && isPushed()) {
-                    // mouse button is release upon the active element
-                    triggerAction();
-                    setPushedState(false);
-                    triggerUpdate = true;
-                }
-            }
-            e->markAsUsed();
         }
-    } else if (e->getEvent()->hash() == TouchEvent::chash()) {
-        auto touchEvent = e->getEventAs<TouchEvent>();
-
-        if (touchEvent->touchPoints().size() == 1) {
-            // allow interaction only for a single touch point
-            const auto &touchPoint = touchEvent->touchPoints().front();
-
-            if (touchPoint.state() == TouchState::Started) {
-                // initial activation since touch event began
-                setPushedState(true);
-                setHoverState(true);
-                currentPickingID_ = e->getPickedId();
-                triggerUpdate = true;
-            } else if (touchPoint.state() == TouchState::Finished) {
-                if (isPushed()) {
-                    // touch event has finished
-                    triggerAction();
-                    setPushedState(false);
-                }
-                setHoverState(false);
-                currentPickingID_ = 0u;
-                triggerUpdate = true;
-            } else if (touchPoint.state() == TouchState::Updated) {
-                const auto delta = touchPoint.pos() - touchPoint.pressedPos();
-                triggerUpdate = moveAction(delta);
-            }
-            e->markAsUsed();
-        }
+        e->markAsUsed();
     }
 
     if (pickingAction_) pickingAction_(e);

--- a/modules/userinterfacegl/src/processors/camerawidget.cpp
+++ b/modules/userinterfacegl/src/processors/camerawidget.cpp
@@ -361,7 +361,14 @@ void CameraWidget::objectPicked(PickingEvent *e) {
     bool triggerSingleEvent = false;
 
     if (e->getPressState() != PickingPressState::None) {
-        if (e->getPressState() == PickingPressState::Move &&
+        if (e->getPressState() == PickingPressState::Press &&
+                 e->getPressItem() & PickingPressItem::Primary) {
+            // initial activation with button press
+            isMouseBeingPressedAndHold_ = true;
+            mouseWasMoved_ = false;
+            currentPickingID_ = e->getPickedId();
+            saveInitialCameraState();
+        } else if (e->getPressState() == PickingPressState::Move &&
             e->getPressItems() & PickingPressItem::Primary) {
             // check whether mouse has been moved for more than 1 pixel
             if (!mouseWasMoved_) {
@@ -370,13 +377,6 @@ void CameraWidget::objectPicked(PickingEvent *e) {
                 mouseWasMoved_ = (squaredDist > 1.0);
             }
             triggerMoveEvent = true;
-        } else if (e->getPressState() == PickingPressState::Press &&
-                   e->getPressItem() & PickingPressItem::Primary) {
-            // initial activation with button press
-            isMouseBeingPressedAndHold_ = true;
-            mouseWasMoved_ = false;
-            currentPickingID_ = e->getPickedId();
-            saveInitialCameraState();
         } else if (e->getPressState() == PickingPressState::Release &&
                    e->getPressItem() & PickingPressItem::Primary) {
             triggerSingleEvent =

--- a/modules/userinterfacegl/src/processors/camerawidget.cpp
+++ b/modules/userinterfacegl/src/processors/camerawidget.cpp
@@ -359,7 +359,7 @@ void CameraWidget::objectPicked(PickingEvent *e) {
 
     bool triggerMoveEvent = false;
     bool triggerSingleEvent = false;
-   
+
     if (e->getPressState() != PickingPressState::None) {
         if (e->getPressState() == PickingPressState::Move &&
             e->getPressItems() & PickingPressItem::Primary) {
@@ -379,8 +379,8 @@ void CameraWidget::objectPicked(PickingEvent *e) {
             saveInitialCameraState();
         } else if (e->getPressState() == PickingPressState::Release &&
                    e->getPressItem() & PickingPressItem::Primary) {
-            triggerSingleEvent = (isMouseBeingPressedAndHold_ &&
-                                  (currentPickingID_ >= 0) && !mouseWasMoved_);
+            triggerSingleEvent =
+                (isMouseBeingPressedAndHold_ && (currentPickingID_ >= 0) && !mouseWasMoved_);
             isMouseBeingPressedAndHold_ = false;
             if (currentPickingID_ >= 0) {
                 currentPickingID_ = -1;

--- a/modules/userinterfacegl/src/processors/camerawidget.cpp
+++ b/modules/userinterfacegl/src/processors/camerawidget.cpp
@@ -362,14 +362,14 @@ void CameraWidget::objectPicked(PickingEvent *e) {
 
     if (e->getPressState() != PickingPressState::None) {
         if (e->getPressState() == PickingPressState::Press &&
-                 e->getPressItem() & PickingPressItem::Primary) {
+            e->getPressItem() & PickingPressItem::Primary) {
             // initial activation with button press
             isMouseBeingPressedAndHold_ = true;
             mouseWasMoved_ = false;
             currentPickingID_ = e->getPickedId();
             saveInitialCameraState();
         } else if (e->getPressState() == PickingPressState::Move &&
-            e->getPressItems() & PickingPressItem::Primary) {
+                   e->getPressItems() & PickingPressItem::Primary) {
             // check whether mouse has been moved for more than 1 pixel
             if (!mouseWasMoved_) {
                 const dvec2 delta(e->getDeltaPressedPosition() * dvec2(e->getCanvasSize()));

--- a/modules/userinterfacegl/src/processors/cropwidget.cpp
+++ b/modules/userinterfacegl/src/processors/cropwidget.cpp
@@ -470,11 +470,11 @@ void CropWidget::objectPicked(PickingEvent *e) {
             isMouseBeingPressedAndHold_ = true;
             lastState_ = cropAxes_[axisID].range.get();
         } else if (e->getPressState() == PickingPressState::Move &&
-            e->getPressItems() & PickingPressItem::Primary) {
+                   e->getPressItems() & PickingPressItem::Primary) {
             InteractionElement element =
-            static_cast<InteractionElement>(e->getPickedId() % numInteractionWidgets);
+                static_cast<InteractionElement>(e->getPickedId() % numInteractionWidgets);
             rangePositionHandlePicked(cropAxes_[axisID], e, element);
-        }  else if (e->getPressState() == PickingPressState::Release &&
+        } else if (e->getPressState() == PickingPressState::Release &&
                    e->getPressItem() & PickingPressItem::Primary) {
             isMouseBeingPressedAndHold_ = false;
             lastState_ = ivec2(-1);

--- a/modules/userinterfacegl/src/processors/cropwidget.cpp
+++ b/modules/userinterfacegl/src/processors/cropwidget.cpp
@@ -457,48 +457,29 @@ void CropWidget::updateBoundingCube() {
     }
 }
 
-void CropWidget::objectPicked(PickingEvent *p) {
-    const auto axisID = p->getPickedId() / static_cast<size_t>(numInteractionWidgets);
+void CropWidget::objectPicked(PickingEvent *e) {
+    const auto axisID = e->getPickedId() / static_cast<size_t>(numInteractionWidgets);
     if (axisID >= cropAxes_.size()) {
         LogWarn("invalid picking ID");
         return;
     }
-
-    if (p->getEvent()->hash() == MouseEvent::chash()) {
-        auto me = p->getEventAs<MouseEvent>();
-        if (me->buttonState() & MouseButton::Left) {
-            if (me->state() == MouseState::Press) {
-                isMouseBeingPressedAndHold_ = true;
-                lastState_ = cropAxes_[axisID].range.get();
-            } else if (me->state() == MouseState::Release) {
-                isMouseBeingPressedAndHold_ = false;
-                lastState_ = ivec2(-1);
-            } else if (me->state() == MouseState::Move) {
-
-                InteractionElement element =
-                    static_cast<InteractionElement>(p->getPickedId() % numInteractionWidgets);
-                rangePositionHandlePicked(cropAxes_[axisID], p, element);
-            }
-            me->markAsUsed();
+    if (e->getPressState() != PickingPressState::None) {
+        if (e->getPressState() == PickingPressState::Press &&
+            e->getPressItem() & PickingPressItem::Primary) {
+            // initial activation with button press
+            isMouseBeingPressedAndHold_ = true;
+            lastState_ = cropAxes_[axisID].range.get();
+        } else if (e->getPressState() == PickingPressState::Move &&
+            e->getPressItems() & PickingPressItem::Primary) {
+            InteractionElement element =
+            static_cast<InteractionElement>(e->getPickedId() % numInteractionWidgets);
+            rangePositionHandlePicked(cropAxes_[axisID], e, element);
+        }  else if (e->getPressState() == PickingPressState::Release &&
+                   e->getPressItem() & PickingPressItem::Primary) {
+            isMouseBeingPressedAndHold_ = false;
+            lastState_ = ivec2(-1);
         }
-    } else if (p->getEvent()->hash() == TouchEvent::chash()) {
-        auto touchEvent = p->getEventAs<TouchEvent>();
-
-        if (touchEvent->touchPoints().size() == 1) {
-            // allow interaction only for a single touch point
-            const auto &touchPoint = touchEvent->touchPoints().front();
-
-            if (touchPoint.state() == TouchState::Started) {
-                lastState_ = cropAxes_[axisID].range.get();
-            } else if (touchPoint.state() == TouchState::Finished) {
-                lastState_ = ivec2(-1);
-            } else if (touchPoint.state() == TouchState::Updated) {
-                InteractionElement element =
-                    static_cast<InteractionElement>(p->getPickedId() % numInteractionWidgets);
-                rangePositionHandlePicked(cropAxes_[axisID], p, element);
-            }
-            p->markAsUsed();
-        }
+        e->markAsUsed();
     }
 }
 

--- a/src/core/interaction/events/touchevent.cpp
+++ b/src/core/interaction/events/touchevent.cpp
@@ -107,8 +107,8 @@ TouchDevice::TouchDevice(DeviceType type, std::string name) : type_(type), name_
 
 TouchEvent::TouchEvent() = default;
 
-TouchEvent::TouchEvent(const std::vector<TouchPoint>& touchPoints, const TouchDevice* source)
-    : InteractionEvent(), touchPoints_(touchPoints), device_(source) {}
+TouchEvent::TouchEvent(const std::vector<TouchPoint>& touchPoints, const TouchDevice* source, KeyModifiers modifiers)
+    : InteractionEvent(modifiers), touchPoints_(touchPoints), device_(source) {}
 
 TouchEvent* TouchEvent::clone() const { return new TouchEvent(*this); }
 

--- a/src/core/interaction/events/touchevent.cpp
+++ b/src/core/interaction/events/touchevent.cpp
@@ -107,7 +107,8 @@ TouchDevice::TouchDevice(DeviceType type, std::string name) : type_(type), name_
 
 TouchEvent::TouchEvent() = default;
 
-TouchEvent::TouchEvent(const std::vector<TouchPoint>& touchPoints, const TouchDevice* source, KeyModifiers modifiers)
+TouchEvent::TouchEvent(const std::vector<TouchPoint>& touchPoints, const TouchDevice* source,
+                       KeyModifiers modifiers)
     : InteractionEvent(modifiers), touchPoints_(touchPoints), device_(source) {}
 
 TouchEvent* TouchEvent::clone() const { return new TouchEvent(*this); }

--- a/src/core/interaction/pickingcontroller.cpp
+++ b/src/core/interaction/pickingcontroller.cpp
@@ -116,7 +116,7 @@ void PickingController::propagateEvent(TouchEvent* e, EventPropagator* propagato
 
         auto ps = TouchEvent::getPickingState(points);
 
-        TouchEvent te(points, e->getDevice());
+        TouchEvent te(points, e->getDevice(), e->modifiers());
         auto prevPos = te.centerNDC();  // Need so save here since te might be modified
 
         size_t currentId = 0;   // TODO

--- a/src/core/interaction/pickingcontroller.cpp
+++ b/src/core/interaction/pickingcontroller.cpp
@@ -143,8 +143,12 @@ void PickingController::propagateEvent(TouchEvent* e, EventPropagator* propagato
                     });
                 if (nPressed == 0) {
                     return PickingPressItem::None;
-                } else {
+                } else if (nPressed == 1) {
                     return PickingPressItem::Primary;
+                } else if (nPressed == 2) {
+                    return PickingPressItem::Secondary;
+                } else {  // nPressed > 2
+                    return PickingPressItem::Tertiary;
                 }
             } else {
                 // Treat touch point on TouchScreen as "button down"

--- a/src/core/interaction/pickingcontroller.cpp
+++ b/src/core/interaction/pickingcontroller.cpp
@@ -143,12 +143,8 @@ void PickingController::propagateEvent(TouchEvent* e, EventPropagator* propagato
                     });
                 if (nPressed == 0) {
                     return PickingPressItem::None;
-                } else if (nPressed == 1) {
+                } else {
                     return PickingPressItem::Primary;
-                } else if (nPressed == 2) {
-                    return PickingPressItem::Secondary;
-                } else {  // nPressed > 2
-                    return PickingPressItem::Tertiary;
                 }
             } else {
                 // Treat touch point on TouchScreen as "button down"

--- a/src/core/interaction/pickingcontroller.cpp
+++ b/src/core/interaction/pickingcontroller.cpp
@@ -137,14 +137,17 @@ void PickingController::propagateEvent(TouchEvent* e, EventPropagator* propagato
         PickingPressItem pressItem = [points, e]() {
             if (e->getDevice()->getType() == TouchDevice::DeviceType::TouchPad) {
                 // Possible to press touchpads
-                auto nPressed = std::accumulate(points.begin(), points.end(), 0u, [](size_t v, const auto& p) -> size_t { return v + (p.state() == TouchState::Stationary ? 1 : 0); });
+                auto nPressed = std::accumulate(
+                    points.begin(), points.end(), 0u, [](size_t v, const auto& p) -> size_t {
+                        return v + (p.state() == TouchState::Stationary ? 1 : 0);
+                    });
                 if (nPressed == 0) {
                     return PickingPressItem::None;
                 } else if (nPressed == 1) {
                     return PickingPressItem::Primary;
                 } else if (nPressed == 2) {
                     return PickingPressItem::Secondary;
-                } else { // nPressed > 2
+                } else {  // nPressed > 2
                     return PickingPressItem::Tertiary;
                 }
             } else {
@@ -153,12 +156,10 @@ void PickingController::propagateEvent(TouchEvent* e, EventPropagator* propagato
             }
         }();
 
-        PickingEvent pickingEvent(
-            pickingIdToAction[pickingId], &te, ps,
-            pressState,
-            pressItem, PickingHoverState::None, pressItem,
-            pickingId, currentId, pressedId, previousId, tstate_.pickingIdToPressNDC[pickingId],
-            tstate_.pickingIdToPreviousNDC[pickingId]);
+        PickingEvent pickingEvent(pickingIdToAction[pickingId], &te, ps, pressState, pressItem,
+                                  PickingHoverState::None, pressItem, pickingId, currentId,
+                                  pressedId, previousId, tstate_.pickingIdToPressNDC[pickingId],
+                                  tstate_.pickingIdToPreviousNDC[pickingId]);
 
         propagator->propagateEvent(&pickingEvent, nullptr);
         if (pickingEvent.hasBeenUsed() || te.hasBeenUsed()) {

--- a/src/core/interaction/pickingcontroller.cpp
+++ b/src/core/interaction/pickingcontroller.cpp
@@ -122,11 +122,41 @@ void PickingController::propagateEvent(TouchEvent* e, EventPropagator* propagato
         size_t currentId = 0;   // TODO
         size_t pressedId = 0;   // TODO
         size_t previousId = 0;  // TODO
+        PickingPressState pressState = [ps]() {
+            switch (ps) {
+                case PickingState::Started:
+                    return PickingPressState::Press;
+                case PickingState::Updated:
+                    return PickingPressState::Move;
+                case PickingState::Finished:
+                    return PickingPressState::Release;
+                default:
+                    return PickingPressState::None;
+            }
+        }();
+        PickingPressItem pressItem = [points, e]() {
+            if (e->getDevice()->getType() == TouchDevice::DeviceType::TouchPad) {
+                // Possible to press touchpads
+                auto nPressed = std::accumulate(points.begin(), points.end(), 0u, [](size_t v, const auto& p) -> size_t { return v + (p.state() == TouchState::Stationary ? 1 : 0); });
+                if (nPressed == 0) {
+                    return PickingPressItem::None;
+                } else if (nPressed == 1) {
+                    return PickingPressItem::Primary;
+                } else if (nPressed == 2) {
+                    return PickingPressItem::Secondary;
+                } else { // nPressed > 2
+                    return PickingPressItem::Tertiary;
+                }
+            } else {
+                // Treat touch point on TouchScreen as "button down"
+                return PickingPressItem::Primary;
+            }
+        }();
 
         PickingEvent pickingEvent(
             pickingIdToAction[pickingId], &te, ps,
-            ps == PickingState::Started ? PickingPressState::Press : PickingPressState::Move,
-            PickingPressItem::Primary, PickingHoverState::None, PickingPressItem::Primary,
+            pressState,
+            pressItem, PickingHoverState::None, pressItem,
             pickingId, currentId, pressedId, previousId, tstate_.pickingIdToPressNDC[pickingId],
             tstate_.pickingIdToPreviousNDC[pickingId]);
 


### PR DESCRIPTION
…ad (Tested on Mac). Use PickingEvent states instead of converting to Mouse/TouchEvent in glUI Element and CameraWidget

- Needs to be tested on Windows
- Need to include touch event states similar to mouse states so that the pressStates preserves the original "button" starting the event sequence. 

These points need to be done before merging. 