### PR TITLE
Input-selection

### DIFF
--- a/include/inviwo/core/interaction/events/event.h
+++ b/include/inviwo/core/interaction/events/event.h
@@ -57,11 +57,25 @@ public:
      */
     virtual bool shouldPropagateTo(Inport* inport, Processor* processor, Outport* source);
 
-    void markAsUsed();
+    bool markAsUsed();
+    /**
+     * Returns the previous used state, and sets it to used;
+     */
     bool hasBeenUsed() const;
-    void markAsUnused();
+    /**
+     * Returns the previous used state, and sets it to unused;
+     */
+    bool markAsUnused();
 
-    void markAsVisited(Processor*);
+    /**
+     * Returns the previous used state, and sets it to 'isUsed';
+     */
+    bool setUsed(bool isUsed);
+
+    /**
+     * Returns false if the processor was already visited;
+     */
+    bool markAsVisited(Processor*);
     void markAsVisited(Event&);
     bool hasVisitedProcessor(Processor*) const;
     // Can be used to figure out where an event came from.
@@ -106,6 +120,26 @@ const EventType* Event::getAs() const {
         return static_cast<const EventType*>(this);
     }
     return nullptr;
+}
+
+inline bool Event::markAsUsed() {
+    const auto curr = used_;
+    used_ = true;
+    return curr;
+}
+
+inline bool Event::hasBeenUsed() const { return used_; }
+
+inline bool Event::markAsUnused() {
+    const auto curr = used_;
+    used_ = false;
+    return curr;
+}
+
+inline bool Event::setUsed(bool isUsed) {
+    const auto curr = used_;
+    used_ = isUsed;
+    return curr;
 }
 
 }  // namespace inviwo

--- a/include/inviwo/core/network/processornetworkevaluator.h
+++ b/include/inviwo/core/network/processornetworkevaluator.h
@@ -63,7 +63,7 @@ private:
 
     // ProcessorObserver overrides
     virtual void onProcessorSinkChanged(Processor*) override;
-    virtual void onProcessorActiveConnectionsChanged(Processor* ) override;
+    virtual void onProcessorActiveConnectionsChanged(Processor*) override;
 
     void requestEvaluate();
     void evaluate();

--- a/include/inviwo/core/network/processornetworkevaluator.h
+++ b/include/inviwo/core/network/processornetworkevaluator.h
@@ -63,6 +63,7 @@ private:
 
     // ProcessorObserver overrides
     virtual void onProcessorSinkChanged(Processor*) override;
+    virtual void onProcessorActiveConnectionsChanged(Processor* ) override;
 
     void requestEvaluate();
     void evaluate();

--- a/include/inviwo/core/ports/inport.h
+++ b/include/inviwo/core/ports/inport.h
@@ -160,7 +160,6 @@ protected:
      */
     virtual void setValid(const Outport* source);
 
-
     // Usually called with false (reset) by Processor::setValid after the Processor::process
     virtual void setChanged(bool changed = true, const Outport* source = nullptr);
 

--- a/include/inviwo/core/ports/inport.h
+++ b/include/inviwo/core/ports/inport.h
@@ -138,6 +138,13 @@ public:
     void removeOnConnect(const BaseCallBack* callback);
     void removeOnDisconnect(const BaseCallBack* callback);
 
+    /**
+     * Called by the connected outports to let the inport know that their ready status has
+     * changed.
+     */
+    void readyUpdate();
+    void setIsReadyUpdater(std::function<bool()> updater);
+
 protected:
     Inport(std::string identifier = "");
 
@@ -153,11 +160,6 @@ protected:
      */
     virtual void setValid(const Outport* source);
 
-    /**
-     * Called by the connected outports to let the inport know that their ready status has
-     * changed.
-     */
-    void readyUpdate();
 
     // Usually called with false (reset) by Processor::setValid after the Processor::process
     virtual void setChanged(bool changed = true, const Outport* source = nullptr);

