### PR TITLE
Python3Qt: disable precompiled headers

### DIFF
--- a/modules/base/src/algorithm/volume/volumevoronoi.cpp
+++ b/modules/base/src/algorithm/volume/volumevoronoi.cpp
@@ -76,7 +76,7 @@ std::shared_ptr<Volume> voronoiSegmentation(
                     return glm::distance2(p1.second, transformedVoxelPos) - w1 * w1 <
                            glm::distance2(p2.second, transformedVoxelPos) - w2 * w2;
                 });
-            volumeIndices[index(voxelPos)] = posWithIndex.first;
+            volumeIndices[index(voxelPos)] = static_cast<unsigned short>(posWithIndex.first);
         });
     } else {
         util::forEachVoxelParallel(volumeDimensions, [&](const size3_t& voxelPos) {
@@ -86,7 +86,7 @@ std::shared_ptr<Volume> voronoiSegmentation(
                                            return glm::distance2(p1.second, transformedVoxelPos) <
                                                   glm::distance2(p2.second, transformedVoxelPos);
                                        });
-            volumeIndices[index(voxelPos)] = it->first;
+            volumeIndices[index(voxelPos)] = static_cast<unsigned short>(it->first);
         });
     }
 

--- a/modules/python3qt/CMakeLists.txt
+++ b/modules/python3qt/CMakeLists.txt
@@ -50,6 +50,4 @@ target_link_libraries(inviwo-module-python3qt PRIVATE Qt5::Core Qt5::Gui Qt5::Wi
 # Add templates directory to packaging
 ivw_add_to_module_pack(${CMAKE_CURRENT_SOURCE_DIR}/templates)
 
-ivw_compile_optimize_on_target(inviwo-module-python3qt)
-
 ivw_make_package(InviwoPython3QtModule inviwo-module-python3qt)


### PR DESCRIPTION
Need to disable PCH for the Python3QT module since Qt macros like `slots` might clash with python data structures. Meaning this module does not compile. 

This happens for example with anaconda's `object.h` and `PyType_Slot *slots;` when compiling `pythoneditordockwidget.cpp` with PCH:
```
1>...\Anaconda3\include\object.h(448,23): error C2059: syntax error: ';'
1>...\Anaconda3\include\object.h(448,23): error C2238: unexpected token(s) preceding ';'
```
relating to
```c
typedef struct{
    int slot;    /* slot id, see below */
    void *pfunc; /* function pointer */
} PyType_Slot;

typedef struct{
    const char* name;
    int basicsize;
    int itemsize;
    unsigned int flags;
    PyType_Slot *slots; /* terminated by slot==0. */    <-- line 448
} PyType_Spec;
```

Disabling Qt's macros in the Python3Qt module was considered to be a non-viable option.

See also https://stackoverflow.com/questions/23068700/embedding-python3-in-qt-5