### PR TITLE
Add addPorts method to processor, see reasoning below

### DIFF
--- a/include/inviwo/core/processors/processor.h
+++ b/include/inviwo/core/processors/processor.h
@@ -386,6 +386,18 @@ public:
     template <typename T>
     T& addPort(T& port, std::string_view portGroup = "default");
 
+    /**
+     * Add ports to processor.
+     * @note Calling this method will add all ports to the default port group. If you wish to
+     * add a port to a certain port group you will need to call addPort(myPort, "myPortGroup")
+     * explicitly instead.
+     * @param ports to add
+     */
+    template <typename... Ts>
+    void addPorts(Ts&... ports) {
+        (addPort(ports), ...);
+    }
+
     Port* removePort(std::string_view identifier);
     Inport* removePort(Inport* port);
     Outport* removePort(Outport* port);


### PR DESCRIPTION
This method will implicitly add all ports in the same port group so if a user wants to add his ports to a certain port group, he will have to do that explicitly with `addPort(myPort, "myPortGroup");`.
I would argue though that in 99% of the cases, adding the ports to the default group is the desired behaviour and that is why I think having this method makes sense in terms of convenience.

The behaviour is stated in the comment.