### PR TITLE
Qt: render context fix

### DIFF
--- a/include/inviwo/qt/editor/processormimedata.h
+++ b/include/inviwo/qt/editor/processormimedata.h
@@ -58,7 +58,19 @@ public:
     static const ProcessorMimeData* toProcessorMimeData(const QMimeData* data);
 
 private:
-    mutable std::unique_ptr<Processor> processor_;
+    struct ContextAwareDelete {
+        template <typename T>
+        ContextAwareDelete(std::default_delete<T>&&) noexcept {}
+
+        template <typename T>
+        operator std::default_delete<T>() {
+            return {};
+        }
+
+        void operator()(Processor* p) const noexcept;
+    };
+
+    mutable std::unique_ptr<Processor, ContextAwareDelete> processor_;
 };
 
 }  // namespace inviwo

--- a/src/qt/editor/processormimedata.cpp
+++ b/src/qt/editor/processormimedata.cpp
@@ -29,6 +29,7 @@
 
 #include <inviwo/qt/editor/processormimedata.h>
 #include <modules/qtwidgets/inviwoqtutils.h>
+#include <inviwo/core/util/rendercontext.h>
 
 #include <warn/push>
 #include <warn/ignore/all>
@@ -38,6 +39,11 @@
 #include <warn/pop>
 
 namespace inviwo {
+
+void ProcessorMimeData::ContextAwareDelete::operator()(Processor* p) const noexcept {
+    rendercontext::activateDefault();
+    delete p;
+}
 
 ProcessorMimeData::ProcessorMimeData(std::unique_ptr<Processor> processor)
     : QMimeData{}, processor_{std::move(processor)} {


### PR DESCRIPTION
* an unsuccessful drag operation from the processor list resulted in destroying the processor in the wrong context
