### PR TITLE
Core: StringProperty: Keep linebreaks in tooltips

### DIFF
--- a/src/core/properties/stringproperty.cpp
+++ b/src/core/properties/stringproperty.cpp
@@ -51,7 +51,7 @@ Document StringProperty::getDescription() const {
     using P = Document::PathComponent;
     Document doc = TemplateProperty<std::string>::getDescription();
     auto b = doc.get({P("html"), P("body")});
-    auto pre = b.append("pre", value_.value, {{"style","font"}});
+    auto pre = b.append("pre", value_.value);
     return doc;
 }
 

--- a/src/core/properties/stringproperty.cpp
+++ b/src/core/properties/stringproperty.cpp
@@ -51,9 +51,7 @@ Document StringProperty::getDescription() const {
     using P = Document::PathComponent;
     Document doc = TemplateProperty<std::string>::getDescription();
     auto b = doc.get({P("html"), P("body")});
-    auto val = value_.value;
-    replaceInString(val, "\n", "<br />\n");
-    b.append("p", val);
+    auto pre = b.append("pre", value_.value, {{"style","font"}});
     return doc;
 }
 

--- a/src/core/properties/stringproperty.cpp
+++ b/src/core/properties/stringproperty.cpp
@@ -51,7 +51,9 @@ Document StringProperty::getDescription() const {
     using P = Document::PathComponent;
     Document doc = TemplateProperty<std::string>::getDescription();
     auto b = doc.get({P("html"), P("body")});
-    b.append("p", value_.value);
+    auto val = value_.value;
+    replaceInString(val, "\n", "<br \>\n");
+    b.append("p", val);
     return doc;
 }
 

--- a/src/core/properties/stringproperty.cpp
+++ b/src/core/properties/stringproperty.cpp
@@ -52,7 +52,7 @@ Document StringProperty::getDescription() const {
     Document doc = TemplateProperty<std::string>::getDescription();
     auto b = doc.get({P("html"), P("body")});
     auto val = value_.value;
-    replaceInString(val, "\n", "<br \>\n");
+    replaceInString(val, "\n", "<br />\n");
     b.append("p", val);
     return doc;
 }


### PR DESCRIPTION
Before fix:
![image](https://user-images.githubusercontent.com/534670/84866888-a5a87200-b07a-11ea-84b9-7e680a091437.png)
After fix:
![image](https://user-images.githubusercontent.com/534670/84866852-99241980-b07a-11ea-987c-8e4d63667c02.png)
