### PR TITLE
Python: Bug fix for saving non-existing canvas image.

### DIFF
--- a/modules/python3/bindings/src/pyprocessors.cpp
+++ b/modules/python3/bindings/src/pyprocessors.cpp
@@ -300,7 +300,7 @@ void exposeProcessors(pybind11::module &m) {
             if (auto layer = canvas->getVisibleLayer()) {
                 writer->writeData(layer, filepath);
             } else {
-                 throw Exception("No image in canvas " + canvas->getIdentifier());
+                throw Exception("No image in canvas " + canvas->getIdentifier());
             }
         });
 

--- a/modules/python3/bindings/src/pyprocessors.cpp
+++ b/modules/python3/bindings/src/pyprocessors.cpp
@@ -294,11 +294,14 @@ void exposeProcessors(pybind11::module &m) {
                               ->getDataWriterFactory()
                               ->getWriterForTypeAndExtension<Layer>(ext);
             if (!writer) {
-                throw Exception("No write for extension " + ext);
+                throw Exception("No writer for extension " + ext);
             }
 
-            auto layer = canvas->getVisibleLayer();
-            writer->writeData(layer, filepath);
+            if (auto layer = canvas->getVisibleLayer()) {
+                writer->writeData(layer, filepath);
+            } else {
+                 throw Exception("No image in canvas " + canvas->getIdentifier());
+            }
         });
 
     py::class_<PythonScriptProcessor, Processor, ProcessorPtr<PythonScriptProcessor>>(


### PR DESCRIPTION
Can occur when Canvas is not ready for example.