--- a/include/inviwo/core/processors/processor.h
+++ b/include/inviwo/core/processors/processor.h
@@ -368,6 +368,8 @@ public:
     Inport* removePort(Inport* port);
     Outport* removePort(Outport* port);
 
+    virtual bool isConnectionActive(Inport*, Outport*) const { return true; }
+
 protected:
     std::unique_ptr<ProcessorWidget> processorWidget_;
     StateCoordinator<bool> isReady_;

--- a/include/inviwo/core/processors/processor.h
+++ b/include/inviwo/core/processors/processor.h
@@ -368,6 +368,15 @@ public:
     Inport* removePort(Inport* port);
     Outport* removePort(Outport* port);
 
+    /**
+     * Return true if ProcessorNetworkEvaluator should evaluate the connection during
+     * ProcessorNetwork traversal. An inactive connection will propagate invalidations and events but
+     * will not be processed. 
+     * Useful if the Processor has states in which it does not use an inport.
+     * @param This processor's inport
+     * @param Another processor's outport
+     * @see InputSelector for an example
+     */
     virtual bool isConnectionActive(Inport*, Outport*) const { return true; }
 
 protected:

--- a/include/inviwo/core/processors/processor.h
+++ b/include/inviwo/core/processors/processor.h
@@ -370,9 +370,9 @@ public:
 
     /**
      * Return true if ProcessorNetworkEvaluator should evaluate the connection during
-     * ProcessorNetwork traversal. An inactive connection will propagate invalidations and events but
-     * will not be processed. 
-     * Useful if the Processor has states in which it does not use an inport.
+     * ProcessorNetwork traversal. An inactive connection will propagate invalidations and events
+     * but will not be processed. Useful if the Processor has states in which it does not use an
+     * inport.
      * @param This processor's inport
      * @param Another processor's outport
      * @see InputSelector for an example

--- a/include/inviwo/core/processors/processorobserver.h
+++ b/include/inviwo/core/processors/processorobserver.h
@@ -89,6 +89,8 @@ public:
      * The processor argument is the modified processor
      */
     virtual void onProcessorReadyChanged(Processor*){};
+
+    virtual void onProcessorActiveConnectionsChanged(Processor*){};
 };
 
 /** \class ProcessorObservable
@@ -145,6 +147,9 @@ protected:
     }
     void notifyObserversReadyChange(Processor* p) {
         forEachObserver([&](ProcessorObserver* o) { o->onProcessorReadyChanged(p); });
+    }
+    void notifyObserversActiveConnectionsChange(Processor* p) {
+        forEachObserver([&](ProcessorObserver* o) { o->onProcessorActiveConnectionsChanged(p); });
     }
 };
 

--- a/include/inviwo/core/processors/processorobserver.h
+++ b/include/inviwo/core/processors/processorobserver.h
@@ -89,7 +89,11 @@ public:
      * The processor argument is the modified processor
      */
     virtual void onProcessorReadyChanged(Processor*){};
-
+    /**
+     * Called after a processor inport and its connected outport(s) changed active state.
+     * The processor argument is the modified processor
+     * @see Processor::isConnectionActive
+     */
     virtual void onProcessorActiveConnectionsChanged(Processor*){};
 };
 

--- a/modules/base/include/modules/base/processors/inputselector.h
+++ b/modules/base/include/modules/base/processors/inputselector.h
@@ -115,9 +115,8 @@ InputSelector<Inport, Outport>::InputSelector()
     inport_.onDisconnect([updateOptions]() { updateOptions(); });
 
     inport_.setIsReadyUpdater([this]() {
-        return selectedPort_.size() > 0 &&
-                   inport_.getConnectedOutports().size() > *selectedPort_ &&
-                   inport_.getConnectedOutports()[*selectedPort_]->isReady();
+        return selectedPort_.size() > 0 && inport_.getConnectedOutports().size() > *selectedPort_ &&
+               inport_.getConnectedOutports()[*selectedPort_]->isReady();
     });
 
     addProperty(selectedPort_);

