### PR TITLE
Python3Qt: include templates folder in packaging, #945

### DIFF
--- a/modules/python3qt/CMakeLists.txt
+++ b/modules/python3qt/CMakeLists.txt
@@ -38,6 +38,10 @@ ivw_group("Source Files" ${SOURCE_FILES})
 ivw_create_module(NO_PCH ${SOURCE_FILES} ${MOCED_FILES} ${HEADER_FILES})
 target_link_libraries(inviwo-module-python3qt PRIVATE Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Svg)
 
+#--------------------------------------------------------------------
+# Add templates directory to packaging
+ivw_add_to_module_pack(${CMAKE_CURRENT_SOURCE_DIR}/templates)
+
 ivw_compile_optimize_on_target(inviwo-module-python3qt)
 
 ivw_make_package(InviwoPython3QtModule inviwo-module-python3qt)


### PR DESCRIPTION
minor fix for including the python processor templates in packaging.