### PR TITLE
TF Histogram Selection

### DIFF
--- a/include/inviwo/core/datastructures/histogram.h
+++ b/include/inviwo/core/datastructures/histogram.h
@@ -40,7 +40,7 @@ namespace inviwo {
 enum class HistogramMode { Off, All, P99, P95, P90, Log };
 
 using HistogramSelection = std::bitset<32>;
-constexpr HistogramSelection histgramSelectionAll{0xffffffff};
+constexpr HistogramSelection histogramSelectionAll{0xffffffff};
 
 /**
  *The NormalizedHistogram has a array of bins and all bins are normalized.

--- a/include/inviwo/core/datastructures/histogram.h
+++ b/include/inviwo/core/datastructures/histogram.h
@@ -34,9 +34,14 @@
 
 #include <iterator>
 #include <vector>
+#include <bitset>
 
 namespace inviwo {
 enum class HistogramMode { Off, All, P99, P95, P90, Log };
+
+using HistogramSelection = std::bitset<32>;
+constexpr HistogramSelection histgramSelectionAll{0xffffffff};
+
 
 /**
  *The NormalizedHistogram has a array of bins and all bins are normalized.

--- a/include/inviwo/core/datastructures/histogram.h
+++ b/include/inviwo/core/datastructures/histogram.h
@@ -42,7 +42,6 @@ enum class HistogramMode { Off, All, P99, P95, P90, Log };
 using HistogramSelection = std::bitset<32>;
 constexpr HistogramSelection histgramSelectionAll{0xffffffff};
 
-
 /**
  *The NormalizedHistogram has a array of bins and all bins are normalized.
  *It can be de-normalized using the maxiumBinValue_.

--- a/include/inviwo/core/io/serialization/deserializer.h
+++ b/include/inviwo/core/io/serialization/deserializer.h
@@ -231,7 +231,7 @@ public:
     void deserialize(std::string_view key, Mat& data);
 
     // bitsets
-    template <unsigned N>
+    template <size_t N>
     void deserialize(std::string_view key, std::bitset<N>& bits);
 
     /**
@@ -784,7 +784,7 @@ void Deserializer::deserialize(std::string_view key, Mat& data) {
     }
 }
 
-template <unsigned N>
+template <size_t N>
 void Deserializer::deserialize(std::string_view key, std::bitset<N>& bits) {
     std::string value = bits.to_string();
     deserialize(key, value);

--- a/include/inviwo/core/io/serialization/serializer.h
+++ b/include/inviwo/core/io/serialization/serializer.h
@@ -141,7 +141,7 @@ public:
     void serialize(std::string_view key, const Mat& data);
 
     // bitsets
-    template <unsigned N>
+    template <size_t N>
     void serialize(std::string_view key, const std::bitset<N>& bits);
 
     // serializable classes
@@ -300,7 +300,7 @@ void Serializer::serialize(std::string_view key, const Mat& data) {
     }
 }
 
-template <unsigned N>
+template <size_t N>
 void Serializer::serialize(std::string_view key, const std::bitset<N>& bits) {
     serialize(key, bits.to_string());
 }

--- a/include/inviwo/core/properties/isotfproperty.h
+++ b/include/inviwo/core/properties/isotfproperty.h
@@ -106,7 +106,7 @@ public:
      */
     IsoTFProperty& setHistogramMode(HistogramMode type);
     HistogramMode getHistogramMode() const;
-    
+
     /**
      * Set the HistogramSelection. The selection determine which of the histograms from the volume
      * in the optional volume port to show. The selection is a bitset, up to 32 histograms are

--- a/include/inviwo/core/properties/isotfproperty.h
+++ b/include/inviwo/core/properties/isotfproperty.h
@@ -92,8 +92,26 @@ public:
     void setZoomV(double zoomVMin, double zoomVMax);
     const dvec2& getZoomV() const;
 
+    /**
+     * Set the HistogramMode to control how to scale the histogram
+     * The options are:
+     *
+     * * Off Don't show any histograms
+     * * All Make sure all the bars are fully visible
+     * * P99 Make sure 99% of the bars are fully visible
+     * * P95 Make sure 95% of the bars are fully visible
+     * * P90 Make sure 90% of the bars are fully visible
+     * * Log Apply logarithmic scaling to each bar.
+     *
+     */
     IsoTFProperty& setHistogramMode(HistogramMode type);
     HistogramMode getHistogramMode() const;
+    
+    /**
+     * Set the HistogramSelection. The selection determine which of the histograms from the volume
+     * in the optional volume port to show. The selection is a bitset, up to 32 histograms are
+     * supported. By default all available histograms will be shown.
+     */
     IsoTFProperty& setHistogramSelection(HistogramSelection selection);
     HistogramSelection getHistogramSelection() const;
 

--- a/include/inviwo/core/properties/isotfproperty.h
+++ b/include/inviwo/core/properties/isotfproperty.h
@@ -92,8 +92,11 @@ public:
     void setZoomV(double zoomVMin, double zoomVMax);
     const dvec2& getZoomV() const;
 
-    void setHistogramMode(HistogramMode type);
-    HistogramMode getHistogramMode();
+    IsoTFProperty& setHistogramMode(HistogramMode type);
+    HistogramMode getHistogramMode() const;
+    IsoTFProperty& setHistogramSelection(HistogramSelection selection);
+    HistogramSelection getHistogramSelection() const;
+
     VolumeInport* getVolumeInport();
 
     IsoValueProperty isovalues_;
@@ -104,6 +107,7 @@ protected:
     virtual void onZoomHChange(const dvec2& zoomH) override;
     virtual void onZoomVChange(const dvec2& zoomV) override;
     virtual void onHistogramModeChange(HistogramMode mode) override;
+    virtual void onHistogramSelectionChange(HistogramSelection selection) override;
 };
 
 }  // namespace inviwo

