### PR TITLE
Added an optional canvas fullscreen command line option to qtminimum-app.

### DIFF
--- a/apps/minimals/qt/qtminimum.cpp
+++ b/apps/minimals/qt/qtminimum.cpp
@@ -93,9 +93,8 @@ int main(int argc, char** argv) {
         1000);
 
     TCLAP::ValueArg<int> fullscreenArg(
-        "f", "fullscreen",
-        "Specify amount of seconds before launching canvas to fullscreen", false, 3,
-        "This will only occur if exactly one canvas is visible during startup");
+        "f", "fullscreen", "Specify amount of seconds before launching canvas to fullscreen", false,
+        3, "This will only occur if exactly one canvas is visible during startup");
 
     cmdparser.add(
         &fullscreenArg,
@@ -121,7 +120,7 @@ int main(int argc, char** argv) {
                     }
                     canvasFullScreenTimer->deleteLater();
                 });
-            canvasFullScreenTimer->start(fullscreenArg.getValue()*1000);
+            canvasFullScreenTimer->start(fullscreenArg.getValue() * 1000);
         },
         1000);
 


### PR DESCRIPTION
In the effort to use Inviwo for public exhibition, the qtminimum app is preferred as the end application running the preferred workspace.
To make it even easier to use for this, I added a the an optional fullscreen command line option to qtminimum-app to occur if a single canvas is already visible, which should be the case in almost every use case as the end result.