### PR TITLE
Feature/qt consolewidget

### DIFF
--- a/include/inviwo/core/util/stringconversion.h
+++ b/include/inviwo/core/util/stringconversion.h
@@ -261,13 +261,24 @@ constexpr std::string_view trim(std::string_view str) noexcept {
     return str.substr(idx1, idx2 + 1 - idx1);
 }
 
-/*
+/**
  * \brief Checks if provided string ends with suffix using case insensitive equal comparison.
  * @param str string to check last part of. Allowed to be smaller than suffix.
  * @param suffix Ending to match.
  * @return True if last part of str is equal to suffix, false otherwise.
  */
 IVW_CORE_API bool iCaseEndsWith(std::string_view str, std::string_view suffix);
+
+/**
+ * \brief Elide parts of lines in \p str which are longer than \p maxLineLength and append \p abbrev
+ * instead.
+ * @param str            string with lines to abbreviate
+ * @param abbrev         placeholder that gets added at the end of abbreviated lines
+ * @param maxLineLength  lines that are longer are abbreviated
+ * @return input string where no line is longer than \p maxLineLength + \p abbrev.size()
+ */
+IVW_CORE_API std::string elideLines(std::string_view str, std::string_view abbrev = "...",
+                                    size_t maxLineLength = 500);
 
 }  // namespace util
 

--- a/modules/python3/bindings/src/pyproperties.cpp
+++ b/modules/python3/bindings/src/pyproperties.cpp
@@ -123,7 +123,8 @@ void exposeProperties(py::module& m) {
         .def_property_readonly("classIdentifier", &Property::getClassIdentifier)
         .def_property_readonly("classIdentifierForWidget", &Property::getClassIdentifierForWidget)
         .def_property_readonly("path", &Property::getPath)
-        .def_property_readonly("invalidationLevel", &Property::getInvalidationLevel)
+        .def_property("invalidationLevel", &Property::getInvalidationLevel,
+                      &Property::setInvalidationLevel)
         .def_property_readonly("widgets", &Property::getWidgets)
         .def_property_readonly("isModified", &Property::isModified)
         .def("hasWidgets", &Property::hasWidgets)

--- a/src/core/util/stringconversion.cpp
+++ b/src/core/util/stringconversion.cpp
@@ -34,6 +34,7 @@
 #include <random>
 #include <iomanip>
 #include <clocale>
+#include <algorithm>
 
 #if defined(__clang__) || defined(__GNUC__)
 #include <cstdlib>
@@ -128,6 +129,16 @@ bool iCaseEndsWith(std::string_view str, std::string_view suffix) {
     return str.size() >= suffix.size() &&
            // Compare last part of path with the extension
            iCaseCmp(str.substr(str.size() - suffix.size()), suffix);
+}
+
+std::string elideLines(std::string_view str, std::string_view abbrev, size_t maxLineLength) {
+    std::string result;
+    util::forEachStringPart(str, "\n", [&](std::string_view line) {
+        result.append(fmt::format("{}{}{}", result.empty() ? "" : "\n",
+                                  line.substr(0, std::min(line.size(), maxLineLength)),
+                                  (line.size() > maxLineLength) ? abbrev : ""));
+    });
+    return result;
 }
 
 }  // namespace util

--- a/src/core/util/stringconversion.cpp
+++ b/src/core/util/stringconversion.cpp
@@ -133,11 +133,17 @@ bool iCaseEndsWith(std::string_view str, std::string_view suffix) {
 
 std::string elideLines(std::string_view str, std::string_view abbrev, size_t maxLineLength) {
     std::string result;
+    const auto maxSize = maxLineLength - abbrev.size();
     util::forEachStringPart(str, "\n", [&](std::string_view line) {
-        result.append(fmt::format("{}{}{}", result.empty() ? "" : "\n",
-                                  line.substr(0, std::min(line.size(), maxLineLength)),
-                                  (line.size() > maxLineLength) ? abbrev : ""));
+        if (line.size() > maxLineLength) {
+            result.append(line.substr(0, maxSize));
+            result.append(abbrev);
+        } else {
+            result.append(line);
+        }
+        result.push_back('\n');
     });
+    result.pop_back();
     return result;
 }
 


### PR DESCRIPTION
Long log messages can clog up the Qt gui and lead to serious delays. This is a cosmetic Qt fix.

* added function to elide strings with lines longer than n characters
* the console widget now shows elided messages
* copying elided messages in the console widget will copy the original message