### PR TITLE
fix: windeploy not found

### DIFF
--- a/cmake/globalutils.cmake
+++ b/cmake/globalutils.cmake
@@ -981,6 +981,14 @@ function(ivw_deploy_qt target)
             find_program(WINDEPLOYQT_EXECUTABLE NAMES windeployqt HINTS ${QTDIR} ENV QTDIR PATH_SUFFIXES bin)
 
             get_filename_component(qt_bin_dir ${WINDEPLOYQT_EXECUTABLE} DIRECTORY  )
+
+            # in case of environment variable QTDIR not set
+            if(NOT EXISTS ${WINDEPLOYQT_EXECUTABLE})
+                get_target_property(qmake_executable Qt5::qmake IMPORTED_LOCATION)
+                get_filename_component(qt_bin_dir "${qmake_executable}" DIRECTORY)
+                find_program(WINDEPLOYQT_EXECUTABLE NAMES windeployqt HINTS ${qt_bin_dir} )
+            endif()
+
             add_custom_command(TARGET ${target} POST_BUILD 
                                 COMMAND ${qt_bin_dir}/qtenv2.bat
                                 COMMAND ${WINDEPLOYQT_EXECUTABLE} --no-compiler-runtime --verbose 1 $<TARGET_FILE:${target}>


### PR DESCRIPTION
windeploy not found if user set Qt path with CMAKE_PREFIX_PATH instead of QTDIR

- Windows 10
- CMake & Visual studio 2019 build tools & Ninja
- Qt 15.0
- CMake 3.17.0-rc1
- Python 3.8.4
