### PR TITLE
Feature/webbrowser touchevents

### DIFF
--- a/modules/webbrowser/data/workspaces/web_property_sync.html
+++ b/modules/webbrowser/data/workspaces/web_property_sync.html
@@ -43,7 +43,7 @@ var ordinalPropertyValue = document.getElementById("ordinalPropertyValue");
 
 
 slider.oninput = function() {
-	inviwo.setProperty("LineRenderer.lineWidth", {value: Number(this.value)});
+	inviwo.setProperty("LineRenderer.lineSettings.lineWidth", {value: Number(this.value)});
     ordinalPropertyValue.innerHTML = this.value;
 }
 

--- a/modules/webbrowser/include/modules/webbrowser/interaction/cefinteractionhandler.h
+++ b/modules/webbrowser/include/modules/webbrowser/interaction/cefinteractionhandler.h
@@ -44,6 +44,7 @@ namespace inviwo {
 class RenderHandlerGL;
 class TouchPoint;
 class TouchEvent;
+class TouchDevice;
 class PickingEvent;
 /*\class CEFInteractionHandler
  * Translates Inviwo events to CEF events and injects them into provided CefBrowserHost.
@@ -78,7 +79,7 @@ public:
 private:
     CefKeyEvent mapKeyEvent(const KeyboardEvent* e);
     CefMouseEvent mapMouseEvent(const MouseInteractionEvent* e);
-    CefMouseEvent mapTouchEvent(const TouchPoint* p);
+    CefTouchEvent mapTouchEvent(const TouchPoint* p, const TouchDevice* device);
 
     void updateMouseStates(MouseEvent* e);
     void updateMouseStates(TouchEvent* e);

--- a/modules/webbrowser/src/interaction/cefinteractionhandler.cpp
+++ b/modules/webbrowser/src/interaction/cefinteractionhandler.cpp
@@ -159,8 +159,8 @@ CefTouchEvent CEFInteractionHandler::mapTouchEvent(const TouchPoint* p, const To
                 return CEF_TET_MOVED;
             case TouchState::Finished:
                 return CEF_TET_RELEASED;
-            default: // Incorrect usage or new state added (warnings if left out)
-                assert(false);  
+            default:  // Incorrect usage or new state added (warnings if left out)
+                assert(false);
                 return CEF_TET_CANCELLED;
         }
     };
@@ -177,8 +177,8 @@ CefTouchEvent CEFInteractionHandler::mapTouchEvent(const TouchPoint* p, const To
                 //    return CEF_POINTER_TYPE_PEN;
                 // case TouchDevice::DeviceType::Eraser:
                 //    return CEF_POINTER_TYPE_ERASER;
-            default: // Incorrect usage or new state added (warnings if left out)
-                assert(false);  
+            default:  // Incorrect usage or new state added (warnings if left out)
+                assert(false);
                 return CEF_POINTER_TYPE_TOUCH;
         }
     };

--- a/modules/webbrowser/src/processors/webbrowserprocessor.cpp
+++ b/modules/webbrowser/src/processors/webbrowserprocessor.cpp
@@ -195,7 +195,9 @@ void WebBrowserProcessor::OnLoadingStateChange(CefRefPtr<CefBrowser> browser, bo
     if (browser_ && browser->GetIdentifier() == browser_->GetIdentifier()) {
         isBrowserLoading_ = isLoading;
         // Render new page (content may have been rendered before the state changed)
-        if (!isLoading) { invalidate(InvalidationLevel::InvalidOutput); }
+        if (!isLoading) {
+            invalidate(InvalidationLevel::InvalidOutput);
+        }
     }
 }
 


### PR DESCRIPTION
Added support for touch events in the web browser module. Tested on touch screen and mac touchpad. Touchpad works as before. Also fixed a page-navigation flickering bug and updated example workspace (due to change in core)

Results from https://patrickhlauke.github.io/touch/tracker/multi-touch-tracker.html
![image](https://user-images.githubusercontent.com/8738140/76501151-0f90fa00-6442-11ea-859b-deca0ba9e6fb.png)