--- a/include/inviwo/core/properties/isovalueproperty.h
+++ b/include/inviwo/core/properties/isovalueproperty.h
@@ -85,8 +85,10 @@ public:
     void setZoomV(double zoomVMin, double zoomVMax);
     const dvec2& getZoomV() const;
 
-    void setHistogramMode(HistogramMode mode);
-    HistogramMode getHistogramMode();
+    IsoValueProperty& setHistogramMode(HistogramMode mode);
+    HistogramMode getHistogramMode() const;
+    IsoValueProperty& setHistogramSelection(HistogramSelection selection);
+    HistogramSelection getHistogramSelection() const;
 
     VolumeInport* getVolumeInport();
 
@@ -110,6 +112,7 @@ private:
     ValueWrapper<dvec2> zoomH_;
     ValueWrapper<dvec2> zoomV_;
     ValueWrapper<HistogramMode> histogramMode_;
+    ValueWrapper<HistogramSelection> histogramSelection_;
 
     VolumeInport* volumeInport_;
 };

--- a/include/inviwo/core/properties/isovalueproperty.h
+++ b/include/inviwo/core/properties/isovalueproperty.h
@@ -85,8 +85,26 @@ public:
     void setZoomV(double zoomVMin, double zoomVMax);
     const dvec2& getZoomV() const;
 
+    /**
+     * Set the HistogramMode to control how to scale the histogram
+     * The options are:
+     *
+     * * Off Don't show any histograms
+     * * All Make sure all the bars are fully visible
+     * * P99 Make sure 99% of the bars are fully visible
+     * * P95 Make sure 95% of the bars are fully visible
+     * * P90 Make sure 90% of the bars are fully visible
+     * * Log Apply logarithmic scaling to each bar.
+     *
+     */
     IsoValueProperty& setHistogramMode(HistogramMode mode);
     HistogramMode getHistogramMode() const;
