### PR TITLE
Core: Threadpool: Prevent SetThreadDescription runtime error on Windows Server 2016

### DIFF
--- a/include/inviwo/core/util/threadutil.h
+++ b/include/inviwo/core/util/threadutil.h
@@ -1,0 +1,40 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2020 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <inviwo/core/common/inviwocoredefine.h>
+
+#include <string>
+#include <thread>
+
+namespace inviwo::util {
+
+IVW_CORE_API void setThreadDescription(std::thread& thread, const std::string& desc);
+
+}  // namespace inviwo::util

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -338,6 +338,7 @@ set(HEADER_FILES
     ${IVW_INCLUDE_DIR}/inviwo/core/util/systemcapabilities.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/templatesampler.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/threadpool.h
+    ${IVW_INCLUDE_DIR}/inviwo/core/util/threadutil.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/timer.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/tinydirinterface.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/transformiterator.h
@@ -610,10 +611,12 @@ set(SOURCE_FILES
     util/spatial4dsampler.cpp
     util/stacktrace.cpp
     util/statecoordinator.cpp
+    util/stdextensions.cpp
     util/stringconversion.cpp
     util/stringlogger.cpp
     util/systemcapabilities.cpp
     util/threadpool.cpp
+    util/threadutil.cpp
     util/timer.cpp
     util/tinydirinterface.cpp
     util/utilities.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -611,7 +611,6 @@ set(SOURCE_FILES
     util/spatial4dsampler.cpp
     util/stacktrace.cpp
     util/statecoordinator.cpp
-    util/stdextensions.cpp
     util/stringconversion.cpp
     util/stringlogger.cpp
     util/systemcapabilities.cpp

--- a/src/core/util/threadpool.cpp
+++ b/src/core/util/threadpool.cpp
@@ -113,7 +113,7 @@ ThreadPool::Worker::Worker(ThreadPool& pool)
     }} {
 #ifdef WIN32
     typedef HRESULT(WINAPI * SetTheadDescriptionFunc)(HANDLE hThread, PCWSTR threadDescription);
-	// SetThreadDescription was introduced with Windows 10, version 1607
+    // SetThreadDescription was introduced with Windows 10, version 1607
     // For that version and later Windows 10 version, the function should be in kernel32.dll
     static SetTheadDescriptionFunc setTheadDescription = reinterpret_cast<SetTheadDescriptionFunc>(
         GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")), "SetThreadDescription"));

--- a/src/core/util/threadpool.cpp
+++ b/src/core/util/threadpool.cpp
@@ -30,10 +30,7 @@
 #include <inviwo/core/util/threadpool.h>
 #include <inviwo/core/util/raiiutils.h>
 #include <inviwo/core/util/stdextensions.h>
-
-#ifdef WIN32
-#include <windows.h>
-#endif
+#include <inviwo/core/util/threadutil.h>
 
 namespace inviwo {
 
@@ -111,21 +108,8 @@ ThreadPool::Worker::Worker(ThreadPool& pool)
         }
         state = State::Done;
     }} {
-#ifdef WIN32
-    typedef HRESULT(WINAPI * SetTheadDescriptionFunc)(HANDLE hThread, PCWSTR threadDescription);
-    // SetThreadDescription was introduced with Windows 10, version 1607
-    // For that version and later Windows 10 version, the function should be in kernel32.dll
-    static SetTheadDescriptionFunc setTheadDescription = reinterpret_cast<SetTheadDescriptionFunc>(
-        GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")), "SetThreadDescription"));
-    // some Windows versions (e.g. 2016 Server) have the function in KernelBase.dll
-    if (!setTheadDescription) {
-        setTheadDescription = reinterpret_cast<SetTheadDescriptionFunc>(
-            GetProcAddress(GetModuleHandle(TEXT("KernelBase.dll")), "SetThreadDescription"));
-    }
-    if (setTheadDescription)
-        setTheadDescription(thread.native_handle(),
-                            util::toWstring(std::string("Inviwo Worker Thread")).c_str());
-#endif
+
+    util::setThreadDescription(thread, "Inviwo Worker Thread");
 }
 
 void ThreadPool::enqueueRaw(std::function<void()> task) {

--- a/src/core/util/threadutil.cpp
+++ b/src/core/util/threadutil.cpp
@@ -32,12 +32,12 @@
 
 #ifdef WIN32
 #include <windows.h>
-#else 
+#else
 #include <pthread.h>
 #endif
 
 namespace inviwo {
- 
+
 void util::setThreadDescription(std::thread& thread, const std::string& desc) {
 #ifdef WIN32
     typedef HRESULT(WINAPI * SetTheadDescriptionFunc)(HANDLE hThread, PCWSTR threadDescription);

--- a/src/core/util/threadutil.cpp
+++ b/src/core/util/threadutil.cpp
@@ -1,0 +1,63 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2020 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/core/util/threadutil.h>
+#include <inviwo/core/util/stringconversion.h>
+
+#ifdef WIN32
+#include <windows.h>
+#else 
+#include <pthread.h>
+#endif
+
+namespace inviwo {
+ 
+void util::setThreadDescription(std::thread& thread, const std::string& desc) {
+#ifdef WIN32
+    typedef HRESULT(WINAPI * SetTheadDescriptionFunc)(HANDLE hThread, PCWSTR threadDescription);
+    // SetThreadDescription was introduced with Windows 10, version 1607
+    // For that version and later Windows 10 version, the function should be in kernel32.dll
+    static SetTheadDescriptionFunc setTheadDescription = reinterpret_cast<SetTheadDescriptionFunc>(
+        GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")), "SetThreadDescription"));
+    // some Windows versions (e.g. 2016 Server) have the function in KernelBase.dll
+    if (!setTheadDescription) {
+        setTheadDescription = reinterpret_cast<SetTheadDescriptionFunc>(
+            GetProcAddress(GetModuleHandle(TEXT("KernelBase.dll")), "SetThreadDescription"));
+    }
+    if (setTheadDescription) {
+        setTheadDescription(thread.native_handle(), util::toWstring(desc).c_str());
+    }
+#elif defined(__APPLE__)
+    // Apple only supports setting the name on the same thread
+#else
+    pthread_setname_np(thread.native_handle(), desc.c_str());
+#endif
+}
+
+}  // namespace inviwo

--- a/src/core/util/timer.cpp
+++ b/src/core/util/timer.cpp
@@ -31,6 +31,7 @@
 #include <inviwo/core/common/inviwoapplication.h>
 #include <inviwo/core/util/exception.h>
 #include <inviwo/core/util/stdextensions.h>
+#include <inviwo/core/util/threadutil.h>
 
 #include <warn/push>
 #include <warn/ignore/all>
@@ -43,7 +44,10 @@ namespace inviwo {
 TimerThread::TimerThread()
     : sort_(false)
     , stop_(false)
-    , thread_{std::make_unique<std::thread>([this]() { TimerLoop(); })} {}
+    , thread_{std::make_unique<std::thread>([this]() { TimerLoop(); })} {
+
+    util::setThreadDescription(*thread_, "Inviwo Timer Thread");
+}
 
 TimerThread::~TimerThread() {
     stop_ = true;


### PR DESCRIPTION
The Windows API function `SetThreadDescription` is not available in `kernel32.dll` in Windows Server 2016 and our include of Windows.h does not lead to locating the function anywhere else. Thus Inviwo crashes upon startup with "Could not locate entry point SetThreadDescription"-error. This commit looks up the function in `kernel32.dll`, where it should be located according to the [documentation](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreaddescription) and falls back on `KernelBase.dll`, where I was able to locate the function on Windows Server. This should also prevent the crash for Windows 10 prior to version 1607. 

Environment:
- Windows Server 2016, Windows 10
- Visual Studio 2017, Visual Studio 2019
- QT 5.13.1, CMake 3.17.1

Note: 
In the screenshot in #906 the worker threads are numbered. This was not the case for me when testing.