### PR TITLE
Plotting,PlottingGL: resolved getVisible() overload issue

### DIFF
--- a/modules/plotting/include/modules/plotting/datastructures/axisdata.h
+++ b/modules/plotting/include/modules/plotting/datastructures/axisdata.h
@@ -70,7 +70,7 @@ public:
     virtual dvec2 getRange() const override;
     virtual bool getUseDataRange() const override;
 
-    virtual bool getVisible() const override;
+    virtual bool getAxisVisible() const override;
     virtual bool getFlipped() const override;
     virtual vec4 getColor() const override;
     virtual float getWidth() const override;

--- a/modules/plotting/include/modules/plotting/datastructures/axissettings.h
+++ b/modules/plotting/include/modules/plotting/datastructures/axissettings.h
@@ -50,7 +50,7 @@ public:
     virtual dvec2 getRange() const = 0;
     virtual bool getUseDataRange() const = 0;
 
-    virtual bool getVisible() const = 0;
+    virtual bool getAxisVisible() const = 0;
     virtual bool getFlipped() const = 0;
     virtual vec4 getColor() const = 0;
     virtual float getWidth() const = 0;

--- a/modules/plotting/include/modules/plotting/properties/axisproperty.h
+++ b/modules/plotting/include/modules/plotting/properties/axisproperty.h
@@ -98,7 +98,7 @@ public:
     virtual dvec2 getRange() const override;
     virtual bool getUseDataRange() const override;
 
-    virtual bool getVisible() const override;
+    virtual bool getAxisVisible() const override;
     virtual bool getFlipped() const override;
     virtual vec4 getColor() const override;
     virtual float getWidth() const override;

--- a/modules/plotting/include/modules/plotting/properties/categoricalaxisproperty.h
+++ b/modules/plotting/include/modules/plotting/properties/categoricalaxisproperty.h
@@ -83,7 +83,7 @@ public:
     virtual dvec2 getRange() const override;
     virtual bool getUseDataRange() const override;
 
-    virtual bool getVisible() const override;
+    virtual bool getAxisVisible() const override;
     virtual bool getFlipped() const override;
     virtual vec4 getColor() const override;
     virtual float getWidth() const override;

