### PR TITLE
Tools: check-format.py: Surround the call to decode in try-except in case it fails with exception

### DIFF
--- a/tools/jenkins/check-format.py
+++ b/tools/jenkins/check-format.py
@@ -94,17 +94,25 @@ def main():
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE)
             formatted_code_raw, err_raw = p.communicate()
-            formatted_code = codecs.decode(formatted_code_raw, encoding="UTF-8")
+            try:
+                formatted_code = codecs.decode(formatted_code_raw, encoding="UTF-8")
+            except Exception as e:
+                sys.stdout.write("Problem checking format for: " + str(filename) + "\n")
+                sys.stdout.write("Failed to decode the source code using UTF-8\n")
+                sys.stdout.write("Error Message: \n")
+                sys.stdout.write(str(e))
+                sys.stdout.write("\n")
+                sys.exit(1)
             
             if p.returncode != 0:
                 sys.stdout.write("Problem checking format for: " + str(filename) + "\n")
                 err = codecs.decode(err_raw, encoding="UTF-8")
-                sys.stdout.write("Errore: \n")
+                sys.stdout.write("Error: \n")
                 sys.stdout.write(err)
                 sys.stdout.write("\nOutput: \n")
                 sys.stdout.write(formatted_code)
                 sys.stdout.write("\n")
-                sys.exit(p.returncode);
+                sys.exit(p.returncode)
 
             formatted_code = codecs.decode(formatted_code_raw, encoding="UTF-8")
 


### PR DESCRIPTION
One of my files had an unsupported character in one of the comments, the check-format.py then got an uncaught exception and exited without indicating which file the problem was in. 
* [Jenkins log when failing to decode](http://jenkins.inviwo.org:8080/job/modules/job/feature%252Fnanovgutils-rebase-3/2/execution/node/39/log/) 
* [Jenkins log when failing to decode, but catching the exception](http://jenkins.inviwo.org:8080/job/modules/job/test%252Fnanovg-format/2/execution/node/39/log/)
* [Commit removing the unsupported character](https://github.com/inviwo/modules/commit/33810d3ff0d30f1eaf9864f378c85b15c8363eae)