### PR TITLE
DataFrame: DataFrameColormapProperty: Only set the current state to default for the colormap properties, not the selected column and override since they will in that case de serialized incorrectly

### DIFF
--- a/modules/dataframe/src/properties/dataframecolormapproperty.cpp
+++ b/modules/dataframe/src/properties/dataframecolormapproperty.cpp
@@ -114,6 +114,7 @@ void DataFrameColormapProperty::createOrUpdateProperties(
         }();
         colormaps_.push_back(colormapProp);
         colormapProp->setupForColumn(*c);
+        colormapProp->setCurrentStateAsDefault();
     }
     // Remove properties that were not reused
     for (auto p : oldColormapProperties) {
@@ -121,7 +122,6 @@ void DataFrameColormapProperty::createOrUpdateProperties(
             removeProperty(p);
         }
     }
-    setCurrentStateAsDefault();
     selectedColorAxis.propertyModified();
 }
 


### PR DESCRIPTION
Prior to this fix the override property in `DataFrameColormapProperty` would not remember its values correctly if set to true before the call to `createOrUpdateProperties`