### PR TITLE
Fix dependency settings for freetype

### DIFF
--- a/modules/fontrendering/ext/freetype/CMakeLists.txt
+++ b/modules/fontrendering/ext/freetype/CMakeLists.txt
@@ -4,17 +4,17 @@ set(SKIP_INSTALL_ALL TRUE)
 
 # Try to explicity control what dependencies freetype uses. 
 # Otherwise it will go ahread and depend on what ever it finds.
-set(FT_WITH_ZLIB ON)
-set(FT_WITH_BZIP2 ON)
-set(FT_WITH_PNG ON)
-set(FT_WITH_HARFBUZZ OFF)
-set(FT_WITH_BROTLI OFF)
+option(FT_WITH_ZLIB "Use system zlib instead of internal library." ON)
+option(FT_WITH_BZIP2 "Support bzip2 compressed fonts." OFF)
+option(FT_WITH_PNG "Support PNG compressed OpenType embedded bitmaps." ON)
+option(FT_WITH_HARFBUZZ "Improve auto-hinting of OpenType fonts." OFF)
+option(FT_WITH_BROTLI "Support compressed WOFF2 fonts." OFF)
 
-set(CMAKE_DISABLE_FIND_PACKAGE_ZLIB OFF)
-set(CMAKE_DISABLE_FIND_PACKAGE_BZip2 OFF)
-set(CMAKE_DISABLE_FIND_PACKAGE_PNG OFF)
-set(CMAKE_DISABLE_FIND_PACKAGE_HarfBuzz ON)
-set(CMAKE_DISABLE_FIND_PACKAGE_BrotliDec ON)
+set(CMAKE_DISABLE_FIND_PACKAGE_ZLIB FALSE)
+set(CMAKE_DISABLE_FIND_PACKAGE_BZip2 FALSE)
+set(CMAKE_DISABLE_FIND_PACKAGE_PNG FALSE)
+set(CMAKE_DISABLE_FIND_PACKAGE_HarfBuzz TRUE)
+set(CMAKE_DISABLE_FIND_PACKAGE_BrotliDec TRUE)
 
 add_subdirectory(freetype)
 ivw_get_targets_in_dir_recursive(targets ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
CMake's `set` and `option`methods don't seem to play ball to the effect that setting i.e. `FT_WITH_BZIP2` to false in the GUI had no effect in the configuration process.
The changes seems to fix that.
I have additionally disabled bzip2 by default since it has not been a required dependency before either.