+
+    /**
+     * Set the HistogramSelection. The selection determine which of the histograms from the volume
+     * in the optional volume port to show. The selection is a bitset, up to 32 histograms are
+     * supported. By default all available histograms will be shown.
+     */
     IsoValueProperty& setHistogramSelection(HistogramSelection selection);
     HistogramSelection getHistogramSelection() const;
 

--- a/include/inviwo/core/properties/transferfunctionproperty.h
+++ b/include/inviwo/core/properties/transferfunctionproperty.h
@@ -105,8 +105,26 @@ public:
     TransferFunctionProperty& setZoomV(double zoomVMin, double zoomVMax);
     const dvec2& getZoomV() const;
 
+    /**
+     * Set the HistogramMode to control how to scale the histogram
+     * The options are:
+     *
+     * * Off Don't show any histograms
+     * * All Make sure all the bars are fully visible
+     * * P99 Make sure 99% of the bars are fully visible
+     * * P95 Make sure 95% of the bars are fully visible
+     * * P90 Make sure 90% of the bars are fully visible
+     * * Log Apply logarithmic scaling to each bar.
+     *
+     */
     TransferFunctionProperty& setHistogramMode(HistogramMode type);
     HistogramMode getHistogramMode() const;
+
+    /**
+     * Set the HistogramSelection. The selection determine which of the histograms from the volume
+     * in the optional volume port to show. The selection is a bitset, up to 32 histograms are
+     * supported. By default all available histograms will be shown.
+     */
     TransferFunctionProperty& setHistogramSelection(HistogramSelection selection);
     HistogramSelection getHistogramSelection() const;
 

--- a/include/inviwo/core/properties/transferfunctionproperty.h
+++ b/include/inviwo/core/properties/transferfunctionproperty.h
@@ -46,13 +46,15 @@ public:
     virtual void onZoomHChange(const dvec2& zoomH);
     virtual void onZoomVChange(const dvec2& zoomV);
     virtual void onHistogramModeChange(HistogramMode mode);
+    virtual void onHistogramSelectionChange(HistogramSelection selection);
 };
 class IVW_CORE_API TFPropertyObservable : public Observable<TFPropertyObserver> {
 protected:
-    virtual void notifyMaskChange(const dvec2& mask);
-    virtual void notifyZoomHChange(const dvec2& zoomH);
-    virtual void notifyZoomVChange(const dvec2& zoomV);
-    virtual void notifyHistogramModeChange(HistogramMode mode);
+    void notifyMaskChange(const dvec2& mask);
+    void notifyZoomHChange(const dvec2& zoomH);
+    void notifyZoomVChange(const dvec2& zoomV);
+    void notifyHistogramModeChange(HistogramMode mode);
+    void notifyHistogramSelectionChange(HistogramSelection selection);
 };
 
 /**
@@ -104,7 +106,10 @@ public:
     const dvec2& getZoomV() const;
 
     TransferFunctionProperty& setHistogramMode(HistogramMode type);
-    HistogramMode getHistogramMode();
+    HistogramMode getHistogramMode() const;
+    TransferFunctionProperty& setHistogramSelection(HistogramSelection selection);
+    HistogramSelection getHistogramSelection() const;
+
     VolumeInport* getVolumeInport();
 
     virtual TransferFunctionProperty& setCurrentStateAsDefault() override;
@@ -128,6 +133,7 @@ private:
     ValueWrapper<dvec2> zoomH_;
     ValueWrapper<dvec2> zoomV_;
     ValueWrapper<HistogramMode> histogramMode_;
+    ValueWrapper<HistogramSelection> histogramSelection_;
 
     VolumeInport* volumeInport_;
 };

--- a/include/inviwo/core/util/colorbrewer.h
+++ b/include/inviwo/core/util/colorbrewer.h
@@ -53,6 +53,11 @@ public:
 };
 
 /**
+ * Returns all families.
+ **/
+IVW_CORE_API std::vector<Family> getFamilies();
+
+/**
  * Returns the colormap specified by its family and number of colors containted in the colormap. For
  * reference see http://colorbrewer2.org/. If the colormap is not available for the given number of
  * colors, a ColorBrewerException is thrown.

--- a/include/inviwo/qt/editor/processorgraphicsitem.h
+++ b/include/inviwo/qt/editor/processorgraphicsitem.h
@@ -160,4 +160,3 @@ private:
 };
 
 }  // namespace inviwo
-

--- a/include/inviwo/qt/editor/processorgraphicsitem.h
+++ b/include/inviwo/qt/editor/processorgraphicsitem.h
@@ -27,8 +27,7 @@
  *
  *********************************************************************************/
 