--- a/modules/base/include/modules/base/processors/inputselector.h
+++ b/modules/base/include/modules/base/processors/inputselector.h
@@ -61,7 +61,7 @@ namespace inviwo {
  * \class InputSelector
  * \brief processor for selecting one of n connected inputs
  */
-template <typename Inport, typename Outport>
+template <typename InportType, typename OutportType>
 class InputSelector : public Processor {
 public:
     InputSelector();
@@ -71,16 +71,15 @@ public:
 
     virtual void process() override;
 
+    virtual bool isConnectionActive(Inport* from, Outport* to) const override;
+
 private:
     void portSettings();
 
-    Inport inport_;
-    Outport outport_;
+    InportType inport_;
+    OutportType outport_;
 
-    OptionPropertyInt selectedPort_;
-
-    void updateOptions();
-    bool updatedNedded_ = true;
+    OptionPropertySize_t selectedPort_;
 };
 
 template <typename Inport, typename Outport>
@@ -99,37 +98,49 @@ InputSelector<Inport, Outport>::InputSelector()
     addPort(inport_);
     addPort(outport_);
 
-    inport_.onConnect([&]() { updatedNedded_ = true; });
+    auto updateOptions = [this]() {
+        if (getNetwork()->isDeserializing()) return;
+        std::vector<OptionPropertySize_tOption> options;
 
-    inport_.onChange([&]() {
-        if (selectedPort_.size() != inport_.getConnectedOutports().size()) updatedNedded_ = true;
+        for (auto port : inport_.getConnectedOutports()) {
+            const auto id = port->getProcessor()->getIdentifier();
+            const auto dispName = port->getProcessor()->getDisplayName();
+            options.emplace_back(id, dispName, options.size());
+        }
+        selectedPort_.replaceOptions(options);
+        selectedPort_.setCurrentStateAsDefault();
+    };
+
+    inport_.onConnect([updateOptions]() { updateOptions(); });
+    inport_.onDisconnect([updateOptions]() { updateOptions(); });
+
+    inport_.setIsReadyUpdater([this]() {
+        return selectedPort_.size() > 0 &&
+                   inport_.getConnectedOutports().size() > *selectedPort_ &&
+                   inport_.getConnectedOutports()[*selectedPort_]->isReady();
     });
 
     addProperty(selectedPort_);
 
     selectedPort_.setSerializationMode(PropertySerializationMode::All);
-
     setAllPropertiesCurrentStateAsDefault();
-}
 
-template <typename Inport, typename Outport>
-void InputSelector<Inport, Outport>::updateOptions() {
-    std::vector<OptionPropertyIntOption> options;
-
-    for (auto port : inport_.getConnectedOutports()) {
-        auto id = port->getProcessor()->getIdentifier();
-        auto dispName = port->getProcessor()->getDisplayName();
-        options.emplace_back(id, dispName, static_cast<int>(options.size()));
-    }
-    selectedPort_.replaceOptions(options);
-    selectedPort_.setCurrentStateAsDefault();
-    updatedNedded_ = false;
+    selectedPort_.onChange([this]() {
+        inport_.readyUpdate();
+        this->notifyObserversActiveConnectionsChange(this);
+    });
 }
 
 template <typename Inport, typename Outport>
 void InputSelector<Inport, Outport>::process() {
-    if (updatedNedded_) updateOptions();
     outport_.setData(inport_.getVectorData().at(selectedPort_.get()));
+}
+
+template <typename InportType, typename OutportType>
+bool InputSelector<InportType, OutportType>::isConnectionActive(Inport* from, Outport* to) const {
+    IVW_ASSERT(from == &inport_, "only one inport");
+    return from->getConnectedOutports().size() > *selectedPort_ &&
+           from->getConnectedOutports()[*selectedPort_] == to;
 }
 
 template <>

--- a/modules/webbrowser/src/webbrowserapp.cpp
+++ b/modules/webbrowser/src/webbrowserapp.cpp
@@ -33,7 +33,7 @@ namespace inviwo {
 
 WebBrowserApp::WebBrowserApp() = default;
 
-void WebBrowserApp::OnBeforeCommandLineProcessing(const CefString& process_type,
+void WebBrowserApp::OnBeforeCommandLineProcessing(const CefString&,
                                                   CefRefPtr<CefCommandLine> command_line) {
     command_line->AppendSwitch("allow-file-access-from-files");
 }

--- a/src/core/interaction/events/event.cpp
+++ b/src/core/interaction/events/event.cpp
@@ -37,7 +37,6 @@ bool Event::shouldPropagateTo(Inport* /*inport*/, Processor* /*processor*/, Outp
     return true;
 }
 
-
 bool Event::markAsVisited(Processor* p) { return util::push_back_unique(visitedProcessors_, p); }
 
 void Event::markAsVisited(Event& e) {

--- a/src/core/interaction/events/event.cpp
+++ b/src/core/interaction/events/event.cpp
@@ -37,13 +37,8 @@ bool Event::shouldPropagateTo(Inport* /*inport*/, Processor* /*processor*/, Outp
     return true;
 }
 
-void Event::markAsUsed() { used_ = true; }
 
-bool Event::hasBeenUsed() const { return used_; }
-
-void Event::markAsUnused() { used_ = false; }
-
-void Event::markAsVisited(Processor* p) { util::push_back_unique(visitedProcessors_, p); }
+bool Event::markAsVisited(Processor* p) { return util::push_back_unique(visitedProcessors_, p); }
 
 void Event::markAsVisited(Event& e) {
     visitedProcessors_.reserve(visitedProcessors_.size() + e.visitedProcessors_.size());

--- a/src/core/network/networkutils.cpp
+++ b/src/core/network/networkutils.cpp
@@ -98,6 +98,25 @@ std::vector<Processor*> topologicalSort(ProcessorNetwork* network) {
     return sorted;
 }
 
+std::vector<Processor*> topologicalSortFiltered(ProcessorNetwork* network) {
+    // perform topological sorting and store processor order in sorted
+
+    std::vector<Processor*> sinkProcessors;
+    util::copy_if(network->getProcessors(), std::back_inserter(sinkProcessors),
+                  [](Processor* p) { return p->isSink(); });
+
+    std::unordered_set<Processor*> state;
+    std::vector<Processor*> sorted;
+    for (auto processor : sinkProcessors) {
+        traverseNetwork<TraversalDirection::Up, VisitPattern::Post>(
+            state, processor, [&sorted](Processor* p) { sorted.push_back(p); },
+            [](Processor* p, Inport* from, Outport* to) {
+                return p->isConnectionActive(from, to);
+            });
+    }
+    return sorted;
+}
+
 std::vector<ivec2> getPositions(const std::vector<Processor*>& processors) {
     return util::transform(processors, [](Processor* p) { return getPosition(p); });
 }

--- a/src/core/network/processornetworkevaluator.cpp
+++ b/src/core/network/processornetworkevaluator.cpp
@@ -40,7 +40,7 @@ namespace inviwo {
 
 ProcessorNetworkEvaluator::ProcessorNetworkEvaluator(ProcessorNetwork* processorNetwork)
     : processorNetwork_(processorNetwork)
-    , processorsSorted_(util::topologicalSort(processorNetwork_))
+    , processorsSorted_(util::topologicalSortFiltered(processorNetwork_))
     , evaulationQueued_(false)
     , exceptionHandler_(StandardEvaluationErrorHandler()) {
 
@@ -158,25 +158,29 @@ void ProcessorNetworkEvaluator::evaluate() {
 }
 
 void ProcessorNetworkEvaluator::onProcessorSinkChanged(Processor*) {
-    processorsSorted_ = util::topologicalSort(processorNetwork_);
+    processorsSorted_ = util::topologicalSortFiltered(processorNetwork_);
+}
+
+void ProcessorNetworkEvaluator::onProcessorActiveConnectionsChanged(Processor*) {
+    processorsSorted_ = util::topologicalSortFiltered(processorNetwork_);
 }
 
 void ProcessorNetworkEvaluator::onProcessorNetworkDidAddProcessor(Processor* p) {
     p->ProcessorObservable::addObserver(this);
-    processorsSorted_ = util::topologicalSort(processorNetwork_);
+    processorsSorted_ = util::topologicalSortFiltered(processorNetwork_);
 }
 
 void ProcessorNetworkEvaluator::onProcessorNetworkDidRemoveProcessor(Processor* p) {
     p->ProcessorObservable::removeObserver(this);
-    processorsSorted_ = util::topologicalSort(processorNetwork_);
+    processorsSorted_ = util::topologicalSortFiltered(processorNetwork_);
 }
 
 void ProcessorNetworkEvaluator::onProcessorNetworkDidAddConnection(const PortConnection&) {
-    processorsSorted_ = util::topologicalSort(processorNetwork_);
+    processorsSorted_ = util::topologicalSortFiltered(processorNetwork_);
 }
 
 void ProcessorNetworkEvaluator::onProcessorNetworkDidRemoveConnection(const PortConnection&) {
-    processorsSorted_ = util::topologicalSort(processorNetwork_);
+    processorsSorted_ = util::topologicalSortFiltered(processorNetwork_);
 }
 
 }  // namespace inviwo

--- a/src/core/ports/inport.cpp
+++ b/src/core/ports/inport.cpp
@@ -81,9 +81,12 @@ void Inport::propagateEvent(Event* event, Outport* target) {
     if (target) {
         target->propagateEvent(event, this);
     } else {
+        bool used = event->hasBeenUsed();
         for (auto outport : getConnectedOutports()) {
             outport->propagateEvent(event, this);
+            used |= event->markAsUnused();
         }
+        event->setUsed(used);
     }
 }
 
@@ -167,6 +170,10 @@ const BaseCallBack* Inport::onDisconnect(std::function<void()> lambda) {
 }
 void Inport::removeOnDisconnect(const BaseCallBack* callback) {
     onDisconnectCallback_.remove(callback);
+}
+
+void Inport::setIsReadyUpdater(std::function<bool()> updater) {
+    isReady_.setUpdate(std::move(updater));
 }
 
 }  // namespace inviwo

--- a/src/core/processors/processor.cpp
+++ b/src/core/processors/processor.cpp
@@ -405,21 +405,19 @@ void Processor::invokeEvent(Event* event) {
 }
 
 void Processor::propagateEvent(Event* event, Outport* source) {
-    if (event->hasVisitedProcessor(this)) return;
-    event->markAsVisited(this);
+    if (!event->markAsVisited(this)) return;
 
     invokeEvent(event);
-    if (event->hasBeenUsed()) return;
-
     bool used = event->hasBeenUsed();
+    if (used) return;
+
     for (auto inport : getInports()) {
         if (event->shouldPropagateTo(inport, this, source)) {
             inport->propagateEvent(event);
-            used |= event->hasBeenUsed();
-            event->markAsUnused();
+            used |= event->markAsUnused();
         }
     }
-    if (used) event->markAsUsed();
+    event->setUsed(used);
 }
 
 std::vector<std::string> Processor::getPath() const {


### PR DESCRIPTION
Make the input selector processsor only evaluare the input that is currently used, by addig a customiation point to the topological sort in the evaluator. A processor can no overload isConnectionActive to specify if a specific connected outport wont be used, and then should not need to be evaluated.
