### PR TITLE
Fix/remove warnings

### DIFF
--- a/include/inviwo/core/datastructures/camera.h
+++ b/include/inviwo/core/datastructures/camera.h
@@ -33,6 +33,8 @@
 #include <inviwo/core/io/serialization/serializable.h>
 #include <inviwo/core/util/glm.h>
 
+#include <memory>
+
 namespace inviwo {
 
 class CompositeProperty;

--- a/include/inviwo/core/datastructures/datagroup.h
+++ b/include/inviwo/core/datastructures/datagroup.h
@@ -35,6 +35,7 @@
 
 #include <type_traits>
 #include <typeindex>
+#include <memory>
 #include <mutex>
 #include <unordered_map>
 

--- a/include/inviwo/core/datastructures/image/layerramconverter.h
+++ b/include/inviwo/core/datastructures/image/layerramconverter.h
@@ -35,6 +35,8 @@
 #include <inviwo/core/datastructures/image/layerdisk.h>
 #include <inviwo/core/datastructures/image/layerramprecision.h>
 
+#include <memory>
+
 namespace inviwo {
 
 class IVW_CORE_API LayerDisk2RAMConverter

--- a/include/inviwo/core/datastructures/representationconverter.h
+++ b/include/inviwo/core/datastructures/representationconverter.h
@@ -32,6 +32,7 @@
 #include <inviwo/core/common/inviwocoredefine.h>
 #include <inviwo/core/util/exception.h>
 
+#include <memory>
 #include <string>
 #include <vector>
 #include <typeindex>

--- a/include/inviwo/core/interaction/events/pickingevent.h
+++ b/include/inviwo/core/interaction/events/pickingevent.h
@@ -36,6 +36,8 @@
 #include <inviwo/core/util/constexprhash.h>
 #include <inviwo/core/util/glmvec.h>
 
+#include <memory>
+
 namespace inviwo {
 
 class PickingAction;

--- a/include/inviwo/core/processors/poolprocessor.h
+++ b/include/inviwo/core/processors/poolprocessor.h
@@ -128,7 +128,7 @@ enum class Option {
 
 }  // namespace pool
 
-ALLOW_FLAGS_FOR_ENUM(pool::Option);
+ALLOW_FLAGS_FOR_ENUM(pool::Option)
 namespace pool {
 
 /**

--- a/include/inviwo/core/processors/processorfactoryobject.h
+++ b/include/inviwo/core/processors/processorfactoryobject.h
@@ -72,6 +72,7 @@ public:
     virtual ~ProcessorFactoryObjectTemplate() = default;
 
     virtual std::unique_ptr<Processor> create(InviwoApplication* app) {
+        (void)app;
         std::unique_ptr<Processor> p;
 
         if constexpr (std::is_constructible_v<T, const std::string&, const std::string&,

--- a/include/inviwo/core/processors/processorinfo.h
+++ b/include/inviwo/core/processors/processorinfo.h
@@ -33,6 +33,7 @@
 #include <inviwo/core/processors/processorstate.h>
 #include <inviwo/core/processors/processortags.h>
 
+#include <tuple>
 #include <string>
 #include <utility>
 

--- a/modules/plottinggl/src/processors/parallelcoordinates/parallelcoordinates.cpp
+++ b/modules/plottinggl/src/processors/parallelcoordinates/parallelcoordinates.cpp
@@ -819,7 +819,7 @@ std::pair<size2_t, size2_t> ParallelCoordinates::axisPos(size_t columnId) const 
 
 std::pair<vec2, vec2> ParallelCoordinates::getDisplayRect(vec2 size) const {
     return {marginsInternal_.first, size - marginsInternal_.second};
-};
+}
 
 void ParallelCoordinates::serialize(Serializer& s) const {
     Processor::serialize(s);

--- a/modules/python3/bindings/src/pyimage.cpp
+++ b/modules/python3/bindings/src/pyimage.cpp
@@ -53,7 +53,7 @@
 
 #include <fmt/format.h>
 
-PYBIND11_MAKE_OPAQUE(inviwo::SwizzleMask);
+PYBIND11_MAKE_OPAQUE(inviwo::SwizzleMask)
 
 namespace py = pybind11;
 
@@ -108,10 +108,12 @@ void exposeImage(py::module& m) {
         .def(py::init<std::shared_ptr<Layer>>())
         .def("clone", [](Image& self) { return self.clone(); })
         .def_property_readonly("dimensions", &Image::getDimensions)
-        .def_property_readonly("depth", [](Image& img) { return img.getDepthLayer(); },
-                               py::return_value_policy::reference_internal)
-        .def_property_readonly("picking", [](Image& img) { return img.getPickingLayer(); },
-                               py::return_value_policy::reference_internal)
+        .def_property_readonly(
+            "depth", [](Image& img) { return img.getDepthLayer(); },
+            py::return_value_policy::reference_internal)
+        .def_property_readonly(
+            "picking", [](Image& img) { return img.getPickingLayer(); },
+            py::return_value_policy::reference_internal)
         .def_property_readonly("colorLayers", getLayers)
         .def("__repr__", [](const Image& self) {
             const auto dims = self.getDimensions();

--- a/src/core/datastructures/camera.cpp
+++ b/src/core/datastructures/camera.cpp
@@ -238,7 +238,7 @@ void OrthographicCamera::configureProperties(CompositeProperty* comp, Config con
             initialWidth = glm::distance(getLookTo(), getLookFrom()) *
                            std::tan(0.5f * glm::radians(fovProp->get()));
         }
-        widthProp = new FloatProperty("width", "Width", 10.0f, 0.01f, 1000.0f, 0.1f);
+        widthProp = new FloatProperty("width", "Width", initialWidth, 0.01f, 1000.0f, 0.1f);
         comp->insertProperty(comp->size() - 1, widthProp, true);
         widthProp->setSerializationMode(PropertySerializationMode::All);
     }

--- a/src/core/util/filesystem.cpp
+++ b/src/core/util/filesystem.cpp
@@ -765,6 +765,9 @@ std::string getCanonicalPath(const std::string& url) {
 
     return result;
 #else
+#ifndef PATH_MAX
+    const int PATH_MAX = 4096;
+#endif
     char buffer[PATH_MAX + 1];
     char* retVal = realpath(url.c_str(), buffer);
     if (retVal == nullptr) {


### PR DESCRIPTION
Thank you for contributing to the Inviwo repository! Great code makes great apps so please ensure the following:

**Always**
- [ x] Code is error and warning free
- [ x] Code follows the [Inviwo coding guidelines](https://github.com/inviwo/inviwo/wiki/Coding-Conventions)

**What evineroment has the code been compiled and tested on?** 
- Operating system: ubuntu 18.04
- Compiler/IDE: GCC 8.3.0, vscode
- QT/CMake/Python versions: QT 5.14.1, cmake 3.13.4, Python 3.6.9

Are you are unsure how to address these points? Please make a note here so that we can help out:
I removed some warning that kept bugging me. Moreover, there is a remaining warning that is troubling me:
```
{
	"resource": "/home/martin/src/placeholder/inviwo/modules/basegl/src/processors/imageprocessing/imagesubsetgl.cpp",
	"owner": "cmake-build-diags",
	"severity": 4,
	"message": "this statement may fall through [-Wimplicit-fallthrough=]",
	"source": "GCC",
	"startLineNumber": 156,
	"startColumn": 30,
	"endLineNumber": 156,
	"endColumn": 1000,
	"relatedInformation": [
		{
			"startLineNumber": 157,
			"startColumn": 9,
			"endLineNumber": 157,
			"endColumn": 1000,
			"message": "here",
			"resource": "/home/martin/src/placeholder/inviwo/modules/basegl/src/processors/imageprocessing/imagesubsetgl.cpp"
		}
	]
}
```
Any ideas how to fix it propertly?