### PR TITLE
Tools: Check-format: Make sure submodules are the same as branch, not PR, since we push to the branch

### DIFF
--- a/tools/jenkins/check-format.py
+++ b/tools/jenkins/check-format.py
@@ -134,6 +134,7 @@ def main():
     if args.fix and args.commit:
         if repo.is_dirty():
             print("There were format fixes, pushing changes")
+            repo.submodule_update()
             repo.git.add(update=True)
             ivwteam = git.Actor("Inviwo Team", "team@inviwo.org")
             repo.index.commit("Jenkins: Format fixes", author=ivwteam, committer=ivwteam)    


### PR DESCRIPTION
If a PR-branch is based on a commit on master that is older than a commit that updates a submodule the `check-format.py` script will push the submodule update as part of the format fixes commit. 

This happens since, when the script starts, it has checked out the branched merged with master, hence has the updated submodule. The script then checksout the brance (non-merged) to do the formating. The submodule will than be listed as updated and the script will include it in the commit. 

For example, the ´FancyMeshRenderer´ branch is based on a commit older than fc6d59cfa7531e62346a8f79d9045a7434f72cdb, which resulted in this 8ccbb649bcb9091285d9783a386ecfe9e25e5fef 