### PR TITLE
External app pre-module registration hook

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,9 @@ ivw_enable_modules_if(IVW_APP_PYTHON Python3 Python3Qt QtWidgets)
 option(IVW_TEST_INTEGRATION_TESTS "Build inviwo integration test" ON)
 ivw_enable_modules_if(IVW_TEST_INTEGRATION_TESTS GLFW Base)
 
+# Provide optional hook for external application setup 
+ivw_external_apps_pre_module_registration_setup()
+
 # Try to find qt and add it if it is not already in CMAKE_PREFIX_PATH
 if(NOT "${CMAKE_PREFIX_PATH}" MATCHES "[Qq][Tt]")
     include(cmake/locateqt.cmake)
@@ -125,7 +128,7 @@ endif()
 ivw_register_modules(all_modules)            # Add inviwo modules
 add_subdirectory(src/qt)                     # Add the Qt network editor
 add_subdirectory(apps)                       # Add all the applications, uses the modules.
-ivw_add_external_projects()                  # Add external projects
+ivw_add_external_apps()                      # Add external projects
 if(IVW_TEST_INTEGRATION_TESTS)
     add_subdirectory(tests/integrationtests) # Add integration tests, uses the modules.
 endif()

--- a/cmake/globalmacros.cmake
+++ b/cmake/globalmacros.cmake
@@ -549,10 +549,20 @@ endfunction()
 
 #--------------------------------------------------------------------
 # Add all external projects specified in cmake string IVW_EXTERNAL_PROJECTS
-function(ivw_add_external_projects)
+function(ivw_add_external_apps)
     foreach(project_root_path ${IVW_EXTERNAL_PROJECTS})
         string(STRIP ${project_root_path} project_root_path)
         get_filename_component(FOLDER_NAME ${project_root_path} NAME)
         add_subdirectory(${project_root_path} ${CMAKE_CURRENT_BINARY_DIR}/ext_${FOLDER_NAME})
+    endforeach()
+endfunction()
+
+# Include file "preModuleRegistration.cmake" in each folder specified in IVW_EXTERNAL_PROJECTS to 
+# allow external application setup before modules are registered. 
+# Typical usage: ivw_enable_modules_if(IVW_APP_MYAPP YourDependentModuleName)
+function(ivw_external_apps_pre_module_registration_setup)
+    foreach(project_root_path ${IVW_EXTERNAL_PROJECTS})
+        string(STRIP ${project_root_path} project_root_path)
+        include(${project_root_path}/preModuleRegistration.cmake OPTIONAL)
     endforeach()
 endfunction()


### PR DESCRIPTION
Provide a hook for external applications such that they can perform the same setup as the internal apps.

