### PR TITLE
BaseGL: ImageLayout fix for when fewer inports are connected than num…

### DIFF
--- a/modules/basegl/src/processors/imageprocessing/imagelayoutgl.cpp
+++ b/modules/basegl/src/processors/imageprocessing/imagelayoutgl.cpp
@@ -193,7 +193,7 @@ void ImageLayoutGL::propagateEvent(Event* event, Outport* source) {
     } else {
         auto& data = multiinport_.getConnectedOutports();
         auto prop = [&](Event* newEvent, size_t ind) {
-            if (ind < viewManager_.size()) {
+            if (ind < viewManager_.size() && ind < data.size()) {
                 multiinport_.propagateEvent(newEvent, data[ind]);
             }
         };


### PR DESCRIPTION
…ber of views

Issue can occur if a single port is connected but a vertical split is chosen. The vertical split adds two views, but there is only one port connected.

