### PR TITLE
Qt: improved filtering in processor list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Here we document changes that affect the public API or changes that needs to be communicated to other developers. 
 
+## 2020-11-10 Improved Filtering in Processor List Widget
+ Filtering in the Processor List Widget is now based on matching substrings (space is the separator). For example, searching for `Vol Source` will return `Volume Source`, `Volume Sequence Source`, and `Image Stack Volume Source`.
+ This also enables searching for processor names and tags at the same time, e.g. `Slice GL`.
+
 ## 2020-10-28 Performance refactoring
 * Serialization no longer supports use of the "allowReferences" to serialize pointer to the same object multiple times. Reasoning being that it requires all properties and ports to always be present in the xml even if they don't have any state that needs serialization. The new solution uses "paths" (a dot separated list of identifiers) instead of pointers where needed.
 * Some of the serialization functions now supports filters and projections to avoid having to create temporary objects to serialize.

--- a/include/inviwo/qt/editor/lineediteventfilter.h
+++ b/include/inviwo/qt/editor/lineediteventfilter.h
@@ -36,6 +36,7 @@
 #include <warn/pop>
 
 class QWidget;
+class QLineEdit;
 class QEvent;
 
 namespace inviwo {

--- a/include/inviwo/qt/editor/lineediteventfilter.h
+++ b/include/inviwo/qt/editor/lineediteventfilter.h
@@ -46,7 +46,7 @@ namespace inviwo {
  */
 class IVW_QTEDITOR_API LineEditEventFilter : public QObject {
 public:
-    explicit LineEditEventFilter(QWidget* w, QObject* parent = nullptr, bool focusAndDown = true);
+    explicit LineEditEventFilter(QWidget* w, QLineEdit* parent, bool focusAndDown = true);
     virtual ~LineEditEventFilter() = default;
 
     bool eventFilter(QObject* obj, QEvent* e);

--- a/include/inviwo/qt/editor/lineediteventfilter.h
+++ b/include/inviwo/qt/editor/lineediteventfilter.h
@@ -1,0 +1,59 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2020 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <inviwo/qt/editor/inviwoqteditordefine.h>
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <QObject>
+#include <warn/pop>
+
+class QWidget;
+class QEvent;
+
+namespace inviwo {
+
+/**
+ * \brief custom event filter for line edit widgets where the 'Esc' key clears the line edit and
+ * 'arrow down' switches focus to the given widget
+ */
+class IVW_QTEDITOR_API LineEditEventFilter : public QObject {
+public:
+    explicit LineEditEventFilter(QWidget* w, QObject* parent = nullptr, bool focusAndDown = true);
+    virtual ~LineEditEventFilter() = default;
+
+    bool eventFilter(QObject* obj, QEvent* e);
+
+private:
+    QWidget* widget_;
+    bool focusAndDown_;
+};
+
+}  // namespace inviwo

--- a/src/qt/editor/CMakeLists.txt
+++ b/src/qt/editor/CMakeLists.txt
@@ -29,6 +29,7 @@ set(HEADER_FILES
     ${IVW_INCLUDE_DIR}/inviwo/qt/editor/inviwoeditmenu.h
     ${IVW_INCLUDE_DIR}/inviwo/qt/editor/inviwomainwindow.h
     ${IVW_INCLUDE_DIR}/inviwo/qt/editor/inviwoqteditordefine.h
+    ${IVW_INCLUDE_DIR}/inviwo/qt/editor/lineediteventfilter.h
     ${IVW_INCLUDE_DIR}/inviwo/qt/editor/linkdialog/linkdialog.h
     ${IVW_INCLUDE_DIR}/inviwo/qt/editor/linkdialog/linkdialogcurvegraphicsitems.h
     ${IVW_INCLUDE_DIR}/inviwo/qt/editor/linkdialog/linkdialoggraphicsitems.h
@@ -77,6 +78,7 @@ set(SOURCE_FILES
     inviwoeditmenu.cpp
     inviwoeditmenu.cpp
     inviwomainwindow.cpp
+    lineediteventfilter.cpp
     linkdialog/linkdialog.cpp
     linkdialog/linkdialogcurvegraphicsitems.cpp
     linkdialog/linkdialogprocessorgraphicsitems.cpp
@@ -179,8 +181,8 @@ if(IVW_CFG_BUILD_CHANGELOG)
         file(GENERATE 
             OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/CopyIfFound.cmake"
             CONTENT 
-                "if (EXISTS \"${buildFile}\")
-                    file(COPY \"${buildFile}\" DESTINATION \"${destDir}\")
+                "if (EXISTS \"${buildFile}\")
+                    file(COPY \"${buildFile}\" DESTINATION \"${destDir}\")
                 endif()"
         )
 

--- a/src/qt/editor/lineediteventfilter.cpp
+++ b/src/qt/editor/lineediteventfilter.cpp
@@ -1,0 +1,73 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2020 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/qt/editor/lineediteventfilter.h>
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <QKeyEvent>
+#include <QCoreApplication>
+#include <warn/pop>
+
+namespace inviwo {
+
+LineEditEventFilter::LineEditEventFilter(QWidget* w, QObject* parent, bool focusAndDown)
+    : QObject(parent), widget_(w), focusAndDown_(focusAndDown) {}
+
+bool LineEditEventFilter::eventFilter(QObject* obj, QEvent* e) {
+    switch (e->type()) {
+        case QEvent::KeyPress: {
+            QKeyEvent* keyEvent = static_cast<QKeyEvent*>(e);
+            switch (keyEvent->key()) {
+                case Qt::Key_Down: {
+                    // set focus to the tree widget
+                    widget_->setFocus(Qt::ShortcutFocusReason);
+                    if (focusAndDown_) {
+                        // move cursor down one row
+                        QKeyEvent* keydown =
+                            new QKeyEvent(QKeyEvent::KeyPress, Qt::Key_Down, Qt::NoModifier);
+                        QCoreApplication::postEvent(widget_, keydown);
+                    }
+                    break;
+                }
+                case Qt::Key_Escape:
+                    reinterpret_cast<QLineEdit*>(parent())->clear();
+                    break;
+                default:
+                    break;
+            }
+            break;
+        }
+        default:
+            break;
+    }
+    return QObject::eventFilter(obj, e);
+}
+
+}  // namespace inviwo

--- a/src/qt/editor/lineediteventfilter.cpp
+++ b/src/qt/editor/lineediteventfilter.cpp
@@ -33,11 +33,12 @@
 #include <warn/ignore/all>
 #include <QKeyEvent>
 #include <QCoreApplication>
+#include <QLineEdit>
 #include <warn/pop>
 
 namespace inviwo {
 
-LineEditEventFilter::LineEditEventFilter(QWidget* w, QObject* parent, bool focusAndDown)
+LineEditEventFilter::LineEditEventFilter(QWidget* w, QLineEdit* parent, bool focusAndDown)
     : QObject(parent), widget_(w), focusAndDown_(focusAndDown) {}
 
 bool LineEditEventFilter::eventFilter(QObject* obj, QEvent* e) {
@@ -57,7 +58,9 @@ bool LineEditEventFilter::eventFilter(QObject* obj, QEvent* e) {
                     break;
                 }
                 case Qt::Key_Escape:
-                    reinterpret_cast<QLineEdit*>(parent())->clear();
+                    if (auto w = dynamic_cast<QLineEdit*>(parent())) {
+                        w->clear();
+                    }
                     break;
                 default:
                     break;

--- a/src/qt/editor/welcomewidget.cpp
+++ b/src/qt/editor/welcomewidget.cpp
@@ -43,6 +43,7 @@
 #include <inviwo/qt/editor/filetreewidget.h>
 #include <inviwo/qt/editor/inviwomainwindow.h>
 #include <inviwo/qt/editor/workspaceannotationsqt.h>
+#include <inviwo/qt/editor/lineediteventfilter.h>
 #include <inviwo/qt/applicationbase/inviwoapplicationqt.h>
 #include <modules/qtwidgets/inviwoqtutils.h>
 
@@ -77,48 +78,6 @@
 #include <warn/pop>
 
 namespace inviwo {
-
-namespace {
-
-class LineEditEventFilter : public QObject {
-public:
-    explicit LineEditEventFilter(QWidget* w, QObject* parent = nullptr)
-        : QObject(parent), widget_(w) {}
-    virtual ~LineEditEventFilter() = default;
-
-    bool eventFilter(QObject* obj, QEvent* e) {
-        switch (e->type()) {
-            case QEvent::KeyPress: {
-                QKeyEvent* keyEvent = static_cast<QKeyEvent*>(e);
-                switch (keyEvent->key()) {
-                    case Qt::Key_Down: {
-                        // set focus to the tree widget
-                        widget_->setFocus(Qt::ShortcutFocusReason);
-                        // move cursor down one row
-                        QKeyEvent* keydown =
-                            new QKeyEvent(QKeyEvent::KeyPress, Qt::Key_Down, Qt::NoModifier);
-                        QCoreApplication::postEvent(widget_, keydown);
-                        break;
-                    }
-                    case Qt::Key_Escape:
-                        reinterpret_cast<QLineEdit*>(parent())->clear();
-                        break;
-                    default:
-                        break;
-                }
-                break;
-            }
-            default:
-                break;
-        }
-        return QObject::eventFilter(obj, e);
-    }
-
-private:
-    QWidget* widget_;
-};
-
-}  // namespace
 
 WelcomeWidget::WelcomeWidget(InviwoMainWindow* window, QWidget* parent)
     : QSplitter(parent), mainWindow_(window) {


### PR DESCRIPTION
* filtering based on matching substrings (space is the separator)
* filter now similar to "go to files" functionality in Visual Studio

![image](https://user-images.githubusercontent.com/9251300/98728716-26556b00-239a-11eb-9daf-ae455cbe2a40.png)

Processor tags are also matched
![image](https://user-images.githubusercontent.com/9251300/98728870-5997fa00-239a-11eb-9cd0-834d018d2c1c.png)

For comparison, "go to file" functionality in Visual Studio
![image](https://user-images.githubusercontent.com/9251300/98728992-81875d80-239a-11eb-8474-d1eaad1f3d5f.png)
