### PR TITLE
Core: Colorbrewer TF Fixes for odd #colors and non-centered midpoint

### DIFF
--- a/src/core/util/colorbrewer.cpp
+++ b/src/core/util/colorbrewer.cpp
@@ -141,20 +141,23 @@ TransferFunction getTransferFunction(const Category& category, const Family& fam
 
     if (category == colorbrewer::Category::Diverging) {
         if (discrete) {
+            double midPointOffset = 0.0;
             if (midPoint > start) {
                 const auto dt = (midPoint - start) / (0.5 * nColors);
+                midPointOffset = 0.5 * dt * (nColors % 2);
                 for (size_t i = 0; i < nColors / 2; i++) {
                     addPoint(start + i * dt, i);
                     addPointAlmost(start + (i + 1) * dt, i);
                 }
             }
-            addPoint(midPoint, nColors / 2);
+            addPoint(midPoint - midPointOffset, nColors / 2);
             if (midPoint < stop) {
                 const auto dt = (stop - midPoint) / (0.5 * nColors);
-                addPointAlmost(midPoint + dt, nColors / 2);
-                for (auto i = nColors / 2 + 1; i < nColors; i++) {
-                    addPoint(start + i * dt, i);
-                    addPointAlmost(start + (i + 1) * dt, i);
+                midPointOffset = 0.5 * dt * (nColors % 2);
+                addPointAlmost(midPoint + dt - midPointOffset, nColors / 2);
+                for (auto i = nColors - 1; i > nColors / 2; i--) {
+                    addPointAlmost(stop - (nColors - 1 - i) * dt, i);
+                    addPoint(stop - (nColors - i) * dt, i);
                 }
             }
         } else {


### PR DESCRIPTION
Fixes two small issues with the diverging colorbrewer transfer functions (assuming I have understood the use of the midpoint variable correctly):
- If the number of colors is odd, the middle color segment needs to be centered around the given mid point.
- If the given mid point is not equal to 0.5, but still within the interval (start, stop), segments in the left and right half will have different sizes. For an odd number of colors, the middle segment is now covering one half of left and right segment sizes respectively.

![DiscreteColorMapsBug](https://user-images.githubusercontent.com/391662/109339048-594b3e00-7867-11eb-9566-cfb247f4d6f3.png)

**Environment** 
- Windows 10
- Visual Studio 2019
- Qt 5.13.1/ CMake 3.19 / Python 3.6