### PR TITLE
BaseGL: Fix to ensure that regular event is propagated if picking eve…

### DIFF
--- a/modules/basegl/include/modules/basegl/viewmanager.h
+++ b/modules/basegl/include/modules/basegl/viewmanager.h
@@ -157,10 +157,10 @@ private:
     };
 
     bool propagatePickingEvent(PickingEvent* pe, Propagator propagator);
-    bool propagateMouseEvent(MouseEvent* me, Propagator propagator);
-    bool propagateWheelEvent(WheelEvent* we, Propagator propagator);
-    bool propagateGestureEvent(GestureEvent* ge, Propagator propagator);
-    bool propagateTouchEvent(TouchEvent* te, Propagator propagator);
+    bool propagateMouseEvent(MouseEvent* me, Propagator propagator, bool isFromPicking);
+    bool propagateWheelEvent(WheelEvent* we, Propagator propagator, bool isFromPicking);
+    bool propagateGestureEvent(GestureEvent* ge, Propagator propagator, bool isFromPicking);
+    bool propagateTouchEvent(TouchEvent* te, Propagator propagator, bool isFromPicking);
 
     std::pair<bool, ViewId> findView(ivec2 pos) const;
     static bool inView(const View& view, const ivec2& pos);

--- a/modules/basegl/src/viewmanager.cpp
+++ b/modules/basegl/src/viewmanager.cpp
@@ -62,8 +62,8 @@ bool ViewManager::propagatePickingEvent(PickingEvent* pe, Propagator propagator)
                                pe->getPreviousGlobalPickingId(), pressNDC, previousNDC);
 
             propagator(&newPe, ind);
-            if (newPe.hasBeenUsed()) newEvent->markAsUsed();
-            for (auto p : newPe.getVisitedProcessors()) newEvent->markAsVisited(p);
+            if (newPe.hasBeenUsed()) pe->markAsUsed();
+            for (auto p : newPe.getVisitedProcessors()) pe->markAsVisited(p);
         }
     };
 
@@ -86,8 +86,6 @@ bool ViewManager::propagatePickingEvent(PickingEvent* pe, Propagator propagator)
             propagated = false;
             break;
     }
-    if (e->hasBeenUsed()) pe->markAsUsed();
-    for (auto p : e->getVisitedProcessors()) pe->markAsVisited(p);
 
     return propagated;
 }
@@ -104,7 +102,6 @@ bool ViewManager::propagateMouseEvent(MouseEvent* me, Propagator propagator) {
         newEvent.setPosNormalized(scale * (newEvent.posNormalized() - offset));
         propagator(&newEvent, selectedView_.second);
         if (newEvent.hasBeenUsed()) me->markAsUsed();
-        for (auto p : newEvent.getVisitedProcessors()) me->markAsVisited(p);
 
         return true;
     } else {
@@ -124,7 +121,6 @@ bool ViewManager::propagateWheelEvent(WheelEvent* we, Propagator propagator) {
         newEvent.setPosNormalized(scale * (newEvent.posNormalized() - offset));
         propagator(&newEvent, selectedView_.second);
         if (newEvent.hasBeenUsed()) we->markAsUsed();
-        for (auto p : newEvent.getVisitedProcessors()) we->markAsVisited(p);
 
         return true;
     } else {
@@ -144,7 +140,6 @@ bool ViewManager::propagateGestureEvent(GestureEvent* ge, Propagator propagator)
         newEvent.setScreenPosNormalized(scale * (newEvent.screenPosNormalized() - offset));
         propagator(&newEvent, selectedView_.second);
         if (newEvent.hasBeenUsed()) ge->markAsUsed();
-        for (auto p : newEvent.getVisitedProcessors()) ge->markAsVisited(p);
 
         return true;
     } else {


### PR DESCRIPTION
…nt is not used

CanvasOpengGLWidget::propagateEvent will first propagate the picking event and then the regular event (if the picking event was not used). The regular event will not be propagated past the viewmanager if it is already is marked as visited when passed along with the picking event. This causes problems for processors not handling the picking, but does handle the original event. E.g., when using EventMatcher since it does not match the picking event, but matches other events. Therefore, the original event must also be propagated to processors up the chain.

