### PR TITLE
Core: StringProperty: Keep linebreaks in tooltips

### DIFF
--- a/src/core/properties/stringproperty.cpp
+++ b/src/core/properties/stringproperty.cpp
@@ -51,7 +51,7 @@ Document StringProperty::getDescription() const {
     using P = Document::PathComponent;
     Document doc = TemplateProperty<std::string>::getDescription();
     auto b = doc.get({P("html"), P("body")});
-    b.append("p", value_.value);
+    b.append("pre", value_.value);
     return doc;
 }
 


### PR DESCRIPTION
Rebase of  #960 