### PR TITLE
WebBrowser: registering of processor callbacks

### DIFF
--- a/modules/webbrowser/data/js/inviwoapi.js
+++ b/modules/webbrowser/data/js/inviwoapi.js
@@ -162,6 +162,22 @@ class InviwoAPI {
             }
         });
     }
+    /*
+     * Call a previously registered processor callback.
+     * @param callback  name of the callback
+     * @param data      payload will be stringified into JSON
+     */
+    async invokeCallback(callback, data) {
+        window.cefQuery({
+            request: JSON.stringify({
+                'command': 'callback',
+                'callback': callback,
+                'data': JSON.stringify(data)
+            }),
+            onSuccess: function (response) { },
+            onFailure: function (error_code, error_message) { }
+        });
+    }
 
     async syncRange(htmlId, prop) {
         var property = document.getElementById(htmlId);

--- a/modules/webbrowser/include/modules/webbrowser/processors/processorcefsynchronizer.h
+++ b/modules/webbrowser/include/modules/webbrowser/processors/processorcefsynchronizer.h
@@ -117,7 +117,7 @@ private:
     const Processor* parent_;
     std::map<Processor*, ProgressBarObserverCEF> progressObservers_;
     // maps callback name used in JavaScript to registered callbacks
-    std::unordered_map<std::string, typename Dispatcher<CallbackFunc>> callbacks_;
+    std::unordered_map<std::string, Dispatcher<CallbackFunc>> callbacks_;
     IMPLEMENT_REFCOUNTING(ProcessorCefSynchronizer);
 };
 #include <warn/pop>

--- a/modules/webbrowser/include/modules/webbrowser/processors/processorcefsynchronizer.h
+++ b/modules/webbrowser/include/modules/webbrowser/processors/processorcefsynchronizer.h
@@ -34,6 +34,7 @@
 
 #include <inviwo/core/network/processornetworkobserver.h>
 #include <inviwo/core/processors/processor.h>
+#include <inviwo/core/util/dispatcher.h>
 
 #include <warn/push>
 #include <warn/ignore/all>
@@ -57,12 +58,28 @@ class IVW_MODULE_WEBBROWSER_API ProcessorCefSynchronizer
       public CefLoadHandler,
       public ProcessorNetworkObserver {
 public:
+    using CallbackFunc = void(const std::string&);
+    using CallbackHandle = std::shared_ptr<std::function<CallbackFunc>>;
+
     /**
      * @param const Processor* parent web browser processor responsible for the browser. Cannot be
      * null.
      */
     explicit ProcessorCefSynchronizer(const Processor* parent);
     virtual ~ProcessorCefSynchronizer() = default;
+
+    /**
+     * Register a \p callback which can be triggered through a cefQuery request where the 'command'
+     * is 'callback' and 'name' refers to \p name in the JSON object. The callback will then be
+     * called with the payload given by 'data'.
+     *
+     * \code{.json}
+     * {"command": "callback", "callback": "name", "data": "string payload"}
+     * \endcode
+     *
+     * \see OnQuery
+     */
+    CallbackHandle registerCallback(const std::string& name, std::function<CallbackFunc> callback);
 
     /**
      * Synchronizes all widgets and sets their frame, called when frame has loaded.
@@ -73,10 +90,21 @@ public:
     /**
      * Called due to cefQuery execution in message_router.html.
      * Expects the request to be a JSON data object, see inviwoapi.js:
-     * {command: "processor.subscribe.progress", "path": ProcessorIdentifier,
+     *
+     * \code{.json}
+     * {"command": "processor.subscribe.progress", "path": ProcessorIdentifier,
      * "onProgressChange":onProgressCallback, "onProgressVisibleChange":onProgressVisibleChange}
+     * \endcode
+     *
      * or
-     * {command: "parentwebbrowserprocessor"}
+     * \code{.json}
+     * {"command": "parentwebbrowserprocessor"}
+     * \endcode
+     *
+     * or, in case callbacks have been registered, calling the given callback
+     * \code{.json}
+     * {"command": "callback", "callback": "name", "data" : "string payload"}
+     * \endcode
      */
     virtual bool OnQuery(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, int64 query_id,
                          const CefString& request, bool persistent,
@@ -88,6 +116,8 @@ public:
 private:
     const Processor* parent_;
     std::map<Processor*, ProgressBarObserverCEF> progressObservers_;
+    // maps callback name used in JavaScript to registered callbacks
+    std::unordered_map<std::string, typename Dispatcher<CallbackFunc>> callbacks_;
     IMPLEMENT_REFCOUNTING(ProcessorCefSynchronizer);
 };
 #include <warn/pop>

--- a/modules/webbrowser/include/modules/webbrowser/webbrowserclient.h
+++ b/modules/webbrowser/include/modules/webbrowser/webbrowserclient.h
@@ -86,6 +86,23 @@ public:
      */
     void setBrowserParent(CefRefPtr<CefBrowser> browser, Processor* parent);
 
+    /**
+     * Register a processor \p callback for a specific \p browser which can be triggered through a
+     * cefQuery request where the 'command' is 'callback' and 'name' refers to \p name in the JSON
+     * object. The callback will then be called with the string payload given by 'data'.
+     *
+     * Note: setBrowserParent() must have been called before.
+     *
+     * \code{.json}
+     * {"command": "callback", "callback": "name", "data": "string payload"}
+     * \endcode
+     *
+     * \see ProcessorCefSynchronizer::registerCallback, setBrowserParent
+     */
+    ProcessorCefSynchronizer::CallbackHandle registerCallback(
+        CefRefPtr<CefBrowser> browser, const std::string& name,
+        std::function<ProcessorCefSynchronizer::CallbackFunc> callback);
+
     CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override { return this; }
 
     bool OnProcessMessageReceived(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,


### PR DESCRIPTION
Added functionality for registering processor callbacks in the browser and invoking them from Javascript. Useful for communicating with the processor. For example in brushing&linking by sending indices of selected elements.

```c++
    auto browserClient = app->getModuleByType<WebBrowserModule>()->getBrowserClient();
    ...
    browserClient->setBrowserParent(browser_, this);
    selectionCallback_ = browserClient->registerCallback(browser_, "selectionChanged",
                                    [&](const std::string& str) { LogInfo("callback: " + str); });
```

Can be invoked via 
```javascript
var data = [ 1, 2, 3, 4, 5 ];
inviwo.invokeCallback("myCallback", data);
```
Payload is stringified into JSON.