### PR TITLE
Feature/openglfixes

### DIFF
--- a/include/inviwo/core/util/colorbrewer.h
+++ b/include/inviwo/core/util/colorbrewer.h
@@ -44,14 +44,12 @@ class IVW_CORE_API ColorBrewerException : public Exception {
 public:
     ColorBrewerException(const std::string& message, ExceptionContext context)
         : Exception(message, context) {}
-    virtual ~ColorBrewerException() throw() {}
 };
 
 class IVW_CORE_API UnsupportedNumberOfColorsException : public Exception {
 public:
     UnsupportedNumberOfColorsException(const std::string& message, ExceptionContext context)
         : Exception(message, context) {}
-    virtual ~UnsupportedNumberOfColorsException() throw() {}
 };
 
 /**

--- a/modules/basegl/src/datastructures/meshshadercache.cpp
+++ b/modules/basegl/src/datastructures/meshshadercache.cpp
@@ -85,7 +85,7 @@ Shader& MeshShaderCache::getShader(const Mesh& mesh, std::optional<Mesh::MeshInf
     if (it != shaders_.end()) {
         return it->second;
     } else {
-        auto ins = shaders_.emplace(state, Shader(items_, Shader::Build::No));
+        auto ins = shaders_.try_emplace(state, items_, Shader::Build::No);
         auto& shader = ins.first->second;
         shader[ShaderType::Vertex]->clearInDeclarations();
 

--- a/modules/basegl/src/processors/tuberendering.cpp
+++ b/modules/basegl/src/processors/tuberendering.cpp
@@ -150,7 +150,7 @@ void TubeRendering::process() {
     // avoid this we turn on face culling.
     utilgl::CullFaceState cullstate(GL_BACK);
 
-    const auto draw = [this, hasAnyLine](const Mesh& mesh, Shader& shader, auto test) {
+    const auto draw = [this](const Mesh& mesh, Shader& shader, auto test) {
         shader.activate();
         TextureUnitContainer units;
         utilgl::bindAndSetUniforms(shader, units, metaColor_);

--- a/modules/basegl/src/processors/tuberendering.cpp
+++ b/modules/basegl/src/processors/tuberendering.cpp
@@ -151,8 +151,6 @@ void TubeRendering::process() {
     utilgl::CullFaceState cullstate(GL_BACK);
 
     const auto draw = [this, hasAnyLine](const Mesh& mesh, Shader& shader, auto test) {
-        if (!hasAnyLine(mesh, test)) return;
-
         shader.activate();
         TextureUnitContainer units;
         utilgl::bindAndSetUniforms(shader, units, metaColor_);
@@ -180,8 +178,12 @@ void TubeRendering::process() {
     };
 
     for (const auto& mesh : inport_) {
-        draw(*mesh, adjacencyShaders_.getShader(*mesh), hasLineAdjacency);
-        draw(*mesh, shaders_.getShader(*mesh), hasLine);
+        if (hasAnyLine(*mesh, hasLineAdjacency)) {
+            draw(*mesh, adjacencyShaders_.getShader(*mesh), hasLineAdjacency);
+        }
+        if (hasAnyLine(*mesh, hasLine)) {
+            draw(*mesh, shaders_.getShader(*mesh), hasLine);
+        }
     }
     utilgl::deactivateCurrentTarget();
 }

--- a/modules/opengl/include/modules/opengl/shader/shaderobject.h
+++ b/modules/opengl/include/modules/opengl/shader/shaderobject.h
@@ -51,7 +51,7 @@ namespace inviwo {
 namespace utilgl {
 IVW_MODULE_OPENGL_API void parseShaderSource(
     std::string_view key, std::string_view source, std::ostream& output, LineNumberResolver& lnr,
-    std::unordered_map<typename ShaderSegment::Type, std::vector<ShaderSegment>> replacements,
+    std::unordered_map<typename ShaderSegment::Placeholder, std::vector<ShaderSegment>> replacements,
     std::function<std::optional<std::pair<std::string, std::string>>(std::string_view)> getSource);
 }
 
@@ -110,7 +110,9 @@ public:
 
     GLuint getID() const;
     std::string getFileName() const;
+    void setResource(std::shared_ptr<const ShaderResource>);
     std::shared_ptr<const ShaderResource> getResource() const;
+
     const std::vector<std::shared_ptr<const ShaderResource>>& getResources() const;
     ShaderType getShaderType() const;
 

--- a/modules/opengl/include/modules/opengl/shader/shaderobject.h
+++ b/modules/opengl/include/modules/opengl/shader/shaderobject.h
@@ -51,7 +51,8 @@ namespace inviwo {
 namespace utilgl {
 IVW_MODULE_OPENGL_API void parseShaderSource(
     std::string_view key, std::string_view source, std::ostream& output, LineNumberResolver& lnr,
-    std::unordered_map<typename ShaderSegment::Placeholder, std::vector<ShaderSegment>> replacements,
+    std::unordered_map<typename ShaderSegment::Placeholder, std::vector<ShaderSegment>>
+        replacements,
     std::function<std::optional<std::pair<std::string, std::string>>(std::string_view)> getSource);
 }
 

--- a/modules/opengl/include/modules/opengl/shader/shadersegment.h
+++ b/modules/opengl/include/modules/opengl/shader/shadersegment.h
@@ -41,19 +41,18 @@ struct IVW_MODULE_OPENGL_API ShaderSegment {
     /**
      * Represents a placeholder in shader code that will be replaced
      */
