### PR TITLE
Jenkins: Enable force assertions on jenkins builds 

### DIFF
--- a/tools/jenkins/util.groovy
+++ b/tools/jenkins/util.groovy
@@ -309,6 +309,7 @@ Map defaultCMakeOptions(String buildType) {
         "BUILD_SHARED_LIBS" : "ON",
         "IVW_CFG_CMAKE_DEBUG" : "ON",
         "IVW_CFG_RUNTIME_MODULE_LOADING" : "OFF",
+        "IVW_CFG_FORCE_ASSERTIONS" : "ON", 
         "IVW_DOXYGEN_PROJECT" : "ON",
         "IVW_APP_MINIMAL_GLFW" : "ON",
         "IVW_APP_MINIMAL_QT" : "ON",


### PR DESCRIPTION
To prevent future issues as solved in #982
