### PR TITLE
QTWidgets: BoolCompositePropertyWidgetQt to update checkbox widget state when changed from code (python/js)

### DIFF
--- a/modules/qtwidgets/include/modules/qtwidgets/properties/boolcompositepropertywidgetqt.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/properties/boolcompositepropertywidgetqt.h
@@ -59,6 +59,7 @@ protected:
 private:
     virtual void setChecked(bool checked) override;
     BoolCompositeProperty* boolCompProperty_;
+    std::shared_ptr<std::function<void()>> onBoolChanged_;
 };
 
 }  // namespace inviwo

--- a/modules/qtwidgets/src/properties/boolcompositepropertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/boolcompositepropertywidgetqt.cpp
@@ -40,6 +40,9 @@ BoolCompositePropertyWidgetQt::BoolCompositePropertyWidgetQt(BoolCompositeProper
     setPropertyOwner(property);
     boolCompProperty_->PropertyOwnerObservable::addObserver(this);
     boolCompProperty_->CompositePropertyObservable::addObserver(this);
+    onBoolChanged_ = boolCompProperty_->getBoolProperty()->onChangeScoped([this]() {
+        CollapsibleGroupBoxWidgetQt::setChecked(boolCompProperty_->getBoolProperty()->get());
+    });
 }
 
 void BoolCompositePropertyWidgetQt::setCollapsed(bool value) {


### PR DESCRIPTION
When setting the BoolProperty of a BoolCompositeProperty through python or javascript the widget was not updated (stayed check/unchecked)