### PR TITLE
Feature/webbrowser refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 Here we document changes that affect the public API or changes that needs to be communicated to other developers. 
 
+## 2020-06-03 WebBrowser Javascript API
+Changed redirection of `https://inviwo` to `api://inviwo` to avoid confusion with the https scheme.
+Your html-files will need to update from 
+'https://inviwo/modules/yourmodule' 
+to 
+'api://inviwo/modules/yourmodule' 
+
 ## 2020-04-03 OrdinalPropertyState
 Added a OrdinalPropertyState helper for constructing ordinal properties.
 And a factory function `util::ordinalColor` for OrdinalProperties representing Colors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 Here we document changes that affect the public API or changes that needs to be communicated to other developers. 
 
 ## 2020-06-03 WebBrowser Javascript API
-Changed redirection of `https://inviwo` to `api://inviwo` to avoid confusion with the https scheme.
+Changed redirection of `https://inviwo` to `inviwo://` to avoid confusion with the https scheme.
 Your html-files will need to update from 
 'https://inviwo/modules/yourmodule' 
 to 
-'api://inviwo/modules/yourmodule' 
+'inviwo://yourmodule' 
 
 ## 2020-04-03 OrdinalPropertyState
 Added a OrdinalPropertyState helper for constructing ordinal properties.

--- a/modules/animation/include/modules/animation/datastructures/propertytrack.h
+++ b/modules/animation/include/modules/animation/datastructures/propertytrack.h
@@ -79,7 +79,6 @@ void setOtherPropertyHelper(OrdinalRefProperty<T>* property, ValueKeyframe<T>* k
     property->set(keyframe->getValue());
 }
 
-
 /**
  * Helper function for inviwo::animation::PropertyTrack::setOtherProperty
  * @see inviwo::animation::BasePropertyTrack::setOtherProperty

--- a/modules/animation/include/modules/animation/datastructures/propertytrack.h
+++ b/modules/animation/include/modules/animation/datastructures/propertytrack.h
@@ -36,6 +36,7 @@
 #include <inviwo/core/properties/property.h>
 #include <inviwo/core/properties/templateproperty.h>
 #include <inviwo/core/properties/ordinalproperty.h>
+#include <inviwo/core/properties/ordinalrefproperty.h>
 #include <inviwo/core/properties/optionproperty.h>
 
 #include <modules/animation/datastructures/valuekeyframe.h>
@@ -74,6 +75,16 @@ void setOtherPropertyHelper(OrdinalProperty<T>* property, ValueKeyframe<T>* keyf
  * @see inviwo::animation::BasePropertyTrack::setOtherProperty
  */
 template <typename T>
+void setOtherPropertyHelper(OrdinalRefProperty<T>* property, ValueKeyframe<T>* keyframe) {
+    property->set(keyframe->getValue());
+}
+
+
+/**
+ * Helper function for inviwo::animation::PropertyTrack::setOtherProperty
+ * @see inviwo::animation::BasePropertyTrack::setOtherProperty
+ */
+template <typename T>
 void setOtherPropertyHelper(TemplateOptionProperty<T>* property, ValueKeyframe<T>* keyframe) {
     property->setSelectedValue(keyframe->getValue());
 }
@@ -93,6 +104,15 @@ void updateKeyframeFromPropertyHelper(TemplateProperty<T>* property, ValueKeyfra
  */
 template <typename T>
 void updateKeyframeFromPropertyHelper(OrdinalProperty<T>* property, ValueKeyframe<T>* keyframe) {
+    keyframe->setValue(property->get());
+}
+
+/**
+ * Helper function for inviwo::animation::PropertyTrack::updateKeyframeFromProperty
+ * @see inviwo::animation::BasePropertyTrack::updateKeyframeFromProperty
+ */
+template <typename T>
+void updateKeyframeFromPropertyHelper(OrdinalRefProperty<T>* property, ValueKeyframe<T>* keyframe) {
     keyframe->setValue(property->get());
 }
 

--- a/modules/animation/src/animationmodule.cpp
+++ b/modules/animation/src/animationmodule.cpp
@@ -35,6 +35,7 @@
 #include <inviwo/core/properties/minmaxproperty.h>
 #include <inviwo/core/properties/optionproperty.h>
 #include <inviwo/core/properties/ordinalproperty.h>
+#include <inviwo/core/properties/ordinalrefproperty.h>
 #include <inviwo/core/properties/stringproperty.h>
 
 #include <modules/animation/interpolation/constantinterpolation.h>
@@ -82,6 +83,10 @@ struct OrdinalReghelper {
         trackRegHelper<PropertyType>(am);
         interpolationRegHelper<PropertyType, LinearInterpolation>(am);
         interpolationRegHelper<PropertyType, ConstantInterpolation>(am);
+        using PropertyRefType = OrdinalRefProperty<T>;
+        trackRegHelper<PropertyRefType>(am);
+        interpolationRegHelper<PropertyRefType, LinearInterpolation>(am);
+        interpolationRegHelper<PropertyRefType, ConstantInterpolation>(am);
     }
 };
 

--- a/modules/webbrowser/CMakeLists.txt
+++ b/modules/webbrowser/CMakeLists.txt
@@ -99,6 +99,7 @@ set(HEADER_FILES
     include/modules/webbrowser/webbrowserclient.h
     include/modules/webbrowser/webbrowsermodule.h
     include/modules/webbrowser/webbrowsermoduledefine.h
+    include/modules/webbrowser/webbrowserutil.h
 )
 ivw_group("Header Files" ${HEADER_FILES})
 
@@ -119,6 +120,7 @@ set(SOURCE_FILES
     src/webbrowserapp.cpp
     src/webbrowserclient.cpp
     src/webbrowsermodule.cpp
+    src/webbrowserutil.cpp
 )
 ivw_group("Source Files" ${SOURCE_FILES})
 

--- a/modules/webbrowser/data/js/inviwoapi.js
+++ b/modules/webbrowser/data/js/inviwoapi.js
@@ -3,7 +3,7 @@
  * API/Object for communicating with Inviwo through Javascript.
  * Include the API using:
  * ```
- * <script src="api://inviwo/modules/webbrowser/data/js/inviwoapi.js"></script>
+ * <script src="inviwo://webbrowser/data/js/inviwoapi.js"></script>
  * ```
  * If you only need one-way synchronization, e.g. always changing values from the
  * webpage:

