### PR TITLE
Removes clang diagnostic warning

### DIFF
--- a/tools/meta/templates/processor.h
+++ b/tools/meta/templates/processor.h
@@ -53,7 +53,7 @@ namespace inviwo {
 class {{ module/api }} {{ file/name }} : public Processor {
 public:
     {{ file/name }}();
-    virtual ~{{ file/name }}() = default;
+    virtual ~{{ file/name }}() override = default;
 
     virtual void process() override;
 


### PR DESCRIPTION
Warning: [clang-diagnostic-inconsistent-missing-destructor-override]