### PR TITLE
Jenkins: Use inviwo team user as authorwhen commiting auto format

### DIFF
--- a/tools/jenkins/check-format.py
+++ b/tools/jenkins/check-format.py
@@ -127,7 +127,8 @@ def main():
         if repo.is_dirty():
             print("There were format fixes, pushing changes")
             repo.git.add(update=True)
-            repo.index.commit("Jenkins: Format fixes")    
+            ivwteam = git.Actor("Inviwo Team", "team@inviwo.org")
+            repo.index.commit("Jenkins: Format fixes", author=ivwteam, committer=ivwteam)    
             repo.remotes.origin.push()
             # remove outfile if wha have fixed formatting
             output = pathlib.Path(args.output)


### PR DESCRIPTION
Using the Inviwo team user as committer for auto format commits. 
It works, **BUT** the Inviwo-team user needs to ~~sign the CLA~~ be whitelisted at CLAassistant 
Also, maybe it shouldn't be the Inviwo-team user but a Jenkins Bot user (or similar) 

Tested in https://github.com/inviwo/inviwo/pull/724 
