### PR TITLE
Feature/brushingandlinking

### DIFF
--- a/include/inviwo/core/datastructures/bitset.h
+++ b/include/inviwo/core/datastructures/bitset.h
@@ -118,13 +118,13 @@ public:
     BitSetIterator end() const;
 
     /**
-     * return the number of elements the bitset holds
+     * Return the number of elements the bitset holds
      *
      * \see size()
      */
     uint32_t cardinality() const;
     /**
-     * return the number of elements the bitset holds
+     * Return the number of elements the bitset holds
      *
      * \see cardinality()
      */
@@ -135,16 +135,16 @@ public:
     void clear();
 
     /**
-     * check whether this bitset is a subset of \p b
+     * Check whether this bitset is a subset of \p b
      */
     bool isSubsetOf(const BitSet& b) const;
     /**
-     * check whether this bitset is a strict subset of \p b
+     * Check whether this bitset is a strict subset of \p b
      */
     bool isStrictSubsetOf(const BitSet& b) const;
 
     /**
-     * replace the bitset with the contents of \p b, returns true if modified
+     * Replace the bitset with the contents of \p b, returns true if modified
      *
      * @return true if the bitset was modified that is \p this and \p b were different
      */
@@ -180,7 +180,7 @@ public:
     bool addChecked(uint32_t v);
 
     /**
-     * adds all values from the open range [min,max)
+     * Adds all values from the open range [min,max)
      *
      * @param min   lower bound
      * @param max   upper bound (not included)
@@ -188,7 +188,7 @@ public:
     void addRange(uint32_t min, uint32_t max);
 
     /**
-     * adds all values from the closed range [min,max]
+     * Adds all values from the closed range [min,max]
      *
      * @param min   lower bound
      * @param max   upper bound (included)
@@ -241,7 +241,7 @@ public:
     bool containsRange(uint32_t min, uint32_t max) const;
 
     /**
-     * flip the value \p v, that is add it to the bitset if not part of it, otherwise remove it
+     * Flip the value \p v, that is add it to the bitset if not part of it, otherwise remove it
      *
      * @param v  value to flip
      */

--- a/include/inviwo/core/datastructures/bitset.h
+++ b/include/inviwo/core/datastructures/bitset.h
@@ -145,7 +145,7 @@ public:
 
     /**
      * update the bitset with the contents of \p b, if \p b is different
-     * 
+     *
      * @return true if the bitset was modified that is \p this and \p b were different
      */
     bool set(const BitSet& b);

--- a/include/inviwo/core/datastructures/bitset.h
+++ b/include/inviwo/core/datastructures/bitset.h
@@ -143,6 +143,13 @@ public:
      */
     bool isStrictSubsetOf(const BitSet& b) const;
 
+    /**
+     * update the bitset with the contents of \p b, if \p b is different
+     * 
+     * @return true if the bitset was modified that is \p this and \p b were different
+     */
+    bool set(const BitSet& b);
+
     void add(util::span<const uint32_t> span);
 
     template <typename InputIt, class = typename std::enable_if_t<is_iterator<InputIt>::value>>

--- a/include/inviwo/core/datastructures/bitset.h
+++ b/include/inviwo/core/datastructures/bitset.h
@@ -144,7 +144,7 @@ public:
     bool isStrictSubsetOf(const BitSet& b) const;
 
     /**
-     * update the bitset with the contents of \p b, if \p b is different
+     * replace the bitset with the contents of \p b, returns true if modified
      *
      * @return true if the bitset was modified that is \p this and \p b were different
      */

--- a/modules/brushingandlinking/include/modules/brushingandlinking/brushingandlinkingmanager.h
+++ b/modules/brushingandlinking/include/modules/brushingandlinking/brushingandlinkingmanager.h
@@ -357,10 +357,16 @@ public:
     void setInvalidationLevels(std::vector<BrushingTargetsInvalidationLevel> invalidationLevels);
 
     /**
-     * propagates the modified state to all child managers and resets the state. Should only be
-     * called by the brushing and linking ports _after_ the process() function has been called.
+     * propagates the modified state to all child managers. Needs to be called by the brushing and
+     * linking ports _before_ the invalidation level is queried.
+     * @see getInvalidationLevel
      */