--- a/modules/webbrowser/data/js/inviwoapi.js
+++ b/modules/webbrowser/data/js/inviwoapi.js
@@ -3,7 +3,7 @@
  * API/Object for communicating with Inviwo through Javascript.
  * Include the API using:
  * ```
- * <script src="https://inviwo/modules/webbrowser/data/js/inviwoapi.js"></script>
+ * <script src="api://inviwo/modules/webbrowser/data/js/inviwoapi.js"></script>
  * ```
  * If you only need one-way synchronization, e.g. always changing values from the
  * webpage:

--- a/modules/webbrowser/data/workspaces/web_property_sync.html
+++ b/modules/webbrowser/data/workspaces/web_property_sync.html
@@ -1,8 +1,9 @@
 <html>
 <head>
 <title>Inviwo property syncing example</title>
-<!-- api://inviwo/modules/yourmodulename will be rediredcted to the module directory on the harddrive -->
-<script src="api://inviwo/modules/webbrowser/data/js/inviwoapi.js"></script>
+<!-- inviwo://yourmodulename will be rediredcted to the module directory on the harddrive -->
+<!-- inviwo://app will be rediredcted to the application (InviwoApplication::getBasePath()) directory on the harddrive -->
+<script src="inviwo://webbrowser/data/js/inviwoapi.js"></script>
 
 <script language="JavaScript">
 // Initialize Inviwo API so that we can use it to synchronize properties

--- a/modules/webbrowser/data/workspaces/web_property_sync.html
+++ b/modules/webbrowser/data/workspaces/web_property_sync.html
@@ -1,8 +1,8 @@
 <html>
 <head>
 <title>Inviwo property syncing example</title>
-<!-- https://inviwo/modules/yourmodulename will be rediredcted to the module directory on the harddrive -->
-<script src="https://inviwo/modules/webbrowser/data/js/inviwoapi.js"></script>
+<!-- api://inviwo/modules/yourmodulename will be rediredcted to the module directory on the harddrive -->
+<script src="api://inviwo/modules/webbrowser/data/js/inviwoapi.js"></script>
 
 <script language="JavaScript">
 // Initialize Inviwo API so that we can use it to synchronize properties

--- a/modules/webbrowser/include/modules/webbrowser/cefimageconverter.h
+++ b/modules/webbrowser/include/modules/webbrowser/cefimageconverter.h
@@ -55,4 +55,3 @@ protected:
 };
 
 }  // namespace inviwo
-

--- a/modules/webbrowser/include/modules/webbrowser/interaction/cefinteractionhandler.h
+++ b/modules/webbrowser/include/modules/webbrowser/interaction/cefinteractionhandler.h
@@ -27,8 +27,7 @@
  *
  *********************************************************************************/
 
-#ifndef IVW_CEFINTERACTIONHANDLER_H
-#define IVW_CEFINTERACTIONHANDLER_H
+#pragma once
 
 #include <modules/webbrowser/webbrowsermoduledefine.h>
 #include <inviwo/core/interaction/interactionhandler.h>
@@ -90,4 +89,3 @@ private:
 
 };  // namespace inviwo
 
-#endif  // IVW_CEFINTERACTIONHANDLER_H

--- a/modules/webbrowser/include/modules/webbrowser/interaction/cefinteractionhandler.h
+++ b/modules/webbrowser/include/modules/webbrowser/interaction/cefinteractionhandler.h
@@ -88,4 +88,3 @@ private:
 };
 
 };  // namespace inviwo
-

--- a/modules/webbrowser/include/modules/webbrowser/interaction/cefkeyboardmapping.h
+++ b/modules/webbrowser/include/modules/webbrowser/interaction/cefkeyboardmapping.h
@@ -49,4 +49,3 @@ unsigned int IVW_MODULE_WEBBROWSER_API keyModifiers(KeyModifiers modifiers, IvwK
 };  // namespace cef
 
 };  // namespace inviwo
-

--- a/modules/webbrowser/include/modules/webbrowser/interaction/cefkeyboardmapping.h
+++ b/modules/webbrowser/include/modules/webbrowser/interaction/cefkeyboardmapping.h
@@ -27,8 +27,7 @@
  *
  *********************************************************************************/
 
-#ifndef IVW_CEFKEYBOARDMAPPING_H
-#define IVW_CEFKEYBOARDMAPPING_H
+#pragma once
 
 #include <modules/webbrowser/webbrowsermoduledefine.h>
 #include <inviwo/core/interaction/events/keyboardkeys.h>
@@ -51,4 +50,3 @@ unsigned int IVW_MODULE_WEBBROWSER_API keyModifiers(KeyModifiers modifiers, IvwK
 
 };  // namespace inviwo
 
-#endif  // IVW_CEFKEYBOARDMAPPING_H

--- a/modules/webbrowser/include/modules/webbrowser/processors/webbrowserprocessor.h
+++ b/modules/webbrowser/include/modules/webbrowser/processors/webbrowserprocessor.h
@@ -151,4 +151,3 @@ protected:
 };
 #include <warn/pop>
 }  // namespace inviwo
-

--- a/modules/webbrowser/include/modules/webbrowser/processors/webbrowserprocessor.h
+++ b/modules/webbrowser/include/modules/webbrowser/processors/webbrowserprocessor.h
@@ -27,8 +27,7 @@
  *
  *********************************************************************************/
 
-#ifndef IVW_WEBBROWSERPROCESSOR_H
-#define IVW_WEBBROWSERPROCESSOR_H
+#pragma once
 
 #include <modules/webbrowser/webbrowsermoduledefine.h>
 #include <modules/webbrowser/webbrowserclient.h>
@@ -106,7 +105,7 @@ namespace inviwo {
 #include <warn/ignore/extra-semi>  // Due to IMPLEMENT_REFCOUNTING, remove when upgrading CEF
 class IVW_MODULE_WEBBROWSER_API WebBrowserProcessor : public Processor, public CefLoadHandler {
 public:
-    WebBrowserProcessor();
+    WebBrowserProcessor(InviwoApplication* app);
     virtual ~WebBrowserProcessor();
 
     virtual void process() override;
@@ -143,7 +142,6 @@ protected:
     CefImageConverter cefToInviwoImageConverter_;
     // create browser-window
     CefRefPtr<RenderHandlerGL> renderHandler_;
-    CefRefPtr<WebBrowserClient> browserClient_;
     CefRefPtr<CefBrowser> browser_;
     bool isBrowserLoading_ = true;
 
@@ -154,4 +152,3 @@ protected:
 #include <warn/pop>
 }  // namespace inviwo
 
-#endif  // IVW_WEBBROWSERPROCESSOR_H

--- a/modules/webbrowser/include/modules/webbrowser/properties/propertycefsynchronizer.h
+++ b/modules/webbrowser/include/modules/webbrowser/properties/propertycefsynchronizer.h
@@ -128,4 +128,3 @@ private:
 #include <warn/pop>
 
 }  // namespace inviwo
