### PR TITLE
DataFramePython: Make sure ivwdataframe is built before the unittests are built/run since its artifacts is used in the tests

### DIFF
--- a/modules/dataframepython/CMakeLists.txt
+++ b/modules/dataframepython/CMakeLists.txt
@@ -26,10 +26,6 @@ set(TEST_FILES
 )
 ivw_add_unittest(${TEST_FILES})
 
-if(IVW_UNITTESTS)
-    add_dependencies(inviwo-unittests-dataframepython ivwdataframe)
-endif()
-
 #--------------------------------------------------------------------
 # Create module
 ivw_create_module(${SOURCE_FILES} ${HEADER_FILES})
@@ -39,3 +35,7 @@ target_link_libraries(inviwo-module-dataframepython PUBLIC
 )
 
 add_subdirectory(bindings)
+
+if(IVW_UNITTESTS)
+    add_dependencies(inviwo-unittests-dataframepython ivwdataframe)
+endif()

--- a/modules/dataframepython/CMakeLists.txt
+++ b/modules/dataframepython/CMakeLists.txt
@@ -26,6 +26,10 @@ set(TEST_FILES
 )
 ivw_add_unittest(${TEST_FILES})
 
+if(IVW_UNITTESTS)
+    add_dependencies(inviwo-unittests-dataframepython ivwdataframe)
+endif()
+
 #--------------------------------------------------------------------
 # Create module
 ivw_create_module(${SOURCE_FILES} ${HEADER_FILES})


### PR DESCRIPTION
Make sure ivwdataframe is built before the unittests are built/run since its artifacts is used in the tests