### PR TITLE
QtWidgets: file dialog fix

### DIFF
--- a/modules/qtwidgets/include/modules/qtwidgets/properties/colorlineedit.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/properties/colorlineedit.h
@@ -99,7 +99,7 @@ private:
 
 template <typename T>
 T ColorLineEdit::getColor() const {
-    if constexpr (std::is_floating_point_v<T>) {
+    if constexpr (std::is_floating_point_v<typename T::value_type>) {
         return util::glm_convert<T>(color_);
     } else {
         return util::glm_convert<T>(color_ * 255.0);

--- a/modules/qtwidgets/src/inviwofiledialog.cpp
+++ b/modules/qtwidgets/src/inviwofiledialog.cpp
@@ -79,7 +79,7 @@ int InviwoFileDialog::exec() {
         }
     }
 
-    if (!currentPath_.isEmpty()) {
+    if (!currentPath_.isEmpty() && QDir(currentPath_).exists()) {
         QFileDialog::setDirectory(currentPath_);
     }
 


### PR DESCRIPTION
* prevents a potential exception in the native file dialog in case the directory does not exist