### PR TITLE
OpenGL: BufferGL optimization

### DIFF
--- a/modules/opengl/include/modules/opengl/buffer/buffergl.h
+++ b/modules/opengl/include/modules/opengl/buffer/buffergl.h
@@ -60,6 +60,11 @@ public:
     virtual ~BufferGL();
     virtual BufferGL* clone() const override;
 
+    /**
+     * \brief set the size of the buffer
+     * Note that the internal BufferObject is only growing in size and never shrinking to avoid
+     * unnecessary reallocations in GPU memory.
+     */
     virtual void setSize(size_t size) override;
     virtual size_t getSize() const override;
 

--- a/modules/opengl/src/buffer/buffergl.cpp
+++ b/modules/opengl/src/buffer/buffergl.cpp
@@ -55,7 +55,9 @@ size_t BufferGL::getSize() const { return size_; }
 void BufferGL::setSize(size_t size) {
     if (size != size_) {
         size_ = size;
-        buffer_->setSizeInBytes(size * getSizeOfElement());
+        if (auto bytes = size * getSizeOfElement(); bytes > buffer_->getSizeInBytes()) {
+            buffer_->setSizeInBytes(bytes);
+        }
     }
 }
 

--- a/modules/opengl/src/buffer/buffergl.cpp
+++ b/modules/opengl/src/buffer/buffergl.cpp
@@ -55,7 +55,8 @@ size_t BufferGL::getSize() const { return size_; }
 void BufferGL::setSize(size_t size) {
     if (size != size_) {
         size_ = size;
-        if (auto bytes = size * getSizeOfElement(); bytes > buffer_->getSizeInBytes()) {
+        if (auto bytes = static_cast<GLsizeiptr>(size * getSizeOfElement());
+            bytes > buffer_->getSizeInBytes()) {
             buffer_->setSizeInBytes(bytes);
         }
     }


### PR DESCRIPTION
* to avoid unnecessary reallocations, the internal `BufferObject` of a `BufferGL` is only updated when requesting more memory
