### PR TITLE
BaseGL: ImageLayout deactive zero-sized layout elements to prevent Op…

### DIFF
--- a/modules/basegl/include/modules/basegl/processors/imageprocessing/imagelayoutgl.h
+++ b/modules/basegl/include/modules/basegl/processors/imageprocessing/imagelayoutgl.h
@@ -104,6 +104,13 @@ public:
 
     virtual void propagateEvent(Event*, Outport* source) override;
 
+    /**
+     * Return true if dimensions of connected port is greater than zero.
+     * @param This processor's inport
+     * @param Another processor's outport
+     */
+    virtual bool isConnectionActive(Inport*, Outport*) const override;
+
 protected:
     virtual void process() override;
 
@@ -120,6 +127,7 @@ private:
     FloatProperty vertical3Left1RightSplitter_;
     FloatProperty vertical3Right1LeftSplitter_;
 
+    CompositeProperty bounds_;
     // Bounds for vertical splitters
     IntMinMaxProperty leftMinMax_;
     IntMinMaxProperty rightMinMax_;

--- a/modules/basegl/include/modules/basegl/processors/imageprocessing/imagelayoutgl.h
+++ b/modules/basegl/include/modules/basegl/processors/imageprocessing/imagelayoutgl.h
@@ -35,6 +35,7 @@
 #include <inviwo/core/processors/processor.h>
 #include <inviwo/core/interaction/events/mouseevent.h>
 #include <inviwo/core/properties/boolproperty.h>
+#include <inviwo/core/properties/compositeproperty.h>
 #include <inviwo/core/properties/minmaxproperty.h>
 #include <inviwo/core/properties/optionproperty.h>
 #include <inviwo/core/properties/ordinalproperty.h>

--- a/modules/basegl/src/processors/imageprocessing/imagelayoutgl.cpp
+++ b/modules/basegl/src/processors/imageprocessing/imagelayoutgl.cpp
@@ -261,9 +261,18 @@ void ImageLayoutGL::onStatusChange(bool propagate) {
     }
 }
 
-inline bool ImageLayoutGL::isConnectionActive(Inport*, Outport* from) const {
-    auto p = static_cast<ImageOutport*>(from);
-    return !glm::any(glm::equal(p->getDimensions(), size2_t(0)));
+inline bool ImageLayoutGL::isConnectionActive(Inport* from, Outport* to) const {
+    IVW_ASSERT(from == &multiinport_, "only one inport");
+    const auto ports = multiinport_.getConnectedOutports();
+    auto portIt = std::find(ports.begin(), ports.end(), to);
+    auto id = static_cast<size_t>(std::distance(ports.begin(), portIt));
+    if (id < viewManager_.size()) {
+        // Note: We cannot use Outport dimensions since it might not exist
+        return !glm::any(glm::equal(viewManager_.getViews()[id].size, ivec2(0)));
+    } else {
+        // More connections than views
+        return false;
+    }
 }
 
 void ImageLayoutGL::process() {

--- a/modules/basegl/src/processors/imageprocessing/imagelayoutgl.cpp
+++ b/modules/basegl/src/processors/imageprocessing/imagelayoutgl.cpp
@@ -93,21 +93,18 @@ ImageLayoutGL::ImageLayoutGL()
         // Ports with zero dimensions will not be active,
         // so disregard them when considering ready status
         return multiinport_.isConnected() &&
-               util::all_of(
-                   multiinport_.getConnectedOutports(), [](Outport* p) {
-                       auto ip = static_cast<ImageOutport*>(p);
-                       return (ip->hasData() && glm::any(glm::equal(
-                                ip->getDimensions(),
-                                size2_t(0))))
-                                ? true
-                                : p->isReady();
-                   });
+               util::all_of(multiinport_.getConnectedOutports(), [](Outport* p) {
+                   auto ip = static_cast<ImageOutport*>(p);
+                   return (ip->hasData() && glm::any(glm::equal(ip->getDimensions(), size2_t(0))))
+                              ? true
+                              : p->isReady();
+               });
     });
     // Ensure that viewports are up-to-date
     // before isConnectionActive is called
     multiinport_.onConnect([this]() { updateViewports(currentDim_, true); });
     multiinport_.onDisconnect([this]() { updateViewports(currentDim_, true); });
-    
+
     addPort(outport_);
 
     addProperty(layout_);
@@ -337,7 +334,7 @@ void ImageLayoutGL::updateViewports(ivec2 dim, bool force) {
         leftBounds.x, leftBounds.y);
     const int midy = glm::clamp(
         static_cast<int>(glm::clamp(*horizontalSplitter_, bottomMinMax.x, bottomMinMax.y) * dim.y),
-       bottomBounds.x, bottomBounds.y);
+        bottomBounds.x, bottomBounds.y);
 
     const int leftWindow3L1RX = glm::clamp(
         static_cast<int>(glm::clamp(*vertical3Left1RightSplitter_, rightMinMax.x, rightMinMax.y) *


### PR DESCRIPTION
…enGL errors. Cap min/max to output dimensions. 

Also performance improvement due to prevension of setVisible state switching
