### PR TITLE
Fix/webbrowser xcode

### DIFF
--- a/cmake/compileoptions.cmake
+++ b/cmake/compileoptions.cmake
@@ -33,6 +33,13 @@
 
 option(IVW_CFG_TREAT_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
 option(IVW_CFG_FORCE_ASSERTIONS "Force use of assertions when not in debug mode" OFF)
+if(CMAKE_GENERATOR STREQUAL "Xcode")
+    # Prevent Xcode 11 from doing automatic codesigning because it will fail the build. 
+    # Causes build to fail if Webbrowser module is enabled due to the added CEF framework
+    # This fix is also performed in the CEF example projects:
+    # https://bitbucket.org/chromiumembedded/cef/src/2de07250dc6c25ccb5484f25002450afb164782b/cmake/cef_variables.cmake.in#lines-339
+    set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "")
+endif()
 
 function(ivw_define_standard_properties)
     foreach(target ${ARGN})

--- a/modules/webbrowser/CMakeLists.txt
+++ b/modules/webbrowser/CMakeLists.txt
@@ -154,7 +154,7 @@ target_include_directories(inviwo-module-webbrowser PUBLIC ${CEF_INCLUDE_PATH})
 
 find_package(nlohmann_json CONFIG REQUIRED)
 target_link_libraries(inviwo-module-webbrowser PUBLIC
-    $<$<NOT:$<BOOL:${OS_MACOSX}>>:libcef_lib>
+    $<$<NOT:$<BOOL:${OS_MAC}>>:libcef_lib>
     libcef_dll_wrapper 
     nlohmann_json::nlohmann_json
     ${CEF_STANDARD_LIBS}
@@ -177,7 +177,7 @@ ivw_register_license_file(NAME "Chromium Embedded Framework" VERSION ${CEF_VERSI
     FILES ${CEF_ROOT}/LICENSE.txt
 )
 
-if (OS_MACOSX)
+if (OS_MAC)
 	# Output path for the main app bundle.
 	set(CEF_APP "${CEF_TARGET_OUT_DIR}/${IVW_APP_INSTALL_NAME}.app")
 	# Copy the CEF framework into the Frameworks directory
@@ -190,6 +190,7 @@ if (OS_MACOSX)
         "${CEF_APP}/Contents/Frameworks/Chromium Embedded Framework.framework"
         VERBATIM
     )
+
     # Copy the CEF framework into the Frameworks directory (used by installer)
     install(DIRECTORY "${CEF_BINARY_DIR}/Chromium Embedded Framework.framework"
             DESTINATION "${IVW_APP_INSTALL_NAME}.app/Contents/Frameworks/Chromium Embedded Framework.framework"

--- a/modules/webbrowser/CMakeLists.txt
+++ b/modules/webbrowser/CMakeLists.txt
@@ -16,7 +16,7 @@
 # FATAL:async_layer_tree_frame_sink.cc
 # Known issue: Dropdown does not work.
 # Probably due to https://magpcss.org/ceforum/viewtopic.php?f=6&t=11618
-set(CEF_VERSION "87.1.6+g315d248+chromium-87.0.4280.66")
+set(CEF_VERSION "89.0.12+g2b76680+chromium-89.0.4389.90")
 
 # Determine the platform.
 include("cmake/cef_platform.cmake")
@@ -35,7 +35,9 @@ if (WIN32)
     option(USE_SANDBOX "Enable or disable use of the sandbox." OFF)
 endif()
 
-set(PROJECT_ARCH "x86_64") # CEF Wants this on OS X.
+if(NOT PROJECT_ARCH)
+    set(PROJECT_ARCH ${CMAKE_SYSTEM_PROCESSOR}) # CEF Wants this on OS X.
+endif()
 
 # Load the CEF configuration.
 # Execute FindCEF.cmake which must exist in CMAKE_MODULE_PATH.

--- a/modules/webbrowser/cmake/cef_platform.cmake
+++ b/modules/webbrowser/cmake/cef_platform.cmake
@@ -5,7 +5,11 @@
 # Determine the platform used by CEF.
 function(determineCEFPlatform CEF_PLATFORM)
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-  set(CEF_PLATFORM "macosx64"  PARENT_SCOPE)
+  if("${PROJECT_ARCH}" STREQUAL "arm64")
+    set(CEF_PLATFORM "macosarm64" PARENT_SCOPE)
+  else()
+    set(CEF_PLATFORM "macosx64" PARENT_SCOPE)
+  endif()
 elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
   if(CMAKE_SIZEOF_VOID_P MATCHES 8)
     set(CEF_PLATFORM "linux64" PARENT_SCOPE)

--- a/modules/webbrowser/cmake/cef_platform.cmake
+++ b/modules/webbrowser/cmake/cef_platform.cmake
@@ -5,7 +5,7 @@
 # Determine the platform used by CEF.
 function(determineCEFPlatform CEF_PLATFORM)
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-  if("${PROJECT_ARCH}" STREQUAL "arm64")
+  if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "arm64")
     set(CEF_PLATFORM "macosarm64" PARENT_SCOPE)
   else()
     set(CEF_PLATFORM "macosx64" PARENT_SCOPE)

--- a/modules/webbrowser/webhelper/CMakeLists.txt
+++ b/modules/webbrowser/webhelper/CMakeLists.txt
@@ -27,7 +27,7 @@ set(WEBBROWSER_HELPER_SOURCES
 set(CEF_HELPER_TARGET "cef_inviwo_helper" CACHE INTERNAL "CEF_HELPER_TARGET")
 
 
-if (NOT OS_MACOSX)
+if (NOT OS_MAC)
     add_executable(${CEF_HELPER_TARGET} WIN32 MACOSX_BUNDLE ${WEBBROWSER_HELPER_SOURCES})
 	set(CEF_HELPER_OUTPUT_NAME "cef_web_helper")
 	set_target_properties(${CEF_HELPER_TARGET} PROPERTIES OUTPUT_NAME ${CEF_HELPER_OUTPUT_NAME})
@@ -36,7 +36,7 @@ if (NOT OS_MACOSX)
     # Build helper before module so that we can copy it
     add_dependencies(inviwo-module-webbrowser ${CEF_HELPER_TARGET})
     target_link_libraries(${CEF_HELPER_TARGET} PRIVATE
-        $<$<NOT:$<BOOL:${OS_MACOSX}>>:libcef_lib>
+        $<$<NOT:$<BOOL:${OS_MAC}>>:libcef_lib>
         libcef_dll_wrapper
         ${CEF_STANDARD_LIBS}
         inviwo::warn
@@ -58,7 +58,7 @@ if (NOT OS_MACOSX)
     ivw_folder(${CEF_HELPER_TARGET} ext/CEF)
 endif()
 
-if (OS_MACOSX)
+if (OS_MAC)
 	# Mac: CEF uses 3 different applications according to following structure:
 	# "<app name> + Helper<type>", e.g. Inviwo Helper (GPU)
 	set(CEF_HELPER_OUTPUT_NAME "${IVW_APP_INSTALL_NAME} Helper")
@@ -100,6 +100,10 @@ if (OS_MACOSX)
         target_link_libraries(${_helper_target} libcef_dll_wrapper ${CEF_STANDARD_LIBS} inviwo::warn)
         set_target_properties(${_helper_target} PROPERTIES
             MACOSX_BUNDLE_INFO_PLIST ${_helper_info_plist}
+            # Remove XCode warning (must match plist)
+            XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "org.inviwo.helper${_plist_suffix}"
+            # See also https://www.magpcss.org/ceforum/viewtopic.php?f=6&t=16481&start=10
+            XCODE_ATTRIBUTE_CODE_SIGN_ENTITLEMENTS "${CMAKE_CURRENT_BINARY_DIR}/helper${_target_suffix}-entitlements.plist"
             OUTPUT_NAME ${_helper_output_name}
         )
         # Output paths for the app bundles: bin/configuration, for example bin/Debug.
@@ -140,10 +144,6 @@ if (OS_MACOSX)
         install(DIRECTORY "${_helper_app}"
             DESTINATION "${IVW_APP_INSTALL_NAME}.app/Contents/Frameworks/${_helper_output_name}.app"
             COMPONENT Application)
-
-        set_target_properties(${_helper_target} PROPERTIES
-            MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/resources/mac/helper-Info.plist
-        )
     endforeach()
 
 elseif (WIN32)

--- a/modules/webbrowser/webhelper/resources/mac/helper-entitlements.plist
+++ b/modules/webbrowser/webhelper/resources/mac/helper-entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+   <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+   <true/>
+   <key>com.apple.security.cs.disable-library-validation</key>
+   <true/>
+   <key>com.apple.security.cs.allow-jit</key>
+   <true/>
+</dict>
+</plist>

--- a/modules/webbrowser/webhelper/resources/mac/helper-info.plist
+++ b/modules/webbrowser/webhelper/resources/mac/helper-info.plist
@@ -9,11 +9,11 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.inviwo.helper</string>
+	<string>org.inviwo.helper${BUNDLE_ID_SUFFIX}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>Inviwo</string>
+	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleSignature</key>
@@ -25,8 +25,6 @@
 	</dict>
 	<key>LSFileQuarantineEnabled</key>
 	<true/>
-	<key>LSMinimumSystemVersion</key>
-	<string>10.9.0</string>
 	<key>LSUIElement</key>
 	<string>1</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>

--- a/modules/webbrowser/webhelper/resources/mac/helper_gpu-entitlements.plist
+++ b/modules/webbrowser/webhelper/resources/mac/helper_gpu-entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+</dict>
+</plist>

--- a/modules/webbrowser/webhelper/resources/mac/helper_plugin-entitlements.plist
+++ b/modules/webbrowser/webhelper/resources/mac/helper_plugin-entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/modules/webbrowser/webhelper/resources/mac/helper_renderer-entitlements.plist
+++ b/modules/webbrowser/webhelper/resources/mac/helper_renderer-entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Mac fixes.
Webbrowser
- Add support for mac arm64
- Remove XCode warnings (tested on XCode 12.5).
- Added entitlements for helpers

CMake
- XCode (version 11 and later?, tested on version 12.5) will fail on build when the Webbrowser module is enabled because of the added CEF framework