-

--- a/modules/webbrowser/include/modules/webbrowser/properties/propertycefsynchronizer.h
+++ b/modules/webbrowser/include/modules/webbrowser/properties/propertycefsynchronizer.h
@@ -27,8 +27,7 @@
  *
  *********************************************************************************/
 
-#ifndef IVW_PROPERTYCEFSYNCHRONIZER_H
-#define IVW_PROPERTYCEFSYNCHRONIZER_H
+#pragma once
 
 #include <modules/webbrowser/webbrowsermoduledefine.h>
 #include <modules/webbrowser/properties/propertywidgetcef.h>
@@ -130,4 +129,3 @@ private:
 
 }  // namespace inviwo
 
-#endif  // IVW_PROPERTYCEFSYNCHRONIZER_H

--- a/modules/webbrowser/include/modules/webbrowser/properties/propertywidgetcef.h
+++ b/modules/webbrowser/include/modules/webbrowser/properties/propertywidgetcef.h
@@ -173,4 +173,3 @@ protected:
 };
 
 }  // namespace inviwo
-

--- a/modules/webbrowser/include/modules/webbrowser/properties/propertywidgetcef.h
+++ b/modules/webbrowser/include/modules/webbrowser/properties/propertywidgetcef.h
@@ -27,8 +27,7 @@
  *
  *********************************************************************************/
 
-#ifndef IVW_PROPERTYWIDGETCEF_H
-#define IVW_PROPERTYWIDGETCEF_H
+#pragma once
 
 #include <modules/webbrowser/webbrowsermoduledefine.h>
 #include <modules/json/io/json/propertyjsonconverter.h>
@@ -175,4 +174,3 @@ protected:
 
 }  // namespace inviwo
 
-#endif  // IVW_PROPERTYWIDGETCEF_H

--- a/modules/webbrowser/include/modules/webbrowser/renderhandlergl.h
+++ b/modules/webbrowser/include/modules/webbrowser/renderhandlergl.h
@@ -33,7 +33,7 @@
 #include <modules/opengl/inviwoopengl.h>
 #include <modules/opengl/texture/texture2d.h>
 
-
+#include <map>
 
 #include <warn/push>
 #include <warn/ignore/all>
@@ -100,7 +100,7 @@ private:
     };
     CefRect GetPopupRectInWebView(CefRefPtr<CefBrowser> browser, const CefRect &original_rect);
 
-    std::unordered_map<int, BrowserData> browserData_; /// Per browser data
+    std::map<int, BrowserData> browserData_; /// Per browser data
 
     OnWebPageCopiedCallback
         onWebPageCopiedCallback;  /// Called after web page has been copied in OnPaint

--- a/modules/webbrowser/include/modules/webbrowser/renderhandlergl.h
+++ b/modules/webbrowser/include/modules/webbrowser/renderhandlergl.h
@@ -27,11 +27,13 @@
  *
  *********************************************************************************/
 
-#ifndef IVW_RENDERHANDLERGL_H
-#define IVW_RENDERHANDLERGL_H
+#pragma once
 
 #include <modules/webbrowser/webbrowsermoduledefine.h>
+#include <modules/opengl/inviwoopengl.h>
 #include <modules/opengl/texture/texture2d.h>
+
+
 
 #include <warn/push>
 #include <warn/ignore/all>
@@ -49,10 +51,11 @@ namespace inviwo {
 #include <warn/ignore/extra-semi>  // Due to IMPLEMENT_REFCOUNTING, remove when upgrading CEF
 class IVW_MODULE_WEBBROWSER_API RenderHandlerGL : public CefRenderHandler {
 public:
-    typedef std::function<void()> OnWebPageCopiedCallback;
+    typedef std::function<void(CefRefPtr<CefBrowser>)> OnWebPageCopiedCallback;
 
     RenderHandlerGL(OnWebPageCopiedCallback onWebPageCopiedCallback);
-    void updateCanvasSize(size2_t newSize);
+    void updateCanvasSize(CefRefPtr<CefBrowser> browser, size2_t newSize);
+
     ///
     // Called to retrieve the view rectangle which is relative to screen
     // coordinates. Return true if the rectangle was provided.
@@ -85,33 +88,25 @@ public:
      *   |        |
      * (0,1) -- (1,1)
      */
-    Texture2D &getTexture2D() { return texture2D_; }
+    Texture2D& getTexture2D(CefRefPtr<CefBrowser> browser);
 
-    /*
-     * Get RGBA color of pixel given top-left as pixel origin.
-     * The coordinate system looks like this:
-     *     (0,0)     --     (width-1,0)
-     *       |                   |
-     * (0,height -1) -- (width-1,height -1)
-     */
-    uvec4 getPixel(int x, int y);
-
-    void ClearPopupRects();
+    void ClearPopupRects(CefRefPtr<CefBrowser> browser);
 
 private:
-    CefRect GetPopupRectInWebView(const CefRect &original_rect);
+    struct BrowserData {
+        Texture2D texture2D{size2_t{1, 1}, GL_BGRA, GL_RGBA, GL_UNSIGNED_BYTE, GL_NEAREST};
+        CefRect popupRect;
+        CefRect originalPopupRect;
+    };
+    CefRect GetPopupRectInWebView(CefRefPtr<CefBrowser> browser, const CefRect &original_rect);
 
-    Texture2D texture2D_;
+    std::unordered_map<int, BrowserData> browserData_; /// Per browser data
+
     OnWebPageCopiedCallback
         onWebPageCopiedCallback;  /// Called after web page has been copied in OnPaint
 
-    CefRect popupRect_;
-    CefRect originalPopupRect_;
-
-public:
     IMPLEMENT_REFCOUNTING(RenderHandlerGL);
 };
 #include <warn/pop>
 };  // namespace inviwo
 
-#endif  // IVW_RENDERHANDLERGL_H

--- a/modules/webbrowser/include/modules/webbrowser/renderhandlergl.h
+++ b/modules/webbrowser/include/modules/webbrowser/renderhandlergl.h
@@ -33,8 +33,6 @@
 #include <modules/opengl/inviwoopengl.h>
 #include <modules/opengl/texture/texture2d.h>
 
