### PR TITLE
Core: ThreadPool: Added name to threadpool threads (windows only)

### DIFF
--- a/src/core/util/threadpool.cpp
+++ b/src/core/util/threadpool.cpp
@@ -31,6 +31,10 @@
 #include <inviwo/core/util/raiiutils.h>
 #include <inviwo/core/util/stdextensions.h>
 
+#ifdef WIN32
+#include <windows.h>
+#endif
+
 namespace inviwo {
 
 // the constructor just launches some amount of workers
@@ -106,7 +110,11 @@ ThreadPool::Worker::Worker(ThreadPool& pool)
             }
         }
         state = State::Done;
-    }} {}
+    }} {
+#ifdef WIN32
+    SetThreadDescription(thread.native_handle(), L"Inviwo Worker Thread");
+#endif
+}
 
 void ThreadPool::enqueueRaw(std::function<void()> task) {
     if (workers.empty()) {


### PR DESCRIPTION
With this commit, the worker threads will be listed as "Inviwo Worker Thread" in Visual Studio when debugging. 

![bild](https://user-images.githubusercontent.com/534670/77653296-ce373900-6f6f-11ea-8205-9eabe50c2348.png)