-#ifndef IVW_PROCESSORGRAPHICSITEM_H
-#define IVW_PROCESSORGRAPHICSITEM_H
+#pragma once
 
 #include <inviwo/core/processors/processorobserver.h>
 #include <inviwo/core/util/clock.h>
@@ -162,4 +161,3 @@ private:
 
 }  // namespace inviwo
 
-#endif  // IVW_PROCESSORGRAPHICSITEM_H

--- a/modules/basegl/include/modules/basegl/processors/multichannelraycaster.h
+++ b/modules/basegl/include/modules/basegl/processors/multichannelraycaster.h
@@ -87,6 +87,7 @@ private:
     ImageOutport outport_;
 
     CompositeProperty transferFunctions_;
+    std::array<TransferFunctionProperty,4> tfs_;
 
     SimpleRaycastingProperty raycasting_;
     CameraProperty camera_;

--- a/modules/basegl/include/modules/basegl/processors/multichannelraycaster.h
+++ b/modules/basegl/include/modules/basegl/processors/multichannelraycaster.h
@@ -87,7 +87,7 @@ private:
     ImageOutport outport_;
 
     CompositeProperty transferFunctions_;
-    std::array<TransferFunctionProperty,4> tfs_;
+    std::array<TransferFunctionProperty, 4> tfs_;
 
     SimpleRaycastingProperty raycasting_;
     CameraProperty camera_;

--- a/modules/basegl/src/processors/volumeraycaster.cpp
+++ b/modules/basegl/src/processors/volumeraycaster.cpp
@@ -82,6 +82,14 @@ VolumeRaycaster::VolumeRaycaster()
 
     channel_.setSerializationMode(PropertySerializationMode::All);
 