-
-
 #include <warn/push>
 #include <warn/ignore/all>
 #include <include/cef_render_handler.h>
@@ -88,7 +86,7 @@ public:
      *   |        |
      * (0,1) -- (1,1)
      */
-    Texture2D& getTexture2D(CefRefPtr<CefBrowser> browser);
+    Texture2D &getTexture2D(CefRefPtr<CefBrowser> browser);
 
     void ClearPopupRects(CefRefPtr<CefBrowser> browser);
 
@@ -100,7 +98,7 @@ private:
     };
     CefRect GetPopupRectInWebView(CefRefPtr<CefBrowser> browser, const CefRect &original_rect);
 
-    std::unordered_map<int, BrowserData> browserData_; /// Per browser data
+    std::unordered_map<int, BrowserData> browserData_;  /// Per browser data
 
     OnWebPageCopiedCallback
         onWebPageCopiedCallback;  /// Called after web page has been copied in OnPaint
@@ -109,4 +107,3 @@ private:
 };
 #include <warn/pop>
 };  // namespace inviwo
-

--- a/modules/webbrowser/include/modules/webbrowser/webbrowserapp.h
+++ b/modules/webbrowser/include/modules/webbrowser/webbrowserapp.h
@@ -27,8 +27,7 @@
  *
  *********************************************************************************/
 
-#ifndef IVW_WEBBROWSERAPP_H
-#define IVW_WEBBROWSERAPP_H
+#pragma once
 
 #include <modules/webbrowser/webbrowsermoduledefine.h>
 
@@ -77,4 +76,4 @@ private:
 #include <warn/pop>
 
 };      // namespace inviwo
-#endif  // IVW_WEBBROWSERAPP_H
+

--- a/modules/webbrowser/include/modules/webbrowser/webbrowserapp.h
+++ b/modules/webbrowser/include/modules/webbrowser/webbrowserapp.h
@@ -75,5 +75,4 @@ private:
 };
 #include <warn/pop>
 
-};      // namespace inviwo
-
+};  // namespace inviwo

--- a/modules/webbrowser/include/modules/webbrowser/webbrowserclient.h
+++ b/modules/webbrowser/include/modules/webbrowser/webbrowserclient.h
@@ -67,7 +67,6 @@ class IVW_MODULE_WEBBROWSER_API WebBrowserClient : public CefClient,
                                                    public CefDisplayHandler,
                                                    public CefResourceRequestHandler {
 public:
-
     WebBrowserClient(const PropertyWidgetCEFFactory* widgetFactory);
 
     virtual CefRefPtr<CefLoadHandler> GetLoadHandler() override { return this; }
@@ -76,7 +75,7 @@ public:
     virtual CefRefPtr<CefDisplayHandler> GetDisplayHandler() override { return this; }
 
     /**
-     * Enable invalidation when the web page repaints and allow the Inviwo javascript API 
+     * Enable invalidation when the web page repaints and allow the Inviwo javascript API
      * to access the parent processor.
      * @param const Processor* parent web browser processor responsible for the browser. Cannot be
      * null.
@@ -195,8 +194,8 @@ protected:
         Processor* processor;
         CefRefPtr<ProcessorCefSynchronizer> processorCefSynchronizer;
     };
-    std::unordered_map<int, BrowserData> browserParents_; /// Owner of each browser
-    const PropertyWidgetCEFFactory* widgetFactory_;  /// Non-owning reference
+    std::unordered_map<int, BrowserData> browserParents_;  /// Owner of each browser
+    const PropertyWidgetCEFFactory* widgetFactory_;        /// Non-owning reference
     CefRefPtr<RenderHandlerGL> renderHandler_;
     // Handles the browser side of query routing.
     CefRefPtr<CefMessageRouterBrowserSide> messageRouter_;
@@ -215,4 +214,3 @@ private:
 };
 #include <warn/pop>
 }  // namespace inviwo
-

--- a/modules/webbrowser/include/modules/webbrowser/webbrowserclient.h
+++ b/modules/webbrowser/include/modules/webbrowser/webbrowserclient.h
@@ -38,6 +38,8 @@
 #include <inviwo/core/processors/processor.h>
 #include <inviwo/core/util/stdextensions.h>
 
+#include <map>
+
 #include <warn/push>
 #include <warn/ignore/all>
 #include <include/cef_client.h>
@@ -195,7 +197,7 @@ protected:
         Processor* processor;
         CefRefPtr<ProcessorCefSynchronizer> processorCefSynchronizer;
     };
-    std::unordered_map<int, BrowserData> browserParents_; /// Owner of each browser
+    std::map<int, BrowserData> browserParents_; /// Owner of each browser
     const PropertyWidgetCEFFactory* widgetFactory_;  /// Non-owning reference
     CefRefPtr<RenderHandlerGL> renderHandler_;
     // Handles the browser side of query routing.

--- a/modules/webbrowser/include/modules/webbrowser/webbrowserclient.h
+++ b/modules/webbrowser/include/modules/webbrowser/webbrowserclient.h
@@ -54,9 +54,9 @@ namespace inviwo {
 
 /* \class WebBrowserClient
  * CefClient with custom render handler and call redirections.
- * Calls to 'api://inviwo/modules/yourmodule' will be redirected to yourmodule
+ * Calls to 'inviwo://yourmodule' will be redirected to yourmodule
  * directory, i.e. InviwoModule::getPath().
- * Calls to 'api://inviwo/app' will be redirected to the InviwoApplication
+ * Calls to 'inviwo://app' will be redirected to the InviwoApplication
  * (executable) directory, i.e. InviwoApplication::getBasePath().
  */
 #include <warn/push>

--- a/modules/webbrowser/include/modules/webbrowser/webbrowserclient.h
+++ b/modules/webbrowser/include/modules/webbrowser/webbrowserclient.h
@@ -197,7 +197,7 @@ protected:
         CefRefPtr<ProcessorCefSynchronizer> processorCefSynchronizer;
     };
 
-    std::map<int, BrowserData> browserParents_;  /// Owner of each browser
+    std::map<int, BrowserData> browserParents_;      /// Owner of each browser
     const PropertyWidgetCEFFactory* widgetFactory_;  /// Non-owning reference
 
     CefRefPtr<RenderHandlerGL> renderHandler_;

