### PR TITLE
Add optional BufferTarget to Column

### DIFF
--- a/modules/dataframe/include/inviwo/dataframe/datastructures/column.h
+++ b/modules/dataframe/include/inviwo/dataframe/datastructures/column.h
@@ -94,8 +94,8 @@ class TemplateColumn : public Column {
 public:
     using type = T;
 
-    TemplateColumn(const std::string &header,
-                   std::shared_ptr<Buffer<T, Target>> buffer = std::make_shared<Buffer<T, Target>>());
+    TemplateColumn(const std::string &header, std::shared_ptr<Buffer<T, Target>> buffer =
+                                                  std::make_shared<Buffer<T, Target>>());
 
     TemplateColumn(const std::string &header, std::vector<T> data);
 
@@ -221,7 +221,8 @@ private:
 };
 
 template <typename T, BufferTarget Target>
-TemplateColumn<T, Target>::TemplateColumn(const std::string &header, std::shared_ptr<Buffer<T, Target>> buffer)
+TemplateColumn<T, Target>::TemplateColumn(const std::string &header,
+                                          std::shared_ptr<Buffer<T, Target>> buffer)
     : header_(header), buffer_(buffer) {}
 
 template <typename T, BufferTarget Target>
@@ -277,7 +278,8 @@ void TemplateColumn<T, Target>::add(const T &value) {
 
 namespace detail {
 
-template <typename T, BufferTarget Target, typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+template <typename T, BufferTarget Target,
+          typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
 void add(Buffer<T, Target> *buffer, const std::string &value) {
     T result;
     std::istringstream stream(value);
@@ -288,7 +290,8 @@ void add(Buffer<T, Target> *buffer, const std::string &value) {
     buffer->getEditableRAMRepresentation()->add(result);
 }
 // Specialization for float and double types, add NaN instead of throwing an error
-template <typename T, BufferTarget Target, typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
+template <typename T, BufferTarget Target,
+          typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
 void add(Buffer<T, Target> *buffer, const std::string &value) {
     T result;
     std::istringstream stream(value);
@@ -382,7 +385,7 @@ std::shared_ptr<const BufferBase> TemplateColumn<T, Target>::getBuffer() const {
 }
 
 template <typename T, BufferTarget Target>
-std::shared_ptr<Buffer<T,Target>> TemplateColumn<T, Target>::getTypedBuffer() {
+std::shared_ptr<Buffer<T, Target>> TemplateColumn<T, Target>::getTypedBuffer() {
     return buffer_;
 }
 

--- a/modules/dataframe/include/inviwo/dataframe/datastructures/dataframe.h
+++ b/modules/dataframe/include/inviwo/dataframe/datastructures/dataframe.h
@@ -103,7 +103,8 @@ public:
      * the DataFrame can be used
      */
     template <typename T, BufferTarget Target = BufferTarget::Data>
-    std::shared_ptr<TemplateColumn<T, Target>> addColumn(const std::string &header, size_t size = 0);
+    std::shared_ptr<TemplateColumn<T, Target>> addColumn(const std::string &header,
+                                                         size_t size = 0);
 
     /**
      * \brief Drop a column from data frame
@@ -204,7 +205,8 @@ createDataFrame(const std::vector<std::vector<std::string>> &exampleRows,
                 const std::vector<std::string> &colHeaders = {});
 
 template <typename T, BufferTarget Target>
-std::shared_ptr<TemplateColumn<T, Target>> DataFrame::addColumn(const std::string &header, size_t size) {
+std::shared_ptr<TemplateColumn<T, Target>> DataFrame::addColumn(const std::string &header,
+                                                                size_t size) {
     auto col = std::make_shared<TemplateColumn<T, Target>>(header);
     col->getTypedBuffer()->getEditableRAMRepresentation()->getDataContainer().resize(size);
     columns_.push_back(col);

--- a/modules/dataframe/include/inviwo/dataframe/datastructures/dataframe.h
+++ b/modules/dataframe/include/inviwo/dataframe/datastructures/dataframe.h
@@ -102,8 +102,8 @@ public:
      * updateIndexBuffer() needs to be called after all columns have been added before
      * the DataFrame can be used
      */
-    template <typename T>
-    std::shared_ptr<TemplateColumn<T>> addColumn(const std::string &header, size_t size = 0);
+    template <typename T, BufferTarget Target = BufferTarget::Data>
+    std::shared_ptr<TemplateColumn<T, Target>> addColumn(const std::string &header, size_t size = 0);
 
     /**
      * \brief Drop a column from data frame
@@ -203,9 +203,9 @@ std::shared_ptr<DataFrame> IVW_MODULE_DATAFRAME_API
 createDataFrame(const std::vector<std::vector<std::string>> &exampleRows,
                 const std::vector<std::string> &colHeaders = {});
 
-template <typename T>
-std::shared_ptr<TemplateColumn<T>> DataFrame::addColumn(const std::string &header, size_t size) {
-    auto col = std::make_shared<TemplateColumn<T>>(header);
+template <typename T, BufferTarget Target>
+std::shared_ptr<TemplateColumn<T, Target>> DataFrame::addColumn(const std::string &header, size_t size) {
+    auto col = std::make_shared<TemplateColumn<T, Target>>(header);
     col->getTypedBuffer()->getEditableRAMRepresentation()->getDataContainer().resize(size);
     columns_.push_back(col);
     return col;

--- a/modules/dataframe/src/datastructures/dataframe.cpp
+++ b/modules/dataframe/src/datastructures/dataframe.cpp
@@ -42,7 +42,7 @@ namespace inviwo {
  */
 DataFrame::DataFrame(std::uint32_t size) : columns_() {
     // at the moment, GPUs only support uints up to 32bit
-    auto &cont = addColumn<std::uint32_t>("index", size)
+    auto &cont = addColumn<std::uint32_t, BufferTarget::Index>("index", size)
                      ->getTypedBuffer()
                      ->getEditableRAMRepresentation()
                      ->getDataContainer();


### PR DESCRIPTION
... such that the index buffer can be declared as such. This is helpful when looping through the columns while wanting to omit the index column.

This doesn't break anything since it's an optional parameter.