### PR TITLE
PlottingGL: Parallel Coord fix

### DIFF
--- a/modules/plottinggl/src/processors/parallelcoordinates/pcpaxissettings.cpp
+++ b/modules/plottinggl/src/processors/parallelcoordinates/pcpaxissettings.cpp
@@ -135,7 +135,7 @@ void PCPAxisSettings::updateFromColumn(std::shared_ptr<const Column> col) {
             double prevMaxRatio = (prevVal.y - prevRange.x) / (l);
 
             Property::OnChangeBlocker block{range};
-            range.setRange(glm::tvec2<T>(minV, maxV));
+            range.setRange({minV, maxV});
             if (l > 0 && maxV != minV) {
                 range.set(
                     {minV + prevMinRatio * (maxV - minV), minV + prevMaxRatio * (maxV - minV)});

--- a/modules/plottinggl/src/processors/parallelcoordinates/pcpaxissettings.cpp
+++ b/modules/plottinggl/src/processors/parallelcoordinates/pcpaxissettings.cpp
@@ -115,7 +115,6 @@ void PCPAxisSettings::updateFromColumn(std::shared_ptr<const Column> col) {
 
     col->getBuffer()->getRepresentation<BufferRAM>()->dispatch<void, dispatching::filter::Scalars>(
         [&](auto ram) -> void {
-            using T = typename util::PrecisionValueType<decltype(ram)>;
             auto& dataVector = ram->getDataContainer();
 
             auto minMax = util::bufferMinMax(ram, IgnoreSpecialValues::Yes);


### PR DESCRIPTION
* fix range for categorical column with single value (uint32_t underflow)