### PR TITLE
QTWidgets: BoolCompositePropertyWidgetQt to update checkbox widget state when changed from code (python/js)

### DIFF
--- a/modules/qtwidgets/include/modules/qtwidgets/properties/boolcompositepropertywidgetqt.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/properties/boolcompositepropertywidgetqt.h
@@ -52,6 +52,8 @@ public:
 
     virtual void initState() override;
 
+    virtual void updateFromProperty() override;
+
 protected:
     // override from CollapsibleGroupBoxWidgetQt
     virtual void setCollapsed(bool value) override;

--- a/modules/qtwidgets/src/properties/boolcompositepropertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/boolcompositepropertywidgetqt.cpp
@@ -60,6 +60,12 @@ void BoolCompositePropertyWidgetQt::initState() {
     updateFromProperty();
 }
 
+void BoolCompositePropertyWidgetQt::updateFromProperty() {
+    CollapsibleGroupBoxWidgetQt::updateFromProperty();
+    CollapsibleGroupBoxWidgetQt::setCollapsed(boolCompProperty_->isCollapsed());
+    CollapsibleGroupBoxWidgetQt::setChecked(boolCompProperty_->getBoolProperty()->get());
+}
+
 void BoolCompositePropertyWidgetQt::onSetDisplayName(Property*, const std::string& displayName) {
     displayName_ = displayName;
     label_->setText(displayName);


### PR DESCRIPTION
When setting the BoolProperty of a BoolCompositeProperty through python or javascript the widget was not updated (stayed check/unchecked)