### PR TITLE
Animation: Bug fixes

### DIFF
--- a/modules/animation/CMakeLists.txt
+++ b/modules/animation/CMakeLists.txt
@@ -5,6 +5,7 @@ ivw_module(Animation)
 #--------------------------------------------------------------------
 # Add header files
 set(HEADER_FILES
+    include/modules/animation/algorithm/animationrange.h
     include/modules/animation/animationcontroller.h
     include/modules/animation/animationcontrollerobserver.h
     include/modules/animation/animationmanager.h
@@ -56,6 +57,7 @@ ivw_group("Header Files" ${HEADER_FILES})
 #--------------------------------------------------------------------
 # Add source files
 set(SOURCE_FILES
+    src/algorithm/animationrange.cpp
     src/animationcontroller.cpp
     src/animationcontrollerobserver.cpp
     src/animationmanager.cpp

--- a/modules/animation/include/modules/animation/algorithm/animationrange.h
+++ b/modules/animation/include/modules/animation/algorithm/animationrange.h
@@ -49,11 +49,11 @@ auto getRange(Iterator begin, Iterator end, Seconds from, Seconds to)
     auto first = std::min(from, to);
     auto last = std::max(from, to);
     // 'fromIt' will be the first item with a time larger than or equal to 'from'
-    auto fromIt =
-        std::lower_bound(begin, end, first, [](const auto& it, const auto& val) { return *it < val; });
+    auto fromIt = std::lower_bound(begin, end, first,
+                                   [](const auto& it, const auto& val) { return *it < val; });
     // 'toIt' will be the first key with a time larger than 'to'
-    auto toIt =
-        std::upper_bound(begin, end, last, [](const auto& val, const auto& it) { return val < *it; });
+    auto toIt = std::upper_bound(begin, end, last,
+                                 [](const auto& val, const auto& it) { return val < *it; });
     return {fromIt, toIt};
 }
 

--- a/modules/animation/include/modules/animation/algorithm/animationrange.h
+++ b/modules/animation/include/modules/animation/algorithm/animationrange.h
@@ -48,10 +48,10 @@ auto getRange(Iterator begin, Iterator end, Seconds from, Seconds to)
     -> std::tuple<decltype(begin), decltype(end)> {
     auto first = std::min(from, to);
     auto last = std::max(from, to);
-    // 'fromIt' will be the first item with a time larger than or equal to 'from'
+    // 'fromIt' will be the first item with a time larger than or equal to 'first'
     auto fromIt = std::lower_bound(begin, end, first,
                                    [](const auto& it, const auto& val) { return *it < val; });
-    // 'toIt' will be the first key with a time larger than 'to'
+    // 'toIt' will be the first key with a time larger than 'last'
     auto toIt = std::upper_bound(begin, end, last,
                                  [](const auto& val, const auto& it) { return val < *it; });
     return {fromIt, toIt};

--- a/modules/animation/include/modules/animation/algorithm/animationrange.h
+++ b/modules/animation/include/modules/animation/algorithm/animationrange.h
@@ -41,22 +41,20 @@ namespace inviwo {
 namespace animation {
 
 namespace detail {
+
 template <typename T>
-struct GetTimeHelper {
-
-    static Seconds getTime(const T& elem, PlaybackDirection direction) {
-        if constexpr (std::is_base_of_v<KeyframeSequence, T>) {
-            if (direction == PlaybackDirection::Forward) {
-                return elem.getLast().getTime();
-            } else {
-                return elem.getFirst().getTime();
-            }
-
+Seconds getTimeHelper(const T& elem, PlaybackDirection direction) {
+    if constexpr (std::is_base_of_v<KeyframeSequence, T>) {
+        if (direction == PlaybackDirection::Forward) {
+            return elem.getLast().getTime();
         } else {
-            return elem.getTime();
-        };
-    }
-};
+            return elem.getFirst().getTime();
+        }
+
+    } else {
+        return elem.getTime();
+    };
+}
 
 }  // namespace detail
 /*
@@ -84,12 +82,8 @@ AnimationTimeState animateRange(Iterator begin, Iterator end, Seconds from, Seco
                 // We jumped in the opposite direction
                 break;
             }
-            // Use jump-to-time if set, previous keyframe time otherwise
-            from = res.time != to
-                       ? res.time
-                       : detail::GetTimeHelper<
-                             std::remove_reference<decltype(**begin)>::type>::getTime(**begin,
-                                                                                      direction);
+            // Use jump-to-time if set, previous Keyframe/KeyframeSequence time otherwise
+            from = res.time != to ? res.time : detail::getTimeHelper(**begin, direction);
 
             ++begin;
         }

--- a/modules/animation/include/modules/animation/animationcontroller.h
+++ b/modules/animation/include/modules/animation/animationcontroller.h
@@ -113,7 +113,6 @@ public:
     DoubleMinMaxProperty playWindow;
     DoubleProperty framesPerSecond;
     TemplateOptionProperty<PlaybackMode> playMode;
-    TemplateOptionProperty<PlaybackDirection> playbackDirection;
 
     CompositeProperty renderOptions;
     OptionPropertyInt renderWindowMode;
@@ -132,8 +131,6 @@ public:
     ButtonProperty controlInsertPauseFrame;
 
 protected:
-    /// Return duration to advance. Negative if PlaybackDirection is backward, positive otherwise.
-    Seconds getTickDeltaTime() const;
     /// Low-level setting of currentTime_. Use eval() to set time in the public interface.
     void setTime(Seconds time);
 

--- a/modules/animation/include/modules/animation/animationcontroller.h
+++ b/modules/animation/include/modules/animation/animationcontroller.h
@@ -95,12 +95,10 @@ public:
     /// Returns the current state of the controller, whether it is playing, or pausing, and such.
     const AnimationState& getState() const;
 
-    /// Returns playback mode such as loop or swing and such.
-    const AnimationPlaySettings& getPlaybackSettings() const { return settingsPlay_; }
-    AnimationPlaySettings& getPlaybackSettings() { return settingsPlay_; }
-    void setPlaybackSettings(const AnimationPlaySettings& newSettings);
+    /// Returns the playback direction used during tick.
+    const PlaybackDirection& getPlaybackDirection() const;
+    void setPlaybackDirection(PlaybackDirection newDirection);
 
-    const AnimationPlaySettings& getRenderingSettings() const { return settingsRendering_; }
     Seconds getCurrentTime() const;
 
     InviwoApplication* getInviwoApplication() override { return app_; }
@@ -115,6 +113,7 @@ public:
     DoubleMinMaxProperty playWindow;
     DoubleProperty framesPerSecond;
     TemplateOptionProperty<PlaybackMode> playMode;
+    TemplateOptionProperty<PlaybackDirection> playbackDirection;
 
     CompositeProperty renderOptions;
     OptionPropertyInt renderWindowMode;
@@ -133,6 +132,8 @@ public:
     ButtonProperty controlInsertPauseFrame;
 
 protected:
+    /// Return duration to advance. Negative if PlaybackDirection is backward, positive otherwise.
+    Seconds getTickDeltaTime() const;
     /// Low-level setting of currentTime_. Use eval() to set time in the public interface.
     void setTime(Seconds time);
 
@@ -147,12 +148,6 @@ protected:
 
     /// State of the animation, such as paused or playing or rendering
     AnimationState state_;
-
-    /// If in playback state, how fast we play the animation and whether we loop, or swing, etc.
-    AnimationPlaySettings settingsPlay_;
-
-    /// If in rendering state, how many frames we render.
-    AnimationPlaySettings settingsRendering_;
 
     /// Current time of the animation. This is an important variable to keep consistent!
     Seconds currentTime_;

--- a/modules/animation/include/modules/animation/animationcontrollerobserver.h
+++ b/modules/animation/include/modules/animation/animationcontrollerobserver.h
@@ -47,10 +47,6 @@ class IVW_MODULE_ANIMATION_API AnimationControllerObserver : public Observer {
 public:
     virtual void onStateChanged(AnimationController* /*controller*/, AnimationState /*prevState*/,
                                 AnimationState /*newState*/){};
-    virtual void onPlaybackSettingsChanged(AnimationController* /*controller*/,
-                                           AnimationPlaySettings /*prevSettings*/,
-                                           AnimationPlaySettings /*newSettings*/){};
-
     virtual void onTimeChanged(AnimationController* /*controller*/, Seconds /*oldTime*/,
                                Seconds /*newTime*/){};
     virtual void onAnimationChanged(AnimationController* /*controller*/, Animation* /*oldAnim*/,
@@ -62,9 +58,6 @@ class IVW_MODULE_ANIMATION_API AnimationControllerObservable
 protected:
     void notifyStateChanged(AnimationController* controller, AnimationState prevState,
                             AnimationState newState);
-    void notifyPlaybackSettingsChanged(AnimationController* controller,
-                                       AnimationPlaySettings prevMode,
-                                       AnimationPlaySettings newMode);
     void notifyTimeChanged(AnimationController* controller, Seconds oldTime, Seconds newTime);
     void notifyAnimationChanged(AnimationController* controller, Animation* oldAnimation,
                                 Animation* newAnimation);

--- a/modules/animation/include/modules/animation/datastructures/animationstate.h
+++ b/modules/animation/include/modules/animation/datastructures/animationstate.h
@@ -39,71 +39,11 @@ enum class AnimationState { Paused = 0, Playing, Rendering };
 
 enum class PlaybackMode { Once = 0, Loop, Swing };
 
+enum class PlaybackDirection { Forward = 0, Backward };
+
 struct AnimationTimeState {
     Seconds time;
     AnimationState state;
-};
-
-/** Keeps animation settings related to playing or rendering.
- *
- *   The settings allow to work either with numFrames or framesPerSecond.
- *   If one is set, the other is computed accordingly in order to stay consistent.
- *
- *   The parameters firstTime and lastTime do not need to coincide
- *   with the corresponding parameters of the animation.
- *   We can choose a smaller time window here,
- *   or a larger one just as well. No harm in doing the latter.
- *
- *   The smallest numFrames is 2, since we will visit at least
- *   firstTime and lastTime during an animation or rendering.
- *   The smallest framesPerSecond is 1e-3, as an arbitrary but positive, non-zero minimum.
- */
-class IVW_MODULE_ANIMATION_API AnimationPlaySettings {
-public:
-    AnimationPlaySettings();
-
-    Seconds getFirstTime() const;
-    void setFirstTime(const Seconds timeValue);
-
-    Seconds getLastTime() const;
-    void setLastTime(const Seconds timeValue);
-
-    /// Returns the number of frames to be rendered between firstTime and lastTime given the
-    /// current framesPerSecond.
-    int getNumFrames() const;
-
-    /** Sets the number of frames to be rendered between firstTime and lastTime, and adjusts
-     *  framesPerSecond accordingly.
-     *
-     *   The smallest numFrames is 2, since we will visit at least
-     *   firstTime and lastTime during an animation or rendering.
-     *
-     *   @returns true on success.
-     */
-    bool setNumFrames(const int desiredFrames);
-
-    /// Returns the frames per second.
-    double getFramesPerSecond() const;
-
-    /** Sets the frames per second for the animation playback, and adjusts numFrames accordingly.
-     *  The smallest framesPerSecond is 1e-3, as an arbitrary but positive, non-zero minimum.
-     *  @returns true on success.
-     */
-    bool setFramesPerSecond(const double desiredFPS);
-
-    bool operator!=(const AnimationPlaySettings& other) const;
-
-    PlaybackMode mode;
-
-protected:
-    Seconds firstTime;
-    Seconds lastTime;
-
-    /// Number of frames to generate between firstTime and lastTime
-    int numFrames;
-
-    /// Frames per second.
-    double framesPerSecond;
 };
 
 }  // namespace animation

--- a/modules/animation/include/modules/animation/datastructures/propertytrack.h
+++ b/modules/animation/include/modules/animation/datastructures/propertytrack.h
@@ -469,7 +469,7 @@ Seq* PropertyTrack<Prop, Key, Seq>::addSequenceUsingPropertyValue(
 template <typename Prop, typename Key, typename Seq>
 void PropertyTrack<Prop, Key, Seq>::serialize(Serializer& s) const {
     if (!property_) {
-        throw SerializationException("No property set for the PropertyTrack");
+        throw SerializationException("No property set for the PropertyTrack", IVW_CONTEXT);
     }
     BaseTrack<Seq>::serialize(s);
     s.serialize("property", property_->getPath());
@@ -485,7 +485,7 @@ void PropertyTrack<Prop, Key, Seq>::deserialize(Deserializer& d) {
     IVW_ASSERT(network_, "Property track deserialization requires a ProcessorNetwork");
     property_ = dynamic_cast<Prop*>(network_->getProperty(propertyId));
     if (!property_) {
-        throw SerializationException("Could not find property " + propertyId);
+        throw SerializationException("Could not find property " + propertyId, IVW_CONTEXT);
     }
 }
 

--- a/modules/animation/include/modules/animation/datastructures/propertytrack.h
+++ b/modules/animation/include/modules/animation/datastructures/propertytrack.h
@@ -433,7 +433,7 @@ Key* PropertyTrack<Prop, Key, Seq>::addKeyFrameUsingPropertyValue(
     auto prop = dynamic_cast<const Prop*>(property);
     if (!prop) {
         throw Exception("Cannot add key frame from property type " +
-                            property->getClassIdentifier() + " for " +
+                            (property ? property->getClassIdentifier() : "null") + " for " +
                             property_->getClassIdentifier(),
                         IVW_CONTEXT);
     }
@@ -468,6 +468,9 @@ Seq* PropertyTrack<Prop, Key, Seq>::addSequenceUsingPropertyValue(
 
 template <typename Prop, typename Key, typename Seq>
 void PropertyTrack<Prop, Key, Seq>::serialize(Serializer& s) const {
+    if (!property_) {
+        throw SerializationException("No property set for the PropertyTrack");
+    }
     BaseTrack<Seq>::serialize(s);
     s.serialize("property", property_->getPath());
 }
@@ -481,6 +484,9 @@ void PropertyTrack<Prop, Key, Seq>::deserialize(Deserializer& d) {
 
     IVW_ASSERT(network_, "Property track deserialization requires a ProcessorNetwork");
     property_ = dynamic_cast<Prop*>(network_->getProperty(propertyId));
+    if (!property_) {
+        throw SerializationException("Could not find property " + propertyId);
+    }
 }
 
 namespace detail {

--- a/modules/animation/include/modules/animation/interpolation/linearinterpolation.h
+++ b/modules/animation/include/modules/animation/interpolation/linearinterpolation.h
@@ -114,8 +114,8 @@ void LinearInterpolation<Key, Result>::operator()(const std::vector<std::unique_
 
     // We have to take special care here since we might have unsigned types.
     // Lets just convert everything to doubles.
-    const auto dv1 = static_cast<DT>(v1);
-    const auto dv2 = static_cast<DT>(v2);
+    const auto& dv1 = static_cast<DT>(v1);
+    const auto& dv2 = static_cast<DT>(v2);
 
     out = static_cast<VT>(glm::mix(dv1, dv2, easing::ease((to - t1) / (t2 - t1), easing)));
 }

--- a/modules/animation/src/algorithm/animationrange.cpp
+++ b/modules/animation/src/algorithm/animationrange.cpp
@@ -27,30 +27,9 @@
  *
  *********************************************************************************/
 
-#include <modules/animation/datastructures/callbackkeyframe.h>
+#include <modules/animation/algorithm/animationrange.h>
 
 namespace inviwo {
 
-namespace animation {
-
-CallbackKeyframe::CallbackKeyframe(Seconds time, std::function<void()> doForward,
-                                   std::function<void()> undo)
-    : BaseKeyframe(time), do_(std::move(doForward)), undo_(std::move(undo)) {}
-
-CallbackKeyframe* CallbackKeyframe::clone() const { return new CallbackKeyframe(*this); }
-
-AnimationTimeState CallbackKeyframe::operator()(Seconds from, Seconds to,
-                                                AnimationState state) const {
-    if (do_ && (from <= getTime() && to >= getTime())) {
-        // Animating forward, passing from left to right
-        do_();
-    } else if (undo_ && (to <= getTime() && from >= getTime())) {
-        // Animating backward, passing from right to left
-        undo_();
-    }
-    return {to, state};
-}
-
-}  // namespace animation
 
 }  // namespace inviwo

--- a/modules/animation/src/algorithm/animationrange.cpp
+++ b/modules/animation/src/algorithm/animationrange.cpp
@@ -29,7 +29,4 @@
 
 #include <modules/animation/algorithm/animationrange.h>
 
-namespace inviwo {
-
-
-}  // namespace inviwo
+namespace inviwo {}  // namespace inviwo

--- a/modules/animation/src/animationcontroller.cpp
+++ b/modules/animation/src/animationcontroller.cpp
@@ -284,9 +284,7 @@ void AnimationController::render() {
                     desiredDims = renderSize.get();
                     break;
                 }
-                default: {
-                    ivwAssert(false, "Should not happen.");
-                }
+                default: { ivwAssert(false, "Should not happen."); }
             }
             // - adjust basic dimensions to the aspect ratio
             if (renderAspectRatio.get() > 0) {

--- a/modules/animation/src/animationcontroller.cpp
+++ b/modules/animation/src/animationcontroller.cpp
@@ -80,9 +80,9 @@ AnimationController::AnimationController(Animation& animation, InviwoApplication
                 {"Swing", "Swing animation", PlaybackMode::Swing}},
                0)
     , playbackDirection("PlayDirection", "Direction",
-                    {{"Forward", "Forward", PlaybackDirection::Forward},
-                     {"Backward", "Backward", PlaybackDirection::Backward}},
-                    0)
+                        {{"Forward", "Forward", PlaybackDirection::Forward},
+                         {"Backward", "Backward", PlaybackDirection::Backward}},
+                        0)
     , renderOptions("RenderOptions", "Render Animation")
     , renderWindowMode("RenderFirstLastTimeOption", "Time",
                        {{"FullTimeWindow", "Render full animation", 0},
@@ -293,9 +293,7 @@ void AnimationController::render() {
                     desiredDims = renderSize.get();
                     break;
                 }
-                default: {
-                    ivwAssert(false, "Should not happen.");
-                }
+                default: { ivwAssert(false, "Should not happen."); }
             }
             // - adjust basic dimensions to the aspect ratio
             if (renderAspectRatio.get() > 0) {

--- a/modules/animation/src/animationcontrollerobserver.cpp
+++ b/modules/animation/src/animationcontrollerobserver.cpp
@@ -42,14 +42,6 @@ void AnimationControllerObservable::notifyStateChanged(AnimationController* cont
         [&](AnimationControllerObserver* o) { o->onStateChanged(controller, oldState, newState); });
 }
 
-void AnimationControllerObservable::notifyPlaybackSettingsChanged(
-    AnimationController* controller, AnimationPlaySettings prevSettings,
-    AnimationPlaySettings newSettings) {
-    forEachObserver([&](AnimationControllerObserver* o) {
-        o->onPlaybackSettingsChanged(controller, prevSettings, newSettings);
-    });
-}
-
 void AnimationControllerObservable::notifyTimeChanged(AnimationController* controller,
                                                       Seconds oldtime, Seconds newTime) {
     forEachObserver(

--- a/modules/animation/src/datastructures/animation.cpp
+++ b/modules/animation/src/datastructures/animation.cpp
@@ -64,6 +64,9 @@ auto Animation::end() const -> const_iterator {
 }
 
 void Animation::add(std::unique_ptr<Track> track) {
+    if (!track) {
+        return;
+    }
     tracks_.push_back(std::move(track));
     priorityTracks_.push_back(tracks_.back().get());
     doPrioritySort();

--- a/modules/animation/src/datastructures/animationstate.cpp
+++ b/modules/animation/src/datastructures/animationstate.cpp
@@ -34,8 +34,6 @@
 
 namespace inviwo {
 
-namespace animation {
-
-}  // namespace animation
+namespace animation {}  // namespace animation
 
 }  // namespace inviwo

--- a/modules/animation/src/datastructures/animationstate.cpp
+++ b/modules/animation/src/datastructures/animationstate.cpp
@@ -36,57 +36,6 @@ namespace inviwo {
 
 namespace animation {
 
-AnimationPlaySettings::AnimationPlaySettings()
-    : mode(PlaybackMode::Once), firstTime(0), lastTime(0), numFrames(2), framesPerSecond(25) {}
-
-Seconds AnimationPlaySettings::getFirstTime() const { return firstTime; }
-
-void AnimationPlaySettings::setFirstTime(const Seconds timeValue) {
-    firstTime = timeValue;
-    if (firstTime > lastTime) std::swap(firstTime, lastTime);
-    setNumFrames(numFrames);
-}
-
-Seconds AnimationPlaySettings::getLastTime() const { return lastTime; }
-
-void AnimationPlaySettings::setLastTime(const Seconds timeValue) {
-    lastTime = timeValue;
-    if (firstTime > lastTime) std::swap(firstTime, lastTime);
-    setNumFrames(numFrames);
-}
-
-int AnimationPlaySettings::getNumFrames() const { return numFrames; }
-
-bool AnimationPlaySettings::setNumFrames(const int desiredFrames) {
-    if (desiredFrames < 2) return false;
-    numFrames = desiredFrames;
-
-    // Adjust fps
-    const Seconds timeWindow(lastTime - firstTime);
-    framesPerSecond = timeWindow.count() / double(numFrames);
-
-    return true;
-}
-
-double AnimationPlaySettings::getFramesPerSecond() const { return framesPerSecond; }
-
-bool AnimationPlaySettings::setFramesPerSecond(const double desiredFPS) {
-    if (desiredFPS < 1e-3) return false;
-    framesPerSecond = desiredFPS;
-
-    // Adjust numFrames
-    const Seconds timeWindow(lastTime - firstTime);
-    numFrames = static_cast<int>(std::ceil(timeWindow.count() * framesPerSecond));
-    if (numFrames < 2) numFrames = 2;  // Only happens for small time windows.
-
-    return true;
-}
-
-bool AnimationPlaySettings::operator!=(const AnimationPlaySettings& other) const {
-    return (mode != other.mode || firstTime != other.firstTime || lastTime != other.lastTime ||
-            numFrames != other.numFrames || framesPerSecond != other.framesPerSecond);
-}
-
 }  // namespace animation
 
 }  // namespace inviwo

--- a/modules/animation/src/datastructures/callbackkeyframesequence.cpp
+++ b/modules/animation/src/datastructures/callbackkeyframesequence.cpp
@@ -28,6 +28,7 @@
  *********************************************************************************/
 
 #include <modules/animation/datastructures/callbackkeyframesequence.h>
+#include <modules/animation/algorithm/animationrange.h>
 
 namespace inviwo {
 
@@ -52,17 +53,9 @@ AnimationTimeState CallbackKeyframeSequence::operator()(Seconds from, Seconds to
         }
         return res;
     };
-    auto direction = from <= to ? PlaybackDirection::Forward : PlaybackDirection::Backward;
-    auto first = direction == PlaybackDirection::Forward ? from : to;
-    auto last = direction == PlaybackDirection::Forward ? to : from;
-    // 'fromIt' will be the first key with a time larger than or equal to 'from'
-    auto fromIt = std::lower_bound(keyframes_.begin(), keyframes_.end(), first,
-                                   [](const auto& a, const auto& b) { return *a < b; });
-    // 'toIt' will be the first key with a time larger than 'to'
-    auto toIt = std::upper_bound(keyframes_.begin(), keyframes_.end(), last,
-                                 [](const auto& a, const auto& b) { return a < *b; });
 
-    if (direction == PlaybackDirection::Forward) {
+    auto [fromIt, toIt] = getRange(keyframes_.begin(), keyframes_.end(), from, to);
+    if (from <= to) {
         return animate(fromIt, toIt, from, to, state);
     } else {
         return animate(std::make_reverse_iterator(toIt), std::make_reverse_iterator(fromIt), from,

--- a/modules/animation/src/datastructures/callbackkeyframesequence.cpp
+++ b/modules/animation/src/datastructures/callbackkeyframesequence.cpp
@@ -44,23 +44,7 @@ CallbackKeyframeSequence* CallbackKeyframeSequence::clone() const {
 
 AnimationTimeState CallbackKeyframeSequence::operator()(Seconds from, Seconds to,
                                                         AnimationState state) const {
-    auto animate = [](auto begin, auto end, Seconds from, Seconds to,
-                      AnimationState state) -> AnimationTimeState {
-        AnimationTimeState res{to, state};
-        while (begin != end) {
-            res = (**begin)(from, to, state);
-            ++begin;
-        }
-        return res;
-    };
-
-    auto [fromIt, toIt] = getRange(keyframes_.begin(), keyframes_.end(), from, to);
-    if (from <= to) {
-        return animate(fromIt, toIt, from, to, state);
-    } else {
-        return animate(std::make_reverse_iterator(toIt), std::make_reverse_iterator(fromIt), from,
-                       to, state);
-    }
+    return animateRange(keyframes_.begin(), keyframes_.end(), from, to, state);
 }
 
 }  // namespace animation

--- a/modules/animation/src/datastructures/callbacktrack.cpp
+++ b/modules/animation/src/datastructures/callbacktrack.cpp
@@ -40,30 +40,9 @@ CallbackTrack::CallbackTrack()
 std::string CallbackTrack::classIdentifier() { return "org.inviwo.animation.CallbackTrack"; }
 std::string CallbackTrack::getClassIdentifier() const { return classIdentifier(); }
 
-/**
- * Track of sequences
- * ----------X======X====X-----------X=========X-------X=====X--------
- * |- case 1-|-case 2----------------|-case 2----------|-case 2------|
- *           |-case 2a---|-case 2b---|
- */
 AnimationTimeState CallbackTrack::operator()(Seconds from, Seconds to, AnimationState state) const {
     if (!isEnabled() || empty()) return {to, state};
-    auto animate = [](auto begin, auto end, Seconds from, Seconds to,
-                      AnimationState state) -> AnimationTimeState {
-        AnimationTimeState res{to, state};
-        while (begin != end) {
-            res = (**begin)(from, to, state);
-            ++begin;
-        }
-        return res;
-    };
-    auto [fromIt, toIt] = getRange(sequences_.begin(), sequences_.end(), from, to);
-    if (from <= to) {
-        return animate(fromIt, toIt, from, to, state);
-    } else {
-        return animate(std::make_reverse_iterator(toIt), std::make_reverse_iterator(fromIt), from,
-                       to, state);
-    }
+    return animateRange(sequences_.begin(), sequences_.end(), from, to, state);
 }
 
 }  // namespace animation

--- a/modules/animation/src/datastructures/controlkeyframe.cpp
+++ b/modules/animation/src/datastructures/controlkeyframe.cpp
@@ -57,7 +57,7 @@ void ControlKeyframe::setJumpTime(Seconds jumpTime) { jumpTime_ = jumpTime; }
 AnimationTimeState ControlKeyframe::operator()(Seconds from, Seconds to, AnimationState state) {
 
     if (state == AnimationState::Playing) {
-        if ((from < getTime() && to >= getTime()) || (to <= getTime() && from > getTime())) {
+        if ((from <= getTime() && to >= getTime()) || (to <= getTime() && from >= getTime())) {
             // We passed over this keyframe
             switch (action_) {
                 case ControlAction::Pause:

--- a/modules/animation/src/datastructures/controlkeyframesequence.cpp
+++ b/modules/animation/src/datastructures/controlkeyframesequence.cpp
@@ -53,31 +53,7 @@ ControlKeyframeSequence* ControlKeyframeSequence::clone() const {
 
 AnimationTimeState ControlKeyframeSequence::operator()(Seconds from, Seconds to,
                                                        AnimationState state) const {
-    auto animate = [](auto begin, auto end, Seconds from, Seconds to,
-                      AnimationState state) -> AnimationTimeState {
-        auto direction = from <= to ? PlaybackDirection::Forward : PlaybackDirection::Backward;
-        AnimationTimeState res{to, state};
-        while (begin != end && res.state != AnimationState::Paused) {
-            res = (**begin)(from, to, state);
-            if ((direction == PlaybackDirection::Forward && res.time <= (**begin)) ||
-                (direction == PlaybackDirection::Backward && res.time >= (**begin))) {
-                // We jumped in the opposite direction
-                break;
-            }
-            // Use jump-to-time if set, previous keyframe time otherwise
-            from = res.time != to ? res.time : (*begin)->getTime();
-
-            ++begin;
-        }
-        return res;
-    };
-    auto [fromIt, toIt] = getRange(keyframes_.begin(), keyframes_.end(), from, to);
-    if (from <= to) {
-        return animate(fromIt, toIt, from, to, state);
-    } else {
-        return animate(std::make_reverse_iterator(toIt), std::make_reverse_iterator(fromIt), from,
-                       to, state);
-    }
+    return animateRange(keyframes_.begin(), keyframes_.end(), from, to, state);
 }
 
 }  // namespace animation

--- a/modules/animation/src/datastructures/controltrack.cpp
+++ b/modules/animation/src/datastructures/controltrack.cpp
@@ -50,7 +50,7 @@ std::string ControlTrack::getClassIdentifier() const { return classIdentifier();
 AnimationTimeState ControlTrack::operator()(Seconds from, Seconds to, AnimationState state) const {
     if (!isEnabled() || empty()) return {to, state};
 
-    // 'it' will be the first seq. with a first time larger then 'to'.
+    // 'it' will be the first seq. with a first time larger than 'to'.
     auto it = std::upper_bound(sequences_.begin(), sequences_.end(), to,
                                [](const auto& a, const auto& b) { return a < *b; });
 


### PR DESCRIPTION
- Control/Callback tracks did not operate on all keyframes
- Added tests for control/callback tracks
- Fixed serialization/deserialization for PropertyTrack where the property is not in the network (if loaded outside of workspace).
- Added functionality for playing animation backwards
- Removed unused code (AnimationPlaySettings)
- Fixed a couple warnings