--- a/modules/webbrowser/include/modules/webbrowser/webbrowserclient.h
+++ b/modules/webbrowser/include/modules/webbrowser/webbrowserclient.h
@@ -52,9 +52,9 @@ namespace inviwo {
 
 /* \class WebBrowserClient
  * CefClient with custom render handler and call redirections.
- * Calls to 'https://inviwo/modules/yourmodule' will be redirected to yourmodule
+ * Calls to 'api://inviwo/modules/yourmodule' will be redirected to yourmodule
  * directory, i.e. InviwoModule::getPath().
- * Calls to 'https://inviwo/app' will be redirected to the InviwoApplication
+ * Calls to 'api://inviwo/app' will be redirected to the InviwoApplication
  * (executable) directory, i.e. InviwoApplication::getBasePath().
  */
 #include <warn/push>

--- a/modules/webbrowser/include/modules/webbrowser/webbrowsermodule.h
+++ b/modules/webbrowser/include/modules/webbrowser/webbrowsermodule.h
@@ -27,11 +27,12 @@
  *
  *********************************************************************************/
 
-#ifndef IVW_WEBBROWSERMODULE_H
-#define IVW_WEBBROWSERMODULE_H
+#pragma once
 
 #include <modules/webbrowser/webbrowsermoduledefine.h>
 #include <modules/webbrowser/properties/propertywidgetceffactory.h>
+#include <modules/webbrowser/renderhandlergl.h>
+#include <modules/webbrowser/webbrowserclient.h>
 
 #include <modules/json/jsonmodule.h>
 
@@ -45,7 +46,6 @@
 #if __APPLE__  // Mac
 #include "include/wrapper/cef_library_loader.h"
 #endif
-
 #include <warn/pop>
 
 namespace inviwo {
@@ -57,6 +57,8 @@ class IVW_MODULE_WEBBROWSER_API WebBrowserModule : public InviwoModule {
 public:
     WebBrowserModule(InviwoApplication* app);
     virtual ~WebBrowserModule();
+
+    CefRefPtr<WebBrowserClient> getBrowserClient() { return browserClient_; }
 
     // Register a JSON converter and its corresponding HTML-synchronization widget.
     template <typename T, typename P>
@@ -73,6 +75,7 @@ public:
     static std::string getCefErrorString(cef_errorcode_t code);
 
 protected:
+    CefRefPtr<WebBrowserClient> browserClient_;
     // HTML-property synchronization widget factory
     PropertyWidgetCEFFactory htmlWidgetFactory_;
     std::vector<std::unique_ptr<PropertyWidgetCEFFactoryObject>> propertyWidgets_;
@@ -98,4 +101,3 @@ inline const PropertyWidgetCEFFactory* WebBrowserModule::getPropertyWidgetCEFFac
 
 }  // namespace inviwo
 
-#endif  // IVW_WEBBROWSERMODULE_H

--- a/modules/webbrowser/include/modules/webbrowser/webbrowsermodule.h
+++ b/modules/webbrowser/include/modules/webbrowser/webbrowsermodule.h
@@ -100,4 +100,3 @@ inline const PropertyWidgetCEFFactory* WebBrowserModule::getPropertyWidgetCEFFac
 }
 
 }  // namespace inviwo
-

--- a/modules/webbrowser/include/modules/webbrowser/webbrowserutil.h
+++ b/modules/webbrowser/include/modules/webbrowser/webbrowserutil.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2018-2020 Inviwo Foundation
+ * Copyright (c) 2020 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,33 +26,29 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  *********************************************************************************/
-
 #pragma once
 
 #include <modules/webbrowser/webbrowsermoduledefine.h>
-#include <modules/webbrowser/renderhandlergl.h>
 
-#include <modules/opengl/texture/texture2d.h>
-#include <modules/opengl/shader/shader.h>
-
-#include <inviwo/core/ports/imageport.h>
+#include <warn/push>
+#include <warn/ignore/all>
+#include <include/cef_base.h>
+#include <warn/pop>
 
 namespace inviwo {
 
-/* \class CefImageConverter
- * Flips vertical component of Cef output image and write to picking layer on non-transparent areas.
- * @see RenderHandlerGL
+namespace cefutil {
+
+/**
+ * Get default settings for CefBrowserHost::CreateBrowserSync
+ *
+ * Enable loading files from other locations than where the .html file is
+ * browserSettings.file_access_from_file_urls = STATE_ENABLED;
+ *
+ * window_info.SetAsWindowless(nullptr);  // nullptr means no transparency (site background colour)
  */
-class IVW_MODULE_WEBBROWSER_API CefImageConverter {
-public:
-    CefImageConverter(vec3 pickingColor);
+IVW_MODULE_WEBBROWSER_API std::tuple<CefWindowInfo, CefBrowserSettings> getDefaultBrowserSettings();
 
-    void convert(const Texture2D& fromCefOutput, ImageOutport& toInviwOutput,
-                 const ImageInport* optionalBackground = nullptr);
-
-protected:
-    Shader shader_{"img_convert_cef.frag", true};  ///< Flip image y compoenent
-};
+}  // namespace cefutil
 
 }  // namespace inviwo
-

--- a/modules/webbrowser/readme.md
+++ b/modules/webbrowser/readme.md
@@ -7,7 +7,7 @@ Insert a WebBrowser processor in your network and point it to your html-page.
 In the html-page:
 Include the Inviwo API for communication using:
 ```
-<script src="https://inviwo/modules/webbrowser/data/js/inviwoapi.js"></script>
+<script src="api://inviwo/modules/webbrowser/data/js/inviwoapi.js"></script>
 ```
 Initialize Inviwo API so that we can use it to synchronize properties
 ```

--- a/modules/webbrowser/readme.md
+++ b/modules/webbrowser/readme.md
@@ -7,7 +7,7 @@ Insert a WebBrowser processor in your network and point it to your html-page.
 In the html-page:
 Include the Inviwo API for communication using:
 ```
-<script src="api://inviwo/modules/webbrowser/data/js/inviwoapi.js"></script>
+<script src="inviwo://webbrowser/data/js/inviwoapi.js"></script>
 ```
 Initialize Inviwo API so that we can use it to synchronize properties
 ```
