### PR TITLE
Feature/miscfixes

### DIFF
--- a/include/inviwo/core/properties/ordinalproperty.h
+++ b/include/inviwo/core/properties/ordinalproperty.h
@@ -249,9 +249,9 @@ void OrdinalProperty<T>::set(const T& value, const T& minVal, const T& maxVal, c
 
     if ((minVal != minValue_.value) || (maxVal != maxValue_.value)) {
         if (glm::max(minVal, maxVal) != maxVal) {
-            LogWarn("Invalid range given for \"" << this->getDisplayName() << "\" ("
-                                                 << Defaultvalues<T>::getName()
-                                                 << "Property). Using min range as reference.");
+            LogWarn("Invalid range given for \""
+                    << this->getDisplayName() << "\" (" << Defaultvalues<T>::getName()
+                    << "Property, " << this->getPath() << "). Using min range as reference.");
         }
         minValue_.value = minVal;
         maxValue_.value = glm::max(minVal, maxVal);

--- a/include/inviwo/core/properties/ordinalproperty.h
+++ b/include/inviwo/core/properties/ordinalproperty.h
@@ -249,9 +249,10 @@ void OrdinalProperty<T>::set(const T& value, const T& minVal, const T& maxVal, c
 
     if ((minVal != minValue_.value) || (maxVal != maxValue_.value)) {
         if (glm::max(minVal, maxVal) != maxVal) {
-            LogWarn("Invalid range given for \""
-                    << this->getDisplayName() << "\" (" << Defaultvalues<T>::getName()
-                    << "Property, " << this->getPath() << "). Using min range as reference.");
+            LogWarn("Invalid range given for \"" << this->getDisplayName() << "\" ("
+                                                 << Defaultvalues<T>::getName() << "Property, "
+                                                 << joinString(this->getPath(), ".")
+                                                 << "). Using min range as reference.");
         }
         minValue_.value = minVal;
         maxValue_.value = glm::max(minVal, maxVal);

--- a/include/inviwo/core/util/foreach.h
+++ b/include/inviwo/core/util/foreach.h
@@ -104,8 +104,7 @@ std::vector<std::future<void>> forEachParallelAsync(const Iterable& iterable, Ca
         size_t end = (s * (job + 1)) / jobs;
         auto a = std::begin(iterable) + start;
         auto b = std::begin(iterable) + end;
-        auto future = dispatchPool([a, b, start, c = callback,
-                                    onTaskDone = onTaskDone]() {
+        auto future = dispatchPool([a, b, start, c = callback, onTaskDone = onTaskDone]() {
             detail::foreach (a, b, c, start);
             onTaskDone();
         });

--- a/include/inviwo/core/util/foreach.h
+++ b/include/inviwo/core/util/foreach.h
@@ -104,8 +104,8 @@ std::vector<std::future<void>> forEachParallelAsync(const Iterable& iterable, Ca
         size_t end = (s * (job + 1)) / jobs;
         auto a = std::begin(iterable) + start;
         auto b = std::begin(iterable) + end;
-        auto future = dispatchPool([a, b, start, c = std::forward<Callback>(callback),
-                                    onTaskDone = std::forward<OnDoneCallback>(onTaskDone)]() {
+        auto future = dispatchPool([a, b, start, c = callback,
+                                    onTaskDone = onTaskDone]() {
             detail::foreach (a, b, c, start);
             onTaskDone();
         });


### PR DESCRIPTION
some fixes. More verbose range warnings for ordinal properties (includes now property path as well).

Before, it was hard to locate the property.
```
17:44:49.188	OrdinalProperty<int>	ordinalproperty.h	Invalid range given for "Volume" (IntProperty). Using min range as reference.
```