### PR TITLE
Feature/various fixes

### DIFF
--- a/include/inviwo/core/util/stdextensions.h
+++ b/include/inviwo/core/util/stdextensions.h
@@ -559,15 +559,14 @@ public:
 };
 
 template <typename F, typename... Args>
-using is_invocable [[deprecated("Use `std::is_invocable` instead")]] =
-    std::is_invocable<F, Args...>;
+using is_invocable[[deprecated("Use `std::is_invocable` instead")]] = std::is_invocable<F, Args...>;
 
 template <typename R, typename F, typename... Args>
-using is_invocable_r [[deprecated("Use `std::is_invocable_r` instead")]] =
+using is_invocable_r[[deprecated("Use `std::is_invocable_r` instead")]] =
     std::is_invocable_r<F, Args...>;
 
 template <typename F, typename... Args>
-using is_callable [[deprecated("Use `std::is_invocable` instead")]] = std::is_invocable<F, Args...>;
+using is_callable[[deprecated("Use `std::is_invocable` instead")]] = std::is_invocable<F, Args...>;
 
 /**
  * A type trait to determine if type "callback" can be called with certain arguments.

--- a/include/inviwo/core/util/stdextensions.h
+++ b/include/inviwo/core/util/stdextensions.h
@@ -129,10 +129,10 @@ using void_t = void;
 * Example useage:
 * \code{.cpp}
 *  std::variant<int, std::string, float, double> data = ...;
-*  std::visit(overloaded{[](const int& arg) {   }, // called if data contains an int
-                         [](const std::string &arg) {  }, // called if data contains a string
-                         [](const auto& arg) {  }} // use auto to capture "the other types"
-                   , data);
+*  std::visit(util::overloaded{[](const int& arg) {   }, // called if data contains an int
+                               [](const std::string &arg) {  }, // called if data contains a string
+                               [](const auto& arg) {  }} // use auto to capture "the other types"
+                               , data);
 *
 * \endcode
 *
@@ -559,17 +559,18 @@ public:
 };
 
 template <typename F, typename... Args>
-using is_invocable[[deprecated("Use `std::is_invocable` instead")]] = std::is_invocable<F, Args...>;
+using is_invocable [[deprecated("Use `std::is_invocable` instead")]] =
+    std::is_invocable<F, Args...>;
 
 template <typename R, typename F, typename... Args>
-using is_invocable_r[[deprecated("Use `std::is_invocable_r` instead")]] =
+using is_invocable_r [[deprecated("Use `std::is_invocable_r` instead")]] =
     std::is_invocable_r<F, Args...>;
 
 template <typename F, typename... Args>
-using is_callable[[deprecated("Use `std::is_invocable` instead")]] = std::is_invocable<F, Args...>;
+using is_callable [[deprecated("Use `std::is_invocable` instead")]] = std::is_invocable<F, Args...>;
 
 /**
- * A type trait to determine if type "callback" cann be called with certain arguments.
+ * A type trait to determine if type "callback" can be called with certain arguments.
  * Example:
  *     util::is_callable_with<float>(callback)
  *     where

--- a/modules/fontrendering/src/textrenderer.cpp
+++ b/modules/fontrendering/src/textrenderer.cpp
@@ -28,7 +28,6 @@
  *
  *********************************************************************************/
 
-
 #include <modules/fontrendering/textrenderer.h>
 
 #include <inviwo/core/datastructures/buffer/bufferramprecision.h>
@@ -42,7 +41,6 @@
 #include <modules/opengl/shader/shaderutils.h>
 #include <modules/opengl/texture/textureutils.h>
 #include <modules/opengl/sharedopenglresources.h>
-
 
 #include <utf8.h>
 

--- a/modules/fontrendering/src/textrenderer.cpp
+++ b/modules/fontrendering/src/textrenderer.cpp
@@ -28,6 +28,9 @@
  *
  *********************************************************************************/
 
+
+#include <modules/fontrendering/textrenderer.h>
+
 #include <inviwo/core/datastructures/buffer/bufferramprecision.h>
 #include <inviwo/core/util/exception.h>
 #include <inviwo/core/util/zip.h>
@@ -40,7 +43,6 @@
 #include <modules/opengl/texture/textureutils.h>
 #include <modules/opengl/sharedopenglresources.h>
 
