### PR TITLE
BaseGL: ViewManager: Only check agains points of used events to determine wether the event was used or not.

### DIFF
--- a/modules/basegl/src/viewmanager.cpp
+++ b/modules/basegl/src/viewmanager.cpp
@@ -155,7 +155,7 @@ bool ViewManager::propagateTouchEvent(TouchEvent* te, Propagator propagator) {
     auto& touchPoints = te->touchPoints();
 
     std::unordered_map<size_t, std::vector<TouchPoint>> viewIdToTouchPoints;
-    std::vector<int> propagatedPointIds;
+    std::vector<int> usedPointIds;
 
     auto idToView = eventState_.getView(*this, te);
     for (auto& point : touchPoints) {
@@ -186,14 +186,20 @@ bool ViewManager::propagateTouchEvent(TouchEvent* te, Propagator propagator) {
         propagator(&newEvent, viewId);
 
         for (auto p : newEvent.getVisitedProcessors()) te->markAsVisited(p);
-        for (const auto& p : points) propagatedPointIds.push_back(p.id());
+        if (newEvent.hasBeenUsed()) {
+            for (const auto& p : points) {
+                usedPointIds.push_back(p.id());
+            }
+        }
     }
 
     // remove the "used" points from the event
-    util::erase_remove_if(
-        touchPoints, [&](const auto& p) { return util::contains(propagatedPointIds, p.id()); });
+    util::erase_remove_if(touchPoints,
+                          [&](const auto& p) { return util::contains(usedPointIds, p.id()); });
 
-    if (touchPoints.empty()) te->markAsUsed();
+    if (touchPoints.empty()) {
+        te->markAsUsed();
+    }
 
     return touchPoints.empty();
 }


### PR DESCRIPTION
Previously, the touch event was always marked as used, even when the propagated event was not marked as used. 