-    void markAsValid();
+    void propagateModifications();
+    /**
+     * resets the modification state. Should only be called by the brushing and linking ports
+     * _after_ the process() function has been called.
+     */
+    void clearModifications();
 
     virtual void serialize(Serializer& s) const override;
     virtual void deserialize(Deserializer& d) override;

--- a/modules/brushingandlinking/include/modules/brushingandlinking/datastructures/indexlist.h
+++ b/modules/brushingandlinking/include/modules/brushingandlinking/datastructures/indexlist.h
@@ -48,7 +48,7 @@ public:
     void clear();
 
     /**
-     * update the indexlist with source \p src and \p indices, if \p indices are different
+     * Update the indexlist with source \p src and \p indices, if \p indices are different
      *
      * @return true if the indexlist was modified that is \p this and \p indices were different
      */

--- a/modules/brushingandlinking/include/modules/brushingandlinking/datastructures/indexlist.h
+++ b/modules/brushingandlinking/include/modules/brushingandlinking/datastructures/indexlist.h
@@ -43,10 +43,17 @@ public:
     IndexList() = default;
     virtual ~IndexList() = default;
 
+    bool empty() const;
     size_t size() const;
     void clear();
 
-    void set(std::string_view src, const BitSet& indices);
+    /**
+     * update the indexlist with source \p src and \p indices, if \p indices are different
+     *
+     * @return true if the indexlist was modified that is \p this and \p indices were different
+     */
+
+    bool set(std::string_view src, const BitSet& indices);
     bool contains(uint32_t idx) const;
 
     const BitSet& getIndices() const;
@@ -59,8 +66,7 @@ public:
 private:
     void update() const;
 
-    using SourceIndexMap = std::unordered_map<std::string, BitSet>;
-    mutable SourceIndexMap indicesBySource_;
+    mutable std::unordered_map<std::string, BitSet> indicesBySource_;
     mutable BitSet indices_;
 
     mutable bool indicesDirty_ = false;

--- a/modules/brushingandlinking/include/modules/brushingandlinking/ports/brushingandlinkingports.h
+++ b/modules/brushingandlinking/include/modules/brushingandlinking/ports/brushingandlinkingports.h
@@ -246,7 +246,7 @@ public:
      * Will invalidate its connected inports if any of the BrushingModifications overlap with
      * the modified brushing targets and actions provided by getInvalidationLevels
      * @param invalidationLevel unused!
-     * @note Port is set to valid after its processor successfully finish processing.
+     * @note Port is set to valid after its processor successfully finished processing.
      */
     virtual void invalidate(InvalidationLevel invalidationLevel) override;
 

