### PR TITLE
CMake: Make the changelog project optional (on by default)

### DIFF
--- a/src/qt/editor/CMakeLists.txt
+++ b/src/qt/editor/CMakeLists.txt
@@ -148,24 +148,28 @@ ivw_compile_optimize_on_target(inviwo-qteditor)
 
 #--------------------------------------------------------------------
 # Generate html version of changelog (for the welcome widget), if python is available
-find_package(PythonInterp QUIET)
-if (PYTHONINTERP_FOUND)
-    add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/changelog.html
-        COMMAND ${PYTHON_EXECUTABLE} ${IVW_ROOT_DIR}/tools/changelog-to-html.py -i ${IVW_ROOT_DIR}/CHANGELOG.md -o ${CMAKE_BINARY_DIR}/changelog.html
-        WORKING_DIRECTORY ${IVW_ROOT_DIR}
-        MAIN_DEPENDENCY ${IVW_ROOT_DIR}/CHANGELOG.md
-        DEPENDS ${IVW_ROOT_DIR}/tools/changelog-to-html.py
-        COMMENT "Generating HTML version of the Inviwo Changelog"
-        VERBATIM
-    )
-    add_custom_target("inviwo-changelog"
-        DEPENDS ${CMAKE_BINARY_DIR}/changelog.html
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            ${CMAKE_BINARY_DIR}/changelog.html
-            ${IVW_RESOURCES_DIR}/changelog.html
-    )
+set(BUILD_CHANGELOG ON CACHE BOOL "Generate html version of changelog (for the welcome widget)")
 
-    add_dependencies("inviwo-qteditor" "inviwo-changelog")
+if(BUILD_CHANGELOG)
+    find_package(PythonInterp QUIET)
+    if (PYTHONINTERP_FOUND)
+        add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/changelog.html
+            COMMAND ${PYTHON_EXECUTABLE} ${IVW_ROOT_DIR}/tools/changelog-to-html.py -i ${IVW_ROOT_DIR}/CHANGELOG.md -o ${CMAKE_BINARY_DIR}/changelog.html
+            WORKING_DIRECTORY ${IVW_ROOT_DIR}
+            MAIN_DEPENDENCY ${IVW_ROOT_DIR}/CHANGELOG.md
+            DEPENDS ${IVW_ROOT_DIR}/tools/changelog-to-html.py
+            COMMENT "Generating HTML version of the Inviwo Changelog"
+            VERBATIM
+        )
+        add_custom_target("inviwo-changelog"
+            DEPENDS ${CMAKE_BINARY_DIR}/changelog.html
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                ${CMAKE_BINARY_DIR}/changelog.html
+                ${IVW_RESOURCES_DIR}/changelog.html
+        )
+
+        add_dependencies("inviwo-qteditor" "inviwo-changelog")
+    endif()
 endif()
 
 ivw_deploy_qt(inviwo-qteditor)

--- a/src/qt/editor/CMakeLists.txt
+++ b/src/qt/editor/CMakeLists.txt
@@ -148,9 +148,9 @@ ivw_compile_optimize_on_target(inviwo-qteditor)
 
 #--------------------------------------------------------------------
 # Generate html version of changelog (for the welcome widget), if python is available
-set(BUILD_CHANGELOG ON CACHE BOOL "Generate html version of changelog (for the welcome widget)")
+set(IVW_BUILD_CHANGELOG ON CACHE BOOL "Generate html version of changelog (for the welcome widget)")
 
-if(BUILD_CHANGELOG)
+if(IVW_BUILD_CHANGELOG)
     find_package(PythonInterp QUIET)
     if (PYTHONINTERP_FOUND)
         add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/changelog.html


### PR DESCRIPTION
The changelog project always generates an edited file (git) which is quite annoying. Would be nice to be able to disable it.