### PR TITLE
AxisRenderer3D: Given caption text rotation is now used.

### DIFF
--- a/modules/plottinggl/src/utils/axisrenderer.cpp
+++ b/modules/plottinggl/src/utils/axisrenderer.cpp
@@ -379,7 +379,7 @@ void AxisRenderer3D::renderText(Camera* camera, const size2_t& outputDims, const
 
         const vec3 pos(plot::getAxisCaptionPosition3D(settings_, startPos, endPos, tickDirection));
 
-		const auto angle = glm::radians(captionSettings.getRotation());
+        const auto angle = glm::radians(captionSettings.getRotation());
         const auto transform = glm::rotate(angle, vec3(0.0f, 0.0f, 1.0f));
 
         quadRenderer_.renderToRect3D(*camera, *captex.texture, pos,

--- a/modules/plottinggl/src/utils/axisrenderer.cpp
+++ b/modules/plottinggl/src/utils/axisrenderer.cpp
@@ -379,8 +379,12 @@ void AxisRenderer3D::renderText(Camera* camera, const size2_t& outputDims, const
 
         const vec3 pos(plot::getAxisCaptionPosition3D(settings_, startPos, endPos, tickDirection));
 
+		const auto angle = glm::radians(captionSettings.getRotation());
+        const auto transform = glm::rotate(angle, vec3(0.0f, 0.0f, 1.0f));
+
         quadRenderer_.renderToRect3D(*camera, *captex.texture, pos,
-                                     ivec2(captex.texture->getDimensions()), outputDims, anchor);
+                                     ivec2(captex.texture->getDimensions()), outputDims, anchor,
+                                     transform);
     }
 
     // axis labels


### PR DESCRIPTION
The rotation given from the PlotTextProperty is now used when AxisRenderer3D renders text, much like AxisRenderer does.
