### PR TITLE
Tools: Check-format to overwrite old local branch with same name if it exists

### DIFF
--- a/tools/jenkins/check-format.py
+++ b/tools/jenkins/check-format.py
@@ -78,7 +78,7 @@ def main():
         print("Fixing format, checking out: " + args.commit)
         fref = repo.remotes.origin.fetch("+refs/heads/"+args.commit+":refs/remotes/origin/"+args.commit, no_tags=True)
         repo.git.execute(["git", "remote", "set-branches", "--add", "origin", args.commit])  
-        localBranch = fref[0].ref.checkout(b=args.commit, track=True)
+        localBranch = fref[0].ref.checkout(B=args.commit, track=True)
 
     extensions = ['*.h', '*.hpp', '*.cpp']
     excludes = ["*/ext/*", "*/templates/*", "*/tools/codegen/*" , "*moc_*", "*cmake*"]


### PR DESCRIPTION
Fixes #752 
When having the `auto format` PR-tag tag the check-format script checks out the named branch early in the script and removes that branch at the end of the script. If the script encounters an error between the checkout and branch-remove the branch wont be removed. 

By changing the `-b [branchname]` flag to `-B [branchname]` [1] for the checkout any existing branch will be "overwritten" (reset in git lingo) 

Tested with success in #805. 

This commit is also cherry-picked onto feature/fancymeshrenderer (#804), since the 'check-format.py' failed on that branch due to incorrect file encoding on one file. 

[1] https://git-scm.com/docs/git-checkout#Documentation/git-checkout.txt--Bltnewbranchgt