### PR TITLE
Core: DataOutport: Added method to move data into the port

### DIFF
--- a/include/inviwo/core/ports/dataoutport.h
+++ b/include/inviwo/core/ports/dataoutport.h
@@ -81,7 +81,7 @@ public:
      * }
      * ```
      */
-    template <typename U = T, typename = std::enable_if_t<std::is_move_constructible_v<T>>>
+    template <typename U = T, typename = std::enable_if_t<std::is_move_constructible_v<U>>>
     void setData(T&& data);
 
     virtual bool hasData() const override;
@@ -144,7 +144,7 @@ std::shared_ptr<const T> DataOutport<T>::detachData() {
 template <typename T>
 template <typename, typename>
 void DataOutport<T>::setData(T&& data) {
-    setData(std::make_shared<T>(std::move(data)));
+    setData(std::make_shared<T>(data));
 }
 
 template <typename T>

--- a/include/inviwo/core/ports/dataoutport.h
+++ b/include/inviwo/core/ports/dataoutport.h
@@ -71,6 +71,20 @@ public:
     virtual void setData(const T* data);  // will assume ownership of data.
     virtual bool hasData() const override;
 
+    /**
+    * Pass data to the port using the Move constructor.
+    * Example: 
+    * ```c++
+    * SomePorcessor::process() {
+    *     std::vector<vec3> points;
+          /// code to fill the points-vector with data
+          myPort_.moveInData(std::move(points));
+    * }
+    * ```
+    */
+    template <typename U = T, typename = std::enable_if_t<std::is_move_constructible_v<U>>>
+    void moveInData(U&& data);
+
 protected:
     std::shared_ptr<const T> data_;
 };
@@ -129,6 +143,12 @@ std::shared_ptr<const T> DataOutport<T>::detachData() {
 template <typename T>
 bool DataOutport<T>::hasData() const {
     return data_.get() != nullptr;
+}
+
+template <typename T>
+template <typename U, typename>
+void DataOutport<T>::moveInData(U&& data) {
+    setData(std::make_shared<T>(std::move(data)));
 }
 
 template <typename T>

--- a/include/inviwo/core/ports/dataoutport.h
+++ b/include/inviwo/core/ports/dataoutport.h
@@ -69,21 +69,22 @@ public:
 
     virtual void setData(std::shared_ptr<const T> data);
     virtual void setData(const T* data);  // will assume ownership of data.
-    virtual bool hasData() const override;
 
     /**
-    * Pass data to the port using the Move constructor.
-    * Example:
-    * ```c++
-    * SomePorcessor::process() {
-    *     std::vector<vec3> points;
-          /// code to fill the points-vector with data
-          myPort_.moveInData(std::move(points));
-    * }
-    * ```
-    */
-    template <typename U = T, typename = std::enable_if_t<std::is_move_constructible_v<U>>>
-    void moveInData(U&& data);
+     * Pass data along to the port using the Move constructor.
+     * Example:
+     * ```c++
+     * void SomePorcessor::process() {
+     *     std::vector<vec3> points;
+     *      /// code to fill the points-vector with data
+     *      myPort_.setData(std::move(points));
+     * }
+     * ```
+     */
+    template <typename = std::enable_if_t<std::is_move_constructible_v<T>>>
+    void setData(T&& data);
+
+    virtual bool hasData() const override;
 
 protected:
     std::shared_ptr<const T> data_;
@@ -141,14 +142,14 @@ std::shared_ptr<const T> DataOutport<T>::detachData() {
 }
 
 template <typename T>
-bool DataOutport<T>::hasData() const {
-    return data_.get() != nullptr;
+template <typename>
+void DataOutport<T>::setData(T&& data) {
+    setData(std::make_shared<T>(std::move(data)));
 }
 
 template <typename T>
-template <typename U, typename>
-void DataOutport<T>::moveInData(U&& data) {
-    setData(std::make_shared<T>(std::move(data)));
+bool DataOutport<T>::hasData() const {
+    return data_.get() != nullptr;
 }
 
 template <typename T>

--- a/include/inviwo/core/ports/dataoutport.h
+++ b/include/inviwo/core/ports/dataoutport.h
@@ -73,7 +73,7 @@ public:
 
     /**
     * Pass data to the port using the Move constructor.
-    * Example: 
+    * Example:
     * ```c++
     * SomePorcessor::process() {
     *     std::vector<vec3> points;

--- a/include/inviwo/core/ports/dataoutport.h
+++ b/include/inviwo/core/ports/dataoutport.h
@@ -81,7 +81,7 @@ public:
      * }
      * ```
      */
-    template <typename = std::enable_if_t<std::is_move_constructible_v<T>>>
+    template <typename U = T, typename = std::enable_if_t<std::is_move_constructible_v<T>>>
     void setData(T&& data);
 
     virtual bool hasData() const override;
@@ -142,7 +142,7 @@ std::shared_ptr<const T> DataOutport<T>::detachData() {
 }
 
 template <typename T>
-template <typename>
+template <typename, typename>
 void DataOutport<T>::setData(T&& data) {
     setData(std::make_shared<T>(std::move(data)));
 }


### PR DESCRIPTION
Added method to data outport that allows data to be moved into the port (for moveable data). 
Lets you write your process function without the need to create shared_ptr, for example 
```c++ 
void SomePorcessor::process() {
    std::vector<vec3> points;
    /// code to fill the points-vector with data
    myPort_.moveInData(std::move(points));
}
```

* Is the name good? I named it `moveInData` since you move the data into the port. 
* I was also considering making the method taking the data by value (instead of &&) to let the compiler select to use the move constructor, but that would allow for calling the method without using std::move and would then use the copy ctor instead of the move ctor. 
