### PR TITLE
Fix/nifti compressed files

### DIFF
--- a/include/inviwo/core/io/datareaderfactory.h
+++ b/include/inviwo/core/io/datareaderfactory.h
@@ -51,8 +51,8 @@ public:
     bool registerObject(DataReader* reader);
     bool unRegisterObject(DataReader* reader);
     virtual std::unique_ptr<DataReader> create(const FileExtension& key) const override;
-    virtual std::unique_ptr<DataReader> create(const std::string& key) const;
-    virtual bool hasKey(const std::string& key) const;
+    virtual std::unique_ptr<DataReader> create(std::string_view key) const;
+    virtual bool hasKey(std::string_view key) const;
     virtual bool hasKey(const FileExtension& key) const override;
 
     template <typename T>

--- a/include/inviwo/core/io/datareaderfactory.h
+++ b/include/inviwo/core/io/datareaderfactory.h
@@ -58,7 +58,8 @@ public:
     /**
      * \brief Return a reader matching the file extension of DataReader of type T.
      * Does case insensitive comparison between the last part of filePathOrExtension and each
-     * registered extension.
+     * registered extension. Does not check for "." before the extension, so it is valid to pass for
+     * example "png".
      * @param filePathOrExtension Path to file, or simply the extension.
      * @return First available DataReaderType<T> if found, nullptr otherwise.
      */
