### PR TITLE
Base: MeshColorFromNormals: Added option to transform the normals to positive only values

### DIFF
--- a/modules/base/include/modules/base/processors/meshcolorfromnormals.h
+++ b/modules/base/include/modules/base/processors/meshcolorfromnormals.h
@@ -44,11 +44,7 @@ namespace inviwo {
  */
 class IVW_MODULE_BASE_API MeshColorFromNormals : public Processor {
 public:
-    enum class Transform {
-        None,
-        Abs, 
-        Shift 
-    };
+    enum class Transform { None, Abs, Shift };
 
     MeshColorFromNormals();
     virtual ~MeshColorFromNormals() = default;

--- a/modules/base/include/modules/base/processors/meshcolorfromnormals.h
+++ b/modules/base/include/modules/base/processors/meshcolorfromnormals.h
@@ -44,6 +44,12 @@ namespace inviwo {
  */
 class IVW_MODULE_BASE_API MeshColorFromNormals : public Processor {
 public:
+    enum class Transform {
+        None,
+        Abs, 
+        Shift 
+    };
+
     MeshColorFromNormals();
     virtual ~MeshColorFromNormals() = default;
 
@@ -55,6 +61,8 @@ public:
 private:
     MeshInport inport_;
     MeshOutport outport_;
+
+    TemplateOptionProperty<Transform> transform_;
 };
 
 }  // namespace inviwo


### PR DESCRIPTION
Due to comments on the previous PR, I added an option to the MeshColorFromNormals to shift the colors (i.e. Normals) to positive values. 

This processor is used to test the calculate normals processors 
![image](https://user-images.githubusercontent.com/534670/74242258-d6982500-4cdd-11ea-81a4-82a0fdf1ab19.png)
