### PR TITLE
Feature/texcoord attrib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Here we document changes that affect the public API or changes that needs to be communicated to other developers. 
 
+## 2021-09-27
+Fixed some naming inconsistencies regarding texture coordinate vertex attributes and buffers. Renamed `BufferType::TexcoordAttrib` to `BufferType::TexCoordAttrib` (`geometrytypes.h`) and `buffertraits::TexcoordBuffer` to `buffertraits::TexCoordBuffer` (`typedmesh.h`). The buffer name of `TexCoordAttrib` now maps to `TexCoord` (previously `Texture`), which is relevant when using the `MeshShaderCache`.
+
+In case you use the `MeshShaderCache` in connection with `TexCoordAttrib` you may need to adjust your shader. If the attribute is available, `HAS_TEXCOORD` is defined and `in_TexCoord` holds the value (previously `HAS_TEXTURE/in_Texture`).
+
 ## 2021-08-31
 Added support for image in the changelog. Add images in the `resources/changelog` folder 
 and enter then in to the resource file `resources/changelog.qrc`. The prefix and alias is 
@@ -375,7 +380,7 @@ Column
 
 Also added a reader for JSON-files which outputs a DataFrame.
 
-## 2019-03-06 
+## 2019-03-06
 New processor `Geometry Entry Exit Points` generates entry point and exit point images from any closed mesh to be used in raycasting. The positions of the input mesh are directly mapped to texture coordinates of a volume. This enables volume rendering within arbitrary bounding geometry.
 
 ## 2019-02-24 Unified line rendering