@@ -115,7 +116,7 @@ template <typename T>
 std::unique_ptr<DataReaderType<T>> DataReaderFactory::getReaderForTypeAndExtension(
     std::string_view path) const {
     for (auto& elem : map_) {
-        if (iCaseEndsWith(path, elem.first.extension_)) {
+        if (util::iCaseEndsWith(path, elem.first.extension_)) {
             if (auto r = dynamic_cast<DataReaderType<T>*>(elem.second)) {
                 return std::unique_ptr<DataReaderType<T>>(r->clone());
             }

--- a/include/inviwo/core/io/datareaderfactory.h
+++ b/include/inviwo/core/io/datareaderfactory.h
@@ -42,7 +42,8 @@ namespace inviwo {
 
 class IVW_CORE_API DataReaderFactory : public Factory<DataReader, const FileExtension&> {
 public:
-    using Map = std::unordered_map<FileExtension, DataReader*>;
+    using Map = std::map<FileExtension, DataReader*,
+                         std::function<bool(const FileExtension&, const FileExtension&)>>;
 
     DataReaderFactory() = default;
     virtual ~DataReaderFactory() = default;
@@ -57,29 +58,46 @@ public:
     template <typename T>
     std::vector<FileExtension> getExtensionsForType() const;
 
+    /**
+     * \brief Return a reader matching the file extension of DataReader of type T.
+     * Does case insensive comparison between the last part of filePathOrExtension and each
+     * registered extension.
+     * @param filePathOrExtension Path to file, or simply the extension.
+     * @return First available DataReaderType<T> if found, nullptr otherwise.
+     */
     template <typename T>
-    std::unique_ptr<DataReaderType<T>> getReaderForTypeAndExtension(const std::string& ext) const;
+    std::unique_ptr<DataReaderType<T>> getReaderForTypeAndExtension(
+        std::string_view filePathOrExtension) const;
     template <typename T>
     std::unique_ptr<DataReaderType<T>> getReaderForTypeAndExtension(const FileExtension& ext) const;
 
     /**
      * First look for a reader using the FileExtension ext, and if no reader was found look for a
-     * reader using the fallbackExt. This is often used with a file open dialog, where the dialog
-     * will have a selectedFileExtension that will be used as ext, and the fallbackExt is taken from
-     * the file to be opened. This way any selected reader will have priority over the file
-     * extension.
+     * reader using the fallbackFilePathOrExtension. This is often used with a file open dialog,
+     * where the dialog will have a selectedFileExtension that will be used as ext, and the
+     * fallbackFilePathOrExtension is taken from the file to be opened. This way any selected reader
+     * will have priority over the file extension.
      */
     template <typename T>
     std::unique_ptr<DataReaderType<T>> getReaderForTypeAndExtension(
-        const FileExtension& ext, const std::string& fallbackExt) const;
+        const FileExtension& ext, std::string_view fallbackFilePathOrExtension) const;
 
     template <typename T>
-    bool hasReaderForTypeAndExtension(const std::string& ext) const;
+    bool hasReaderForTypeAndExtension(std::string_view filePathOrExtension) const;
     template <typename T>
     bool hasReaderForTypeAndExtension(const FileExtension& ext) const;
 
 protected:
-    Map map_;
+    // Sort extensions by length to first compare long extensions. Avoids selecting extension xyz in
+    // case xyzw exist, see getReaderForTypeAndExtension
+    Map map_ = Map([](const auto& a, const auto& b) -> bool {
+        if (a.extension_.size() != b.extension_.size()) {
+            return a.extension_.size() > b.extension_.size();
+        } else {
+            // Order does not matter
+            return a < b;
+        }
+    });
 };
 
 template <typename T>
@@ -96,11 +114,12 @@ std::vector<FileExtension> DataReaderFactory::getExtensionsForType() const {
 
 template <typename T>
 std::unique_ptr<DataReaderType<T>> DataReaderFactory::getReaderForTypeAndExtension(
-    const std::string& ext) const {
-
-    auto lkey = toLower(ext);
+    std::string_view path) const {
     for (auto& elem : map_) {
-        if (toLower(elem.first.extension_) == lkey) {
+        if (path.size() >= elem.first.extension_.size() &&
+            // Compare last part of path with the extension
+            iCaseCmp(path.substr(path.size() - elem.first.extension_.size()),
+                     elem.first.extension_)) {
             if (auto r = dynamic_cast<DataReaderType<T>*>(elem.second)) {
                 return std::unique_ptr<DataReaderType<T>>(r->clone());
             }
@@ -123,24 +142,16 @@ std::unique_ptr<DataReaderType<T>> DataReaderFactory::getReaderForTypeAndExtensi
 
 template <typename T>
 std::unique_ptr<DataReaderType<T>> DataReaderFactory::getReaderForTypeAndExtension(
-    const FileExtension& ext, const std::string& fallbackExt) const {
+    const FileExtension& ext, std::string_view fallbackFilePathOrExtension) const {
     if (auto reader = getReaderForTypeAndExtension<T>(ext)) {
         return reader;
     }
-    return getReaderForTypeAndExtension<T>(fallbackExt);
+    return getReaderForTypeAndExtension<T>(fallbackFilePathOrExtension);
 }
 
 template <typename T>
-bool DataReaderFactory::hasReaderForTypeAndExtension(const std::string& ext) const {
-    auto lkey = toLower(ext);
-    for (auto& elem : map_) {
-        if (toLower(elem.first.extension_) == lkey) {
-            if (auto r = dynamic_cast<DataReaderType<T>*>(elem.second)) {
-                return true;
-            }
-        }
-    }
-    return false;
+bool DataReaderFactory::hasReaderForTypeAndExtension(std::string_view path) const {
+    return getReaderForTypeAndExtension<T>(path) != nullptr;
 }
 
 template <typename T>

--- a/include/inviwo/core/io/datareaderfactory.h
+++ b/include/inviwo/core/io/datareaderfactory.h
@@ -60,7 +60,7 @@ public:
 
     /**
      * \brief Return a reader matching the file extension of DataReader of type T.
-     * Does case insensive comparison between the last part of filePathOrExtension and each
+     * Does case insensitive comparison between the last part of filePathOrExtension and each
      * registered extension.
      * @param filePathOrExtension Path to file, or simply the extension.
      * @return First available DataReaderType<T> if found, nullptr otherwise.

--- a/include/inviwo/core/io/datawriterfactory.h
+++ b/include/inviwo/core/io/datawriterfactory.h
@@ -63,7 +63,7 @@ public:
     std::vector<FileExtension> getExtensionsForType() const;
     /**
      * \brief Return a writer matching the file extension of DataWriterType of type T.
-     * Does case insensive comparison between the last part of filePathOrExtension and each
+     * Does case insensitive comparison between the last part of filePathOrExtension and each
      * registered extension.
      * @param filePathOrExtension Path to file, or simply the extension.
      * @return First available DataWriterType<T> if found, nullptr otherwise.

--- a/include/inviwo/core/io/datawriterfactory.h
+++ b/include/inviwo/core/io/datawriterfactory.h
@@ -62,7 +62,8 @@ public:
     /**
      * \brief Return a writer matching the file extension of DataWriterType of type T.
      * Does case insensitive comparison between the last part of filePathOrExtension and each
-     * registered extension.
+     * registered extension. Does not check for "." before the extension, so it is valid to pass for
+     * example "png".
      * @param filePathOrExtension Path to file, or simply the extension.
      * @return First available DataWriterType<T> if found, nullptr otherwise.
      */
@@ -115,7 +116,7 @@ template <typename T>
 std::unique_ptr<DataWriterType<T>> DataWriterFactory::getWriterForTypeAndExtension(
     std::string_view path) const {
     for (auto& elem : map_) {
-        if (iCaseEndsWith(path, elem.first.extension_)) {
+        if (util::iCaseEndsWith(path, elem.first.extension_)) {
             if (auto r = dynamic_cast<DataWriterType<T>*>(elem.second)) {
                 return std::unique_ptr<DataWriterType<T>>(r->clone());
             }

--- a/include/inviwo/core/io/datawriterfactory.h
+++ b/include/inviwo/core/io/datawriterfactory.h
@@ -53,10 +53,10 @@ public:
     bool registerObject(DataWriter* reader);
     bool unRegisterObject(DataWriter* reader);
 
-    virtual std::unique_ptr<DataWriter> create(const std::string& key) const;
+    virtual std::unique_ptr<DataWriter> create(std::string_view key) const;
     virtual std::unique_ptr<DataWriter> create(const FileExtension& key) const override;
 
-    virtual bool hasKey(const std::string& key) const;
+    virtual bool hasKey(std::string_view key) const;
     virtual bool hasKey(const FileExtension& key) const override;
 
     template <typename T>

--- a/include/inviwo/core/rendering/datavisualizermanager.h
+++ b/include/inviwo/core/rendering/datavisualizermanager.h
@@ -75,8 +75,7 @@ public:
      * \brief Get a list of Data Visualizers supporting the file extension of the supplied string.
      * @param filePathOrExtension Path to file, or simply the extension.
      */
-    std::vector<DataVisualizer*> getDataVisualizersForExtension(
-        std::string_view pathOrExtension) const;
+    std::vector<DataVisualizer*> getDataVisualizersForFile(std::string_view pathOrExtension) const;
 
     /**
      * Get a list of Data Visualizers supporting the supplied outport.

--- a/include/inviwo/core/rendering/datavisualizermanager.h
+++ b/include/inviwo/core/rendering/datavisualizermanager.h
@@ -72,9 +72,11 @@ public:
     std::vector<FileExtension> getSupportedFileExtensions() const;
 
     /**
-     * Get a list of Data Visualizers supporting the supplied extension.
+     * \brief Get a list of Data Visualizers supporting the file extension of the supplied string.
+     * @param filePathOrExtension Path to file, or simply the extension.
      */
-    std::vector<DataVisualizer*> getDataVisualizersForExtension(const std::string& ext) const;
+    std::vector<DataVisualizer*> getDataVisualizersForExtension(
+        std::string_view pathOrExtension) const;
 
     /**
      * Get a list of Data Visualizers supporting the supplied outport.

--- a/include/inviwo/core/util/filesystem.h
+++ b/include/inviwo/core/util/filesystem.h
@@ -311,6 +311,20 @@ IVW_CORE_API std::string addBasePath(std::string_view url);
 IVW_CORE_API std::string getFileDirectory(std::string_view url);
 IVW_CORE_API std::string getFileNameWithExtension(std::string_view url);
 IVW_CORE_API std::string getFileNameWithoutExtension(std::string_view url);
+/**
+ * \brief Returns the characters after last dot (.).
+ *
+ * @note Avoid using this function for extracting file extensions if you are not sure that the
+ * expected extension only contains one dot. In general, there is no way to safely consider cases
+ * with multiple dots. File extensions with multiple dots can exist for compressed files (for
+ * example nii.gz). Instead, compare the url with registered extensions, see inviwo::FileExtension
+ * and inviwo::DataReaderFactory
+ *
+ * @see DataReaderFactory
+ * @see getFileNameWithExtension
+ * @param url Path to extract extension from.
+ * @return Extension excluding ., empty if no dot or filename are found.
+ */
 IVW_CORE_API std::string getFileExtension(std::string_view url);
 
 /**

--- a/include/inviwo/core/util/stringconversion.h
+++ b/include/inviwo/core/util/stringconversion.h
@@ -329,6 +329,15 @@ struct IVW_CORE_API CaseInsensitiveCompare {
     bool operator()(std::string_view a, std::string_view b) const;
 };
 
+
+/*
+ * \brief Checks if provided string ends with suffix using case insensitive equal comparison.
+ * @param str string to check last part of. Allowed to be smaller than suffix.
+ * @param suffix Ending to match.
+ * @return True if last part of str is equal to suffix, false otherwise.
+ */
+IVW_CORE_API bool iCaseEndsWith(std::string_view str, std::string_view suffix);
+
 /**
  * \brief convert the given duration from milliseconds to a string.
  * The returned string will have the format "%dd %dh %dmin %dsec %.3fms", where days, hours,

--- a/include/inviwo/core/util/stringconversion.h
+++ b/include/inviwo/core/util/stringconversion.h
@@ -261,6 +261,14 @@ constexpr std::string_view trim(std::string_view str) noexcept {
     return str.substr(idx1, idx2 + 1 - idx1);
 }
 
+/*
+ * \brief Checks if provided string ends with suffix using case insensitive equal comparison.
+ * @param str string to check last part of. Allowed to be smaller than suffix.
+ * @param suffix Ending to match.
+ * @return True if last part of str is equal to suffix, false otherwise.
+ */
+IVW_CORE_API bool iCaseEndsWith(std::string_view str, std::string_view suffix);
+
 }  // namespace util
 
 // Keep this here to avoid breaking old code
@@ -328,14 +336,6 @@ IVW_CORE_API bool iCaseLess(std::string_view l, std::string_view r);
 struct IVW_CORE_API CaseInsensitiveCompare {
     bool operator()(std::string_view a, std::string_view b) const;
 };
-
-/*
- * \brief Checks if provided string ends with suffix using case insensitive equal comparison.
- * @param str string to check last part of. Allowed to be smaller than suffix.
- * @param suffix Ending to match.
- * @return True if last part of str is equal to suffix, false otherwise.
- */
-IVW_CORE_API bool iCaseEndsWith(std::string_view str, std::string_view suffix);
 
 /**
  * \brief convert the given duration from milliseconds to a string.

--- a/include/inviwo/core/util/stringconversion.h
+++ b/include/inviwo/core/util/stringconversion.h
@@ -329,7 +329,6 @@ struct IVW_CORE_API CaseInsensitiveCompare {
     bool operator()(std::string_view a, std::string_view b) const;
 };
 
-
 /*
  * \brief Checks if provided string ends with suffix using case insensitive equal comparison.
  * @param str string to check last part of. Allowed to be smaller than suffix.

--- a/modules/base/include/modules/base/processors/dataexport.h
+++ b/modules/base/include/modules/base/processors/dataexport.h
@@ -104,7 +104,7 @@ void DataExport<DataType, PortType>::exportData() {
         auto factory = getNetwork()->getApplication()->getDataWriterFactory();
 
         auto writer = factory->template getWriterForTypeAndExtension<DataType>(
-            file_.getSelectedExtension(), filesystem::getFileExtension(file_.get()));
+            file_.getSelectedExtension(), file_.get());
 
         if (!writer) {
             LogProcessorError(

--- a/modules/base/include/modules/base/processors/datasource.h
+++ b/modules/base/include/modules/base/processors/datasource.h
@@ -175,8 +175,7 @@ void DataSource<DataType, PortType>::load(bool deserialized) {
     if (file_.get().empty()) return;
 
     const auto sext = reader_.getSelectedValue();
-    const auto fext = filesystem::getFileExtension(file_.get());
-    if (auto reader = rf_->template getReaderForTypeAndExtension<DataType>(sext, fext)) {
+    if (auto reader = rf_->template getReaderForTypeAndExtension<DataType>(sext, file_.get())) {
         try {
             auto data = reader->readData(file_.get());
             port_.setData(data);

--- a/modules/base/src/io/datvolumesequencereader.cpp
+++ b/modules/base/src/io/datvolumesequencereader.cpp
@@ -73,7 +73,6 @@ std::shared_ptr<DatVolumeSequenceReader::VolumeSequence> DatVolumeSequenceReader
     }
 
     std::string fileDirectory = filesystem::getFileDirectory(fileName);
-    std::string fileExtension = filesystem::getFileExtension(fileName);
 
     // Read the dat file content
     auto f = filesystem::ifstream(fileName);

--- a/modules/base/src/processors/imagesource.cpp
+++ b/modules/base/src/processors/imagesource.cpp
@@ -87,8 +87,7 @@ void ImageSource::process() {
     if (file_.get().empty()) return;
 
     const auto sext = reader_.getSelectedValue();
-    const auto fext = filesystem::getFileExtension(file_.get());
-    if (auto reader = rf_->getReaderForTypeAndExtension<Layer>(sext, fext)) {
+    if (auto reader = rf_->getReaderForTypeAndExtension<Layer>(sext, file_.get())) {
         try {
             auto outLayer = reader->readData(file_.get());
             outport_.setData(std::make_shared<Image>(outLayer));

--- a/modules/base/src/processors/imagesourceseries.cpp
+++ b/modules/base/src/processors/imagesourceseries.cpp
@@ -108,11 +108,10 @@ void ImageSourceSeries::process() {
     }
 
     const auto currentFileName = fileList_[index];
-    const auto fext = filesystem::getFileExtension(currentFileName);
     const auto sext = imageFilePattern_.getSelectedExtension();
 
     auto factory = getNetwork()->getApplication()->getDataReaderFactory();
-    auto reader = factory->getReaderForTypeAndExtension<Layer>(sext, fext);
+    auto reader = factory->getReaderForTypeAndExtension<Layer>(sext, currentFileName);
 
     // there should always be a reader since we asked the reader for valid extensions
     ivwAssert(reader != nullptr, "Could not find reader for \"" << currentFileName << "\"");

--- a/modules/base/src/processors/imagesourceseries.cpp
+++ b/modules/base/src/processors/imagesourceseries.cpp
@@ -163,9 +163,8 @@ void ImageSourceSeries::updateFileName() {
 }
 
 bool ImageSourceSeries::isValidImageFile(std::string fileName) {
-    std::string fileExtension = filesystem::getFileExtension(fileName);
     return util::contains_if(validExtensions_,
-                             [&](const FileExtension& f) { return f.extension_ == fileExtension; });
+                             [&](const FileExtension& f) { return f.matches(fileName); });
 }
 
 }  // namespace inviwo

--- a/modules/base/src/processors/imagestackvolumesource.cpp
+++ b/modules/base/src/processors/imagestackvolumesource.cpp
@@ -122,8 +122,7 @@ void ImageStackVolumeSource::process() {
 }
 
 bool ImageStackVolumeSource::isValidImageFile(std::string fileName) {
-    return readerFactory_->hasReaderForTypeAndExtension<Layer>(
-        filesystem::getFileExtension(fileName));
+    return readerFactory_->hasReaderForTypeAndExtension<Layer>(fileName);
 }
 
 std::shared_ptr<Volume> ImageStackVolumeSource::load() {

--- a/modules/base/src/processors/imagestackvolumesource.cpp
+++ b/modules/base/src/processors/imagestackvolumesource.cpp
@@ -134,11 +134,12 @@ std::shared_ptr<Volume> ImageStackVolumeSource::load() {
     std::vector<std::pair<std::string, std::unique_ptr<DataReaderType<Layer>>>> slices;
     slices.reserve(files.size());
 
-    std::transform(files.begin(), files.end(), std::back_inserter(slices),
-                   [&](const auto& file) -> std::pair<std::string, std::unique_ptr<DataReaderType<Layer>>> {
-                       return {file, std::move(readerFactory_->getReaderForTypeAndExtension<Layer>(
-                                         filePattern_.getSelectedExtension(), file))};
-                   });
+    std::transform(
+        files.begin(), files.end(), std::back_inserter(slices),
+        [&](const auto& file) -> std::pair<std::string, std::unique_ptr<DataReaderType<Layer>>> {
+            return {file, std::move(readerFactory_->getReaderForTypeAndExtension<Layer>(
+                              filePattern_.getSelectedExtension(), file))};
+        });
     if (skipUnsupportedFiles_) {
         slices.erase(std::remove_if(slices.begin(), slices.end(),
                                     [](auto& elem) { return elem.second == nullptr; }),

--- a/modules/base/src/processors/volumesequencesource.cpp
+++ b/modules/base/src/processors/volumesequencesource.cpp
@@ -138,8 +138,7 @@ void VolumeSequenceSource::loadFile(bool deserialize) {
     if (file_.get().empty()) return;
 
     const auto sext = file_.getSelectedExtension();
-    const auto fext = filesystem::getFileExtension(file_.get());
-    if (auto reader = rf_->getReaderForTypeAndExtension<VolumeSequence>(sext, fext)) {
+    if (auto reader = rf_->getReaderForTypeAndExtension<VolumeSequence>(sext, file_.get())) {
         try {
             volumes_ = reader->readData(file_.get(), this);
         } catch (DataReaderException const& e) {
@@ -170,14 +169,13 @@ void VolumeSequenceSource::loadFolder(bool deserialize) {
     for (auto f : files) {
         auto file = folder_.get() + "/" + f;
         if (filesystem::wildcardStringMatch(filter_, file)) {
-            std::string ext = filesystem::getFileExtension(file);
             try {
-                if (auto reader1 = rf_->getReaderForTypeAndExtension<Volume>(ext)) {
+                if (auto reader1 = rf_->getReaderForTypeAndExtension<Volume>(file)) {
                     auto volume = reader1->readData(file, this);
                     volume->setMetaData<StringMetaData>("filename", file);
                     volumes_->push_back(volume);
 
-                } else if (auto reader2 = rf_->getReaderForTypeAndExtension<VolumeSequence>(ext)) {
+                } else if (auto reader2 = rf_->getReaderForTypeAndExtension<VolumeSequence>(file)) {
                     auto volumes = reader2->readData(file, this);
                     for (auto volume : *volumes) {
                         volume->setMetaData<StringMetaData>("filename", file);

--- a/modules/base/src/processors/volumesource.cpp
+++ b/modules/base/src/processors/volumesource.cpp
@@ -109,11 +109,13 @@ void VolumeSource::load(bool deserialize) {
         volumes_ = rm->getResource<VolumeSequence>(file_.get());
     } else {
         try {
-            if (auto volVecReader = rf->getReaderForTypeAndExtension<VolumeSequence>(sext, file_.get())) {
+            if (auto volVecReader =
+                    rf->getReaderForTypeAndExtension<VolumeSequence>(sext, file_.get())) {
                 auto volumes = volVecReader->readData(file_.get(), this);
                 std::swap(volumes, volumes_);
                 rm->addResource(file_.get(), volumes_, reload_.isModified());
-            } else if (auto volreader = rf->getReaderForTypeAndExtension<Volume>(sext, file_.get())) {
+            } else if (auto volreader =
+                           rf->getReaderForTypeAndExtension<Volume>(sext, file_.get())) {
                 auto volume = volreader->readData(file_.get(), this);
                 auto volumes = std::make_shared<VolumeSequence>();
                 volumes->push_back(volume);

--- a/modules/base/src/processors/volumesource.cpp
+++ b/modules/base/src/processors/volumesource.cpp
@@ -101,7 +101,6 @@ void VolumeSource::load(bool deserialize) {
     auto rm = app_->getResourceManager();
 
     const auto sext = reader_.getSelectedValue();
-    const auto fext = filesystem::getFileExtension(file_.get());
 
     // use resource unless the "Reload data"-button (reload_) was pressed,
     // Note: reload_ will be marked as modified when deserializing.
@@ -110,11 +109,11 @@ void VolumeSource::load(bool deserialize) {
         volumes_ = rm->getResource<VolumeSequence>(file_.get());
     } else {
         try {
-            if (auto volVecReader = rf->getReaderForTypeAndExtension<VolumeSequence>(sext, fext)) {
+            if (auto volVecReader = rf->getReaderForTypeAndExtension<VolumeSequence>(sext, file_.get())) {
                 auto volumes = volVecReader->readData(file_.get(), this);
                 std::swap(volumes, volumes_);
                 rm->addResource(file_.get(), volumes_, reload_.isModified());
-            } else if (auto volreader = rf->getReaderForTypeAndExtension<Volume>(sext, fext)) {
+            } else if (auto volreader = rf->getReaderForTypeAndExtension<Volume>(sext, file_.get())) {
                 auto volume = volreader->readData(file_.get(), this);
                 auto volumes = std::make_shared<VolumeSequence>();
                 volumes->push_back(volume);

--- a/modules/python3/bindings/src/pyimage.cpp
+++ b/modules/python3/bindings/src/pyimage.cpp
@@ -152,8 +152,7 @@ void exposeImage(py::module& m) {
                                    ->getDataWriterFactory()
                                    ->getWriterForTypeAndExtension<Layer>(filepath);
                  if (!writer) {
-                     throw Exception("No write for " + filepath,
-                                     IVW_CONTEXT_CUSTOM("exposeImage"));
+                     throw Exception("No write for " + filepath, IVW_CONTEXT_CUSTOM("exposeImage"));
                  }
                  writer->writeData(&self, filepath);
              })

--- a/modules/python3/bindings/src/pyimage.cpp
+++ b/modules/python3/bindings/src/pyimage.cpp
@@ -148,13 +148,11 @@ void exposeImage(py::module& m) {
         .def_property("wrapping", &Layer::getWrapping, &Layer::setWrapping)
         .def("save",
              [](Layer& self, std::string filepath) {
-                 auto ext = filesystem::getFileExtension(filepath);
-
                  auto writer = InviwoApplication::getPtr()
                                    ->getDataWriterFactory()
-                                   ->getWriterForTypeAndExtension<Layer>(ext);
+                                   ->getWriterForTypeAndExtension<Layer>(filepath);
                  if (!writer) {
-                     throw Exception("No write for extension " + ext,
+                     throw Exception("No write for " + filepath,
                                      IVW_CONTEXT_CUSTOM("exposeImage"));
                  }
                  writer->writeData(&self, filepath);

--- a/modules/python3/bindings/src/pyprocessors.cpp
+++ b/modules/python3/bindings/src/pyprocessors.cpp
@@ -300,14 +300,12 @@ void exposeProcessors(pybind11::module& m) {
         .def_property_readonly("ready", &CanvasProcessor::isReady)
         .def("snapshot",
              [](CanvasProcessor* canvas, std::string filepath) {
-                 auto ext = filesystem::getFileExtension(filepath);
-
                  auto writer = canvas->getNetwork()
                                    ->getApplication()
                                    ->getDataWriterFactory()
-                                   ->getWriterForTypeAndExtension<Layer>(ext);
+                                   ->getWriterForTypeAndExtension<Layer>(filepath);
                  if (!writer) {
-                     throw Exception("No writer for extension " + ext,
+                     throw Exception("No writer for " + filepath,
                                      IVW_CONTEXT_CUSTOM("exposeProcessors"));
                  }
 
@@ -320,15 +318,13 @@ void exposeProcessors(pybind11::module& m) {
              })
 
         .def("snapshotAsync", [](CanvasProcessor* canvas, std::string filepath) {
-            auto ext = filesystem::getFileExtension(filepath);
-
             auto writer = std::shared_ptr<DataWriterType<Layer>>{
                 canvas->getNetwork()
                     ->getApplication()
                     ->getDataWriterFactory()
-                    ->getWriterForTypeAndExtension<Layer>(ext)};
+                    ->getWriterForTypeAndExtension<Layer>(filepath)};
             if (!writer) {
-                throw Exception("No writer for extension " + ext,
+                throw Exception("No writer for " + filepath,
                                 IVW_CONTEXT_CUSTOM("exposeProcessors"));
             }
 

--- a/modules/qtwidgets/src/properties/filepropertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/filepropertywidgetqt.cpp
@@ -186,9 +186,8 @@ void FilePropertyWidgetQt::dragEnterEvent(QDragEnterEvent* event) {
                             case FileMode::AnyFile:
                             case FileMode::ExistingFile:
                             case FileMode::ExistingFiles: {
-                                auto ext = toLower(filesystem::getFileExtension(file));
                                 for (const auto& filter : property_->getNameFilters()) {
-                                    if (filter.extension_ == ext) {
+                                    if (filter.matches(file)) {
                                         event->accept();
                                         return;
                                     }

--- a/modules/qtwidgets/src/properties/multifilepropertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/multifilepropertywidgetqt.cpp
@@ -179,9 +179,8 @@ void MultiFilePropertyWidgetQt::dragEnterEvent(QDragEnterEvent* event) {
                             case FileMode::AnyFile:
                             case FileMode::ExistingFile:
                             case FileMode::ExistingFiles: {
-                                auto ext = toLower(filesystem::getFileExtension(file));
                                 for (const auto& filter : property_->getNameFilters()) {
-                                    if (filter.extension_ == ext) {
+                                    if (filter.matches(file)) {
                                         event->accept();
                                         return;
                                     }

--- a/modules/userinterfacegl/src/glui/widgets/toolbutton.cpp
+++ b/modules/userinterfacegl/src/glui/widgets/toolbutton.cpp
@@ -117,9 +117,8 @@ void ToolButton::renderWidget(const ivec2& origin, const size2_t& canvasDim) {
 }
 
 std::shared_ptr<Texture2D> ToolButton::loadImage(const std::string& filename) {
-    auto ext = filesystem::getFileExtension(filename);
     auto factory = InviwoApplication::getPtr()->getDataReaderFactory();
-    if (auto reader = factory->getReaderForTypeAndExtension<Layer>(ext)) {
+    if (auto reader = factory->getReaderForTypeAndExtension<Layer>(filename)) {
         try {
             // try to load texture data from current file
             auto layer = reader->readData(filename);
@@ -132,7 +131,7 @@ std::shared_ptr<Texture2D> ToolButton::loadImage(const std::string& filename) {
         }
     } else {
         LogErrorCustom("ToolButton::loadImage",
-                       "Could not find a data reader for texture data (" << ext << ").");
+                       "Could not find a data reader for texture data (" << filename << ").");
         return nullptr;
     }
 }

--- a/modules/userinterfacegl/src/processors/presentationprocessor.cpp
+++ b/modules/userinterfacegl/src/processors/presentationprocessor.cpp
@@ -175,10 +175,9 @@ void PresentationProcessor::updateSlideImage() {
     }
 
     const std::string currentFileName = fileList_[index];
-    const std::string ext = filesystem::getFileExtension(currentFileName);
 
     auto factory = getNetwork()->getApplication()->getDataReaderFactory();
-    auto reader = factory->getReaderForTypeAndExtension<Layer>(ext);
+    auto reader = factory->getReaderForTypeAndExtension<Layer>(currentFileName);
 
     // there should always be a reader since we asked the reader for valid extensions
     ivwAssert(reader != nullptr, "Could not find reader for \"" << currentFileName << "\"");

--- a/modules/userinterfacegl/src/processors/presentationprocessor.cpp
+++ b/modules/userinterfacegl/src/processors/presentationprocessor.cpp
@@ -232,9 +232,8 @@ void PresentationProcessor::updateFileName() {
 }
 
 bool PresentationProcessor::isValidImageFile(std::string fileName) {
-    std::string fileExtension = toLower(filesystem::getFileExtension(fileName));
     return util::contains_if(validExtensions_,
-                             [&](const FileExtension& f) { return f.extension_ == fileExtension; });
+                             [&](const FileExtension& f) { return f.matches(fileName); });
 }
 
 void PresentationProcessor::nextSlide(Event* e) {

--- a/src/core/datastructures/transferfunction.cpp
+++ b/src/core/datastructures/transferfunction.cpp
@@ -180,17 +180,13 @@ void TransferFunction::save(const std::string& filename, const FileExtension& ex
 }
 
 void TransferFunction::load(const std::string& filename, const FileExtension& ext) {
-    std::string extension = toLower(filesystem::getFileExtension(filename));
-
-    if (ext.extension_ == "itf" || (ext.empty() && extension == "itf")) {
+    if (ext.extension_ == "itf" ||
+        (ext.empty() && iCaseCmp(filesystem::getFileExtension(filename), "itf"))) {
         Deserializer deserializer(filename);
         deserialize(deserializer);
     } else {
         auto factory = InviwoApplication::getPtr()->getDataReaderFactory();
-        auto reader = factory->getReaderForTypeAndExtension<Layer>(ext);
-        if (!reader) {
-            reader = factory->getReaderForTypeAndExtension<Layer>(extension);
-        }
+        auto reader = factory->getReaderForTypeAndExtension<Layer>(ext, filename);
         if (!reader) {
             throw DataReaderException("Data reader not found for requested format", IVW_CONTEXT);
         }

--- a/src/core/io/datareaderfactory.cpp
+++ b/src/core/io/datareaderfactory.cpp
@@ -41,7 +41,7 @@ bool DataReaderFactory::registerObject(DataReader* reader) {
 
 bool DataReaderFactory::unRegisterObject(DataReader* reader) {
     size_t removed = util::map_erase_remove_if(
-        map_, [reader](Map::value_type& elem) { return elem.second == reader; });
+        map_, [reader](auto& elem) { return elem.second == reader; });
 
     return removed > 0;
 }

--- a/src/core/io/datareaderfactory.cpp
+++ b/src/core/io/datareaderfactory.cpp
@@ -40,8 +40,8 @@ bool DataReaderFactory::registerObject(DataReader* reader) {
 }
 
 bool DataReaderFactory::unRegisterObject(DataReader* reader) {
-    size_t removed = util::map_erase_remove_if(
-        map_, [reader](auto& elem) { return elem.second == reader; });
+    size_t removed =
+        util::map_erase_remove_if(map_, [reader](auto& elem) { return elem.second == reader; });
 
     return removed > 0;
 }

--- a/src/core/io/datareaderfactory.cpp
+++ b/src/core/io/datareaderfactory.cpp
@@ -51,20 +51,18 @@ std::unique_ptr<DataReader> DataReaderFactory::create(const FileExtension& key) 
         util::map_find_or_null(map_, key, [](DataReader* o) { return o->clone(); }));
 }
 
-std::unique_ptr<DataReader> DataReaderFactory::create(const std::string& key) const {
-    auto lkey = toLower(key);
+std::unique_ptr<DataReader> DataReaderFactory::create(std::string_view key) const {
     for (auto& elem : map_) {
-        if (toLower(elem.first.extension_) == toLower(lkey)) {
+        if (iCaseCmp(elem.first.extension_, key)) {
             return std::unique_ptr<DataReader>(elem.second->clone());
         }
     }
     return nullptr;
 }
 
-bool DataReaderFactory::hasKey(const std::string& key) const {
-    auto lkey = toLower(key);
+bool DataReaderFactory::hasKey(std::string_view key) const {
     for (auto& elem : map_) {
-        if (toLower(elem.first.extension_) == toLower(lkey)) return true;
+        if (iCaseCmp(elem.first.extension_, key)) return true;
     }
     return false;
 }

--- a/src/core/io/datawriterfactory.cpp
+++ b/src/core/io/datawriterfactory.cpp
@@ -49,10 +49,9 @@ bool DataWriterFactory::unRegisterObject(DataWriter* writer) {
     return removed > 0;
 }
 
-std::unique_ptr<DataWriter> DataWriterFactory::create(const std::string& key) const {
-    auto lkey = toLower(key);
+std::unique_ptr<DataWriter> DataWriterFactory::create(std::string_view key) const {
     for (auto& elem : map_) {
-        if (toLower(elem.first.extension_) == toLower(lkey)) {
+        if (iCaseCmp(elem.first.extension_, key)) {
             return std::unique_ptr<DataWriter>(elem.second->clone());
         }
     }
@@ -66,10 +65,9 @@ std::unique_ptr<DataWriter> DataWriterFactory::create(const FileExtension& key) 
 
 bool DataWriterFactory::hasKey(const FileExtension& key) const { return util::has_key(map_, key); }
 
-bool DataWriterFactory::hasKey(const std::string& key) const {
-    auto lkey = toLower(key);
+bool DataWriterFactory::hasKey(std::string_view key) const {
     for (auto& elem : map_) {
-        if (toLower(elem.first.extension_) == toLower(lkey)) return true;
+        if (iCaseCmp(elem.first.extension_, key)) return true;
     }
     return false;
 }

--- a/src/core/io/datawriterfactory.cpp
+++ b/src/core/io/datawriterfactory.cpp
@@ -44,7 +44,7 @@ bool DataWriterFactory::registerObject(DataWriter* writer) {
 
 bool DataWriterFactory::unRegisterObject(DataWriter* writer) {
     size_t removed = util::map_erase_remove_if(
-        map_, [writer](Map::value_type& elem) { return elem.second == writer; });
+        map_, [writer](auto& elem) { return elem.second == writer; });
 
     return removed > 0;
 }

--- a/src/core/io/datawriterfactory.cpp
+++ b/src/core/io/datawriterfactory.cpp
@@ -43,8 +43,8 @@ bool DataWriterFactory::registerObject(DataWriter* writer) {
 }
 
 bool DataWriterFactory::unRegisterObject(DataWriter* writer) {
-    size_t removed = util::map_erase_remove_if(
-        map_, [writer](auto& elem) { return elem.second == writer; });
+    size_t removed =
+        util::map_erase_remove_if(map_, [writer](auto& elem) { return elem.second == writer; });
 
     return removed > 0;
 }

--- a/src/core/io/imagewriterutil.cpp
+++ b/src/core/io/imagewriterutil.cpp
@@ -45,20 +45,13 @@ void saveLayer(const Layer& layer, std::string_view path, const FileExtension& e
     auto factory = InviwoApplication::getPtr()->getDataWriterFactory();
 
     auto writer = std::shared_ptr<DataWriterType<Layer>>(
-        factory->getWriterForTypeAndExtension<Layer>(extension));
+        factory->getWriterForTypeAndExtension<Layer>(extension, path));
 
     if (!writer) {
-        // could not find a reader for the given extension, extension might be invalid
-        // try to get reader for the extension extracted from the file name, i.e. path
-        const auto ext = filesystem::getFileExtension(path);
-        writer = std::shared_ptr<DataWriterType<Layer>>(
-            factory->getWriterForTypeAndExtension<Layer>(ext));
-        if (!writer) {
-            LogInfoCustom(
-                "ImageWriterUtil",
-                "Could not find a writer for the specified file extension (\"" << ext << "\")");
-            return;
-        }
+
+        LogInfoCustom("ImageWriterUtil",
+                      fmt::format("Could not find a writer for {} of the specified extension {}", path, extension));
+        return;
     }
 
     try {

--- a/src/core/io/imagewriterutil.cpp
+++ b/src/core/io/imagewriterutil.cpp
@@ -50,7 +50,8 @@ void saveLayer(const Layer& layer, std::string_view path, const FileExtension& e
     if (!writer) {
 
         LogInfoCustom("ImageWriterUtil",
-                      fmt::format("Could not find a writer for {} of the specified extension {}", path, extension));
+                      fmt::format("Could not find a writer for {} of the specified extension {}",
+                                  path, extension));
         return;
     }
 

--- a/src/core/io/imagewriterutil.cpp
+++ b/src/core/io/imagewriterutil.cpp
@@ -51,7 +51,7 @@ void saveLayer(const Layer& layer, std::string_view path, const FileExtension& e
 
         LogInfoCustom("ImageWriterUtil",
                       fmt::format("Could not find a writer for {} of the specified extension {}",
-                                  path, extension));
+                                  path, extension.toString()));
         return;
     }
 

--- a/src/core/rendering/datavisualizermanager.cpp
+++ b/src/core/rendering/datavisualizermanager.cpp
@@ -53,11 +53,11 @@ std::vector<FileExtension> DataVisualizerManager::getSupportedFileExtensions() c
 }
 
 std::vector<DataVisualizer*> DataVisualizerManager::getDataVisualizersForExtension(
-    const std::string& ext) const {
+    std::string_view path) const {
     return util::copy_if(visualizers_, [&](auto& visualizer) {
         return visualizer->hasSourceProcessor() &&
                util::contains_if(visualizer->getSupportedFileExtensions(),
-                                 [&](const auto& item) { return item.extension_ == ext; });
+                                 [&](const auto& item) { return item.matches(path); });
     });
 }
 

--- a/src/core/rendering/datavisualizermanager.cpp
+++ b/src/core/rendering/datavisualizermanager.cpp
@@ -52,7 +52,7 @@ std::vector<FileExtension> DataVisualizerManager::getSupportedFileExtensions() c
     return res;
 }
 
-std::vector<DataVisualizer*> DataVisualizerManager::getDataVisualizersForExtension(
+std::vector<DataVisualizer*> DataVisualizerManager::getDataVisualizersForFile(
     std::string_view path) const {
     return util::copy_if(visualizers_, [&](auto& visualizer) {
         return visualizer->hasSourceProcessor() &&

--- a/src/core/util/fileextension.cpp
+++ b/src/core/util/fileextension.cpp
@@ -98,12 +98,7 @@ bool FileExtension::matches(std::string_view str) const {
     if (extension_.empty()) {
         return true;  // wildcard '*' matches everything
     }
-    if (str.size() >= extension_.size()) {
-        // Compare last part of path with the extension
-        return iCaseCmp(str.substr(str.size() - extension_.size()), extension_);
-    } else {
-        return false;
-    }
+    return iCaseEndsWith(str, extension_);
 }
 
 void FileExtension::serialize(Serializer& s) const {

--- a/src/core/util/fileextension.cpp
+++ b/src/core/util/fileextension.cpp
@@ -98,8 +98,12 @@ bool FileExtension::matches(std::string_view str) const {
     if (extension_.empty()) {
         return true;  // wildcard '*' matches everything
     }
-
-    return iCaseCmp(filesystem::getFileExtension(str), extension_);
+    if (str.size() >= extension_.size()) {
+        // Compare last part of path with the extension
+        return iCaseCmp(str.substr(str.size() - extension_.size()), extension_);
+    } else {
+        return false;
+    }
 }
 
 void FileExtension::serialize(Serializer& s) const {

--- a/src/core/util/fileextension.cpp
+++ b/src/core/util/fileextension.cpp
@@ -98,7 +98,7 @@ bool FileExtension::matches(std::string_view str) const {
     if (extension_.empty()) {
         return true;  // wildcard '*' matches everything
     }
-    return iCaseEndsWith(str, extension_);
+    return util::iCaseEndsWith(str, extension_);
 }
 
 void FileExtension::serialize(Serializer& s) const {

--- a/src/core/util/imageramutils.cpp
+++ b/src/core/util/imageramutils.cpp
@@ -74,8 +74,7 @@ void flipImageHorizontal(Image& img) { img.forEachLayer(flipLayerHorizontal); }
 std::shared_ptr<Image> readImageFromDisk(std::string filename) {
     auto app = InviwoApplication::getPtr();
     auto factory = app->getDataReaderFactory();
-    auto ext = filesystem::getFileExtension(filename);
-    if (auto reader = factory->getReaderForTypeAndExtension<Layer>(ext)) {
+    if (auto reader = factory->getReaderForTypeAndExtension<Layer>(filename)) {
         auto outLayer = reader->readData(filename);
         return std::make_shared<Image>(outLayer);
     } else {

--- a/src/core/util/stringconversion.cpp
+++ b/src/core/util/stringconversion.cpp
@@ -315,8 +315,8 @@ bool iCaseLess(std::string_view l, std::string_view r) {
 
 bool iCaseEndsWith(std::string_view str, std::string_view suffix) {
     return str.size() >= suffix.size() &&
-        // Compare last part of path with the extension
-        iCaseCmp(str.substr(str.size() - suffix.size()), suffix);
+           // Compare last part of path with the extension
+           iCaseCmp(str.substr(str.size() - suffix.size()), suffix);
 }
 
 // trim from start

--- a/src/core/util/stringconversion.cpp
+++ b/src/core/util/stringconversion.cpp
@@ -124,6 +124,12 @@ std::string fromWstring(std::wstring_view str) {
 #endif
 }
 
+bool iCaseEndsWith(std::string_view str, std::string_view suffix) {
+    return str.size() >= suffix.size() &&
+        // Compare last part of path with the extension
+        iCaseCmp(str.substr(str.size() - suffix.size()), suffix);
+}
+
 }  // namespace util
 
 std::vector<std::string> util::splitString(std::string_view str, char delimiter) {
@@ -311,12 +317,6 @@ bool iCaseLess(std::string_view l, std::string_view r) {
         [](std::string_view::value_type l1, std::string_view::value_type r1) {
             return std::tolower(l1) < std::tolower(r1);
         });
-}
-
-bool iCaseEndsWith(std::string_view str, std::string_view suffix) {
-    return str.size() >= suffix.size() &&
-           // Compare last part of path with the extension
-           iCaseCmp(str.substr(str.size() - suffix.size()), suffix);
 }
 
 // trim from start

--- a/src/core/util/stringconversion.cpp
+++ b/src/core/util/stringconversion.cpp
@@ -313,6 +313,12 @@ bool iCaseLess(std::string_view l, std::string_view r) {
         });
 }
 
+bool iCaseEndsWith(std::string_view str, std::string_view suffix) {
+    return str.size() >= suffix.size() &&
+        // Compare last part of path with the extension
+        iCaseCmp(str.substr(str.size() - suffix.size()), suffix);
+}
+
 // trim from start
 std::string ltrim(std::string s) {
     s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](auto c) {

--- a/src/core/util/stringconversion.cpp
+++ b/src/core/util/stringconversion.cpp
@@ -126,8 +126,8 @@ std::string fromWstring(std::wstring_view str) {
 
 bool iCaseEndsWith(std::string_view str, std::string_view suffix) {
     return str.size() >= suffix.size() &&
-        // Compare last part of path with the extension
-        iCaseCmp(str.substr(str.size() - suffix.size()), suffix);
+           // Compare last part of path with the extension
+           iCaseCmp(str.substr(str.size() - suffix.size()), suffix);
 }
 
 }  // namespace util

--- a/src/qt/editor/dataopener.cpp
+++ b/src/qt/editor/dataopener.cpp
@@ -107,8 +107,7 @@ void util::insertNetworkForData(const std::string& dataFile, ProcessorNetwork* n
                                 bool alwaysFirst, bool onlySource, QWidget* parent) {
     auto app = net->getApplication();
 
-    auto visualizers = app->getDataVisualizerManager()->getDataVisualizersForExtension(
-        toLower(filesystem::getFileExtension(dataFile)));
+    auto visualizers = app->getDataVisualizerManager()->getDataVisualizersForExtension(dataFile);
 
     if (visualizers.empty()) return;
 

--- a/src/qt/editor/dataopener.cpp
+++ b/src/qt/editor/dataopener.cpp
@@ -107,7 +107,7 @@ void util::insertNetworkForData(const std::string& dataFile, ProcessorNetwork* n
                                 bool alwaysFirst, bool onlySource, QWidget* parent) {
     auto app = net->getApplication();
 
-    auto visualizers = app->getDataVisualizerManager()->getDataVisualizersForExtension(dataFile);
+    auto visualizers = app->getDataVisualizerManager()->getDataVisualizersForFile(dataFile);
 
     if (visualizers.empty()) return;
 

--- a/src/qt/editor/inviwomainwindow.cpp
+++ b/src/qt/editor/inviwomainwindow.cpp
@@ -1422,11 +1422,11 @@ void InviwoMainWindow::dragMoveEvent(QDragMoveEvent* event) {
     auto mimeData = event->mimeData();
     if (mimeData->hasUrls()) {
         QList<QUrl> urlList = mimeData->urls();
-        auto filename = urlList.front().toLocalFile();
-        auto ext = toLower(filesystem::getFileExtension(utilqt::fromQString(filename)));
+        auto filename = utilqt::fromQString(urlList.front().toLocalFile());
+        auto ext = toLower(filesystem::getFileExtension(filename));
 
         if (ext == "inv" ||
-            !app_->getDataVisualizerManager()->getDataVisualizersForExtension(ext).empty()) {
+            !app_->getDataVisualizerManager()->getDataVisualizersForExtension(filename).empty()) {
 
             if (event->keyboardModifiers() & Qt::ControlModifier) {
                 event->setDropAction(Qt::CopyAction);

--- a/src/qt/editor/inviwomainwindow.cpp
+++ b/src/qt/editor/inviwomainwindow.cpp
@@ -1426,7 +1426,7 @@ void InviwoMainWindow::dragMoveEvent(QDragMoveEvent* event) {
         auto ext = toLower(filesystem::getFileExtension(filename));
 
         if (ext == "inv" ||
-            !app_->getDataVisualizerManager()->getDataVisualizersForExtension(filename).empty()) {
+            !app_->getDataVisualizerManager()->getDataVisualizersForFile(filename).empty()) {
 
             if (event->keyboardModifiers() & Qt::ControlModifier) {
                 event->setDropAction(Qt::CopyAction);

--- a/tests/integrationtests/image-test.cpp
+++ b/tests/integrationtests/image-test.cpp
@@ -57,7 +57,7 @@ TEST(ImageTests, ImageLoadWhite) {
 
     auto reader =
         InviwoApplication::getPtr()->getDataReaderFactory()->getReaderForTypeAndExtension<Layer>(
-            ext);
+            imgFile);
     ASSERT_TRUE(reader != 0);
     auto layer = reader->readData(imgFile);
 
@@ -97,7 +97,7 @@ TEST(ImageTests, ImageLoadRGB) {
 
     auto reader =
         InviwoApplication::getPtr()->getDataReaderFactory()->getReaderForTypeAndExtension<Layer>(
-            ext);
+            imgFile);
     ASSERT_TRUE(reader != 0);
     auto layer = reader->readData(imgFile);
 
@@ -136,7 +136,7 @@ TEST(ImageTests, ImageLoadRange) {
 
     auto reader =
         InviwoApplication::getPtr()->getDataReaderFactory()->getReaderForTypeAndExtension<Layer>(
-            ext);
+            imgFile);
     ASSERT_TRUE(reader != 0);
     auto layer = reader->readData(imgFile);
 
@@ -165,7 +165,7 @@ TEST(ImageTests, ImageResize) {
 
     auto reader =
         InviwoApplication::getPtr()->getDataReaderFactory()->getReaderForTypeAndExtension<Layer>(
-            ext);
+            imgFile);
     ASSERT_TRUE(reader != 0);
     auto layer = reader->readData(imgFile);
 

--- a/tests/integrationtests/volume-test.cpp
+++ b/tests/integrationtests/volume-test.cpp
@@ -71,10 +71,9 @@ template <typename T>
 void testDatVolumeLoad(std::string filename) {
     std::string file = filesystem::getPath(PathType::Tests) + "/volumes/" + filename;
 
-    auto reader =
-        InviwoApplication::getPtr()
-            ->getDataReaderFactory()
-            ->getReaderForTypeAndExtension<std::vector<std::shared_ptr<Volume>>>(file);
+    auto reader = InviwoApplication::getPtr()
+                      ->getDataReaderFactory()
+                      ->getReaderForTypeAndExtension<std::vector<std::shared_ptr<Volume>>>(file);
     ASSERT_TRUE(reader.get() != nullptr);
     auto volumeSeq = reader->readData(file);
     ASSERT_EQ(1, volumeSeq->size());
@@ -168,10 +167,9 @@ void testVolumeClone(Volume* volume) {
 template <typename T>
 void testDatVolumeClone(std::string filename) {
     std::string file = filesystem::getPath(PathType::Tests) + "/volumes/" + filename;
-    auto reader =
-        InviwoApplication::getPtr()
-            ->getDataReaderFactory()
-            ->getReaderForTypeAndExtension<std::vector<std::shared_ptr<Volume>>>(file);
+    auto reader = InviwoApplication::getPtr()
+                      ->getDataReaderFactory()
+                      ->getReaderForTypeAndExtension<std::vector<std::shared_ptr<Volume>>>(file);
     ASSERT_TRUE(reader.get() != nullptr);
     auto volumeSeq = reader->readData(file);
     ASSERT_EQ(1, volumeSeq->size());

--- a/tests/integrationtests/volume-test.cpp
+++ b/tests/integrationtests/volume-test.cpp
@@ -70,12 +70,11 @@ void testVolumeLoad(Volume* volume) {
 template <typename T>
 void testDatVolumeLoad(std::string filename) {
     std::string file = filesystem::getPath(PathType::Tests) + "/volumes/" + filename;
-    std::string fileExtension = filesystem::getFileExtension(file);
 
     auto reader =
         InviwoApplication::getPtr()
             ->getDataReaderFactory()
-            ->getReaderForTypeAndExtension<std::vector<std::shared_ptr<Volume>>>(fileExtension);
+            ->getReaderForTypeAndExtension<std::vector<std::shared_ptr<Volume>>>(file);
     ASSERT_TRUE(reader.get() != nullptr);
     auto volumeSeq = reader->readData(file);
     ASSERT_EQ(1, volumeSeq->size());
@@ -88,10 +87,9 @@ void testDatVolumeLoad(std::string filename) {
 template <typename T>
 void testIvfVolumeLoad(std::string filename) {
     std::string file = filesystem::getPath(PathType::Tests) + "/volumes/" + filename;
-    std::string fileExtension = filesystem::getFileExtension(file);
     auto reader =
         InviwoApplication::getPtr()->getDataReaderFactory()->getReaderForTypeAndExtension<Volume>(
-            fileExtension);
+            file);
     ASSERT_TRUE(reader.get() != nullptr);
     auto volume = reader->readData(file);
 
@@ -170,11 +168,10 @@ void testVolumeClone(Volume* volume) {
 template <typename T>
 void testDatVolumeClone(std::string filename) {
     std::string file = filesystem::getPath(PathType::Tests) + "/volumes/" + filename;
-    std::string fileExtension = filesystem::getFileExtension(file);
     auto reader =
         InviwoApplication::getPtr()
             ->getDataReaderFactory()
-            ->getReaderForTypeAndExtension<std::vector<std::shared_ptr<Volume>>>(fileExtension);
+            ->getReaderForTypeAndExtension<std::vector<std::shared_ptr<Volume>>>(file);
     ASSERT_TRUE(reader.get() != nullptr);
     auto volumeSeq = reader->readData(file);
     ASSERT_EQ(1, volumeSeq->size());
@@ -187,10 +184,9 @@ void testDatVolumeClone(std::string filename) {
 template <typename T>
 void testIvfVolumeClone(std::string filename) {
     std::string file = filesystem::getPath(PathType::Tests) + "/volumes/" + filename;
-    std::string fileExtension = filesystem::getFileExtension(file);
     auto reader =
         InviwoApplication::getPtr()->getDataReaderFactory()->getReaderForTypeAndExtension<Volume>(
-            fileExtension);
+            file);
     ASSERT_TRUE(reader.get() != nullptr);
     auto volume = reader->readData(file);
 


### PR DESCRIPTION
Fix bug causing .nii.gz files to not find its associated data reader due to their two dots in the extension. 
We now support extensions with two dots, .eg. filename.xyz.zip, which seem to occur for compressed files sometimes.

Because it is hard to find a general solution to finding extensions with multiple dots we instead pass in the entire file and compare its ending with the supported file extensions. The changes are backwards compatible.  
