### PR TITLE
Assimp/Fontrendering: Get rid of CMake warning CMP0042 and fix packag…

### DIFF
--- a/modules/assimp/ext/assimp/CMakeLists.txt
+++ b/modules/assimp/ext/assimp/CMakeLists.txt
@@ -27,6 +27,8 @@ add_subdirectory(assimp)
 ivw_move_targets_in_dir_to_folder(${CMAKE_CURRENT_SOURCE_DIR} ext/assimp)
 ivw_get_targets_in_dir_recursive(targets ${CMAKE_CURRENT_SOURCE_DIR})
 ivw_suppress_compiler_warnings(${targets})
-    
+set_target_properties(${targets} PROPERTIES MACOSX_RPATH ON)
+ivw_default_install_targets(${targets})
+
 # debug
 #ivw_print_targets_in_dir_recursive(${CMAKE_CURRENT_SOURCE_DIR})

--- a/modules/assimp/ext/assimp/CMakeLists.txt
+++ b/modules/assimp/ext/assimp/CMakeLists.txt
@@ -28,7 +28,6 @@ ivw_move_targets_in_dir_to_folder(${CMAKE_CURRENT_SOURCE_DIR} ext/assimp)
 ivw_get_targets_in_dir_recursive(targets ${CMAKE_CURRENT_SOURCE_DIR})
 ivw_suppress_compiler_warnings(${targets})
 set_target_properties(${targets} PROPERTIES MACOSX_RPATH ON)
-ivw_default_install_targets(${targets})
 
 # debug
 #ivw_print_targets_in_dir_recursive(${CMAKE_CURRENT_SOURCE_DIR})

--- a/modules/assimp/ext/assimp/CMakeLists.txt
+++ b/modules/assimp/ext/assimp/CMakeLists.txt
@@ -27,6 +27,8 @@ add_subdirectory(assimp)
 ivw_move_targets_in_dir_to_folder(${CMAKE_CURRENT_SOURCE_DIR} ext/assimp)
 ivw_get_targets_in_dir_recursive(targets ${CMAKE_CURRENT_SOURCE_DIR})
 ivw_suppress_compiler_warnings(${targets})
+# Required when INSTALL_NAME_DIR is set
+# https://blog.kitware.com/upcoming-in-cmake-2-8-12-osx-rpath-support/
 set_target_properties(${targets} PROPERTIES MACOSX_RPATH ON)
 
 # debug

--- a/modules/dataframe/src/dataframemodule.cpp
+++ b/modules/dataframe/src/dataframemodule.cpp
@@ -63,7 +63,7 @@ DataFrameModule::DataFrameModule(InviwoApplication* app) : InviwoModule(app, "Da
     // Properties
     registerProperty<ColormapProperty>();
     registerProperty<DataFrameColumnProperty>();
-    
+
     // Readers and writes
     registerDataReader(std::make_unique<CSVReader>());
     registerDataReader(std::make_unique<JSONDataFrameReader>());

--- a/modules/dataframe/src/dataframemodule.cpp
+++ b/modules/dataframe/src/dataframemodule.cpp
@@ -36,11 +36,12 @@
 #include <inviwo/dataframe/processors/syntheticdataframe.h>
 #include <inviwo/dataframe/processors/volumetodataframe.h>
 #include <inviwo/dataframe/processors/volumesequencetodataframe.h>
-
 #include <inviwo/dataframe/properties/colormapproperty.h>
 
 #include <inviwo/dataframe/io/csvreader.h>
 #include <inviwo/dataframe/io/jsonreader.h>
+
+#include <inviwo/core/properties/propertyconverter.h>
 
 #include <modules/json/jsonmodule.h>
 
@@ -62,12 +63,13 @@ DataFrameModule::DataFrameModule(InviwoApplication* app) : InviwoModule(app, "Da
     // Properties
     registerProperty<ColormapProperty>();
     registerProperty<DataFrameColumnProperty>();
-
+    
     // Readers and writes
     registerDataReader(std::make_unique<CSVReader>());
     registerDataReader(std::make_unique<JSONDataFrameReader>());
 
     // Data converters
+    registerPropertyConverter(std::make_unique<OptionToStringConverter<DataFrameColumnProperty>>());
     app->getModuleByType<JSONModule>()->registerPropertyJSONConverter<DataFrameColumnProperty>();
 }
 

--- a/modules/fontrendering/ext/freetype/CMakeLists.txt
+++ b/modules/fontrendering/ext/freetype/CMakeLists.txt
@@ -1,8 +1,11 @@
-add_subdirectory(freetype)
+# Use our own packaging/install locations
+set(SKIP_INSTALL_ALL TRUE)
 
-#--------------------------------------------------------------------
-# Supress warnings
-ivw_suppress_compiler_warnings(freetype)
+add_subdirectory(freetype)
+ivw_get_targets_in_dir_recursive(targets ${CMAKE_CURRENT_SOURCE_DIR})
+ivw_suppress_compiler_warnings(${targets})
+set_target_properties(${targets} PROPERTIES MACOSX_RPATH ON)
+ivw_default_install_targets(${targets})
 
 #--------------------------------------------------------------------
 # Creates VS folder structure
@@ -11,5 +14,5 @@ ivw_folder(freetype ext)
 
 #--------------------------------------------------------------------
 # Make package (for other projects to find)
-#ivw_default_install_targets(freetype)
 ivw_make_package(Freetype freetype)
+

--- a/modules/glfw/ext/glfw/CMakeLists.txt
+++ b/modules/glfw/ext/glfw/CMakeLists.txt
@@ -1,10 +1,12 @@
 option(GLFW_BUILD_EXAMPLES "Build the GLFW example programs" OFF)
 option(GLFW_BUILD_TESTS "Build the GLFW test programs" OFF)
 option(GLFW_BUILD_DOCS "Build the GLFW documentation" OFF)
-option(GLFW_INSTALL "Generate installation target" ON)
+option(GLFW_INSTALL "Generate installation target" OFF)
 option(GLFW_DOCUMENT_INTERNALS "Include internals in documentation" OFF)
 
 add_subdirectory(glfw)
 ivw_folder(glfw ext)
 
-ivw_suppress_compiler_warnings(glfw)
+ivw_get_targets_in_dir_recursive(targets ${CMAKE_CURRENT_SOURCE_DIR})
+ivw_suppress_compiler_warnings(${targets})
+ivw_default_install_targets(${targets})


### PR DESCRIPTION
…ing paths

Fixed the following errors I got when trying to run packaging on Mac:
  '@rpath/libfreetyped.6.dylib': No such file or directory


Also sneaked in DataFrameColumnProperty converter