--- a/modules/brushingandlinking/src/datastructures/indexlist.cpp
+++ b/modules/brushingandlinking/src/datastructures/indexlist.cpp
@@ -53,16 +53,21 @@ const BitSet& IndexList::getIndices() const {
 }
 
 bool IndexList::set(std::string_view src, const BitSet& indices) {
-    if ((indicesBySource_.count(std::string(src)) > 0)) {
-        if (indicesBySource_[std::string(src)] == indices) return false;
-    } else if (indices.empty()) {
-        return false;
-    }
+    const std::string source(src);
+    auto it = indicesBySource_.find(source);
 
-    if (indices.empty()) {
-        indicesBySource_.erase(std::string(src));
+    if (it == indicesBySource_.end()) {
+        if (indices.empty()) return false;
+
+        indicesBySource_.emplace(std::make_pair(source, indices));
     } else {
-        indicesBySource_[std::string(src)] = indices;
+        if (it->second == indices) return false;
+
+        if (indices.empty()) {
+            indicesBySource_.erase(it);
+        } else {
+            it->second = indices;
+        }
     }
     indicesDirty_ = true;
     return true;

--- a/modules/brushingandlinking/src/ports/brushingandlinkingports.cpp
+++ b/modules/brushingandlinking/src/ports/brushingandlinkingports.cpp
@@ -182,12 +182,13 @@ Document BrushingAndLinkingInport::getInfo() const {
 
 void BrushingAndLinkingInport::setChanged(bool changed, const Outport* source) {
     if (!changed) {
-        manager_.markAsValid();
+        manager_.clearModifications();
     }
     Inport::setChanged(changed, source);
 }
 
 void BrushingAndLinkingInport::invalidate(InvalidationLevel invalidationLevel) {
+    manager_.propagateModifications();
     // Override with the modification-based (brushing target and action) invalidation level.
     // This enables more selective invalidations that are dependent on this manager's settings
     // instead of the one of the top-most brushing manager that initiated the invalidation.
@@ -204,6 +205,7 @@ BrushingAndLinkingManager& BrushingAndLinkingOutport::getManager() { return mana
 const BrushingAndLinkingManager& BrushingAndLinkingOutport::getManager() const { return manager_; }
 
 void BrushingAndLinkingOutport::invalidate(InvalidationLevel invalidationLevel) {
+    manager_.propagateModifications();
     // Override with the modification-based (brushing target and action) invalidation level.
     // This enables more selective invalidations that are dependent on this manager's settings
     // instead of the one of the top-most brushing manager that initiated the invalidation.
@@ -231,7 +233,7 @@ void BrushingAndLinkingOutport::deserialize(Deserializer& d) {
 }
 
 void BrushingAndLinkingOutport::setValid() {
-    manager_.markAsValid();
+    manager_.clearModifications();
     Outport::setValid();
 }
 

--- a/modules/brushingandlinking/src/processors/brushingandlinkingprocessor.cpp
+++ b/modules/brushingandlinking/src/processors/brushingandlinkingprocessor.cpp
@@ -99,8 +99,8 @@ BrushingAndLinkingProcessor::BrushingAndLinkingProcessor()
             indices.size() > maxIndices ? "..." : "");
 
         LogProcessorInfo(fmt::format(
-            "{:<20} action: {:<13} target: {}\n  source: {}\n  indices: [{}] ({})", getDisplayName(),
-            action, target.getString(), source, str, indices.cardinality()));
+            "{:<20} action: {:<13} target: {}\n  source: {}\n  indices: [{}] ({})",
+            getDisplayName(), action, target.getString(), source, str, indices.cardinality()));
     });
 }
 

--- a/modules/brushingandlinking/src/processors/brushingandlinkingprocessor.cpp
+++ b/modules/brushingandlinking/src/processors/brushingandlinkingprocessor.cpp
@@ -51,18 +51,24 @@ BrushingAndLinkingProcessor::BrushingAndLinkingProcessor()
     : Processor()
     , inport_("inport")
     , outport_("outport")
