### PR TITLE
Fix/remove warnings

### DIFF
--- a/include/inviwo/core/processors/poolprocessor.h
+++ b/include/inviwo/core/processors/poolprocessor.h
@@ -128,7 +128,7 @@ enum class Option {
 
 }  // namespace pool
 
-ALLOW_FLAGS_FOR_ENUM(pool::Option);
+ALLOW_FLAGS_FOR_ENUM(pool::Option)
 namespace pool {
 
 /**

--- a/include/inviwo/core/processors/processorfactoryobject.h
+++ b/include/inviwo/core/processors/processorfactoryobject.h
@@ -72,6 +72,7 @@ public:
     virtual ~ProcessorFactoryObjectTemplate() = default;
 
     virtual std::unique_ptr<Processor> create(InviwoApplication* app) {
+        (void)app;
         std::unique_ptr<Processor> p;
 
         if constexpr (std::is_constructible_v<T, const std::string&, const std::string&,

--- a/modules/plottinggl/src/processors/parallelcoordinates/parallelcoordinates.cpp
+++ b/modules/plottinggl/src/processors/parallelcoordinates/parallelcoordinates.cpp
@@ -819,7 +819,7 @@ std::pair<size2_t, size2_t> ParallelCoordinates::axisPos(size_t columnId) const 
 
 std::pair<vec2, vec2> ParallelCoordinates::getDisplayRect(vec2 size) const {
     return {marginsInternal_.first, size - marginsInternal_.second};
-};
+}
 
 void ParallelCoordinates::serialize(Serializer& s) const {
     Processor::serialize(s);

--- a/modules/python3/bindings/src/pyimage.cpp
+++ b/modules/python3/bindings/src/pyimage.cpp
@@ -53,7 +53,7 @@
 
 #include <fmt/format.h>
 
-PYBIND11_MAKE_OPAQUE(inviwo::SwizzleMask);
+PYBIND11_MAKE_OPAQUE(inviwo::SwizzleMask)
 
 namespace py = pybind11;
 
@@ -108,10 +108,12 @@ void exposeImage(py::module& m) {
         .def(py::init<std::shared_ptr<Layer>>())
         .def("clone", [](Image& self) { return self.clone(); })
         .def_property_readonly("dimensions", &Image::getDimensions)
-        .def_property_readonly("depth", [](Image& img) { return img.getDepthLayer(); },
-                               py::return_value_policy::reference_internal)
-        .def_property_readonly("picking", [](Image& img) { return img.getPickingLayer(); },
-                               py::return_value_policy::reference_internal)
+        .def_property_readonly(
+            "depth", [](Image& img) { return img.getDepthLayer(); },
+            py::return_value_policy::reference_internal)
+        .def_property_readonly(
+            "picking", [](Image& img) { return img.getPickingLayer(); },
+            py::return_value_policy::reference_internal)
         .def_property_readonly("colorLayers", getLayers)
         .def("__repr__", [](const Image& self) {
             const auto dims = self.getDimensions();

--- a/src/core/datastructures/camera.cpp
+++ b/src/core/datastructures/camera.cpp
@@ -238,7 +238,7 @@ void OrthographicCamera::configureProperties(CompositeProperty* comp, Config con
             initialWidth = glm::distance(getLookTo(), getLookFrom()) *
                            std::tan(0.5f * glm::radians(fovProp->get()));
         }
-        widthProp = new FloatProperty("width", "Width", 10.0f, 0.01f, 1000.0f, 0.1f);
+        widthProp = new FloatProperty("width", "Width", initialWidth, 0.01f, 1000.0f, 0.1f);
         comp->insertProperty(comp->size() - 1, widthProp, true);
         widthProp->setSerializationMode(PropertySerializationMode::All);
     }


### PR DESCRIPTION
Thank you for contributing to the Inviwo repository! Great code makes great apps so please ensure the following:

**Always**
- [ x] Code is error and warning free
- [ x] Code follows the [Inviwo coding guidelines](https://github.com/inviwo/inviwo/wiki/Coding-Conventions)

**What evineroment has the code been compiled and tested on?** 
- Operating system: ubuntu 18.04
- Compiler/IDE: GCC 8.3.0, vscode
- QT/CMake/Python versions: QT 5.14.1, cmake 3.13.4, Python 3.6.9

Are you are unsure how to address these points? Please make a note here so that we can help out:
I removed some warning that kept bugging me. Moreover, there is a remaining warning that is troubling me:
```
{
	"resource": "/home/martin/src/placeholder/inviwo/modules/basegl/src/processors/imageprocessing/imagesubsetgl.cpp",
	"owner": "cmake-build-diags",
	"severity": 4,
	"message": "this statement may fall through [-Wimplicit-fallthrough=]",
	"source": "GCC",
	"startLineNumber": 156,
	"startColumn": 30,
	"endLineNumber": 156,
	"endColumn": 1000,
	"relatedInformation": [
		{
			"startLineNumber": 157,
			"startColumn": 9,
			"endLineNumber": 157,
			"endColumn": 1000,
			"message": "here",
			"resource": "/home/martin/src/placeholder/inviwo/modules/basegl/src/processors/imageprocessing/imagesubsetgl.cpp"
		}
	]
}
```
Any ideas how to fix it propertly?