### PR TITLE
Base: Readded printing newlines between keys in the DatVolumeWriter

### DIFF
--- a/modules/base/src/io/datvolumewriter.cpp
+++ b/modules/base/src/io/datvolumewriter.cpp
@@ -76,16 +76,16 @@ void DatVolumeWriter::writeData(const Volume* data, const std::string filePath) 
     glm::mat4 wtm = glm::transpose(data->getWorldMatrix());
 
     auto print = util::overloaded{
-        [&](std::string_view key, const std::string& val) { fmt::print(ss, "{}: {}", key, val); },
-        [&](std::string_view key, InterpolationType val) { fmt::print(ss, "{}: {}", key, val); },
+        [&](std::string_view key, const std::string& val) { fmt::print(ss, "{}: {}\n", key, val); },
+        [&](std::string_view key, InterpolationType val) { fmt::print(ss, "{}: {}\n", key, val); },
         [&](std::string_view key, const SwizzleMask& mask) {
-            fmt::print(ss, "{}: {}{}{}{}", key, mask[0], mask[1], mask[2], mask[3]);
+            fmt::print(ss, "{}: {}{}{}{}\n", key, mask[0], mask[1], mask[2], mask[3]);
         },
         [&](std::string_view key, const Wrapping3D& wrapping) {
-            fmt::print(ss, "{}: {} {} {}", key, wrapping[0], wrapping[1], wrapping[2]);
+            fmt::print(ss, "{}: {} {} {}\n", key, wrapping[0], wrapping[1], wrapping[2]);
         },
         [&](std::string_view key, const auto& vec) {
-            fmt::print(ss, "{}: {}", key, fmt::join(begin(vec), end(vec), " "));
+            fmt::print(ss, "{}: {}\n", key, fmt::join(begin(vec), end(vec), " "));
         }};
 
     print("RawFile", fileName + ".raw");


### PR DESCRIPTION
Commit 7b71f0e19137b85d4a9627d4b2ec7087bacbff24 reworked the way inviwo writes ivw-dat volumes and the linebreaks where accidentally missing in the new implementation. 
This resulted in a dat-file with a single long line that the reader could not read. 

https://github.com/inviwo/inviwo/commit/7b71f0e19137b85d4a9627d4b2ec7087bacbff24#diff-087e112ac5ebf2b7145ddf8a52f3b442L66-L81

https://github.com/inviwo/inviwo/commit/7b71f0e19137b85d4a9627d4b2ec7087bacbff24#diff-cd2eac0617a2116cc80e156cafb0032cR78-R89