### PR TITLE
FormatDispatching: Remove Win32 macro

### DIFF
--- a/include/inviwo/core/util/formatdispatching.h
+++ b/include/inviwo/core/util/formatdispatching.h
@@ -111,11 +111,7 @@ struct DispatchHelper<Result, B, E, std::tuple<Formats...>> {
                 IVW_CONTEXT_CUSTOM("Dispatching"));
 
         if (id == Format::id()) {
-#ifdef _WIN32  // TODO: remove win fix when VS does the right thing...
-            return (obj.operator()<Result, Format>(std::forward<Args>(args)...));
-#else
             return (obj.template operator()<Result, Format>(std::forward<Args>(args)...));
-#endif
         } else if (static_cast<int>(id) < static_cast<int>(Format::id())) {
             return DispatchHelper<Result, B, M - 1, std::tuple<Formats...>>::dispatch(
                 id, std::forward<Callable>(obj), std::forward<Args>(args)...);


### PR DESCRIPTION
Tested on Microsoft Visual Studio Community 2019 Preview Version 16.4.0 Preview 3.0