@@ -29,4 +29,10 @@ inviwo.getProperty('Path.To.Property', function(prop) {
     }
 });
 ```
+
+The application base path, i.e. where the core data and modules folder and etc are, can be retrieved using:
+```
+<script src="inviwo://app"></script>
+```
+
 An example can be seen in data/workspaces/web_property_sync.html

--- a/modules/webbrowser/src/interaction/cefinteractionhandler.cpp
+++ b/modules/webbrowser/src/interaction/cefinteractionhandler.cpp
@@ -48,7 +48,7 @@ void CEFInteractionHandler::invokeEvent(Event* event) {
     switch (event->hash()) {
         case ResizeEvent::chash(): {
             auto resizeEvent = static_cast<ResizeEvent*>(event);
-            renderHandler_->updateCanvasSize(resizeEvent->size());
+            renderHandler_->updateCanvasSize(host_->GetBrowser(), resizeEvent->size());
             host_->WasResized();
             break;
         }

--- a/modules/webbrowser/src/renderhandlergl.cpp
+++ b/modules/webbrowser/src/renderhandlergl.cpp
@@ -28,48 +28,50 @@
  *********************************************************************************/
 
 #include <modules/webbrowser/renderhandlergl.h>
-#include <modules/opengl/inviwoopengl.h>
+
 #include <inviwo/core/util/rendercontext.h>
 
 namespace inviwo {
 
-RenderHandlerGL::RenderHandlerGL(OnWebPageCopiedCallback onWebPageCopiedCallback)
-    : CefRenderHandler()
-    , texture2D_(size2_t{1, 1}, GL_BGRA, GL_RGBA, GL_UNSIGNED_BYTE, GL_NEAREST)
-    , onWebPageCopiedCallback{onWebPageCopiedCallback} {}
+RenderHandlerGL::RenderHandlerGL(OnWebPageCopiedCallback cb) : onWebPageCopiedCallback{cb} {}
 
-void RenderHandlerGL::updateCanvasSize(size2_t newSize) {
+void RenderHandlerGL::updateCanvasSize(CefRefPtr<CefBrowser> browser, size2_t newSize) {
     // Prevent crash when newSize = 0
-    texture2D_.resize(glm::max(size2_t{1, 1}, newSize));
+    browserData_[browser->GetIdentifier()].texture2D.resize(glm::max(size2_t{1, 1}, newSize));
 }
 
 void RenderHandlerGL::GetViewRect(CefRefPtr<CefBrowser> browser, CefRect& rect) {
-    rect = CefRect{0, 0, static_cast<int>(texture2D_.getWidth()),
-                   static_cast<int>(texture2D_.getHeight())};
+    auto& texture2D = browserData_[browser->GetIdentifier()].texture2D;
+    rect = CefRect{0, 0, static_cast<int>(texture2D.getWidth()),
+                   static_cast<int>(texture2D.getHeight())};
 }
 
 void RenderHandlerGL::OnPopupShow(CefRefPtr<CefBrowser> browser, bool show) {
     if (!show) {
         // Clear the popup rectangle.
-        ClearPopupRects();
+        ClearPopupRects(browser);
         browser->GetHost()->Invalidate(PET_VIEW);
     }
 }
 
 void RenderHandlerGL::OnPopupSize(CefRefPtr<CefBrowser> browser, const CefRect& rect) {
     if (rect.width <= 0 || rect.height <= 0) return;
-    originalPopupRect_ = rect;
-    popupRect_ = GetPopupRectInWebView(originalPopupRect_);
+    auto& browserData = browserData_[browser->GetIdentifier()];
+    browserData.originalPopupRect = rect;
+    browserData.popupRect =
+        GetPopupRectInWebView(browser, browserData.originalPopupRect);
 }
 
-CefRect RenderHandlerGL::GetPopupRectInWebView(const CefRect& original_rect) {
+CefRect RenderHandlerGL::GetPopupRectInWebView(CefRefPtr<CefBrowser> browser,
+                                               const CefRect& original_rect) {
     CefRect rc(original_rect);
     // if x or y are negative, move them to 0.
     if (rc.x < 0) rc.x = 0;
     if (rc.y < 0) rc.y = 0;
     // if popup goes outside the view, try to reposition origin
-    auto width = static_cast<int>(texture2D_.getWidth());
-    auto height = static_cast<int>(texture2D_.getHeight());
+    auto& texture2D = browserData_[browser->GetIdentifier()].texture2D;
+    auto width = static_cast<int>(texture2D.getWidth());
+    auto height = static_cast<int>(texture2D.getHeight());
     if (rc.x + rc.width > width) rc.x = width - rc.width;
     if (rc.y + rc.height > height) rc.y = height - rc.height;
     // if x or y became negative, move them to 0 again.
@@ -78,17 +80,21 @@ CefRect RenderHandlerGL::GetPopupRectInWebView(const CefRect& original_rect) {
     return rc;
 }
 
-void RenderHandlerGL::ClearPopupRects() {
-    popupRect_.Set(0, 0, 0, 0);
-    originalPopupRect_.Set(0, 0, 0, 0);
+void RenderHandlerGL::ClearPopupRects(CefRefPtr<CefBrowser> browser) {
+    auto& browserData = browserData_[browser->GetIdentifier()];
+    browserData.popupRect.Set(0, 0, 0, 0);
+    browserData.originalPopupRect.Set(0, 0, 0, 0);
 }
 
 void RenderHandlerGL::OnPaint(CefRefPtr<CefBrowser> browser, PaintElementType type,
                               const RectList& dirtyRects, const void* buffer, int width,
                               int height) {
     RenderContext::getPtr()->activateLocalRenderContext();
-    if (type == PET_VIEW && width == static_cast<int>(texture2D_.getWidth()) &&
-        height == static_cast<int>(texture2D_.getHeight())) {
+    auto& browserData = browserData_[browser->GetIdentifier()];
+    auto& texture2D = browserData.texture2D;
+    auto& popupRect = browserData.popupRect;
+    if (type == PET_VIEW && width == static_cast<int>(texture2D.getWidth()) &&
+        height == static_cast<int>(texture2D.getHeight())) {
         // CPU implementation using LayerRAM
 
         // Flipping image and swizzling using CPU code was too slow.
@@ -111,10 +117,10 @@ void RenderHandlerGL::OnPaint(CefRefPtr<CefBrowser> browser, PaintElementType ty
         //}
         if ((dirtyRects.size() == 1 && dirtyRects[0] == CefRect(0, 0, width, height))) {
             // Upload all data
-            texture2D_.upload(buffer);
+            texture2D.upload(buffer);
         } else {
             // Update dirty areas
-            texture2D_.bind();
+            texture2D.bind();
             glPixelStorei(GL_UNPACK_ALIGNMENT, 4);  // RGBA 8-bit are always aligned
             glPixelStorei(GL_UNPACK_ROW_LENGTH, width);
             for (const auto& rect : dirtyRects) {
@@ -122,13 +128,13 @@ void RenderHandlerGL::OnPaint(CefRefPtr<CefBrowser> browser, PaintElementType ty
                 glPixelStorei(GL_UNPACK_SKIP_PIXELS, rect.x);
                 glPixelStorei(GL_UNPACK_SKIP_ROWS, rect.y);
                 glTexSubImage2D(GL_TEXTURE_2D, 0, rect.x, rect.y, rect.width, rect.height,
-                                texture2D_.getFormat(), texture2D_.getDataType(), buffer);
+                                texture2D.getFormat(), texture2D.getDataType(), buffer);
             }
         }
-    } else if (type == PET_POPUP && popupRect_.width > 0 && popupRect_.height > 0) {
+    } else if (type == PET_POPUP && popupRect.width > 0 && popupRect.height > 0) {
         //  buffer only contains data for drawing the popup widget (including dropdown elements)
-        int skip_pixels = 0, x = popupRect_.x;
-        int skip_rows = 0, y = popupRect_.y;
+        int skip_pixels = 0, x = popupRect.x;
+        int skip_rows = 0, y = popupRect.y;
         int w = width;
         int h = height;
 
@@ -141,30 +147,34 @@ void RenderHandlerGL::OnPaint(CefRefPtr<CefBrowser> browser, PaintElementType ty
             skip_rows = -y;
             y = 0;
         }
-        auto texWidth = static_cast<int>(texture2D_.getWidth());
-        auto texHeight = static_cast<int>(texture2D_.getHeight());
+        auto texWidth = static_cast<int>(texture2D.getWidth());
+        auto texHeight = static_cast<int>(texture2D.getHeight());
 
         if (x + w > texWidth) w -= x + w - texWidth;
         if (y + h > texHeight) h -= y + h - texHeight;
-        texture2D_.bind();
+        texture2D.bind();
         // Update the popup rectangle.
         glPixelStorei(GL_UNPACK_ALIGNMENT, 4);  // RGBA 8-bit are always aligned
         glPixelStorei(GL_UNPACK_ROW_LENGTH, width);
         glPixelStorei(GL_UNPACK_SKIP_PIXELS, skip_pixels);
         glPixelStorei(GL_UNPACK_SKIP_ROWS, skip_rows);
-        glTexSubImage2D(GL_TEXTURE_2D, 0, x, y, w, h, texture2D_.getFormat(),
-                        texture2D_.getDataType(), buffer);
+        glTexSubImage2D(GL_TEXTURE_2D, 0, x, y, w, h, texture2D.getFormat(),
+                        texture2D.getDataType(), buffer);
     }
     // Reset states
     glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
     glPixelStorei(GL_UNPACK_SKIP_PIXELS, 0);
     glPixelStorei(GL_UNPACK_SKIP_ROWS, 0);
 
-    if (type == PET_VIEW && !popupRect_.IsEmpty()) {
+    if (type == PET_VIEW && !popupRect.IsEmpty()) {
         browser->GetHost()->Invalidate(PET_POPUP);
     }
     // Notify that we are done copying
-    onWebPageCopiedCallback();
+    onWebPageCopiedCallback(browser);
+}
+
+Texture2D& RenderHandlerGL::getTexture2D(CefRefPtr<CefBrowser> browser) {
+    return browserData_[browser->GetIdentifier()].texture2D;
 }
 
 };  // namespace inviwo

--- a/modules/webbrowser/src/renderhandlergl.cpp
+++ b/modules/webbrowser/src/renderhandlergl.cpp
@@ -58,8 +58,7 @@ void RenderHandlerGL::OnPopupSize(CefRefPtr<CefBrowser> browser, const CefRect& 
     if (rect.width <= 0 || rect.height <= 0) return;
     auto& browserData = browserData_[browser->GetIdentifier()];
     browserData.originalPopupRect = rect;
-    browserData.popupRect =
-        GetPopupRectInWebView(browser, browserData.originalPopupRect);
+    browserData.popupRect = GetPopupRectInWebView(browser, browserData.originalPopupRect);
 }
 
 CefRect RenderHandlerGL::GetPopupRectInWebView(CefRefPtr<CefBrowser> browser,

--- a/modules/webbrowser/src/webbrowserclient.cpp
+++ b/modules/webbrowser/src/webbrowserclient.cpp
@@ -63,18 +63,24 @@ void setupResourceManager(CefRefPtr<CefResourceManager> resource_manager) {
 
 }  // namespace detail
 
-WebBrowserClient::WebBrowserClient(const Processor* parent,
-                                   CefRefPtr<RenderHandlerGL> renderHandler,
-                                   const PropertyWidgetCEFFactory* widgetFactory)
-    : parent_(parent)
-    , widgetFactory_(widgetFactory)
-    , renderHandler_(renderHandler)
+WebBrowserClient::WebBrowserClient(const PropertyWidgetCEFFactory* widgetFactory)
+    : widgetFactory_(widgetFactory)
+    , renderHandler_(new RenderHandlerGL([&](CefRefPtr<CefBrowser> browser) {
+        auto bdIt = browserParents_.find(browser->GetIdentifier());
+        if (bdIt != browserParents_.end()) {
+            bdIt->second.processor->invalidate(InvalidationLevel::InvalidOutput);
+        }
+    }))
     , resourceManager_(new CefResourceManager()) {
     detail::setupResourceManager(resourceManager_);
 }
 
-void WebBrowserClient::SetRenderHandler(CefRefPtr<RenderHandlerGL> renderHandler) {
-    renderHandler_ = renderHandler;
+void WebBrowserClient::setBrowserParent(CefRefPtr<CefBrowser> browser, Processor* parent) {
+    CEF_REQUIRE_UI_THREAD();
+    BrowserData bd{parent, new ProcessorCefSynchronizer(parent)};
+    browserParents_[browser->GetIdentifier()] = bd;
+    addLoadHandler(bd.processorCefSynchronizer);
+    messageRouter_->AddHandler(bd.processorCefSynchronizer.get(), false);
 }
 
 bool WebBrowserClient::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
@@ -97,9 +103,6 @@ void WebBrowserClient::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
         propertyCefSynchronizer_ = new PropertyCefSynchronizer(widgetFactory_);
         addLoadHandler(propertyCefSynchronizer_);
         messageRouter_->AddHandler(propertyCefSynchronizer_.get(), false);
-        processorCefSynchronizer_ = new ProcessorCefSynchronizer(parent_);
-        addLoadHandler(processorCefSynchronizer_);
-        messageRouter_->AddHandler(processorCefSynchronizer_.get(), false);
     }
 
     browserCount_++;
@@ -115,15 +118,18 @@ bool WebBrowserClient::DoClose(CefRefPtr<CefBrowser> browser) {
 
 void WebBrowserClient::OnBeforeClose(CefRefPtr<CefBrowser> browser) {
     CEF_REQUIRE_UI_THREAD();
+    auto bdIt = browserParents_.find(browser->GetIdentifier());
+    if (bdIt != browserParents_.end()) {
+        messageRouter_->RemoveHandler(bdIt->second.processorCefSynchronizer.get());
+        removeLoadHandler(bdIt->second.processorCefSynchronizer);
+        browserParents_.erase(bdIt);
+    }
 
     if (--browserCount_ == 0) {
         // Free the router when the last browser is closed.
         messageRouter_->RemoveHandler(propertyCefSynchronizer_.get());
         removeLoadHandler(propertyCefSynchronizer_);
         propertyCefSynchronizer_ = nullptr;
-        messageRouter_->RemoveHandler(processorCefSynchronizer_.get());
-        removeLoadHandler(processorCefSynchronizer_);
-        processorCefSynchronizer_ = nullptr;
 
         messageRouter_ = NULL;
     }

--- a/modules/webbrowser/src/webbrowserclient.cpp
+++ b/modules/webbrowser/src/webbrowserclient.cpp
@@ -46,16 +46,16 @@ void setupResourceManager(CefRefPtr<CefResourceManager> resource_manager) {
         CefPostTask(TID_IO, base::Bind(setupResourceManager, resource_manager));
         return;
     }
-    std::string origin = "api://inviwo";
+    std::string origin = "inviwo://";
     // Redirect paths to corresponding app/module directories.
     // Enables resource loading from these directories directory (js-files and so on).
-    auto appOrigin = origin + "/app";
+    auto appOrigin = origin + "app";
     resource_manager->AddDirectoryProvider(appOrigin, InviwoApplication::getPtr()->getBasePath(),
                                            99, std::string());
 
-    auto moduleOrigin = origin + "/modules";
+    auto moduleOrigin = origin;
     for (const auto& m : InviwoApplication::getPtr()->getModules()) {
-        auto mOrigin = moduleOrigin + "/" + toLower(m->getIdentifier());
+        auto mOrigin = moduleOrigin + toLower(m->getIdentifier());
         auto moduleDir = m->getPath();
         resource_manager->AddDirectoryProvider(mOrigin, moduleDir, 100, std::string());
     }

--- a/modules/webbrowser/src/webbrowserclient.cpp
+++ b/modules/webbrowser/src/webbrowserclient.cpp
@@ -46,7 +46,7 @@ void setupResourceManager(CefRefPtr<CefResourceManager> resource_manager) {
         CefPostTask(TID_IO, base::Bind(setupResourceManager, resource_manager));
         return;
     }
-    std::string origin = "https://inviwo";
+    std::string origin = "api://inviwo";
     // Redirect paths to corresponding app/module directories.
     // Enables resource loading from these directories directory (js-files and so on).
     auto appOrigin = origin + "/app";

--- a/modules/webbrowser/src/webbrowsermodule.cpp
+++ b/modules/webbrowser/src/webbrowsermodule.cpp
@@ -238,6 +238,8 @@ WebBrowserModule::WebBrowserModule(InviwoApplication* app)
     registerProcessor<WebBrowserProcessor>();
 
     doChromiumWork_.start();
+
+    browserClient_ = new WebBrowserClient(getPropertyWidgetCEFFactory());
 }
 
 WebBrowserModule::~WebBrowserModule() {

--- a/modules/webbrowser/src/webbrowserutil.cpp
+++ b/modules/webbrowser/src/webbrowserutil.cpp
@@ -47,7 +47,6 @@ std::tuple<CefWindowInfo, CefBrowserSettings> getDefaultBrowserSettings() {
     browserSettings.file_access_from_file_urls = STATE_ENABLED;
 
     return std::tuple<CefWindowInfo, CefBrowserSettings>{windowInfo, browserSettings};
-
 }
 
 }  // namespace cefutil

--- a/modules/webbrowser/src/webbrowserutil.cpp
+++ b/modules/webbrowser/src/webbrowserutil.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2018-2020 Inviwo Foundation
+ * Copyright (c) 2020 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,32 +27,29 @@
  *
  *********************************************************************************/
 
-#pragma once
-
-#include <modules/webbrowser/webbrowsermoduledefine.h>
-#include <modules/webbrowser/renderhandlergl.h>
-
-#include <modules/opengl/texture/texture2d.h>
-#include <modules/opengl/shader/shader.h>
-
-#include <inviwo/core/ports/imageport.h>
+#include <modules/webbrowser/webbrowserutil.h>
+#include <tuple>
 
 namespace inviwo {
 
-/* \class CefImageConverter
- * Flips vertical component of Cef output image and write to picking layer on non-transparent areas.
- * @see RenderHandlerGL
- */
-class IVW_MODULE_WEBBROWSER_API CefImageConverter {
-public:
-    CefImageConverter(vec3 pickingColor);
+namespace cefutil {
 
-    void convert(const Texture2D& fromCefOutput, ImageOutport& toInviwOutput,
-                 const ImageInport* optionalBackground = nullptr);
+std::tuple<CefWindowInfo, CefBrowserSettings> getDefaultBrowserSettings() {
+    CefWindowInfo windowInfo;
+    // in linux set a gtk widget, in windows a hwnd. If not available set nullptr
+    // - may cause
+    // some render errors, in context-menu and plugins.
+    windowInfo.SetAsWindowless(nullptr);  // nullptr means no transparency (site background colour)
 
-protected:
-    Shader shader_{"img_convert_cef.frag", true};  ///< Flip image y compoenent
-};
+    CefBrowserSettings browserSettings;
+
+    // Enable loading files from other locations than where the .html file is
+    browserSettings.file_access_from_file_urls = STATE_ENABLED;
+
+    return std::tuple<CefWindowInfo, CefBrowserSettings>{windowInfo, browserSettings};
+
+}
+
+}  // namespace cefutil
 
 }  // namespace inviwo
-


### PR DESCRIPTION
- Use one CefClient and RenderHandler for multiple browsers as it is originally designed for. The CefClient can now be accessed via the WebBrowserModule.

- Changed redirection of https://inviwo to api://inviwo to avoid confusion with the https scheme