-    , clearSelection_("clearSelection", "Clear Selection",
-                      [&]() { outport_.getManager().clearSelected(); })
-    , clearHighlight_("clearHighlight", "Clear Highlighting",
-                      [&]() { outport_.getManager().clearHighlighted(); })
-    , clearCols_("clearCols", "Clear Columns",
-                 [&]() { outport_.getManager().clearSelected(BrushingTarget::Column); })
-    , clearAll_("clearAll", "Clear Selections and Highlights",
-                [&]() {
-                    outport_.getManager().clearSelected();
-                    outport_.getManager().clearHighlighted();
-                    outport_.getManager().clearSelected(BrushingTarget::Column);
-                })
+    , clearSelection_(
+          "clearSelection", "Clear Selection", [&]() { outport_.getManager().clearSelected(); },
+          InvalidationLevel::Valid)
+    , clearHighlight_(
+          "clearHighlight", "Clear Highlighting",
+          [&]() { outport_.getManager().clearHighlighted(); }, InvalidationLevel::Valid)
+    , clearCols_(
+          "clearCols", "Clear Columns",
+          [&]() { outport_.getManager().clearSelected(BrushingTarget::Column); },
+          InvalidationLevel::Valid)
+    , clearAll_(
+          "clearAll", "Clear Selections and Highlights",
+          [&]() {
+              outport_.getManager().clearSelected();
+              outport_.getManager().clearHighlighted();
+              outport_.getManager().clearSelected(BrushingTarget::Column);
+          },
+          InvalidationLevel::Valid)
     , logging_("logging", "Logging", false, InvalidationLevel::Valid)
     , logFilterActions_("filterActions", "Filter Actions", true, InvalidationLevel::Valid)
     , logSelectActions_("selectActions", "Select Actions", true, InvalidationLevel::Valid)
@@ -93,7 +99,7 @@ BrushingAndLinkingProcessor::BrushingAndLinkingProcessor()
             indices.size() > maxIndices ? "..." : "");
 
         LogProcessorInfo(fmt::format(
-            "{:<20} action: {:<13}, target: {}\nsource: {}\nindices: [{}] ({})", getDisplayName(),
+            "{:<20} action: {:<13} target: {}\n  source: {}\n  indices: [{}] ({})", getDisplayName(),
             action, target.getString(), source, str, indices.cardinality()));
     });
 }

--- a/src/core/datastructures/bitset.cpp
+++ b/src/core/datastructures/bitset.cpp
@@ -135,6 +135,12 @@ bool BitSet::isStrictSubsetOf(const BitSet& b) const {
     return roaring_->isStrictSubset(*(b.roaring_));
 }
 
+bool BitSet::set(const BitSet& b) {
+    if (operator==(b)) return false;
+    *this = b;
+    return true;
+}
+
 void BitSet::add(util::span<const uint32_t> span) { addMany(span.size(), span.data()); }
 
 bool BitSet::addChecked(uint32_t v) { return roaring_->addChecked(v); }

--- a/src/qt/editor/welcomewidget.cpp
+++ b/src/qt/editor/welcomewidget.cpp
@@ -447,8 +447,8 @@ WelcomeWidget::WelcomeWidget(InviwoApplication* app, QWidget* parent)
                                         QSizePolicy::MinimumExpanding);
             leftSplitter->addWidget(centerWidget);
         }
-        leftSplitter->setStretchFactor(0, 1);    // FileTree
-        leftSplitter->setStretchFactor(1, 1.5);  // Center widget
+        leftSplitter->setStretchFactor(0, 2);    // FileTree
+        leftSplitter->setStretchFactor(1, 3);  // Center widget
         leftSplitter->handle(1)->setAttribute(Qt::WA_Hover);
     }
     {  // right splitter pane: changelog / options

--- a/src/qt/editor/welcomewidget.cpp
+++ b/src/qt/editor/welcomewidget.cpp
@@ -447,7 +447,7 @@ WelcomeWidget::WelcomeWidget(InviwoApplication* app, QWidget* parent)
                                         QSizePolicy::MinimumExpanding);
             leftSplitter->addWidget(centerWidget);
         }
-        leftSplitter->setStretchFactor(0, 2);    // FileTree
+        leftSplitter->setStretchFactor(0, 2);  // FileTree
         leftSplitter->setStretchFactor(1, 3);  // Center widget
         leftSplitter->handle(1)->setAttribute(Qt::WA_Hover);
     }


### PR DESCRIPTION
This should fix several issues with the Brushing and Linking.

* fixed propagation of the modification state, now forwarded via port invalidation (otherwise `manager_.getInvalidationLevel()` will not reflect the new state and return `Valid`) 
* to avoid unnecessary invalidations changes are only propagated upward if the indices have changed 
* when clearing indices, all managers should be cleared by propagating to parent and children