### PR TITLE
Fixing same-depth fragments

### DIFF
--- a/modules/meshrenderinggl/glsl/oit/display.frag
+++ b/modules/meshrenderinggl/glsl/oit/display.frag
@@ -97,7 +97,8 @@ void main() {
 
         // front-to-back shading
         vec4 color = vec4(0);
-        vec4 nextFragment = selectionSortNext(pixelIdx, 0.0);
+        uint lastPtr = 0;
+        vec4 nextFragment = selectionSortNext(pixelIdx, 0.0, lastPtr);
         abufferPixel unpackedFragment = uncompressPixelData(nextFragment);
         gl_FragDepth = min(backgroundDepth, unpackedFragment.depth);
 
@@ -106,7 +107,7 @@ void main() {
             color.rgb = color.rgb + (1 - color.a) * c.a * c.rgb;
             color.a = color.a + (1 - color.a) * c.a;
 
-            nextFragment = selectionSortNext(pixelIdx, unpackedFragment.depth);
+            nextFragment = selectionSortNext(pixelIdx, unpackedFragment.depth, lastPtr);
             unpackedFragment = uncompressPixelData(nextFragment);
         }
 

--- a/modules/meshrenderinggl/glsl/oit/sort.glsl
+++ b/modules/meshrenderinggl/glsl/oit/sort.glsl
@@ -45,7 +45,8 @@ void bitonicSort(int n);
 void fillFragmentArray(uint idx, out int numFrag);
 // Fill local memory array with lowest values
 void fillFragmentArraySortedUntilDepth(uint pixelIdx, float maxDepth, out int numFrag);
-// Selection sort, allowing to get the first elements of a larger series
+// Selection sort, allowing to get the next elements of a larger series.
+// Returns the next fragment with lowest depth but behind/at the same depth as the last.
 vec4 selectionSortNext(uint headPtr, float lastDepth, inout uint lastPtr);
 
 // Bubble sort used to sort fragments
@@ -117,13 +118,17 @@ void fillFragmentArraySortedUntilDepth(uint pixelIdx, float maxDepth, out int nu
 }
 
 vec4 selectionSortNext(uint headPtr, float lastDepth, inout uint lastPtr) {
+    // Remember the next fragment closest to the camera.
     vec4 closestVal = vec4(-1.0);
     float minDepth = 1.0;
-    bool passedLastPtr = false;
     uint minPtr = 0;
+    // Remember whether the previous element was visited yet to work through fragemtns of same depth in order. 
+    bool passedLastPtr = false;
     while (headPtr != 0) {
         vec4 val = readPixelStorage(headPtr - 1);
         if (headPtr == lastPtr) passedLastPtr = true;
+        // Require fragment to be both closer than the current nearest one
+        // and behind the previous fragment returned in either depth or, iff at the same depth, in order. 
         else if (val.y < minDepth && (val.y > lastDepth || (passedLastPtr && val.y == lastDepth) )) {
             minDepth = val.y;
             closestVal = val;
@@ -131,6 +136,7 @@ vec4 selectionSortNext(uint headPtr, float lastDepth, inout uint lastPtr) {
         }
         headPtr = floatBitsToUint(val.x);
     }
+    // Update pointer to selected fragment.
     lastPtr = minPtr;
     return closestVal;
 }


### PR DESCRIPTION
Fixing fragment list rendering for multiple fragments of exact same depth.
![MartinZ-Fighting](https://user-images.githubusercontent.com/2829051/93656037-ba085c00-fa27-11ea-83e3-cc215b2c5d1b.png)
Lower right: Twice the same mesh at the same time.

There is still z-fighting, in the sense that the fragment first in the linked list is alpha-blended first. You see that when changing the order of rasterizations in the port (disconnect and reconnect) - one mesh will be "before" the other. 
Not sure if we need that fixed, it's a border case and I find it more of a hidden feature right now. Opinions?