### PR TITLE
Fix/web animation

### DIFF
--- a/modules/animation/src/animationcontroller.cpp
+++ b/modules/animation/src/animationcontroller.cpp
@@ -364,13 +364,13 @@ void AnimationController::tick() {
         firstTime = animation_->getFirstTime();
         lastTime = animation_->getLastTime();
     }
-
+    auto newState{state_};
     // Ping at the end of time
     if (newTime > lastTime) {
         switch (playMode.get()) {
             case PlaybackMode::Once: {
                 newTime = lastTime;
-                setState(AnimationState::Paused);
+                newState = AnimationState::Paused;
                 break;
             }
             case PlaybackMode::Loop: {
@@ -392,7 +392,7 @@ void AnimationController::tick() {
         switch (playMode.get()) {
             case PlaybackMode::Once: {
                 newTime = firstTime;
-                setState(AnimationState::Paused);
+                newState = AnimationState::Paused;
                 break;
             }
             case PlaybackMode::Loop: {
@@ -411,6 +411,9 @@ void AnimationController::tick() {
 
     // Evaluate animation
     eval(currentTime_, newTime);
+
+    // May be in paused state
+    setState(newState);
 }
 
 void AnimationController::tickRender() {

--- a/modules/animation/src/datastructures/animation.cpp
+++ b/modules/animation/src/datastructures/animation.cpp
@@ -149,9 +149,9 @@ std::unique_ptr<Track> Animation::remove(size_t i) {
     auto track = std::move(tracks_[i]);
     tracks_.erase(tracks_.begin() + i);
     util::erase_remove(priorityTracks_, track.get());
-    if (auto propertyTrack = dynamic_cast<BasePropertyTrack*>(track.get())) {
+    if (auto propertyTrack = dynamic_cast<BasePropertyTrack*>(track.get());
+        auto owner = propertyTrack->getProperty()->getOwner()) {
         // Only stop observing property owner if no other track needs it
-        auto owner = propertyTrack->getProperty()->getOwner();
         auto sameOwnerIt = std::find_if(tracks_.begin(), tracks_.end(), [owner](const auto& elem) {
             if (auto ptrck = dynamic_cast<BasePropertyTrack*>(elem.get())) {
                 return ptrck->getProperty()->getOwner() == owner;

--- a/modules/webbrowser/include/modules/webbrowser/processors/webbrowserprocessor.h
+++ b/modules/webbrowser/include/modules/webbrowser/processors/webbrowserprocessor.h
@@ -145,6 +145,7 @@ protected:
     // create browser-window
     CefRefPtr<RenderHandlerGL> renderHandler_;
     CefRefPtr<CefBrowser> browser_;
+    WebBrowserClient::BrowserParentHandle browserParentHandle_;
 
     SingleFileObserver fileObserver_;
 

--- a/modules/webbrowser/include/modules/webbrowser/processors/webbrowserprocessor.h
+++ b/modules/webbrowser/include/modules/webbrowser/processors/webbrowserprocessor.h
@@ -145,7 +145,6 @@ protected:
     // create browser-window
     CefRefPtr<RenderHandlerGL> renderHandler_;
     CefRefPtr<CefBrowser> browser_;
-    WebBrowserClient::BrowserParentHandle browserParentHandle_;
 
     SingleFileObserver fileObserver_;
 

--- a/modules/webbrowser/include/modules/webbrowser/webbrowserclient.h
+++ b/modules/webbrowser/include/modules/webbrowser/webbrowserclient.h
@@ -70,8 +70,6 @@ class IVW_MODULE_WEBBROWSER_API WebBrowserClient : public CefClient,
                                                    public CefDisplayHandler,
                                                    public CefResourceRequestHandler {
 public:
-    using BrowserParentHandle = std::shared_ptr<Processor*>;
-
     WebBrowserClient(ModuleManager& moduleManager, const PropertyWidgetCEFFactory* widgetFactory);
 
     virtual CefRefPtr<CefLoadHandler> GetLoadHandler() override { return this; }
@@ -83,16 +81,21 @@ public:
     /**
      * Enable invalidation when the web page repaints and allow the Inviwo javascript API
      * to access the parent processor.
-     * Connection will be removed when the browser closes.
-     * Processor invalidation on repaints will not be called if BrowserParentHandle has been
-     * destroyed.
+     * Connection will be removed when the browser closes or removeBrowserParent is called.
+     * A browser can only have one Processor as parent.
+     * @param CefRefPtr<CefBrowser> browser to be associated with a processor.
      * @param const Processor* parent web browser processor responsible for the browser. Cannot be
-     * null.
-     * @return Handle to a dummy object that must be kept alive until no Processor::invalidate calls
-     * should be made.
-     *
+     * null. 
+     * @see ProcessorCefSynchronizer
      */
-    BrowserParentHandle setBrowserParent(CefRefPtr<CefBrowser> browser, Processor* parent);
+    void setBrowserParent(CefRefPtr<CefBrowser> browser, Processor* parent);
+    /**
+     * Removes Processor parent associated with the provided browser.
+     * Processor invalidation will not be called on repaints after removing the processor.
+     * Will do nothing if browser has no assoicated Processor.
+     * @param CefRefPtr<CefBrowser> browser to remove processor association from. 
+     */
+    void removeBrowserParent(CefRefPtr<CefBrowser> browser);
 
     /**
      * Register a processor \p callback for a specific \p browser which can be triggered through a
@@ -217,7 +220,7 @@ public:
 
 protected:
     struct BrowserData {
-        std::weak_ptr<Processor*> processor;  // Use weak_ptr since Browser might outlive Processor
+        Processor* processor; 
         CefRefPtr<ProcessorCefSynchronizer> processorCefSynchronizer;
     };
 

--- a/modules/webbrowser/include/modules/webbrowser/webbrowserclient.h
+++ b/modules/webbrowser/include/modules/webbrowser/webbrowserclient.h
@@ -85,7 +85,7 @@ public:
      * A browser can only have one Processor as parent.
      * @param CefRefPtr<CefBrowser> browser to be associated with a processor.
      * @param const Processor* parent web browser processor responsible for the browser. Cannot be
-     * null. 
+     * null.
      * @see ProcessorCefSynchronizer
      */
     void setBrowserParent(CefRefPtr<CefBrowser> browser, Processor* parent);
@@ -93,7 +93,7 @@ public:
      * Removes Processor parent associated with the provided browser.
      * Processor invalidation will not be called on repaints after removing the processor.
      * Will do nothing if browser has no assoicated Processor.
-     * @param CefRefPtr<CefBrowser> browser to remove processor association from. 
+     * @param CefRefPtr<CefBrowser> browser to remove processor association from.
      */
     void removeBrowserParent(CefRefPtr<CefBrowser> browser);
 
@@ -220,7 +220,7 @@ public:
 
 protected:
     struct BrowserData {
-        Processor* processor; 
+        Processor* processor;
         CefRefPtr<ProcessorCefSynchronizer> processorCefSynchronizer;
     };
 

--- a/modules/webbrowser/include/modules/webbrowser/webbrowserclient.h
+++ b/modules/webbrowser/include/modules/webbrowser/webbrowserclient.h
@@ -70,7 +70,7 @@ class IVW_MODULE_WEBBROWSER_API WebBrowserClient : public CefClient,
                                                    public CefDisplayHandler,
                                                    public CefResourceRequestHandler {
 public:
-    using BrowserParentHandle = std::shared_ptr<Processor*>; 
+    using BrowserParentHandle = std::shared_ptr<Processor*>;
 
     WebBrowserClient(ModuleManager& moduleManager, const PropertyWidgetCEFFactory* widgetFactory);
 
@@ -84,11 +84,13 @@ public:
      * Enable invalidation when the web page repaints and allow the Inviwo javascript API
      * to access the parent processor.
      * Connection will be removed when the browser closes.
-     * Processor invalidation on repaints will not be called if BrowserParentHandle has been destroyed. 
+     * Processor invalidation on repaints will not be called if BrowserParentHandle has been
+     * destroyed.
      * @param const Processor* parent web browser processor responsible for the browser. Cannot be
      * null.
-     * @return Handle to a dummy object that must be kept alive until no Processor::invalidate calls should be made.
-     * 
+     * @return Handle to a dummy object that must be kept alive until no Processor::invalidate calls
+     * should be made.
+     *
      */
     BrowserParentHandle setBrowserParent(CefRefPtr<CefBrowser> browser, Processor* parent);
 
@@ -108,8 +110,6 @@ public:
     ProcessorCefSynchronizer::CallbackHandle registerCallback(
         CefRefPtr<CefBrowser> browser, const std::string& name,
         std::function<ProcessorCefSynchronizer::CallbackFunc> callback);
-
-
 
     bool OnProcessMessageReceived(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
                                   CefProcessId source_process,
@@ -217,7 +217,7 @@ public:
 
 protected:
     struct BrowserData {
-        std::weak_ptr<Processor*> processor; // Use weak_ptr since Browser might outlive Processor
+        std::weak_ptr<Processor*> processor;  // Use weak_ptr since Browser might outlive Processor
         CefRefPtr<ProcessorCefSynchronizer> processorCefSynchronizer;
     };
 

--- a/modules/webbrowser/src/interaction/cefinteractionhandler.cpp
+++ b/modules/webbrowser/src/interaction/cefinteractionhandler.cpp
@@ -47,9 +47,11 @@ CEFInteractionHandler::CEFInteractionHandler(CefRefPtr<CefBrowserHost> host) : h
 void CEFInteractionHandler::invokeEvent(Event* event) {
     switch (event->hash()) {
         case ResizeEvent::chash(): {
-            auto resizeEvent = static_cast<ResizeEvent*>(event);
-            renderHandler_->updateCanvasSize(host_->GetBrowser(), resizeEvent->size());
-            host_->WasResized();
+            if (renderHandler_) {
+                auto resizeEvent = static_cast<ResizeEvent*>(event);
+                renderHandler_->updateCanvasSize(host_->GetBrowser(), resizeEvent->size());
+                host_->WasResized();
+            }
             break;
         }
         case KeyboardEvent::chash(): {

--- a/modules/webbrowser/src/processors/webbrowserprocessor.cpp
+++ b/modules/webbrowser/src/processors/webbrowserprocessor.cpp
@@ -125,7 +125,7 @@ WebBrowserProcessor::WebBrowserProcessor(InviwoApplication* app)
     // destructor
     browser_ = CefBrowserHost::CreateBrowserSync(windowInfo, browserClient, getSource(),
                                                  browserSettings, nullptr, nullptr);
-    browserClient->setBrowserParent(browser_, this);
+    browserParentHandle_ = browserClient->setBrowserParent(browser_, this);
     // Observe when page has loaded
     browserClient->addLoadHandler(this);
     // Inject events into CEF browser_

--- a/modules/webbrowser/src/processors/webbrowserprocessor.cpp
+++ b/modules/webbrowser/src/processors/webbrowserprocessor.cpp
@@ -153,8 +153,8 @@ std::string WebBrowserProcessor::getSource() {
 WebBrowserProcessor::~WebBrowserProcessor() {
     auto client = static_cast<WebBrowserClient*>(browser_->GetHost()->GetClient().get());
     client->removeLoadHandler(this);
-    // Explicitly remove parent because CloseBrowser may result in WebBrowserClient::OnBeforeClose after
-    // this processor has been destroyed.
+    // Explicitly remove parent because CloseBrowser may result in WebBrowserClient::OnBeforeClose
+    // after this processor has been destroyed.
     client->removeBrowserParent(browser_);
     // Force close browser
     browser_->GetHost()->CloseBrowser(true);

--- a/modules/webbrowser/src/properties/propertywidgetcef.cpp
+++ b/modules/webbrowser/src/properties/propertywidgetcef.cpp
@@ -135,6 +135,9 @@ void PropertyWidgetCEF::updateFromProperty() {
 }
 
 void PropertyWidgetCEF::onSetIdentifier(Property* /*property*/, const std::string& identifier) {
+    if (!frame_) {
+        return;
+    }
     std::stringstream script;
     auto p = json{{"identifier", identifier}};
     script << this->getPropertyObserverCallback() << "(" << p.dump() << ");";
@@ -142,24 +145,36 @@ void PropertyWidgetCEF::onSetIdentifier(Property* /*property*/, const std::strin
 }
 
 void PropertyWidgetCEF::onSetDisplayName(Property* /*property*/, const std::string& displayName) {
+    if (!frame_) {
+        return;
+    }
     std::stringstream script;
     auto p = json{{"displayName", displayName}};
     script << this->getPropertyObserverCallback() << "(" << p.dump() << ");";
     frame_->ExecuteJavaScript(script.str(), frame_->GetURL(), 0);
 }
 void PropertyWidgetCEF::onSetSemantics(Property* /*property*/, const PropertySemantics& semantics) {
+    if (!frame_) {
+        return;
+    }
     std::stringstream script;
     auto p = json{{"semantics", semantics.getString()}};
     script << this->getPropertyObserverCallback() << "(" << p.dump() << ");";
     frame_->ExecuteJavaScript(script.str(), frame_->GetURL(), 0);
 }
 void PropertyWidgetCEF::onSetReadOnly(Property* /*property*/, bool readonly) {
+    if (!frame_) {
+        return;
+    }
     std::stringstream script;
     auto p = json{{"readOnly", (readonly ? "true" : "false")}};
     script << this->getPropertyObserverCallback() << "(" << p.dump() << ");";
     frame_->ExecuteJavaScript(script.str(), frame_->GetURL(), 0);
 }
 void PropertyWidgetCEF::onSetVisible(Property* /*property*/, bool visible) {
+    if (!frame_) {
+        return;
+    }
     std::stringstream script;
     auto p = json{{"visible", (visible ? "true" : "false")}};
     script << this->getPropertyObserverCallback() << "(" << p.dump() << ");";
@@ -167,6 +182,9 @@ void PropertyWidgetCEF::onSetVisible(Property* /*property*/, bool visible) {
 }
 
 void PropertyWidgetCEF::onSetUsageMode(Property* /*property*/, UsageMode usageMode) {
+    if (!frame_) {
+        return;
+    }
     std::stringstream script;
     std::stringstream mode;
     mode << usageMode;

--- a/modules/webbrowser/src/webbrowserclient.cpp
+++ b/modules/webbrowser/src/webbrowserclient.cpp
@@ -82,8 +82,7 @@ WebBrowserClient::WebBrowserClient(ModuleManager& moduleManager,
     });
 }
 
-void WebBrowserClient::setBrowserParent(
-    CefRefPtr<CefBrowser> browser, Processor* parent) {
+void WebBrowserClient::setBrowserParent(CefRefPtr<CefBrowser> browser, Processor* parent) {
     CEF_REQUIRE_UI_THREAD();
     BrowserData bd{parent, new ProcessorCefSynchronizer(parent)};
     browserParents_[browser->GetIdentifier()] = bd;

--- a/modules/webbrowser/src/webbrowserclient.cpp
+++ b/modules/webbrowser/src/webbrowserclient.cpp
@@ -82,7 +82,8 @@ WebBrowserClient::WebBrowserClient(ModuleManager& moduleManager,
     });
 }
 
-WebBrowserClient::BrowserParentHandle WebBrowserClient::setBrowserParent(CefRefPtr<CefBrowser> browser, Processor* parent) {
+WebBrowserClient::BrowserParentHandle WebBrowserClient::setBrowserParent(
+    CefRefPtr<CefBrowser> browser, Processor* parent) {
     CEF_REQUIRE_UI_THREAD();
     auto processor = std::make_shared<Processor*>(parent);
     BrowserData bd{processor, new ProcessorCefSynchronizer(parent)};


### PR DESCRIPTION

- Closes issue #1109 (Processor was destroyed before OnBeforeClose(CefRefPtr<CefBrowser> browser) was called)
- Fixes issue when a property changed without the CefFrame being set.
- Animation: Fixes bugs when PropertyTrack has no owner and where AnimationState was set before evaluating animation