-#include <modules/fontrendering/textrenderer.h>
 
 #include <utf8.h>
 

--- a/modules/opengl/include/modules/opengl/texture/textureunit.h
+++ b/modules/opengl/include/modules/opengl/texture/textureunit.h
@@ -75,6 +75,8 @@ public:
     ~TextureUnitContainer() = default;
 
     void push_back(TextureUnit&& unit);
+    TextureUnit& emplace_back();
+
 
     TextureUnit& operator[](size_t i);
     size_t size() const;

--- a/modules/opengl/include/modules/opengl/texture/textureunit.h
+++ b/modules/opengl/include/modules/opengl/texture/textureunit.h
@@ -77,7 +77,6 @@ public:
     void push_back(TextureUnit&& unit);
     TextureUnit& emplace_back();
 
-
     TextureUnit& operator[](size_t i);
     size_t size() const;
 

--- a/modules/opengl/src/image/layergl.cpp
+++ b/modules/opengl/src/image/layergl.cpp
@@ -27,8 +27,9 @@
  *
  *********************************************************************************/
 
-#include <inviwo/core/util/formats.h>
 #include <modules/opengl/image/layergl.h>
+
+#include <inviwo/core/util/formats.h>
 #include <modules/opengl/glformats.h>
 #include <modules/opengl/texture/texture.h>
 #include <modules/opengl/texture/texture2d.h>

--- a/modules/opengl/src/texture/textureunit.cpp
+++ b/modules/opengl/src/texture/textureunit.cpp
@@ -94,6 +94,8 @@ TextureUnitContainer& TextureUnitContainer::operator=(TextureUnitContainer&& tha
 
 void TextureUnitContainer::push_back(TextureUnit&& unit) { units_.push_back(std::move(unit)); }
 
+TextureUnit& TextureUnitContainer::emplace_back() { return units_.emplace_back(); }
+
 TextureUnit& TextureUnitContainer::operator[](size_t i) { return units_[i]; }
 size_t TextureUnitContainer::size() const { return units_.size(); }
 

--- a/modules/opengl/src/texture/textureutils.cpp
+++ b/modules/opengl/src/texture/textureutils.cpp
@@ -27,9 +27,10 @@
  *
  *********************************************************************************/
 
+#include <modules/opengl/texture/textureutils.h>
+
 #include <inviwo/core/datastructures/geometry/mesh.h>
 
-#include <modules/opengl/texture/textureutils.h>
 #include <modules/opengl/canvasgl.h>
 #include <modules/opengl/volume/volumegl.h>
 #include <modules/opengl/geometry/meshgl.h>

--- a/modules/qtwidgets/src/properties/colorlineedit.cpp
+++ b/modules/qtwidgets/src/properties/colorlineedit.cpp
@@ -199,7 +199,7 @@ void ColorLineEdit::updateText() {
 }
 
 void ColorLineEdit::updateColor() {
-    QStringList tokens = text().split(QRegularExpression("\\s+"));
+    QStringList tokens = text().trimmed().split(QRegularExpression("\\s+"));
 
     ivwAssert((tokens.size() == 1) || (tokens.size() == 3) || (tokens.size() == 4),
               "Invalid number of color components");

--- a/src/core/properties/listproperty.cpp
+++ b/src/core/properties/listproperty.cpp
@@ -169,6 +169,8 @@ Property* ListProperty::constructProperty(size_t prefabIndex) {
 
     if ((maxNumElements_ == 0) || (size() + 1 < maxNumElements_)) {
         auto property = prefabs_[prefabIndex]->clone();
+        IVW_ASSERT(property->getClassIdentifier() == prefabs_[prefabIndex]->getClassIdentifier(),
+                   "Class identifer missmatch after cloning, does your property implement clone?");
         property->setSerializationMode(PropertySerializationMode::All);
         property->setIdentifier(util::findUniqueIdentifier(
             property->getIdentifier(),


### PR DESCRIPTION
* QtWidgets: Trims color string to avoid crash when trailing spaces is present
* OpenGL: Added a emplace_back to TextureUnit
* Core: StdExtensions: Added namespace to example in comment
* Core: List property: Assetion when cloning prefab to ensure correct impl of clone
* OpenGL/FontRedering:: Include order fix
