### PR TITLE
Base: DatVolumeSequenceReader fix for dat-file containing multiple fi…

### DIFF
--- a/modules/base/src/io/datvolumesequencereader.cpp
+++ b/modules/base/src/io/datvolumesequencereader.cpp
@@ -250,7 +250,7 @@ std::shared_ptr<DatVolumeSequenceReader::VolumeSequence> DatVolumeSequenceReader
         for (size_t t = 0; t < state.datFiles.size(); ++t) {
             auto datVolReader = std::make_unique<DatVolumeSequenceReader>();
             datVolReader->enableLogOutput_ = false;
-            auto v = datVolReader->readData(state.datFiles[t]);
+            auto v = datVolReader->readData(fileDirectory + "/" +state.datFiles[t]);
 
             std::copy(v->begin(), v->end(), std::back_inserter(*volumes));
         }

--- a/modules/base/src/io/datvolumesequencereader.cpp
+++ b/modules/base/src/io/datvolumesequencereader.cpp
@@ -250,7 +250,10 @@ std::shared_ptr<DatVolumeSequenceReader::VolumeSequence> DatVolumeSequenceReader
         for (size_t t = 0; t < state.datFiles.size(); ++t) {
             auto datVolReader = std::make_unique<DatVolumeSequenceReader>();
             datVolReader->enableLogOutput_ = false;
-            auto v = datVolReader->readData(fileDirectory + "/" +state.datFiles[t]);
+            auto path = filesystem::isAbsolutePath(state.datFiles[t])
+                            ? state.datFiles[t]
+                            : fileDirectory + "/" + state.datFiles[t];
+            auto v = datVolReader->readData(path);
 
             std::copy(v->begin(), v->end(), std::back_inserter(*volumes));
         }


### PR DESCRIPTION
…les. Each path in the file should be supplied relative to the containing dat-file, but the reader considered absolute path..


