### PR TITLE
Fixing reference of $(ConfigurationName) in ext/vld/CMakeLists.txt

### DIFF
--- a/ext/vld/CMakeLists.txt
+++ b/ext/vld/CMakeLists.txt
@@ -13,19 +13,19 @@ set(dll "vld_x64.dll")
 add_custom_target(vld
     ${CMAKE_COMMAND} -E copy_if_different 
         ${CMAKE_CURRENT_SOURCE_DIR}/vld.ini
-        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$(ConfigurationName)/vld.ini
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/vld.ini
 
     COMMAND ${CMAKE_COMMAND} -E copy_if_different 
         ${CMAKE_CURRENT_SOURCE_DIR}/bin/${arch}/${dll}
-        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$(ConfigurationName)/${dll} 
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/${dll}
 
     COMMAND ${CMAKE_COMMAND} -E copy_if_different 
         ${CMAKE_CURRENT_SOURCE_DIR}/bin/${arch}/dbghelp.dll
-        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$(ConfigurationName)/dbghelp.dll
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/dbghelp.dll
 
     COMMAND ${CMAKE_COMMAND} -E copy_if_different 
         ${CMAKE_CURRENT_SOURCE_DIR}/bin/${arch}/Microsoft.DTfW.DHL.manifest
-        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$(ConfigurationName)/Microsoft.DTfW.DHL.manifest
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/Microsoft.DTfW.DHL.manifest
 
     DEPENDS 
         ${CMAKE_CURRENT_SOURCE_DIR}/vld.ini


### PR DESCRIPTION
This is an almost trivial change. It replaces `$(ConfigurationName)` in CMakeLists.txt with `${CMAKE_CFG_INTDIR}` as discussed [in the cmake documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_CFG_INTDIR.html). This fixes the broken build for [the ninja build system](https://ninja-build.org/).

**Always**
- [x] Code is error and warning free
- [x] Code follows the [Inviwo coding guidelines](https://github.com/inviwo/inviwo/wiki/Coding-Conventions)

**What envinroment has the code been compiled and tested on?** 
- MSVC 2017 and 2019 with ninja, Ubuntu Linux 18.04 x86_64 with ninja.