### PR TITLE
Core: MSVC fix for debugbreak crash

### DIFF
--- a/src/core/util/assertion.cpp
+++ b/src/core/util/assertion.cpp
@@ -34,6 +34,8 @@
 
 #ifndef WIN32
 #include <signal.h>
+#else
+extern "C" __declspec(dllimport) int __stdcall IsDebuggerPresent();
 #endif
 
 namespace inviwo {
@@ -61,7 +63,9 @@ void assertion(std::string_view, std::string_view, long, std::string_view) {}
 
 void util::debugBreak() {
 #ifdef WIN32
-    __debugbreak();
+    if (IsDebuggerPresent()) {
+        __debugbreak();
+    }
 #else
     raise(SIGTRAP);
 #endif


### PR DESCRIPTION
* added check if debugger is present for Visual Studio builds

**Reason:** both `__debugbreak` and `SIGTRAP` terminate the program if no debugger is present. 

So dragging a processor into the network which causes an OpenGL error will kill Inviwo when not using a debugger and the "Break on" setting is set to anything else than "off".