@@ -708,7 +713,7 @@ struct DataTraits<MyDataType> {
 
 Port registration also now gets the port classIdentifier via PortTraits, so no need to specify the class identifier that registering the port.
 
-## 2017-11-07 Breaking changes: Static functioned moved from BasicMesh 
+## 2017-11-07 Breaking changes: Static functioned moved from BasicMesh
 Before this change, BasicMesh had various static functions to create meshes. These methods have been moved to a new file and namespace. They are now located in `<modules/base/algorithm/meshutils.h>` and the namespace meshutil. 
 Hence, where you have used methods like `BasicMesh::sphere(...)`: you have to change to use `meshutil::sphere(...)` and add include `#include <modules/base/algorithm/meshutils.h>`. You also have to add `InviwoBaseModule` to your modules `depends.cmake`
 

--- a/include/inviwo/core/datastructures/geometry/geometrytype.h
+++ b/include/inviwo/core/datastructures/geometry/geometrytype.h
@@ -53,7 +53,7 @@ enum class BufferType {
     PositionAttrib = 0,
     NormalAttrib,
     ColorAttrib,
-    TexcoordAttrib,
+    TexCoordAttrib,
     CurvatureAttrib,
     IndexAttrib,
     RadiiAttrib,
@@ -145,8 +145,8 @@ std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& s
         case BufferType::ColorAttrib:
             ss << "Color";
             break;
-        case BufferType::TexcoordAttrib:
-            ss << "Texture";
+        case BufferType::TexCoordAttrib:
+            ss << "TexCoord";
             break;
         case BufferType::CurvatureAttrib:
             ss << "Curvature";
@@ -221,8 +221,8 @@ struct formatter<::inviwo::BufferType> : formatter<string_view> {
                     return "Normal"sv;
                 case ::inviwo::BufferType::ColorAttrib:
                     return "Color"sv;
-                case ::inviwo::BufferType::TexcoordAttrib:
-                    return "Texture"sv;
+                case ::inviwo::BufferType::TexCoordAttrib:
+                    return "TexCoord"sv;
                 case ::inviwo::BufferType::CurvatureAttrib:
                     return "Curvature"sv;
                 case ::inviwo::BufferType::IndexAttrib:

--- a/include/inviwo/core/datastructures/geometry/typedmesh.h
+++ b/include/inviwo/core/datastructures/geometry/typedmesh.h
@@ -161,10 +161,10 @@ public:
  * BufferTrait for Texture Coordinate buffers
  */
 template <unsigned DIMS = 3>
-class TexcoordBuffer
-    : public TypedMeshBufferBase<float, DIMS, static_cast<int>(BufferType::TexcoordAttrib)> {
+class TexCoordBuffer
+    : public TypedMeshBufferBase<float, DIMS, static_cast<int>(BufferType::TexCoordAttrib)> {
 public:
-    using Base = TypedMeshBufferBase<float, DIMS, static_cast<int>(BufferType::TexcoordAttrib)>;
+    using Base = TypedMeshBufferBase<float, DIMS, static_cast<int>(BufferType::TexCoordAttrib)>;
     using Base::Base;
 
     std::shared_ptr<const Buffer<typename Base::type>> getTexCoords() const {
@@ -297,7 +297,7 @@ public:
  * If texture coordinates are also needed for each vertex in the mesh then one could instead use:
  *
  * \code{.cpp}
- * using MyMesh = TypedMesh<buffertraits::PositionsBuffer, buffertraits::TexcoordBuffer,
+ * using MyMesh = TypedMesh<buffertraits::PositionsBuffer, buffertraits::TexCoordBuffer,
  * buffertraits::ColorsBuffer>;
  * MyMesh mesh;
  * mesh.addVertex(vec3(0.0f), vec3(0.0f), vec4(1,0,0,1) );
@@ -633,7 +633,7 @@ using ColoredMesh = TypedMesh<buffertraits::PositionsBuffer, buffertraits::Color
  * coordinates(vec3) and colors(vec4).
  */
 using BasicMesh = TypedMesh<buffertraits::PositionsBuffer, buffertraits::NormalBuffer,
-                            buffertraits::TexcoordBuffer<3>, buffertraits::ColorsBuffer>;
+                            buffertraits::TexCoordBuffer<3>, buffertraits::ColorsBuffer>;
 
 /**
  * \ingroup typedmesh
@@ -641,7 +641,7 @@ using BasicMesh = TypedMesh<buffertraits::PositionsBuffer, buffertraits::NormalB
  * coordinates(vec3) and colors(vec4). Example usage:
  * \snippet modules/base/src/algorithm/meshutils.cpp Using PosTexColorMesh
  */
-using PosTexColorMesh = TypedMesh<buffertraits::PositionsBuffer, buffertraits::TexcoordBuffer<3>,
+using PosTexColorMesh = TypedMesh<buffertraits::PositionsBuffer, buffertraits::TexCoordBuffer<3>,
                                   buffertraits::ColorsBuffer>;
 
 }  // namespace inviwo

--- a/modules/assimp/src/assimpreader.cpp
+++ b/modules/assimp/src/assimpreader.cpp
@@ -377,8 +377,8 @@ std::shared_ptr<Mesh> AssimpReader::readData(const std::string& filePath) {
 
     // texture coords
     for (size_t i = 0; i < texture_channels; ++i) {
-        int location = (i == 0 ? static_cast<int>(BufferType::TexcoordAttrib) : auxLocation++);
-        mesh->addBuffer(Mesh::BufferInfo(BufferType::TexcoordAttrib, location), tbuff[i]);
+        int location = (i == 0 ? static_cast<int>(BufferType::TexCoordAttrib) : auxLocation++);
+        mesh->addBuffer(Mesh::BufferInfo(BufferType::TexCoordAttrib, location), tbuff[i]);
     }
 
     mesh->addIndices(Mesh::MeshInfo(dt, ConnectivityType::None), inds);

--- a/modules/base/src/algorithm/volume/marchingcubesopt.cpp
+++ b/modules/base/src/algorithm/volume/marchingcubesopt.cpp
@@ -573,7 +573,7 @@ std::shared_ptr<Mesh> marchingCubesOpt(std::shared_ptr<const Volume> volume, dou
     mesh->setWorldMatrix(volume->getWorldMatrix());
     mesh->addIndices({DrawType::Triangles, ConnectivityType::None}, indexBuffer);
     mesh->addBuffer(BufferType::PositionAttrib, vertexBuffer);
-    mesh->addBuffer(BufferType::TexcoordAttrib, textureBuffer);
+    mesh->addBuffer(BufferType::TexCoordAttrib, textureBuffer);
     mesh->addBuffer(BufferType::ColorAttrib, colorBuffer);
     mesh->addBuffer(BufferType::NormalAttrib, normalBuffer);
 

--- a/modules/base/src/io/wavefrontwriter.cpp
+++ b/modules/base/src/io/wavefrontwriter.cpp
@@ -98,7 +98,7 @@ void WaveFrontWriter::writeData(const Mesh* data, std::ostream& f) const {
     bool hasTextures = false;
     {
         auto tit = util::find_if(data->getBuffers(), [](const auto& buf) {
-            return buf.first.type == BufferType::TexcoordAttrib;
+            return buf.first.type == BufferType::TexCoordAttrib;
         });
         if (tit != data->getBuffers().end()) {
             if (const auto texRam = tit->second->getRepresentation<BufferRAM>()) {

--- a/modules/base/src/processors/buffertomeshprocessor.cpp
+++ b/modules/base/src/processors/buffertomeshprocessor.cpp
@@ -97,7 +97,7 @@ void BufferToMeshProcessor::process() {
             throw Exception("Number of texture coordinates does not match number of vertices",
                             IVW_CONTEXT);
         }
-        mesh->addBuffer(BufferType::TexcoordAttrib,
+        mesh->addBuffer(BufferType::TexCoordAttrib,
                         std::const_pointer_cast<BufferBase>(textureCoordinates_.getData()));
     }
     if (vertexColors_.isConnected()) {

--- a/modules/basegl/include/modules/basegl/processors/imageprocessing/imagesubsetgl.h
+++ b/modules/basegl/include/modules/basegl/processors/imageprocessing/imagesubsetgl.h
@@ -91,7 +91,7 @@ private:
     size2_t rangePressedY_;
 
     Shader shader_;
-    TypedMesh<buffertraits::PositionsBuffer2D, buffertraits::TexcoordBuffer<2>> rect_;
+    TypedMesh<buffertraits::PositionsBuffer2D, buffertraits::TexCoordBuffer<2>> rect_;
     std::shared_ptr<Buffer<vec2>> texCoordsBuffer_;
 };
 

--- a/modules/basegl/src/processors/imageprocessing/imagesubsetgl.cpp
+++ b/modules/basegl/src/processors/imageprocessing/imagesubsetgl.cpp
@@ -117,7 +117,7 @@ void ImageSubsetGL::process() {
         // Texture coordinates of the region we should copy
         vec2 texOffset = vec2(offset) / vec2(inputDim);
         vec2 texEnd = vec2(offset + dim) / vec2(inputDim);
-        auto texCoordsBuffer = rect_.getTypedBuffer<buffertraits::TexcoordBuffer<2>>();
+        auto texCoordsBuffer = rect_.getTypedBuffer<buffertraits::TexCoordBuffer<2>>();
         auto coords = texCoordsBuffer->getEditableRAMRepresentation();
         coords->set(0, texOffset);
         coords->set(1, {texEnd.x, texOffset.y});

--- a/modules/opengl/src/texture/textureutils.cpp
+++ b/modules/opengl/src/texture/textureutils.cpp
@@ -405,7 +405,7 @@ std::unique_ptr<Mesh> planeRect() {
 
     auto m = std::make_unique<Mesh>();
     m->addBuffer(BufferType::PositionAttrib, verticesBuffer);
-    m->addBuffer(BufferType::TexcoordAttrib, texCoordsBuffer);
+    m->addBuffer(BufferType::TexCoordAttrib, texCoordsBuffer);
     m->addIndices(Mesh::MeshInfo(DrawType::Triangles, ConnectivityType::Strip), indices_);
 
     return m;

--- a/modules/python3/bindings/src/pybuffer.cpp
+++ b/modules/python3/bindings/src/pybuffer.cpp
@@ -96,7 +96,7 @@ void exposeBuffer(pybind11::module& m) {
         .value("PositionAttrib", BufferType::PositionAttrib)
         .value("NormalAttrib", BufferType::NormalAttrib)
         .value("ColorAttrib", BufferType::ColorAttrib)
-        .value("TexcoordAttrib", BufferType::TexcoordAttrib)
+        .value("TexCoordAttrib", BufferType::TexCoordAttrib)
         .value("CurvatureAttrib", BufferType::CurvatureAttrib)
         .value("IndexAttrib", BufferType::IndexAttrib)
         .value("RadiiAttrib", BufferType::RadiiAttrib)

--- a/modules/userinterfacegl/src/glui/renderer.cpp
+++ b/modules/userinterfacegl/src/glui/renderer.cpp
@@ -193,7 +193,7 @@ void Renderer::setupRectangleMesh() {
 
     rectangleMesh_ = std::make_shared<Mesh>();
     rectangleMesh_->addBuffer(BufferType::PositionAttrib, verticesBuffer);
-    rectangleMesh_->addBuffer(BufferType::TexcoordAttrib, texCoordsBuffer);
+    rectangleMesh_->addBuffer(BufferType::TexCoordAttrib, texCoordsBuffer);
 
     // first row
     auto indices = util::makeIndexBuffer({0, 4, 1, 5, 2, 6, 3, 7});

--- a/modules/userinterfacegl/src/processors/cropwidget.cpp
+++ b/modules/userinterfacegl/src/processors/cropwidget.cpp
@@ -256,9 +256,6 @@ void CropWidget::initializeResources() {
     lineShader_[ShaderType::Vertex]->addInDeclaration("in_" + toString(BufferType::ColorAttrib),
                                                       static_cast<int>(BufferType::ColorAttrib),
                                                       "vec4");
-    lineShader_[ShaderType::Vertex]->addInDeclaration("in_" + toString(BufferType::TexcoordAttrib),
-                                                      static_cast<int>(BufferType::TexcoordAttrib),
-                                                      "vec2");
     lineShader_.build();
     lineShader_.activate();
     lineShader_.setUniform("antialiasing", 1.0f);
@@ -310,14 +307,11 @@ void CropWidget::createLineStripMesh() {
     auto linestrip = std::make_shared<Mesh>(DrawType::Lines, ConnectivityType::StripAdjacency);
     auto vertices = std::make_shared<Buffer<vec3>>();
     auto colors = std::make_shared<Buffer<vec4>>();
-    auto texCoords = std::make_shared<Buffer<vec2>>();
 
     auto vBuffer = vertices->getEditableRAMRepresentation();
     auto colorBuffer = colors->getEditableRAMRepresentation();
-    auto texBuffer = texCoords->getEditableRAMRepresentation();
 
     vec3 p(0.0f);
-    vec2 t(0.0f, 0.0f);
     vec3 mask[5] = {{0.0f, 0.0f, 0.0f},
                     {1.0f, 0.0f, 0.0f},
                     {1.0f, 1.0f, 0.0f},
@@ -326,7 +320,6 @@ void CropWidget::createLineStripMesh() {
     for (int i = 0; i < 5; ++i) {
         vBuffer->add(p + mask[i]);
         colorBuffer->add(cropLineColor_.get());
-        texBuffer->add(t + vec2(i / 4.0f, 0.0f));
     }
 
     auto indices = std::make_shared<IndexBuffer>();
@@ -335,7 +328,6 @@ void CropWidget::createLineStripMesh() {
 
     linestrip->addBuffer(BufferType::PositionAttrib, vertices);
     linestrip->addBuffer(BufferType::ColorAttrib, colors);
-    linestrip->addBuffer(BufferType::TexcoordAttrib, texCoords);
     linestrip->addIndices(Mesh::MeshInfo(DrawType::Lines, ConnectivityType::StripAdjacency),
                           indices);
 

--- a/resources/changelog.html
+++ b/resources/changelog.html
@@ -26,6 +26,9 @@
 </style>
 </head>
 <body>
+<h2>2021-09-27</h2>
+<p>Fixed some naming inconsistencies regarding texture coordinate vertex attributes and buffers. Renamed <code>BufferType::TexcoordAttrib</code> to <code>BufferType::TexCoordAttrib</code> (<code>geometrytypes.h</code>) and <code>buffertraits::TexcoordBuffer</code> to <code>buffertraits::TexCoordBuffer</code> (<code>typedmesh.h</code>). The buffer name of <code>TexCoordAttrib</code> now maps to <code>TexCoord</code> (previously <code>Texture</code>), which is relevant when using the <code>MeshShaderCache</code>.</p>
+<p>In case you use the <code>MeshShaderCache</code> in connection with <code>TexCoordAttrib</code> you may need to adjust your shader. If the attribute is available, <code>HAS_TEXCOORD</code> is defined and <code>in_TexCoord</code> holds the value (previously <code>HAS_TEXTURE/in_Texture</code>).</p>
 <h2>2021-08-31</h2>
 <p>Added support for image in the changelog. Add images in the <code>resources/changelog</code> folder<br>
 and enter then in to the resource file <code>resources/changelog.qrc</code>. The prefix and alias is<br>

--- a/src/core/datastructures/geometry/simplemesh.cpp
+++ b/src/core/datastructures/geometry/simplemesh.cpp
@@ -34,7 +34,7 @@ namespace inviwo {
 
 SimpleMesh::SimpleMesh(DrawType dt, ConnectivityType ct) : Mesh(dt, ct) {
     addBuffer(BufferType::PositionAttrib, std::make_shared<Buffer<vec3>>());  // pos 0
-    addBuffer(BufferType::TexcoordAttrib, std::make_shared<Buffer<vec3>>());  // pos 1
+    addBuffer(BufferType::TexCoordAttrib, std::make_shared<Buffer<vec3>>());  // pos 1
     addBuffer(BufferType::ColorAttrib, std::make_shared<Buffer<vec4>>());     // pos 2
 }
 

--- a/src/core/tests/unittests/typedmesh-test.cpp
+++ b/src/core/tests/unittests/typedmesh-test.cpp
@@ -126,11 +126,11 @@ TEST(buffertraits, normalbuffer) {
 }
 
 TEST(buffertraits, texcoordbuffer2) {
-    EXPECT_EQ(BufferType::TexcoordAttrib, buffertraits::TexcoordBuffer<2>::bi().type);
-    ASSERT_EQ(2, util::extent<buffertraits::TexcoordBuffer<2>::type>::value)
-        << "buffertraits::TexcoordBuffer<2> expected to hold vec2";
+    EXPECT_EQ(BufferType::TexCoordAttrib, buffertraits::TexCoordBuffer<2>::bi().type);
+    ASSERT_EQ(2, util::extent<buffertraits::TexCoordBuffer<2>::type>::value)
+        << "buffertraits::TexCoordBuffer<2> expected to hold vec2";
 
-    buffertraits::TexcoordBuffer<2> texcoordbuf;
+    buffertraits::TexCoordBuffer<2> texcoordbuf;
     texcoordbuf.getEditableTexCoords()->setSize(1);
     texcoordbuf.setVertexTexCoord(0, vec2(0.25f, 1.0f));
 


### PR DESCRIPTION
Fixed some naming inconsistencies regarding texture coordinate vertex attributes and buffers. Renamed `BufferType::TexcoordAttrib` to `BufferType::TexCoordAttrib` (`geometrytypes.h`) and `buffertraits::TexcoordBuffer` to `buffertraits::TexCoordBuffer` (`typedmesh.h`). The buffer name of `TexCoordAttrib` now maps to `TexCoord` (previously `Texture`), which is relevant when using the `MeshShaderCache`.

In case you use the `MeshShaderCache` in connection with `TexCoordAttrib` you may need to adjust your shader. If the attribute is available, `HAS_TEXCOORD` is defined and `in_TexCoord` holds the value (previously `HAS_TEXTURE/in_Texture`).