### PR TITLE
Feature/sphereselection

### DIFF
--- a/modules/basegl/depends.cmake
+++ b/modules/basegl/depends.cmake
@@ -3,5 +3,6 @@
 set(dependencies
     InviwoOpenGLModule
     InviwoBaseModule
+	InviwoBrushingAndLinkingModule
 )
 set(EnableByDefault ON)

--- a/modules/basegl/glsl/sphereglyph.vert
+++ b/modules/basegl/glsl/sphereglyph.vert
@@ -37,6 +37,10 @@ uniform vec4 defaultColor = vec4(1, 0, 0, 1);
 uniform float defaultRadius = 0.1f;
 uniform sampler2D metaColor;
 
+uniform float selectionMix = 0.0;
+uniform float selectionScaleFactor = 1.0;
+uniform vec4 selectionColor = vec4(1.0, 0.769, 0.247, 1.0);
+
 out vec4 worldPosition_;
 out vec4 sphereColor_;
 flat out float sphereRadius_;
@@ -50,12 +54,14 @@ void main(void) {
 #else
     sphereColor_ = defaultColor;
 #endif
+    sphereColor_ = mix(sphereColor_, selectionColor, selectionMix);
 
 #if defined(HAS_RADII) && !defined(FORCE_RADIUS)
     sphereRadius_ = in_Radii;
 #else 
     sphereRadius_ = defaultRadius;
 #endif
+    sphereRadius_ = mix(sphereRadius_, sphereRadius_ * selectionScaleFactor, selectionMix);
 
 #if defined(HAS_PICKING)
     pickID_ = in_Picking;

--- a/modules/basegl/include/modules/basegl/processors/sphererenderer.h
+++ b/modules/basegl/include/modules/basegl/processors/sphererenderer.h
@@ -27,8 +27,7 @@
  *
  *********************************************************************************/
 
-#ifndef IVW_SPHERERENDERER_H
-#define IVW_SPHERERENDERER_H
+#pragma once
 
 #include <modules/basegl/baseglmoduledefine.h>
 #include <inviwo/core/common/inviwo.h>
@@ -40,11 +39,13 @@
 #include <inviwo/core/properties/ordinalproperty.h>
 #include <inviwo/core/properties/boolproperty.h>
 #include <inviwo/core/properties/compositeproperty.h>
+#include <inviwo/core/properties/boolcompositeproperty.h>
 #include <inviwo/core/properties/optionproperty.h>
 #include <inviwo/core/properties/simplelightingproperty.h>
 #include <inviwo/core/properties/transferfunctionproperty.h>
 #include <modules/opengl/shader/shader.h>
 #include <modules/basegl/datastructures/meshshadercache.h>
+#include <modules/brushingandlinking/ports/brushingandlinkingports.h>
 
 namespace inviwo {
 
@@ -115,6 +116,7 @@ private:
 
     MeshFlatMultiInport inport_;
     ImageInport imageInport_;
+    BrushingAndLinkingInport brushLinkPort_;
     ImageOutport outport_;
 
     TemplateOptionProperty<RenderMode> renderMode_;
@@ -132,6 +134,10 @@ private:
     BoolProperty useMetaColor_;
     TransferFunctionProperty metaColor_;
 
+    BoolCompositeProperty selectionProperties_;
+    FloatVec4Property selectionColor_;
+    FloatProperty selectionRadiusFactor_;
+
     CameraProperty camera_;
     CameraTrackball trackball_;
     SimpleLightingProperty lighting_;
@@ -140,5 +146,3 @@ private:
 };
 
 }  // namespace inviwo
-
-#endif  // IVW_SPHERERENDERER_H

--- a/modules/plottinggl/src/plotters/scatterplotgl.cpp
+++ b/modules/plottinggl/src/plotters/scatterplotgl.cpp
@@ -246,7 +246,7 @@ void ScatterPlotGL::plot(const size2_t& dims, IndexBuffer* indexBuffer, bool use
 
     if (radius_) {
         shader_.setUniform("minmaxR", minmaxR_);
-        shader_.setUniform("has_radius", (minmaxR_.x != minmaxR_.y ? 1: 0));
+        shader_.setUniform("has_radius", (minmaxR_.x != minmaxR_.y ? 1 : 0));
 
         auto rbuf = radius_->getRepresentation<BufferGL>();
         auto rbufObj = rbuf->getBufferObject();

--- a/modules/plottinggl/src/plotters/scatterplotgl.cpp
+++ b/modules/plottinggl/src/plotters/scatterplotgl.cpp
@@ -246,7 +246,7 @@ void ScatterPlotGL::plot(const size2_t& dims, IndexBuffer* indexBuffer, bool use
 
     if (radius_) {
         shader_.setUniform("minmaxR", minmaxR_);
-        shader_.setUniform("has_radius", 1);
+        shader_.setUniform("has_radius", (minmaxR_.x != minmaxR_.y ? 1: 0));
 
         auto rbuf = radius_->getRepresentation<BufferGL>();
         auto rbufObj = rbuf->getBufferObject();


### PR DESCRIPTION
SphereRenderer processor showing selected indices via enlarged and colored sphere glyphs. Selected indices are provided by a Brushing and Linking port (only rendering, no active selection!).

**Note:** at the moment it only supports selection in the first mesh and there is no index mapping, i.e. selection IDs must match with vertex IDs (starting from 0).

<img src='https://user-images.githubusercontent.com/9251300/66136285-81475b00-e5fb-11e9-8729-5ece8fa12f75.png' width='600px'/>