-    class IVW_MODULE_OPENGL_API Type {
+    struct IVW_MODULE_OPENGL_API Type {
     public:
         Type() = default;
-        explicit Type(std::string type);
-        const std::string& getString() const { return value_; }
+        explicit Type(std::string key, std::string name);
 
         IVW_MODULE_OPENGL_API friend std::ostream& operator<<(std::ostream& os, const Type& obj);
 
         IVW_MODULE_OPENGL_API friend bool operator==(const Type& lhs, const Type& rhs) {
-            return lhs.getString() == rhs.getString();
+            return lhs.key == rhs.key;
         }
         IVW_MODULE_OPENGL_API friend bool operator<(const Type& lhs, const Type& rhs) {
-            return lhs.getString() < rhs.getString();
+            return lhs.key < rhs.key;
         }
         IVW_MODULE_OPENGL_API friend bool operator!=(const Type& lhs, const Type& rhs) {
             return !operator==(lhs, rhs);
@@ -68,8 +67,8 @@ struct IVW_MODULE_OPENGL_API ShaderSegment {
             return !operator<(lhs, rhs);
         }
 
-    private:
-        std::string value_;
+        std::string key;
+        std::string name;
     };
 
     Type type;  //!< The placeholder that will be replaced
@@ -92,7 +91,7 @@ namespace std {
 template <>
 struct hash<typename inviwo::ShaderSegment::Type> {
     size_t operator()(typename inviwo::ShaderSegment::Type const& type) const {
-        return std::hash<std::string>{}(type.getString());
+        return std::hash<std::string>{}(type.key);
     }
 };
 }  // namespace std

--- a/modules/opengl/include/modules/opengl/shader/shadersegment.h
+++ b/modules/opengl/include/modules/opengl/shader/shadersegment.h
@@ -29,7 +29,10 @@
 #pragma once
 
 #include <modules/opengl/openglmoduledefine.h>
-#include <inviwo/core/common/inviwo.h>
+
+#include <string>
+#include <string_view>
+#include <functional>
 
 namespace inviwo {
 
@@ -41,37 +44,39 @@ struct IVW_MODULE_OPENGL_API ShaderSegment {
     /**
      * Represents a placeholder in shader code that will be replaced
      */
-    struct IVW_MODULE_OPENGL_API Type {
+    struct IVW_MODULE_OPENGL_API Placeholder {
     public:
-        Type() = default;
-        explicit Type(std::string key, std::string name);
+        Placeholder() = default;
+        explicit constexpr Placeholder(std::string_view key, std::string_view name)
+            : key{key}, name{name} {}
 
-        IVW_MODULE_OPENGL_API friend std::ostream& operator<<(std::ostream& os, const Type& obj);
-
-        IVW_MODULE_OPENGL_API friend bool operator==(const Type& lhs, const Type& rhs) {
+        inline friend bool operator==(const Placeholder& lhs, const Placeholder& rhs) {
             return lhs.key == rhs.key;
         }
-        IVW_MODULE_OPENGL_API friend bool operator<(const Type& lhs, const Type& rhs) {
+        inline friend bool operator<(const Placeholder& lhs, const Placeholder& rhs) {
             return lhs.key < rhs.key;
         }
-        IVW_MODULE_OPENGL_API friend bool operator!=(const Type& lhs, const Type& rhs) {
+        inline friend bool operator!=(const Placeholder& lhs, const Placeholder& rhs) {
             return !operator==(lhs, rhs);
         }
-        IVW_MODULE_OPENGL_API friend bool operator>(const Type& lhs, const Type& rhs) {
+        inline friend bool operator>(const Placeholder& lhs, const Placeholder& rhs) {
             return operator<(rhs, lhs);
         }
-        IVW_MODULE_OPENGL_API friend bool operator<=(const Type& lhs, const Type& rhs) {
+        inline friend bool operator<=(const Placeholder& lhs, const Placeholder& rhs) {
             return !operator>(lhs, rhs);
         }
-        IVW_MODULE_OPENGL_API friend bool operator>=(const Type& lhs, const Type& rhs) {
+        inline friend bool operator>=(const Placeholder& lhs, const Placeholder& rhs) {
             return !operator<(lhs, rhs);
         }
 
-        std::string key;
-        std::string name;
+        IVW_MODULE_OPENGL_API friend std::ostream& operator<<(std::ostream& os,
+                                                              const Placeholder& obj);
+
+        std::string_view key;
+        std::string_view name;
     };
 
-    Type type;  //!< The placeholder that will be replaced
+    Placeholder placeholder;  //!< The placeholder that will be replaced
     /**
      * A name of the snippet, used by the LineNumberResolver and to identify the segment in the
      * ShaderObject
@@ -79,8 +84,8 @@ struct IVW_MODULE_OPENGL_API ShaderSegment {
     std::string name;
     std::string snippet;  //!< The replacement code
     /**
-     * If there are multiple replacement with the same Type, they will be sorted using priority,
-     * lower goes first.
+     * If there are multiple replacement with the same Placeholder, they will be sorted using
+     * priority, lower goes first.
      */
     size_t priority = 1000;
 };
@@ -89,9 +94,9 @@ struct IVW_MODULE_OPENGL_API ShaderSegment {
 
 namespace std {
 template <>
-struct hash<typename inviwo::ShaderSegment::Type> {
-    size_t operator()(typename inviwo::ShaderSegment::Type const& type) const {
-        return std::hash<std::string>{}(type.key);
+struct hash<typename inviwo::ShaderSegment::Placeholder> {
+    size_t operator()(typename inviwo::ShaderSegment::Placeholder const& type) const {
+        return std::hash<std::string_view>{}(type.key);
     }
 };
 }  // namespace std

--- a/modules/opengl/src/shader/shaderobject.cpp
+++ b/modules/opengl/src/shader/shaderobject.cpp
@@ -159,14 +159,14 @@ struct Psm {
         auto replace = [](Char c, State& s) {
             using SegType = typename ShaderSegment::Type;
             const auto lineEnd = std::find(c.curr, c.end, '\n');
-            const auto type = SegType{trim(std::string{c.curr, lineEnd})};
+            const auto type = SegType{trim(std::string{c.curr, lineEnd}), ""};
             const auto it = s.replacements.find(type);
             if (it != s.replacements.end()) {
                 for (auto segIt = it->second.begin(); segIt != it->second.end(); ++segIt) {
                     const auto& segment = *segIt;
                     const auto snippet = psm::indent(segment.snippet, s.column);
                     utilgl::parseShaderSource(
-                        fmt::format("{}[{},{}]", segment.name, segment.type.getString(),
+                        fmt::format("{}[{},{}]", segment.name, segment.type.name,
                                     segment.priority),
                         snippet, s.output, s.lnr, s.replacements, s.getSource);
                     if (std::next(segIt) != it->second.end()) {
@@ -188,7 +188,7 @@ struct Psm {
 
         auto repl = [](Char c, State& s) {
             for (auto& [key, val] : s.replacements) {
-                if (c.peek(key.getString())) return true;
+                if (c.peek(key.key)) return true;
             }
             return false;
         };

--- a/modules/opengl/src/shader/shadersegment.cpp
+++ b/modules/opengl/src/shader/shadersegment.cpp
@@ -32,10 +32,11 @@
 namespace inviwo {
 
 std::ostream& operator<<(std::ostream& os, const ShaderSegment::Type& obj) {
-    os << obj.getString();
+    os << obj.key;
     return os;
 }
 
-ShaderSegment::Type::Type(std::string value) : value_{std::move(value)} {}
+ShaderSegment::Type::Type(std::string aKey, std::string aName)
+    : key{std::move(aKey)}, name{std::move(aName)} {}
 
 }  // namespace inviwo

--- a/modules/opengl/src/shader/shadersegment.cpp
+++ b/modules/opengl/src/shader/shadersegment.cpp
@@ -29,14 +29,13 @@
 
 #include <modules/opengl/shader/shadersegment.h>
 
+#include <iostream>
+
 namespace inviwo {
 
-std::ostream& operator<<(std::ostream& os, const ShaderSegment::Type& obj) {
+std::ostream& operator<<(std::ostream& os, const ShaderSegment::Placeholder& obj) {
     os << obj.key;
     return os;
 }
-
-ShaderSegment::Type::Type(std::string aKey, std::string aName)
-    : key{std::move(aKey)}, name{std::move(aName)} {}
 
 }  // namespace inviwo

--- a/modules/opengl/tests/unittests/shaderobject-test.cpp
+++ b/modules/opengl/tests/unittests/shaderobject-test.cpp
@@ -126,10 +126,10 @@ TEST(ShaderObject, parseSource) {
 
     using SegType = typename ShaderSegment::Type;
     std::unordered_map<SegType, std::vector<ShaderSegment>> replacements{
-        {SegType{"MAGIC_REPLACEMENT"},
-         {ShaderSegment{SegType{"MAGIC_REPLACEMENT"}, "Repl1",
+        {SegType("MAGIC_REPLACEMENT", "REPLACEMENT"),
+         {ShaderSegment{SegType{"MAGIC_REPLACEMENT", "REPLACEMENT"}, "Repl1",
                         "replacement code1;\nreplacement code2;", 900},
-          ShaderSegment{SegType{"MAGIC_REPLACEMENT"}, "Repl2",
+          ShaderSegment{SegType{"MAGIC_REPLACEMENT", "REPLACEMENT"}, "Repl2",
                         "replacement code3;\nreplacement code4;", 1100}}}
 
     };
@@ -181,10 +181,10 @@ TEST(ShaderObject, parseSource) {
                                         "Code1",
                                         "Code1",
                                         "Code1",
-                                        "Repl1[MAGIC_REPLACEMENT,900]",
-                                        "Repl1[MAGIC_REPLACEMENT,900]",
-                                        "Repl2[MAGIC_REPLACEMENT,1100]",
-                                        "Repl2[MAGIC_REPLACEMENT,1100]",
+                                        "Repl1[REPLACEMENT,900]",
+                                        "Repl1[REPLACEMENT,900]",
+                                        "Repl2[REPLACEMENT,1100]",
+                                        "Repl2[REPLACEMENT,1100]",
                                         "Code1",
                                         "Code1",
                                         "Code1",

--- a/modules/opengl/tests/unittests/shaderobject-test.cpp
+++ b/modules/opengl/tests/unittests/shaderobject-test.cpp
@@ -124,12 +124,12 @@ TEST(ShaderObject, parseSource) {
         return std::nullopt;
     };
 
-    using SegType = typename ShaderSegment::Type;
-    std::unordered_map<SegType, std::vector<ShaderSegment>> replacements{
-        {SegType("MAGIC_REPLACEMENT", "REPLACEMENT"),
-         {ShaderSegment{SegType{"MAGIC_REPLACEMENT", "REPLACEMENT"}, "Repl1",
+    using Placeholder = typename ShaderSegment::Placeholder;
+    std::unordered_map<Placeholder, std::vector<ShaderSegment>> replacements{
+        {Placeholder("MAGIC_REPLACEMENT", "REPLACEMENT"),
+         {ShaderSegment{Placeholder{"MAGIC_REPLACEMENT", "REPLACEMENT"}, "Repl1",
                         "replacement code1;\nreplacement code2;", 900},
-          ShaderSegment{SegType{"MAGIC_REPLACEMENT", "REPLACEMENT"}, "Repl2",
+          ShaderSegment{Placeholder{"MAGIC_REPLACEMENT", "REPLACEMENT"}, "Repl2",
                         "replacement code3;\nreplacement code4;", 1100}}}
 
     };

--- a/modules/openglqt/include/modules/openglqt/shaderwidget.h
+++ b/modules/openglqt/include/modules/openglqt/shaderwidget.h
@@ -60,6 +60,8 @@ protected:
 
 private:
     void save();
+    void apply();
+    void revert();
 
     void updateState();
     void queryReloadFile();
@@ -72,6 +74,10 @@ private:
     std::vector<std::shared_ptr<std::function<void()>>> codeCallbacks_;
     QAction* preprocess_;
     QAction* save_;
+    QAction* apply_;
+    QAction* revert_;
+    std::shared_ptr<const ShaderResource> orignal_;
+
 
     bool fileChangedInBackground_ = false;
     bool reloadQueryInProgress_ = false;

--- a/modules/openglqt/include/modules/openglqt/shaderwidget.h
+++ b/modules/openglqt/include/modules/openglqt/shaderwidget.h
@@ -78,7 +78,6 @@ private:
     QAction* revert_;
     std::shared_ptr<const ShaderResource> orignal_;
 
-
     bool fileChangedInBackground_ = false;
     bool reloadQueryInProgress_ = false;
     bool ignoreNextUpdate_ = false;

--- a/modules/openglqt/src/hiddencanvasqt.cpp
+++ b/modules/openglqt/src/hiddencanvasqt.cpp
@@ -92,6 +92,11 @@ std::unique_ptr<Canvas> HiddenCanvasQt::createHiddenQtCanvas() {
     // OpenGL can be initialized in this thread
     newContext->initializeGL();
 
+    // Since the qt context has to be created on the main thread and moved to the background we need
+    // to update the registered thread id to the correct one here
+    RenderContext::getPtr()->setContextThreadId(newContext->contextId(),
+                                                std::this_thread::get_id());
+
     return newContext;
 }
 

--- a/modules/openglqt/src/shaderwidget.cpp
+++ b/modules/openglqt/src/shaderwidget.cpp
@@ -181,7 +181,7 @@ void ShaderWidget::closeEvent(QCloseEvent* event) {
     InviwoDockWidget::closeEvent(event);
 }
 
-inline bool ShaderWidget::eventFilter(QObject* obj, QEvent* event) {
+bool ShaderWidget::eventFilter(QObject* obj, QEvent* event) {
     if (event->type() == QEvent::FocusIn) {
         if (fileChangedInBackground_) {
             queryReloadFile();

--- a/modules/qtwidgets/include/modules/qtwidgets/codeedit.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/codeedit.h
@@ -57,6 +57,7 @@ public:
     virtual void keyPressEvent(QKeyEvent* keyEvent) override;
 
     void setLineAnnotation(std::function<std::string(int)>);
+    void setLineAnnotationColor(std::function<vec4(int, vec4)>);
     void setAnnotationSpace(std::function<int(int)>);
 
     SyntaxHighlighter& syntaxHighlighter();
@@ -86,6 +87,7 @@ protected:
     vec4 highlightColor_;
     SyntaxHighlighter* sh_;
     std::function<std::string(int)> annotateLine_;
+    std::function<vec4(int, vec4)> annotateColor_;
     std::function<int(int)> annotationSpace_;
 };
 

--- a/modules/qtwidgets/src/codeedit.cpp
+++ b/modules/qtwidgets/src/codeedit.cpp
@@ -48,6 +48,7 @@ CodeEdit::CodeEdit(QWidget* parent)
     , highlightColor_{1.0f}
     , sh_{new SyntaxHighlighter(document())}
     , annotateLine_{[](int line) { return std::to_string(line); }}
+    , annotateColor_{[](int, vec4 orgColor) { return orgColor; }}
     , annotationSpace_{[](int maxDigits) { return maxDigits; }} {
 
     setObjectName("CodeEdit");
@@ -89,6 +90,10 @@ CodeEdit::CodeEdit(QWidget* parent)
 
 void CodeEdit::setLineAnnotation(std::function<std::string(int)> func) {
     annotateLine_ = std::move(func);
+    updateLineNumberAreaWidth(0);
+}
+void CodeEdit::setLineAnnotationColor(std::function<vec4(int, vec4)> annotateColor) {
+    annotateColor_ = std::move(annotateColor);
     updateLineNumberAreaWidth(0);
 }
 void CodeEdit::setAnnotationSpace(std::function<int(int)> func) {
@@ -179,11 +184,10 @@ void CodeEdit::lineNumberAreaPaintEvent(QPaintEvent* event) {
     const int height = fontMetrics().height();
     const int width = lineNumberArea_->width() - offset;
 
-    painter.setPen(utilqt::toQColor(textColor_));
-
     while (block.isValid() && top <= event->rect().bottom()) {
         if (block.isVisible() && bottom >= event->rect().top()) {
             const auto number = utilqt::toQString(annotateLine_(blockNumber + 1));
+            painter.setPen(utilqt::toQColor(annotateColor_(blockNumber + 1, textColor_)));
             painter.drawText(0, top, width, height, Qt::AlignRight, number);
         }
 

--- a/src/core/network/evaluationerrorhandler.cpp
+++ b/src/core/network/evaluationerrorhandler.cpp
@@ -30,6 +30,8 @@
 #include <inviwo/core/network/evaluationerrorhandler.h>
 #include <inviwo/core/processors/processor.h>
 
+#include <fmt/format.h>
+
 namespace inviwo {
 
 void StandardEvaluationErrorHandler::operator()(Processor* processor, EvaluationType type,
@@ -62,6 +64,10 @@ void StandardEvaluationErrorHandler::operator()(Processor* processor, Evaluation
             e.getStack(ss);
             util::log(e.getContext(), ss.str(), LogLevel::Info);
         }
+    } catch (fmt::format_error& e) {
+        util::log(context,
+                  id + " Error in " + func + " using fmt::format: " + std::string(e.what()),
+                  LogLevel::Error);
     } catch (std::exception& e) {
         util::log(context, id + " Error in " + func + ": " + std::string(e.what()),
                   LogLevel::Error);

--- a/tools/natvis/inviwo.natvis
+++ b/tools/natvis/inviwo.natvis
@@ -157,7 +157,7 @@
       <Synthetic Name="Data"><DisplayString>{dimensions_}</DisplayString>
         <Expand>
           <ArrayItems Condition="data_._Mypair._Myval2 != nullptr">
-            <Direction>Forward</Direction>
+            <Direction>Backward</Direction>
             <Rank>3</Rank>
             <Size>((size_t*)(&amp;dimensions_))[$i]</Size>
             <ValuePointer>data_._Mypair._Myval2</ValuePointer>
@@ -346,7 +346,7 @@
       <Synthetic Name="Data"><DisplayString>{dimensions_}</DisplayString>
         <Expand>
           <ArrayItems Condition="data_._Mypair._Myval2 != nullptr">
-            <Direction>Forward</Direction>
+            <Direction>Backward</Direction>
             <Rank>2</Rank>
             <Size>((size_t*)(&amp;dimensions_))[$i]</Size>
             <ValuePointer>data_._Mypair._Myval2</ValuePointer>


### PR DESCRIPTION
Fix for qt context thread id
The Shader editor now has run butotn (Ctrl-R) to apply changes wth out writing to disk.
The Shader segments now uses more string_views.
The MeshShaderCache now avoids some extra copies.
Fixes a shader registration issue.