+    auto updateTFHistSel = [this]() {
+        HistogramSelection selection{};
+        selection[channel_] = true;
+        isotfComposite_.setHistogramSelection(selection);
+    };
+    updateTFHistSel();
+    channel_.onChange(updateTFHistSel);
+
     volumePort_.onChange([this]() {
         if (volumePort_.hasData()) {
             size_t channels = volumePort_.getData()->getDataFormat()->getComponents();

--- a/modules/qtwidgets/include/modules/qtwidgets/tf/tfeditorview.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/tf/tfeditorview.h
@@ -71,6 +71,7 @@ protected:
     virtual void onZoomHChange(const dvec2& zoomH) override;
     virtual void onZoomVChange(const dvec2& zoomV) override;
     virtual void onHistogramModeChange(HistogramMode mode) override;
+    virtual void onHistogramSelectionChange(HistogramSelection selection) override;
 
     virtual void wheelEvent(QWheelEvent* event) override;
 
@@ -78,6 +79,7 @@ private:
     util::TFPropertyConcept* tfPropertyPtr_;
     VolumeInport* volumeInport_;
     HistogramMode histogramMode_;
+    HistogramSelection histogramSelection_;
 
     std::vector<QPolygonF> histograms_;
 

--- a/modules/qtwidgets/include/modules/qtwidgets/tf/tfpropertyconcept.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/tf/tfpropertyconcept.h
@@ -71,7 +71,11 @@ struct IVW_MODULE_QTWIDGETS_API TFPropertyConcept {
     virtual const dvec2& getZoomV() const = 0;
 
     virtual void setHistogramMode(HistogramMode type) = 0;
-    virtual HistogramMode getHistogramMode() = 0;
+    virtual HistogramMode getHistogramMode() const = 0;
+
+    virtual void setHistogramSelection(HistogramSelection selection) = 0;
+    virtual HistogramSelection getHistogramSelection() const = 0;
+
     virtual VolumeInport* getVolumeInport() = 0;
     virtual void addObserver(TFPropertyObserver* observer) = 0;
     virtual void removeObserver(TFPropertyObserver* observer) = 0;
@@ -156,7 +160,15 @@ public:
     virtual const dvec2& getZoomV() const override { return data_->getZoomV(); }
 
     virtual void setHistogramMode(HistogramMode type) override { data_->setHistogramMode(type); }
-    virtual HistogramMode getHistogramMode() override { return data_->getHistogramMode(); }
+    virtual HistogramMode getHistogramMode() const override { return data_->getHistogramMode(); }
+
+    virtual void setHistogramSelection(HistogramSelection selection) override {
+        data_->setHistogramSelection(selection);
+    }
+    virtual HistogramSelection getHistogramSelection() const override {
+        return data_->getHistogramSelection();
+    }
+
     virtual VolumeInport* getVolumeInport() override { return data_->getVolumeInport(); }
 
     virtual void addObserver(TFPropertyObserver* observer) override {

--- a/src/core/properties/isotfproperty.cpp
+++ b/src/core/properties/isotfproperty.cpp
@@ -42,8 +42,7 @@ IsoTFProperty::IsoTFProperty(const std::string& identifier, const std::string& d
     , isovalues_("isovalues", "Iso Values", isovalues, volumeInport)
     , tf_("transferFunction", "Transfer Function", tf, volumeInport) {
 
-    addProperty(isovalues_);
-    addProperty(tf_);
+    addProperties(isovalues_, tf_);
 
     tf_.TFPropertyObservable::addObserver(this);
     isovalues_.TFPropertyObservable::addObserver(this);
@@ -59,8 +58,7 @@ IsoTFProperty::IsoTFProperty(const std::string& identifier, const std::string& d
 IsoTFProperty::IsoTFProperty(const IsoTFProperty& rhs)
     : CompositeProperty(rhs), isovalues_(rhs.isovalues_), tf_(rhs.tf_) {
 
-    addProperty(isovalues_);
-    addProperty(tf_);
+    addProperties(isovalues_, tf_);
 
     tf_.TFPropertyObservable::addObserver(this);
     isovalues_.TFPropertyObservable::addObserver(this);
@@ -106,12 +104,23 @@ void IsoTFProperty::setZoomV(double zoomVMin, double zoomVMax) {
 
 const dvec2& IsoTFProperty::getZoomV() const { return tf_.getZoomV(); }
 
-void IsoTFProperty::setHistogramMode(HistogramMode type) {
+IsoTFProperty& IsoTFProperty::setHistogramMode(HistogramMode type) {
     tf_.setHistogramMode(type);
     isovalues_.setHistogramMode(type);
+    return *this;
 }
 
-HistogramMode IsoTFProperty::getHistogramMode() { return tf_.getHistogramMode(); }
+HistogramMode IsoTFProperty::getHistogramMode() const { return tf_.getHistogramMode(); }
+
+IsoTFProperty& IsoTFProperty::setHistogramSelection(HistogramSelection selection) {
+    tf_.setHistogramSelection(selection);
+    isovalues_.setHistogramSelection(selection);
+    return *this;
+}
+
+HistogramSelection IsoTFProperty::getHistogramSelection() const {
+    return tf_.getHistogramSelection();
+}
 
 VolumeInport* IsoTFProperty::getVolumeInport() { return tf_.getVolumeInport(); }
 
@@ -122,5 +131,9 @@ void IsoTFProperty::onZoomHChange(const dvec2& zoomH) { notifyZoomHChange(zoomH)
 void IsoTFProperty::onZoomVChange(const dvec2& zoomV) { notifyZoomVChange(zoomV); }
 
 void IsoTFProperty::onHistogramModeChange(HistogramMode mode) { notifyHistogramModeChange(mode); }
+
+void IsoTFProperty::onHistogramSelectionChange(HistogramSelection selection) {
+    notifyHistogramSelectionChange(selection);
+}
 
 }  // namespace inviwo

--- a/src/core/properties/isovalueproperty.cpp
+++ b/src/core/properties/isovalueproperty.cpp
@@ -44,7 +44,7 @@ IsoValueProperty::IsoValueProperty(const std::string& identifier, const std::str
     , zoomH_("zoomH_", dvec2(0.0, 1.0))
     , zoomV_("zoomV_", dvec2(0.0, 1.0))
     , histogramMode_("showHistogram_", HistogramMode::All)
-    , histogramSelection_("histogramSelection", histgramSelectionAll)
+    , histogramSelection_("histogramSelection", histogramSelectionAll)
     , volumeInport_(volumeInport) {
 
     iso_.value.addObserver(this);

--- a/src/core/properties/isovalueproperty.cpp
+++ b/src/core/properties/isovalueproperty.cpp
@@ -44,6 +44,7 @@ IsoValueProperty::IsoValueProperty(const std::string& identifier, const std::str
     , zoomH_("zoomH_", dvec2(0.0, 1.0))
     , zoomV_("zoomV_", dvec2(0.0, 1.0))
     , histogramMode_("showHistogram_", HistogramMode::All)
+    , histogramSelection_("histogramSelection", histgramSelectionAll)
     , volumeInport_(volumeInport) {
 
     iso_.value.addObserver(this);
@@ -60,6 +61,7 @@ IsoValueProperty::IsoValueProperty(const IsoValueProperty& rhs)
     , zoomH_(rhs.zoomH_)
     , zoomV_(rhs.zoomV_)
     , histogramMode_(rhs.histogramMode_)
+    , histogramSelection_(rhs.histogramSelection_)
     , volumeInport_(rhs.volumeInport_) {
 
     iso_.value.addObserver(this);
@@ -96,14 +98,27 @@ void IsoValueProperty::setZoomV(double zoomVMin, double zoomVMax) {
 
 const dvec2& IsoValueProperty::getZoomV() const { return zoomV_; }
 
-void IsoValueProperty::setHistogramMode(HistogramMode mode) {
+IsoValueProperty& IsoValueProperty::setHistogramMode(HistogramMode mode) {
     if (histogramMode_ != mode) {
         histogramMode_ = mode;
         notifyHistogramModeChange(histogramMode_);
     }
+    return *this;
 }
 
-HistogramMode IsoValueProperty::getHistogramMode() { return histogramMode_; }
+HistogramMode IsoValueProperty::getHistogramMode() const { return histogramMode_; }
+
+IsoValueProperty& IsoValueProperty::setHistogramSelection(HistogramSelection selection) {
+    if (histogramSelection_ != selection) {
+        histogramSelection_ = selection;
+        notifyHistogramSelectionChange(histogramSelection_);
+    }
+    return *this;
+}
+
+auto IsoValueProperty::getHistogramSelection() const -> HistogramSelection {
+    return histogramSelection_;
+}
 
 VolumeInport* IsoValueProperty::getVolumeInport() { return volumeInport_; }
 
@@ -113,6 +128,7 @@ IsoValueProperty& IsoValueProperty::setCurrentStateAsDefault() {
     zoomH_.setAsDefault();
     zoomV_.setAsDefault();
     histogramMode_.setAsDefault();
+    histogramSelection_.setAsDefault();
     return *this;
 }
 
@@ -124,6 +140,7 @@ IsoValueProperty& IsoValueProperty::resetToDefaultState() {
     modified |= zoomH_.reset();
     modified |= zoomV_.reset();
     modified |= histogramMode_.reset();
+    modified |= histogramSelection_.reset();
     if (modified) this->propertyModified();
     return *this;
 }
@@ -135,6 +152,7 @@ void IsoValueProperty::serialize(Serializer& s) const {
     zoomH_.serialize(s, this->serializationMode_);
     zoomV_.serialize(s, this->serializationMode_);
     histogramMode_.serialize(s, this->serializationMode_);
+    histogramSelection_.serialize(s, this->serializationMode_);
 }
 
 void IsoValueProperty::deserialize(Deserializer& d) {
@@ -145,6 +163,7 @@ void IsoValueProperty::deserialize(Deserializer& d) {
     modified |= zoomH_.deserialize(d, this->serializationMode_);
     modified |= zoomV_.deserialize(d, this->serializationMode_);
     modified |= histogramMode_.deserialize(d, this->serializationMode_);
+    modified |= histogramSelection_.deserialize(d, this->serializationMode_);
     if (modified) propertyModified();
 }
 

--- a/src/core/properties/transferfunctionproperty.cpp
+++ b/src/core/properties/transferfunctionproperty.cpp
@@ -75,7 +75,7 @@ TransferFunctionProperty::TransferFunctionProperty(
     , zoomH_("zoomH_", dvec2(0.0, 1.0))
     , zoomV_("zoomV_", dvec2(0.0, 1.0))
     , histogramMode_("showHistogram_", HistogramMode::All)
-    , histogramSelection_("histogramSelection", histgramSelectionAll)
+    , histogramSelection_("histogramSelection", histogramSelectionAll)
     , volumeInport_(volumeInport) {
 
     tf_.value.addObserver(this);

--- a/src/core/properties/transferfunctionproperty.cpp
+++ b/src/core/properties/transferfunctionproperty.cpp
@@ -45,6 +45,8 @@ void TFPropertyObserver::onZoomVChange(const dvec2&) {}
 
 void TFPropertyObserver::onHistogramModeChange(HistogramMode) {}
 
+void TFPropertyObserver::onHistogramSelectionChange(HistogramSelection selection) {}
+
 void TFPropertyObservable::notifyMaskChange(const dvec2& mask) {
     forEachObserver([&](TFPropertyObserver* o) { o->onMaskChange(mask); });
 }
@@ -61,6 +63,10 @@ void TFPropertyObservable::notifyHistogramModeChange(HistogramMode mode) {
     forEachObserver([&](TFPropertyObserver* o) { o->onHistogramModeChange(mode); });
 }
 
+void TFPropertyObservable::notifyHistogramSelectionChange(HistogramSelection selection) {
+    forEachObserver([&](TFPropertyObserver* o) { o->onHistogramSelectionChange(selection); });
+}
+
 TransferFunctionProperty::TransferFunctionProperty(
     const std::string& identifier, const std::string& displayName, const TransferFunction& value,
     VolumeInport* volumeInport, InvalidationLevel invalidationLevel, PropertySemantics semantics)
@@ -69,6 +75,7 @@ TransferFunctionProperty::TransferFunctionProperty(
     , zoomH_("zoomH_", dvec2(0.0, 1.0))
     , zoomV_("zoomV_", dvec2(0.0, 1.0))
     , histogramMode_("showHistogram_", HistogramMode::All)
+    , histogramSelection_("histogramSelection", histgramSelectionAll)
     , volumeInport_(volumeInport) {
 
     tf_.value.addObserver(this);
@@ -90,6 +97,7 @@ TransferFunctionProperty::TransferFunctionProperty(const TransferFunctionPropert
     , zoomH_(rhs.zoomH_)
     , zoomV_(rhs.zoomV_)
     , histogramMode_(rhs.histogramMode_)
+    , histogramSelection_(rhs.histogramSelection_)
     , volumeInport_(rhs.volumeInport_) {
 
     tf_.value.addObserver(this);
@@ -113,7 +121,20 @@ TransferFunctionProperty& TransferFunctionProperty::setHistogramMode(HistogramMo
     return *this;
 }
 
-auto TransferFunctionProperty::getHistogramMode() -> HistogramMode { return histogramMode_; }
+auto TransferFunctionProperty::getHistogramMode() const -> HistogramMode { return histogramMode_; }
+
+TransferFunctionProperty& TransferFunctionProperty::setHistogramSelection(
+    HistogramSelection selection) {
+    if (histogramSelection_ != selection) {
+        histogramSelection_ = selection;
+        notifyHistogramSelectionChange(histogramSelection_);
+    }
+    return *this;
+}
+
+auto TransferFunctionProperty::getHistogramSelection() const -> HistogramSelection {
+    return histogramSelection_;
+}
 
 VolumeInport* TransferFunctionProperty::getVolumeInport() { return volumeInport_; }
 
@@ -125,6 +146,7 @@ TransferFunctionProperty& TransferFunctionProperty::resetToDefaultState() {
     modified |= zoomH_.reset();
     modified |= zoomV_.reset();
     modified |= histogramMode_.reset();
+    modified |= histogramSelection_.reset();
     if (modified) this->propertyModified();
     return *this;
 }
@@ -135,6 +157,7 @@ TransferFunctionProperty& TransferFunctionProperty::setCurrentStateAsDefault() {
     zoomH_.setAsDefault();
     zoomV_.setAsDefault();
     histogramMode_.setAsDefault();
+    histogramSelection_.setAsDefault();
     return *this;
 }
 
@@ -145,6 +168,7 @@ void TransferFunctionProperty::serialize(Serializer& s) const {
     zoomH_.serialize(s, this->serializationMode_);
     zoomV_.serialize(s, this->serializationMode_);
     histogramMode_.serialize(s, this->serializationMode_);
+    histogramSelection_.serialize(s, this->serializationMode_);
 }
 
 void TransferFunctionProperty::deserialize(Deserializer& d) {
@@ -155,6 +179,7 @@ void TransferFunctionProperty::deserialize(Deserializer& d) {
     modified |= zoomH_.deserialize(d, this->serializationMode_);
     modified |= zoomV_.deserialize(d, this->serializationMode_);
     modified |= histogramMode_.deserialize(d, this->serializationMode_);
+    modified |= histogramSelection_.deserialize(d, this->serializationMode_);
     if (modified) propertyModified();
 }
 

--- a/src/core/util/colorbrewer.cpp
+++ b/src/core/util/colorbrewer.cpp
@@ -36,6 +36,15 @@
 namespace inviwo {
 namespace colorbrewer {
 
+std::vector<colorbrewer::Family> getFamilies() {
+    using Index = std::underlying_type_t<Family>;
+    std::vector<Family> res;
+    for (Index i = 0; i < static_cast<Index>(Family::NumberOfColormapFamilies); ++i) {
+        res.push_back(static_cast<Family>(i));
+    }
+    return res;
+}
+
 const std::vector<dvec4>& getColormap(const Family& family, glm::uint8 numberOfColors) {
     const auto minColors = getMinNumberOfColorsForFamily(family);
     const auto maxColors = getMaxNumberOfColorsForFamily(family);


### PR DESCRIPTION
Core/BaseGL/Qt: added a histogram selection setting to the tf/iso prop, to be able to affect which channels histogram that is visible in the tf

Thank you for contributing to the Inviwo repository! Great code makes great apps so please ensure the following:

**Always**
- [ ] Code is error and warning free
- [ ] Code follows the [Inviwo coding guidelines](https://github.com/inviwo/inviwo/wiki/Coding-Conventions)

**New features**
- [ ] Code / Processors follows the [Inviwo documentation guidelines](https://github.com/inviwo/inviwo/wiki/Documentation-guide)
- [ ] Code / processors are tested in [unittest and/or regresion tests](https://github.com/inviwo/inviwo/wiki/Manual#testing)

**Updated feature / Fixes** 
- [ ] Relevant documentation has been updated

**What evineroment has the code been compiled and tested on?** 
- Operating system
- Compiler/IDE
- QT/CMake/Python versions

Are you are unsure how to address these points? Please make a note here so that we can help out:
