### PR TITLE
Markdown: Fixed slack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Below follow some general information about the framework:
   - [API](https://inviwo.github.io/inviwo/doc/)
   - [Changelog](/CHANGELOG.md)
 
-For help and general discussion join us on our [Slack](https://join.slack.com/t/inviwo/shared_invite/enQtNTc2Nzc2NDQwNzIxLWM0N2VlYmNiZGU2MThiY2I5MGMwZTc3NzI2MjRkODg2M2NmMzRlYjRhNjU3YzUwNGQ1OWE0ZGE1NTAwZGU2YzI) server
+For help and general discussion join us on our [Slack](https://join.slack.com/t/inviwo/shared_invite/enQtNTc2Nzc2NDQwNzIxLTRiMWM1ZWJiYjljZjkwNWE3OTk3MzYxODZlMDUyMzRmZjUzMzBiZjVhNTM3NWUyNzU1MjI4OWJjMzdkODViMzM) server
 
 #### Sponsors
 This work was supported by Linköping University,  KTH Royal Institute of Technology, Ulm University, and through grants from the Swedish e-Science Research Centre (SeRC).

--- a/docs/markdown/Index.md
+++ b/docs/markdown/Index.md
@@ -39,7 +39,7 @@ Below follow some general information about the framework:
 #### Documentation
   - [Manual](https://github.com/inviwo/inviwo/wiki/Manual)
 
-For help and general discussion join us on our [Slack](https://join.slack.com/t/inviwo/shared_invite/enQtNTc2Nzc2NDQwNzIxLWM0N2VlYmNiZGU2MThiY2I5MGMwZTc3NzI2MjRkODg2M2NmMzRlYjRhNjU3YzUwNGQ1OWE0ZGE1NTAwZGU2YzI) server
+For help and general discussion join us on our [Slack](https://join.slack.com/t/inviwo/shared_invite/enQtNTc2Nzc2NDQwNzIxLTRiMWM1ZWJiYjljZjkwNWE3OTk3MzYxODZlMDUyMzRmZjUzMzBiZjVhNTM3NWUyNzU1MjI4OWJjMzdkODViMzM) server
 
 #### Sponsors
 This work was supported by Linköping University,  KTH Royal Institute of Technology, Ulm University, and through grants from the Swedish e-Science Research Centre (SeRC).


### PR DESCRIPTION
Seems our slack link has expired or been deactivated, changed to a new working one. Webpage needs to be updated as well