--- a/modules/plotting/src/datastructures/axisdata.cpp
+++ b/modules/plotting/src/datastructures/axisdata.cpp
@@ -35,7 +35,7 @@ namespace plot {
 AxisData::AxisData(const AxisSettings& s)
     : range{s.getRange()}
     , useDataRange{s.getUseDataRange()}
-    , visible{s.getVisible()}
+    , visible{s.getAxisVisible()}
     , color{s.getColor()}
     , width{s.getWidth()}
     , orientation{s.getOrientation()}
@@ -47,7 +47,7 @@ AxisData::AxisData(const AxisSettings& s)
     , majorTicks{s.getMajorTicks()}
     , minorticks{s.getMinorTicks()} {}
 
-bool AxisData::getVisible() const { return visible; }
+bool AxisData::getAxisVisible() const { return visible; }
 
 bool AxisData::getFlipped() const { return flipped; }
 

--- a/modules/plotting/src/datastructures/axissettings.cpp
+++ b/modules/plotting/src/datastructures/axissettings.cpp
@@ -37,7 +37,7 @@ bool AxisSettings::isVertical() const { return getOrientation() == Orientation::
 
 bool operator==(const AxisSettings& a, const AxisSettings& b) {
     return a.getCaption() == b.getCaption() && a.getLabels() == b.getLabels() &&
-           a.getVisible() == b.getVisible() && a.getFlipped() == b.getFlipped() &&
+           a.getAxisVisible() == b.getAxisVisible() && a.getFlipped() == b.getFlipped() &&
            a.getColor() == b.getColor() && a.getWidth() == b.getWidth() &&
            a.getUseDataRange() == b.getUseDataRange() && a.getRange() == b.getRange() &&
            a.getOrientation() == b.getOrientation() && a.getPlacement() == b.getPlacement() &&

--- a/modules/plotting/src/properties/axisproperty.cpp
+++ b/modules/plotting/src/properties/axisproperty.cpp
@@ -241,7 +241,7 @@ void AxisProperty::adjustAlignment() {
     captionSettings_.font_.anchorPos_.set(captionAnchor);
 }
 
-bool AxisProperty::getVisible() const { return visible_.get(); }
+bool AxisProperty::getAxisVisible() const { return visible_.get(); }
 
 bool AxisProperty::getFlipped() const { return flipped_.get(); }
 

--- a/modules/plotting/src/properties/categoricalaxisproperty.cpp
+++ b/modules/plotting/src/properties/categoricalaxisproperty.cpp
@@ -168,7 +168,7 @@ void CategoricalAxisProperty::adjustAlignment() {
     captionSettings_.font_.anchorPos_.set(anchor);
 }
 
-bool CategoricalAxisProperty::getVisible() const { return visible_.get(); }
+bool CategoricalAxisProperty::getAxisVisible() const { return visible_.get(); }
 
 bool CategoricalAxisProperty::getFlipped() const { return flipped_.get(); }
 

--- a/modules/plottinggl/include/modules/plottinggl/processors/parallelcoordinates/pcpaxissettings.h
+++ b/modules/plottinggl/include/modules/plottinggl/processors/parallelcoordinates/pcpaxissettings.h
@@ -173,7 +173,7 @@ public:
     virtual dvec2 getRange() const override;
     virtual bool getUseDataRange() const override;
 
-    virtual bool getVisible() const override;
+    virtual bool getAxisVisible() const override;
     virtual bool getFlipped() const override;
     virtual vec4 getColor() const override;
     virtual float getWidth() const override;

--- a/modules/plottinggl/include/modules/plottinggl/processors/volumeaxis.h
+++ b/modules/plottinggl/include/modules/plottinggl/processors/volumeaxis.h
@@ -76,7 +76,7 @@ namespace plot {
  */
 class IVW_MODULE_PLOTTINGGL_API VolumeAxis : public Processor {
 public:
-    enum class AxisRangeMode { VolumeDims, VolumeBasis, Custom };
+    enum class AxisRangeMode { VolumeDims, VolumeBasis, VolumeBasisOffset, Custom };
 
     VolumeAxis();
     virtual ~VolumeAxis() = default;

--- a/modules/plottinggl/src/processors/parallelcoordinates/pcpaxissettings.cpp
+++ b/modules/plottinggl/src/processors/parallelcoordinates/pcpaxissettings.cpp
@@ -292,7 +292,7 @@ dvec2 PCPAxisSettings::getRange() const {
 
 bool PCPAxisSettings::getUseDataRange() const { return false; }
 
-bool PCPAxisSettings::getVisible() const { return BoolCompositeProperty::getVisible(); }
+bool PCPAxisSettings::getAxisVisible() const { return BoolCompositeProperty::isChecked(); }
 
 bool PCPAxisSettings::getFlipped() const { return invertRange.get(); }
 

--- a/modules/plottinggl/src/processors/volumeaxis.cpp
+++ b/modules/plottinggl/src/processors/volumeaxis.cpp
@@ -58,6 +58,7 @@ VolumeAxis::VolumeAxis()
     , rangeMode_("rangeMode", "Axis Range Mode",
                  {{"dims", "Volume Dimensions (voxel)", AxisRangeMode::VolumeDims},
                   {"basis", "Volume Basis", AxisRangeMode::VolumeBasis},
+                  {"basisOffset", "Volume Basis & Offset", AxisRangeMode::VolumeBasisOffset},
                   {"custom", "Custom", AxisRangeMode::Custom}})
     , customRanges_("customRanges", "Custom Ranges")
     , rangeXaxis_("rangeX", "X Axis", 0.0, 1.0, DataFloat32::lowest(), DataFloat32::max())
@@ -178,6 +179,7 @@ void VolumeAxis::process() {
 
 void VolumeAxis::adjustRanges() {
     dvec3 volDims(1.0);
+    dvec3 offset(0.0);
     dvec3 basisLen(1.0);
     auto volume = inport_.getData();
     if (volume) {
@@ -185,6 +187,7 @@ void VolumeAxis::adjustRanges() {
         for (size_t i = 0; i < 3; ++i) {
             basisLen[i] = glm::length(volume->getBasis()[i]);
         }
+        offset = volume->getOffset();
     }
 
     util::KeepTrueWhileInScope b(&propertyUpdate_);
@@ -198,6 +201,11 @@ void VolumeAxis::adjustRanges() {
             xAxis_.range_.set(dvec2(0.0, basisLen.x));
             yAxis_.range_.set(dvec2(0.0, basisLen.y));
             zAxis_.range_.set(dvec2(0.0, basisLen.z));
+            break;
+        case AxisRangeMode::VolumeBasisOffset:
+            xAxis_.range_.set(dvec2(offset.x, offset.x + basisLen.x));
+            yAxis_.range_.set(dvec2(offset.y, offset.y + basisLen.y));
+            zAxis_.range_.set(dvec2(offset.z, offset.z + basisLen.z));
             break;
         case AxisRangeMode::Custom:
             xAxis_.range_.set(rangeXaxis_.get());

--- a/modules/plottinggl/src/utils/axisrenderer.cpp
+++ b/modules/plottinggl/src/utils/axisrenderer.cpp
@@ -211,7 +211,7 @@ AxisRenderer::AxisRenderer(const AxisSettings& settings)
 
 void AxisRenderer::render(const size2_t& outputDims, const size2_t& startPos, const size2_t& endPos,
                           bool antialiasing) {
-    if (!settings_.getVisible()) {
+    if (!settings_.getAxisVisible()) {
         return;
     }
 
@@ -360,7 +360,7 @@ AxisRenderer3D::AxisRenderer3D(const AxisSettings& settings)
 
 void AxisRenderer3D::render(Camera* camera, const size2_t& outputDims, const vec3& startPos,
                             const vec3& endPos, const vec3& tickDirection, bool antialiasing) {
-    if (!settings_.getVisible()) return;
+    if (!settings_.getAxisVisible()) return;
 
     utilgl::BlendModeState blending(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
     renderAxis(camera, startPos, endPos, tickDirection, outputDims, antialiasing);


### PR DESCRIPTION
`getVisible()` overload in axis settings caused axis properties to disappear/go to hidden