### PR TITLE
Core: color conversion uvec3 overloads

### DIFF
--- a/include/inviwo/core/util/colorconversion.h
+++ b/include/inviwo/core/util/colorconversion.h
@@ -314,7 +314,14 @@ IVW_CORE_API vec3 Luv2XYZ(const vec3& Luv, vec3 whitePointXYZ = getD65WhitePoint
  * See https://doc.qt.io/qt-5/qcolor.html#lighter
  */
 IVW_CORE_API vec3 lighter(const vec3& rgb, float factor = 1.5f);
+/**
+ * \overload vec4 lighter(const vec4&, float)
+ */
 IVW_CORE_API vec4 lighter(const vec4& rgba, float factor = 1.5f);
+/**
+ * \overload uvec3 lighter(const uvec3&, float)
+ */
+IVW_CORE_API uvec3 lighter(const uvec3& rgb, float factor = 1.5f);
 
 /**
  * \brief Return a darker color by adjusting the brightness
@@ -331,7 +338,14 @@ IVW_CORE_API vec4 lighter(const vec4& rgba, float factor = 1.5f);
  * See https://doc.qt.io/qt-5/qcolor.html#lighter
  */
 IVW_CORE_API vec3 darker(const vec3& rgb, float factor = 2.0f);
+/**
+ * \overload vec4 darker(const vec4&, float)
+ */
 IVW_CORE_API vec4 darker(const vec4& rgba, float factor = 2.0f);
+/**
+ * \overload uvec3 darker(const uvec3&, float)
+ */
+IVW_CORE_API uvec3 darker(const uvec3& rgb, float factor = 2.0f);
 
 }  // namespace color
 

--- a/src/core/util/colorconversion.cpp
+++ b/src/core/util/colorconversion.cpp
@@ -470,6 +470,10 @@ vec3 LuvChromaticity2XYZ(const vec3& LuvChroma, vec3 whitePointXYZ) {
     return Luv2XYZ(vec3(L, u, v));
 }
 
+uvec3 lighter(const uvec3& rgb, float factor) {
+    return uvec3{lighter(vec3{rgb} / 255.0f, factor) * 255.0f};
+}
+
 vec3 lighter(const vec3& rgb, float factor) {
     vec3 hsv = rgb2hsv(rgb);
     hsv.z = std::min(hsv.z * factor, 1.0f);
@@ -480,6 +484,10 @@ vec4 lighter(const vec4& rgba, float factor) {
     vec3 hsv = rgb2hsv(rgba);
     hsv.z = std::min(hsv.z * factor, 1.0f);
     return vec4(hsv2rgb(hsv), rgba.a);
+}
+
+uvec3 darker(const uvec3& rgb, float factor) {
+    return uvec3{darker(vec3{rgb} / 255.0f, factor) * 255.0f};
 }
 
 vec3 darker(const vec3& rgb, float factor) {


### PR DESCRIPTION
color conversions were lacking a `uvec8` overloads of `lighter()` and `darker()` which are used by `DataTraits<T>::colorCode()` for vector ports.