### PR TITLE
Base: Fix writing of byte offset in DatVolumeWriter

### DIFF
--- a/modules/base/src/io/datvolumewriter.cpp
+++ b/modules/base/src/io/datvolumewriter.cpp
@@ -69,7 +69,7 @@ void DatVolumeWriter::writeData(const Volume* data, const std::string filePath) 
     writeKeyToString(ss, "RawFile", fileName + ".raw");
     writeKeyToString(ss, "Resolution", vr->getDimensions());
     writeKeyToString(ss, "Format", vr->getDataFormatString());
-    writeKeyToString(ss, "ByteOffset", 0);
+    writeKeyToString(ss, "ByteOffset", "0");
     writeKeyToString(ss, "BasisVector1", basis[0]);
     writeKeyToString(ss, "BasisVector2", basis[1]);
     writeKeyToString(ss, "BasisVector3", basis[2]);


### PR DESCRIPTION
Writing the byte offset caused a runtime error as the 0 passed to the std::string constructor is interpreted as a char*

**Always**
- [x] Code is error and warning free
- [x] Code follows the [Inviwo coding guidelines](https://github.com/inviwo/inviwo/wiki/Coding-Conventions)

**Updated feature / Fixes** 
- [x] Relevant documentation has been updated

**What environment has the code been compiled and tested on?** 
- Windows 10 64 bit
- Visual Studio 15 2017 [Release+Debug]
- Qt Version 5.13.1
- CMake 3.13.2
