### PR TITLE
Feature/stipplingcleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Here we document changes that affect the public API or changes that needs to be communicated to other developers. 
 
+## 2020-06-16 StipplingProperty now in BaseGL
+Moved StipplingProperty and associated settings from Base module to BaseGL.
+
 ## 2020-06-03 WebBrowser Javascript API
 Changed redirection of `https://inviwo` to `inviwo://` to avoid confusion with the https scheme.
 Your html-files will need to update from 

--- a/modules/base/CMakeLists.txt
+++ b/modules/base/CMakeLists.txt
@@ -38,8 +38,6 @@ set(HEADER_FILES
     include/modules/base/datastructures/disjointsets.h
     include/modules/base/datastructures/imagereusecache.h
     include/modules/base/datastructures/kdtree.h
-    include/modules/base/datastructures/stipplingsettings.h
-    include/modules/base/datastructures/stipplingsettingsinterface.h
     include/modules/base/io/binarystlwriter.h
     include/modules/base/io/datvolumesequencereader.h
     include/modules/base/io/datvolumewriter.h
@@ -124,7 +122,6 @@ set(HEADER_FILES
     include/modules/base/properties/layerinformationproperty.h
     include/modules/base/properties/meshinformationproperty.h
     include/modules/base/properties/sequencetimerproperty.h
-    include/modules/base/properties/stipplingproperty.h
     include/modules/base/properties/transformlistproperty.h
     include/modules/base/properties/volumeinformationproperty.h
 )
@@ -163,8 +160,6 @@ set(SOURCE_FILES
     src/basemodule.cpp
     src/datastructures/disjointsets.cpp
     src/datastructures/imagereusecache.cpp
-    src/datastructures/stipplingsettings.cpp
-    src/datastructures/stipplingsettingsinterface.cpp
     src/io/binarystlwriter.cpp
     src/io/datvolumesequencereader.cpp
     src/io/datvolumewriter.cpp
@@ -244,7 +239,6 @@ set(SOURCE_FILES
     src/properties/layerinformationproperty.cpp
     src/properties/meshinformationproperty.cpp
     src/properties/sequencetimerproperty.cpp
-    src/properties/stipplingproperty.cpp
     src/properties/transformlistproperty.cpp
     src/properties/volumeinformationproperty.cpp
 )

--- a/modules/base/src/basemodule.cpp
+++ b/modules/base/src/basemodule.cpp
@@ -102,7 +102,6 @@
 #include <modules/base/properties/bufferinformationproperty.h>
 #include <modules/base/properties/volumeinformationproperty.h>
 #include <modules/base/properties/sequencetimerproperty.h>
-#include <modules/base/properties/stipplingproperty.h>
 
 // Io
 #include <modules/base/io/binarystlwriter.h>
@@ -219,7 +218,6 @@ BaseModule::BaseModule(InviwoApplication* app) : InviwoModule(app, "Base") {
 
     registerProperty<Gaussian1DProperty>();
     registerProperty<Gaussian2DProperty>();
-    registerProperty<StipplingProperty>();
 
     registerProperty<transform::TranslateProperty>();
     registerProperty<transform::RotateProperty>();

--- a/modules/basegl/CMakeLists.txt
+++ b/modules/basegl/CMakeLists.txt
@@ -12,6 +12,8 @@ set(HEADER_FILES
     include/modules/basegl/datastructures/linesettings.h
     include/modules/basegl/datastructures/linesettingsinterface.h
     include/modules/basegl/datastructures/meshshadercache.h
+    include/modules/basegl/datastructures/stipplingsettings.h
+    include/modules/basegl/datastructures/stipplingsettingsinterface.h
     include/modules/basegl/datavisualizer/imagebackgroundvisualizer.h
     include/modules/basegl/datavisualizer/imagevisualizer.h
     include/modules/basegl/datavisualizer/meshvisualizer.h
@@ -76,6 +78,7 @@ set(HEADER_FILES
     include/modules/basegl/processors/volumeraycaster.h
     include/modules/basegl/processors/volumeslicegl.h
     include/modules/basegl/properties/linesettingsproperty.h
+    include/modules/basegl/properties/stipplingproperty.h
     include/modules/basegl/rendering/linerenderer.h
     include/modules/basegl/viewmanager.h
 )
@@ -90,6 +93,8 @@ set(SOURCE_FILES
     src/datastructures/linesettings.cpp
     src/datastructures/linesettingsinterface.cpp
     src/datastructures/meshshadercache.cpp
+    src/datastructures/stipplingsettings.cpp
+    src/datastructures/stipplingsettingsinterface.cpp
     src/datavisualizer/imagebackgroundvisualizer.cpp
     src/datavisualizer/imagevisualizer.cpp
     src/datavisualizer/meshvisualizer.cpp
@@ -154,6 +159,7 @@ set(SOURCE_FILES
     src/processors/volumeraycaster.cpp
     src/processors/volumeslicegl.cpp
     src/properties/linesettingsproperty.cpp
+    src/properties/stipplingproperty.cpp
     src/rendering/linerenderer.cpp
     src/viewmanager.cpp
 )

--- a/modules/basegl/include/modules/basegl/datastructures/linesettings.h
+++ b/modules/basegl/include/modules/basegl/datastructures/linesettings.h
@@ -30,7 +30,7 @@
 
 #include <modules/basegl/baseglmoduledefine.h>
 #include <modules/basegl/datastructures/linesettingsinterface.h>
-#include <modules/base/datastructures/stipplingsettings.h>
+#include <modules/basegl/datastructures/stipplingsettings.h>
 
 namespace inviwo {
 

--- a/modules/basegl/include/modules/basegl/datastructures/linesettingsinterface.h
+++ b/modules/basegl/include/modules/basegl/datastructures/linesettingsinterface.h
@@ -31,7 +31,7 @@
 #include <modules/basegl/baseglmoduledefine.h>
 #include <inviwo/core/common/inviwo.h>
 
-#include <modules/base/properties/stipplingproperty.h>
+#include <modules/basegl/properties/stipplingproperty.h>
 
 namespace inviwo {
 /*

--- a/modules/basegl/include/modules/basegl/datastructures/stipplingsettings.h
+++ b/modules/basegl/include/modules/basegl/datastructures/stipplingsettings.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2019-2020 Inviwo Foundation
+ * Copyright (c) 2020 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,19 +26,47 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  *********************************************************************************/
+#pragma once
 
-#include <modules/base/datastructures/stipplingsettingsinterface.h>
+#include <modules/basegl/baseglmoduledefine.h>
+#include <modules/basegl/datastructures/stipplingsettingsinterface.h>
 
 namespace inviwo {
 
-bool operator==(const StipplingSettingsInterface& a, const StipplingSettingsInterface& b) {
-    return a.getMode() == b.getMode() && a.getLength() == b.getLength() &&
-           a.getSpacing() == b.getSpacing() && a.getOffset() == b.getOffset() &&
-           a.getWorldScale() == b.getWorldScale();
-}
+/**
+ * \brief Basic implementation of the StipplingSettingsInterface
+ */
+class IVW_MODULE_BASEGL_API StipplingSettings : public StipplingSettingsInterface {
+public:
+    StipplingSettings() = default;
+    StipplingSettings(const StipplingSettingsInterface* other);
+    virtual ~StipplingSettings() = default;
 
-bool operator!=(const StipplingSettingsInterface& a, const StipplingSettingsInterface& b) {
-    return !(a == b);
-}
+    Mode mode = Mode::None;
+    float length = 30.f;
+    float spacing = 10.f;
+    float offset = 0.f;
+    float worldScale = 4.f;
+    /*
+     * @copydoc StipplingSettingsInterface::getMode
+     */
+    virtual StipplingSettingsInterface::Mode getMode() const override;
+    /*
+     * @copydoc StipplingSettingsInterface::getLength
+     */
+    virtual float getLength() const override;
+    /*
+     * @copydoc StipplingSettingsInterface::getSpacing
+     */
+    virtual float getSpacing() const override;
+    /*
+     * @copydoc StipplingSettingsInterface::getOffset
+     */
+    virtual float getOffset() const override;
+    /*
+     * @copydoc StipplingSettingsInterface::getWorldScale
+     */
+    virtual float getWorldScale() const override;
+};
 
 }  // namespace inviwo

--- a/modules/basegl/include/modules/basegl/datastructures/stipplingsettingsinterface.h
+++ b/modules/basegl/include/modules/basegl/datastructures/stipplingsettingsinterface.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2019-2020 Inviwo Foundation
+ * Copyright (c) 2020 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,27 +26,48 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  *********************************************************************************/
+#pragma once
 
-#include <modules/base/datastructures/stipplingsettingsinterface.h>
-#include <modules/base/datastructures/stipplingsettings.h>
+#include <modules/basegl/baseglmoduledefine.h>
 
 namespace inviwo {
 
-StipplingSettings::StipplingSettings(const StipplingSettingsInterface* other)
-    : mode(other->getMode())
-    , length(other->getLength())
-    , spacing(other->getSpacing())
-    , offset(other->getOffset())
-    , worldScale(other->getWorldScale()) {}
+/*
+ * \brief Settings for stippling (Dashed line, e.g., - - -)
+ */
+class IVW_MODULE_BASEGL_API StipplingSettingsInterface {
+public:
+    /*
+     * \brief Determines in which space the stippling parameters should be applied.
+     */
+    enum class Mode { None, ScreenSpace, WorldSpace };
+    StipplingSettingsInterface() = default;
+    virtual ~StipplingSettingsInterface() = default;
+    /*
+     * Determines which space the other settings should be applied.
+     */
+    virtual Mode getMode() const = 0;
+    /*
+     * Return length of dash, in pixels if Mode is ScreenSpace.
+     */
+    virtual float getLength() const = 0;
+    /*
+     * Return distance between dashes, in pixels if Mode is ScreenSpace.
+     */
+    virtual float getSpacing() const = 0;
+    /*
+     * Return offset of first dash, in pixels if Mode is ScreenSpace.
+     */
+    virtual float getOffset() const = 0;
+    /*
+     * Return scaling of parameters. Only applicable if Mode is WorldSpace.
+     */
+    virtual float getWorldScale() const = 0;
+};
 
-StipplingSettingsInterface::Mode StipplingSettings::getMode() const { return mode; }
-
-float StipplingSettings::getLength() const { return length; }
-
-float StipplingSettings::getSpacing() const { return spacing; }
-
-float StipplingSettings::getOffset() const { return offset; }
-
-float StipplingSettings::getWorldScale() const { return worldScale; }
+IVW_MODULE_BASEGL_API bool operator==(const StipplingSettingsInterface& a,
+                                    const StipplingSettingsInterface& b);
+IVW_MODULE_BASEGL_API bool operator!=(const StipplingSettingsInterface& a,
+                                    const StipplingSettingsInterface& b);
 
 }  // namespace inviwo

--- a/modules/basegl/include/modules/basegl/datastructures/stipplingsettingsinterface.h
+++ b/modules/basegl/include/modules/basegl/datastructures/stipplingsettingsinterface.h
@@ -66,8 +66,8 @@ public:
 };
 
 IVW_MODULE_BASEGL_API bool operator==(const StipplingSettingsInterface& a,
-                                    const StipplingSettingsInterface& b);
+                                      const StipplingSettingsInterface& b);
 IVW_MODULE_BASEGL_API bool operator!=(const StipplingSettingsInterface& a,
-                                    const StipplingSettingsInterface& b);
+                                      const StipplingSettingsInterface& b);
 
 }  // namespace inviwo

--- a/modules/basegl/include/modules/basegl/properties/linesettingsproperty.h
+++ b/modules/basegl/include/modules/basegl/properties/linesettingsproperty.h
@@ -39,6 +39,9 @@ namespace inviwo {
 class IVW_MODULE_BASEGL_API LineSettingsProperty : public LineSettingsInterface,
                                                    public CompositeProperty {
 public:
+    virtual std::string getClassIdentifier() const override;
+    static const std::string classIdentifier;
+    
     LineSettingsProperty(const std::string& identifier, const std::string& displayName,
                          InvalidationLevel invalidationLevel = InvalidationLevel::InvalidResources,
                          PropertySemantics semantics = PropertySemantics::Default);

--- a/modules/basegl/include/modules/basegl/properties/linesettingsproperty.h
+++ b/modules/basegl/include/modules/basegl/properties/linesettingsproperty.h
@@ -41,7 +41,7 @@ class IVW_MODULE_BASEGL_API LineSettingsProperty : public LineSettingsInterface,
 public:
     virtual std::string getClassIdentifier() const override;
     static const std::string classIdentifier;
-    
+
     LineSettingsProperty(const std::string& identifier, const std::string& displayName,
                          InvalidationLevel invalidationLevel = InvalidationLevel::InvalidResources,
                          PropertySemantics semantics = PropertySemantics::Default);

--- a/modules/basegl/include/modules/basegl/properties/linesettingsproperty.h
+++ b/modules/basegl/include/modules/basegl/properties/linesettingsproperty.h
@@ -45,6 +45,7 @@ public:
     LineSettingsProperty(const std::string& identifier, const std::string& displayName,
                          InvalidationLevel invalidationLevel = InvalidationLevel::InvalidResources,
                          PropertySemantics semantics = PropertySemantics::Default);
+    LineSettingsProperty(const LineSettingsProperty& rhs);
     virtual ~LineSettingsProperty() = default;
 
     virtual LineSettingsProperty* clone() const override;

--- a/modules/basegl/include/modules/basegl/properties/linesettingsproperty.h
+++ b/modules/basegl/include/modules/basegl/properties/linesettingsproperty.h
@@ -29,7 +29,7 @@
 #pragma once
 
 #include <modules/basegl/datastructures/linesettingsinterface.h>
-#include <modules/base/properties/stipplingproperty.h>
+#include <modules/basegl/properties/stipplingproperty.h>
 #include <inviwo/core/properties/compositeproperty.h>
 #include <inviwo/core/properties/boolproperty.h>
 #include <inviwo/core/properties/ordinalproperty.h>

--- a/modules/basegl/include/modules/basegl/properties/stipplingproperty.h
+++ b/modules/basegl/include/modules/basegl/properties/stipplingproperty.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2017-2020 Inviwo Foundation
+ * Copyright (c) 2020 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,21 +26,21 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  *********************************************************************************/
+#pragma once
 
-#ifndef IVW_STIPPLINGPROPERTY_H
-#define IVW_STIPPLINGPROPERTY_H
-
-#include <modules/base/basemoduledefine.h>
-#include <modules/base/datastructures/stipplingsettingsinterface.h>
+#include <modules/basegl/baseglmoduledefine.h>
+#include <modules/basegl/datastructures/stipplingsettingsinterface.h>
 
 #include <inviwo/core/properties/compositeproperty.h>
 #include <inviwo/core/properties/optionproperty.h>
 #include <inviwo/core/properties/ordinalproperty.h>
 
+#include <modules/opengl/shader/shader.h>
+
 namespace inviwo {
 
-class IVW_MODULE_BASE_API StipplingProperty : public CompositeProperty,
-                                              public StipplingSettingsInterface {
+class IVW_MODULE_BASEGL_API StipplingProperty : public CompositeProperty,
+                                                public StipplingSettingsInterface {
 public:
     virtual std::string getClassIdentifier() const override;
     static const std::string classIdentifier;
@@ -66,6 +66,13 @@ public:
     FloatProperty worldScale_;
 };
 
-}  // namespace inviwo
+namespace utilgl {
 
-#endif  // IVW_STIPPLINGPROPERTY_H
+IVW_MODULE_BASEGL_API void addShaderDefines(Shader& shader, const StipplingProperty& property);
+IVW_MODULE_BASEGL_API void addShaderDefines(Shader& shader, const StipplingProperty::Mode& mode);
+IVW_MODULE_BASEGL_API void setShaderUniforms(Shader& shader, const StipplingProperty& property,
+                                             const std::string& name);
+
+}  // namespace utilgl
+
+}  // namespace inviwo

--- a/modules/basegl/src/baseglmodule.cpp
+++ b/modules/basegl/src/baseglmodule.cpp
@@ -86,6 +86,7 @@
 #include <modules/basegl/processors/volumeraycaster.h>
 #include <modules/basegl/processors/volumeslicegl.h>
 #include <modules/basegl/processors/volumeprocessing/volumeshader.h>
+#include <modules/basegl/properties/stipplingproperty.h>
 #include <modules/basegl/datavisualizer/volumeraycastvisualizer.h>
 #include <modules/basegl/datavisualizer/volumeslicevisualizer.h>
 #include <modules/basegl/datavisualizer/imagevisualizer.h>
@@ -102,6 +103,8 @@ namespace inviwo {
 BaseGLModule::BaseGLModule(InviwoApplication* app) : InviwoModule(app, "BaseGL") {
 
     basegl::addShaderResources(ShaderManager::getPtr(), {getPath(ModulePath::GLSL)});
+
+    registerProperty<StipplingProperty>();
 
     registerProcessor<AxisAlignedCutPlane>();
     registerProcessor<Background>();

--- a/modules/basegl/src/baseglmodule.cpp
+++ b/modules/basegl/src/baseglmodule.cpp
@@ -86,6 +86,7 @@
 #include <modules/basegl/processors/volumeraycaster.h>
 #include <modules/basegl/processors/volumeslicegl.h>
 #include <modules/basegl/processors/volumeprocessing/volumeshader.h>
+#include <modules/basegl/properties/linesettingsproperty.h>
 #include <modules/basegl/properties/stipplingproperty.h>
 #include <modules/basegl/datavisualizer/volumeraycastvisualizer.h>
 #include <modules/basegl/datavisualizer/volumeslicevisualizer.h>
@@ -104,6 +105,7 @@ BaseGLModule::BaseGLModule(InviwoApplication* app) : InviwoModule(app, "BaseGL")
 
     basegl::addShaderResources(ShaderManager::getPtr(), {getPath(ModulePath::GLSL)});
 
+    registerProperty<LineSettingsProperty>();
     registerProperty<StipplingProperty>();
 
     registerProcessor<AxisAlignedCutPlane>();

--- a/modules/basegl/src/datastructures/stipplingsettings.cpp
+++ b/modules/basegl/src/datastructures/stipplingsettings.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2019-2020 Inviwo Foundation
+ * Copyright (c) 2020 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,46 +26,27 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  *********************************************************************************/
-#pragma once
 
-#include <modules/base/basemoduledefine.h>
+#include <modules/basegl/datastructures/stipplingsettings.h>
+#include <modules/basegl/datastructures/stipplingsettings.h>
 
 namespace inviwo {
-/*
- * \brief Settings for stippling (Dashed line, e.g., - - -)
- */
-class IVW_MODULE_BASE_API StipplingSettingsInterface {
-public:
-    /*
-     * \brief Determines in which space the stippling parameters should be applied.
-     */
-    enum class Mode { None, ScreenSpace, WorldSpace };
-    StipplingSettingsInterface() = default;
-    virtual ~StipplingSettingsInterface() = default;
-    /*
-     * Determines which space the other settings should be applied.
-     */
-    virtual Mode getMode() const = 0;
-    /*
-     * Return length of dash, in pixels if Mode is ScreenSpace.
-     */
-    virtual float getLength() const = 0;
-    /*
-     * Return distance between dashes, in pixels if Mode is ScreenSpace.
-     */
-    virtual float getSpacing() const = 0;
-    /*
-     * Return offset of first dash, in pixels if Mode is ScreenSpace.
-     */
-    virtual float getOffset() const = 0;
-    /*
-     * Return scaling of parameters. Only applicable if Mode is WorldSpace.
-     */
-    virtual float getWorldScale() const = 0;
-};
-IVW_MODULE_BASE_API bool operator==(const StipplingSettingsInterface& a,
-                                    const StipplingSettingsInterface& b);
-IVW_MODULE_BASE_API bool operator!=(const StipplingSettingsInterface& a,
-                                    const StipplingSettingsInterface& b);
+
+StipplingSettings::StipplingSettings(const StipplingSettingsInterface* other)
+    : mode(other->getMode())
+    , length(other->getLength())
+    , spacing(other->getSpacing())
+    , offset(other->getOffset())
+    , worldScale(other->getWorldScale()) {}
+
+StipplingSettingsInterface::Mode StipplingSettings::getMode() const { return mode; }
+
+float StipplingSettings::getLength() const { return length; }
+
+float StipplingSettings::getSpacing() const { return spacing; }
+
+float StipplingSettings::getOffset() const { return offset; }
+
+float StipplingSettings::getWorldScale() const { return worldScale; }
 
 }  // namespace inviwo

--- a/modules/basegl/src/datastructures/stipplingsettingsinterface.cpp
+++ b/modules/basegl/src/datastructures/stipplingsettingsinterface.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2019-2020 Inviwo Foundation
+ * Copyright (c) 2020 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,47 +26,19 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  *********************************************************************************/
-#pragma once
 
-#include <modules/base/basemoduledefine.h>
-#include <modules/base/datastructures/stipplingsettingsinterface.h>
+#include <modules/basegl/datastructures/stipplingsettingsinterface.h>
 
 namespace inviwo {
 
-/**
- * \brief Basic implementation of the StipplingSettingsInterface
- */
-class IVW_MODULE_BASE_API StipplingSettings : public StipplingSettingsInterface {
-public:
-    StipplingSettings() = default;
-    StipplingSettings(const StipplingSettingsInterface* other);
-    virtual ~StipplingSettings() = default;
+bool operator==(const StipplingSettingsInterface& a, const StipplingSettingsInterface& b) {
+    return a.getMode() == b.getMode() && a.getLength() == b.getLength() &&
+           a.getSpacing() == b.getSpacing() && a.getOffset() == b.getOffset() &&
+           a.getWorldScale() == b.getWorldScale();
+}
 
-    Mode mode = Mode::None;
-    float length = 30.f;
-    float spacing = 10.f;
-    float offset = 0.f;
-    float worldScale = 4.f;
-    /*
-     * @copydoc StipplingSettingsInterface::getMode
-     */
-    virtual StipplingSettingsInterface::Mode getMode() const override;
-    /*
-     * @copydoc StipplingSettingsInterface::getLength
-     */
-    virtual float getLength() const override;
-    /*
-     * @copydoc StipplingSettingsInterface::getSpacing
-     */
-    virtual float getSpacing() const override;
-    /*
-     * @copydoc StipplingSettingsInterface::getOffset
-     */
-    virtual float getOffset() const override;
-    /*
-     * @copydoc StipplingSettingsInterface::getWorldScale
-     */
-    virtual float getWorldScale() const override;
-};
+bool operator!=(const StipplingSettingsInterface& a, const StipplingSettingsInterface& b) {
+    return !(a == b);
+}
 
 }  // namespace inviwo

--- a/modules/basegl/src/properties/linesettingsproperty.cpp
+++ b/modules/basegl/src/properties/linesettingsproperty.cpp
@@ -31,6 +31,9 @@
 
 namespace inviwo {
 
+const std::string LineSettingsProperty::classIdentifier = "org.inviwo.LineSettingsProperty";
+std::string LineSettingsProperty::getClassIdentifier() const { return classIdentifier; }
+
 LineSettingsProperty::LineSettingsProperty(const std::string& identifier,
                                            const std::string& displayName,
                                            InvalidationLevel invalidationLevel,

--- a/modules/basegl/src/properties/linesettingsproperty.cpp
+++ b/modules/basegl/src/properties/linesettingsproperty.cpp
@@ -52,6 +52,19 @@ LineSettingsProperty::LineSettingsProperty(const std::string& identifier,
                   roundDepthProfile_, stippling_);
 }
 
+LineSettingsProperty::LineSettingsProperty(const LineSettingsProperty& rhs)
+    : CompositeProperty(rhs)
+    , lineWidth_(rhs.lineWidth_)
+    , antialiasing_(rhs.antialiasing_)
+    , miterLimit_(rhs.miterLimit_)
+    , roundCaps_(rhs.roundCaps_)
+    , pseudoLighting_(rhs.pseudoLighting_)
+    , roundDepthProfile_(rhs.roundDepthProfile_)
+    , stippling_(rhs.stippling_) {
+    addProperties(lineWidth_, antialiasing_, miterLimit_, roundCaps_, pseudoLighting_,
+                  roundDepthProfile_, stippling_);
+}
+
 LineSettingsProperty* LineSettingsProperty::clone() const {
     return new LineSettingsProperty(*this);
 }

--- a/modules/basegl/src/properties/stipplingproperty.cpp
+++ b/modules/basegl/src/properties/stipplingproperty.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2017-2020 Inviwo Foundation
+ * Copyright (c) 2020 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,7 +27,7 @@
  *
  *********************************************************************************/
 
-#include <modules/base/properties/stipplingproperty.h>
+#include <modules/basegl/properties/stipplingproperty.h>
 
 namespace inviwo {
 
@@ -76,5 +76,43 @@ StipplingProperty::StipplingProperty(const StipplingProperty& rhs)
 }
 
 StipplingProperty* StipplingProperty::clone() const { return new StipplingProperty(*this); }
+
+namespace utilgl {
+
+void addShaderDefines(Shader& shader, const StipplingProperty& property) {
+    addShaderDefines(shader, property.mode_.get());
+}
+
+void addShaderDefines(Shader& shader, const StipplingProperty::Mode& mode) {
+    std::string value;
+    switch (mode) {
+        case StipplingProperty::Mode::ScreenSpace:
+            value = "1";
+            break;
+        case StipplingProperty::Mode::WorldSpace:
+            value = "2";
+            break;
+        case StipplingProperty::Mode::None:
+        default:
+            break;
+    }
+
+    auto fragShader = shader.getFragmentShaderObject();
+    if (mode != StipplingProperty::Mode::None) {
+        fragShader->addShaderDefine("ENABLE_STIPPLING");
+    } else {
+        fragShader->removeShaderDefine("ENABLE_STIPPLING");
+    }
+    fragShader->addShaderDefine("STIPPLE_MODE", value);
+}
+
+void setShaderUniforms(Shader& shader, const StipplingProperty& property, const std::string& name) {
+    shader.setUniform(name + ".length", property.length_.get());
+    shader.setUniform(name + ".spacing", property.spacing_.get());
+    shader.setUniform(name + ".offset", property.offset_.get());
+    shader.setUniform(name + ".worldScale", property.worldScale_.get());
+}
+
+}  // namespace utilgl
 
 }  // namespace inviwo

--- a/modules/basegl/src/properties/stipplingproperty.cpp
+++ b/modules/basegl/src/properties/stipplingproperty.cpp
@@ -98,11 +98,7 @@ void addShaderDefines(Shader& shader, const StipplingProperty::Mode& mode) {
     }
 
     auto fragShader = shader.getFragmentShaderObject();
-    if (mode != StipplingProperty::Mode::None) {
-        fragShader->addShaderDefine("ENABLE_STIPPLING");
-    } else {
-        fragShader->removeShaderDefine("ENABLE_STIPPLING");
-    }
+    fragShader->setShaderDefine("ENABLE_STIPPLING", mode != StipplingProperty::Mode::None);
     fragShader->addShaderDefine("STIPPLE_MODE", value);
 }
 

--- a/modules/opengl/depends.cmake
+++ b/modules/opengl/depends.cmake
@@ -1,6 +1,5 @@
 #--------------------------------------------------------------------
 # Dependencies for OpenGL module
 set(dependencies 
-	InviwoBaseModule
 )
 set(EnableByDefault ON)

--- a/modules/opengl/include/modules/opengl/shader/shaderutils.h
+++ b/modules/opengl/include/modules/opengl/shader/shaderutils.h
@@ -41,7 +41,6 @@
 #include <inviwo/core/properties/simplelightingproperty.h>
 #include <inviwo/core/properties/raycastingproperty.h>
 #include <inviwo/core/ports/port.h>
-#include <modules/base/properties/stipplingproperty.h>
 #include <modules/opengl/volume/volumeutils.h>
 #include <modules/opengl/texture/textureutils.h>
 
@@ -127,12 +126,6 @@ IVW_MODULE_OPENGL_API void addShaderDefines(Shader& shader,
                                             const VolumeIndicatorProperty& property);
 IVW_MODULE_OPENGL_API void setShaderUniforms(Shader& shader,
                                              const VolumeIndicatorProperty& property,
-                                             const std::string& name);
-
-// StipplingProperty
-IVW_MODULE_OPENGL_API void addShaderDefines(Shader& shader, const StipplingProperty& property);
-IVW_MODULE_OPENGL_API void addShaderDefines(Shader& shader, const StipplingProperty::Mode& mode);
-IVW_MODULE_OPENGL_API void setShaderUniforms(Shader& shader, const StipplingProperty& property,
                                              const std::string& name);
 
 // Ordinal Property

--- a/modules/opengl/src/shader/shaderutils.cpp
+++ b/modules/opengl/src/shader/shaderutils.cpp
@@ -542,40 +542,6 @@ void setShaderUniforms(Shader& shader, const VolumeIndicatorProperty& indicator,
     }
 }
 
-void addShaderDefines(Shader& shader, const StipplingProperty& property) {
-    addShaderDefines(shader, property.mode_.get());
-}
-
-void addShaderDefines(Shader& shader, const StipplingProperty::Mode& mode) {
-    std::string value;
-    switch (mode) {
-        case StipplingProperty::Mode::ScreenSpace:
-            value = "1";
-            break;
-        case StipplingProperty::Mode::WorldSpace:
-            value = "2";
-            break;
-        case StipplingProperty::Mode::None:
-        default:
-            break;
-    }
-
-    auto fragShader = shader.getFragmentShaderObject();
-    if (mode != StipplingProperty::Mode::None) {
-        fragShader->addShaderDefine("ENABLE_STIPPLING");
-    } else {
-        fragShader->removeShaderDefine("ENABLE_STIPPLING");
-    }
-    fragShader->addShaderDefine("STIPPLE_MODE", value);
-}
-
-void setShaderUniforms(Shader& shader, const StipplingProperty& property, const std::string& name) {
-    shader.setUniform(name + ".length", property.length_.get());
-    shader.setUniform(name + ".spacing", property.spacing_.get());
-    shader.setUniform(name + ".offset", property.offset_.get());
-    shader.setUniform(name + ".worldScale", property.worldScale_.get());
-}
-
 int getLogLineNumber(const std::string& compileLogLine) {
     int result = -1;
     std::istringstream input(compileLogLine);

--- a/modules/plottinggl/include/modules/plottinggl/plotters/scatterplotgl.h
+++ b/modules/plottinggl/include/modules/plottinggl/plotters/scatterplotgl.h
@@ -38,7 +38,7 @@
 #include <inviwo/core/util/dispatcher.h>
 
 #include <modules/base/algorithm/dataminmax.h>
-#include <modules/base/properties/stipplingproperty.h>
+#include <modules/basegl/properties/stipplingproperty.h>
 #include <modules/basegl/properties/linesettingsproperty.h>
 
 #include <modules/opengl/texture/textureutils.h>

--- a/resources/changelog.html
+++ b/resources/changelog.html
@@ -86,6 +86,14 @@
 </head>
 <body >
 <h1>Latest Changes</h1>
+<h2>2020-06-16 StipplingProperty now in BaseGL</h2>
+<p>Moved StipplingProperty and associated settings from Base module to BaseGL.</p>
+<h2>2020-06-03 WebBrowser Javascript API</h2>
+<p>Changed redirection of <code>https://inviwo</code> to <code>inviwo://</code> to avoid confusion with the https scheme.<br />
+Your html-files will need to update from <br />
+'<a href="https://inviwo/modules/yourmodule">https://inviwo/modules/yourmodule</a>' <br />
+to <br />
+'inviwo://yourmodule' </p>
 <h2>2020-04-03 OrdinalPropertyState</h2>
 <p>Added a OrdinalPropertyState helper for constructing ordinal properties.<br />
 And a factory function <code>util::ordinalColor</code> for OrdinalProperties representing Colors<br />
@@ -222,7 +230,7 @@ See web_property_sync.html in the Webbrowser module</p>
 Bellow follows an example of a python processor:</p>
 <div class="highlight"><pre><span></span><span class="c1"># Name: PythonExample </span>
 
-<span class="kn">import</span> <span class="nn">inviwopy</span> <span class="k">as</span> <span class="nn">ivw</span>
+<span class="kn">import</span> <span class="nn">inviwopy</span> <span class="kn">as</span> <span class="nn">ivw</span>
 
 <span class="k">class</span> <span class="nc">PythonExample</span><span class="p">(</span><span class="n">ivw</span><span class="o">.</span><span class="n">Processor</span><span class="p">):</span>
     <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="nb">id</span><span class="p">,</span> <span class="n">name</span><span class="p">):</span>
@@ -249,10 +257,10 @@ Bellow follows an example of a python processor:</p>
         <span class="k">return</span> <span class="n">PythonExample</span><span class="o">.</span><span class="n">processorInfo</span><span class="p">()</span>
 
     <span class="k">def</span> <span class="nf">initializeResources</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="nb">print</span><span class="p">(</span><span class="s2">&quot;init&quot;</span><span class="p">)</span>
+        <span class="k">print</span><span class="p">(</span><span class="s2">&quot;init&quot;</span><span class="p">)</span>
 
     <span class="k">def</span> <span class="nf">process</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="nb">print</span><span class="p">(</span><span class="s2">&quot;process: &quot;</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">slider</span><span class="o">.</span><span class="n">value</span><span class="p">)</span>
+        <span class="k">print</span><span class="p">(</span><span class="s2">&quot;process: &quot;</span><span class="p">,</span> <span class="bp">self</span><span class="o">.</span><span class="n">slider</span><span class="o">.</span><span class="n">value</span><span class="p">)</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">outport</span><span class="o">.</span><span class="n">setData</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">inport</span><span class="o">.</span><span class="n">getData</span><span class="p">())</span>
 </pre></div>
 
@@ -262,8 +270,8 @@ To register an Inviwo python processor one can put in in the <user setttings fol
 <h2>2019-04-30 Python Applications</h2>
 <p>It is now possible to run inviwo directly from python using a new inviwopyapp python package found in <code>apps/inviwopyapp</code>.<br />
 An example of running inviwo can be found in <code>apps/inviwopyapp/inviwo.py</code>. </p>
-<div class="highlight"><pre><span></span><span class="kn">import</span> <span class="nn">inviwopy</span> <span class="k">as</span> <span class="nn">ivw</span>
-<span class="kn">import</span> <span class="nn">inviwopyapp</span> <span class="k">as</span> <span class="nn">qt</span>
+<div class="highlight"><pre><span></span><span class="kn">import</span> <span class="nn">inviwopy</span> <span class="kn">as</span> <span class="nn">ivw</span>
+<span class="kn">import</span> <span class="nn">inviwopyapp</span> <span class="kn">as</span> <span class="nn">qt</span>
 
 <span class="k">if</span> <span class="vm">__name__</span> <span class="o">==</span> <span class="s1">&#39;__main__&#39;</span><span class="p">:</span>
     <span class="c1"># Inviwo requires that a logcentral is created.</span>


### PR DESCRIPTION
Moved `StipplingProperty` from Base module to BaseGL. Thus getting rid of BaseGL depending on Base.