### PR TITLE
Feature/csv filtering

### DIFF
--- a/include/inviwo/core/io/tempfilehandle.h
+++ b/include/inviwo/core/io/tempfilehandle.h
@@ -45,7 +45,7 @@ namespace util {
 class IVW_CORE_API TempFileHandle {
 public:
     explicit TempFileHandle(const std::string& prefix = "", const std::string& suffix = "",
-                            const char* mode = "rw");
+                            const char* mode = "wb+");
 
     TempFileHandle(const TempFileHandle&) = delete;
     TempFileHandle& operator=(const TempFileHandle&) = delete;

--- a/modules/dataframe/CMakeLists.txt
+++ b/modules/dataframe/CMakeLists.txt
@@ -31,8 +31,10 @@ set(HEADER_FILES
     include/inviwo/dataframe/properties/columnmetadataproperty.h
     include/inviwo/dataframe/properties/columnoptionproperty.h
     include/inviwo/dataframe/properties/dataframecolormapproperty.h
+    include/inviwo/dataframe/properties/filterlistproperty.h
     include/inviwo/dataframe/properties/optionconverter.h
     include/inviwo/dataframe/util/dataframeutil.h
+    include/inviwo/dataframe/util/filters.h
 )
 ivw_group("Header Files" ${HEADER_FILES})
 
@@ -63,8 +65,10 @@ set(SOURCE_FILES
     src/properties/columnmetadataproperty.cpp
     src/properties/columnoptionproperty.cpp
     src/properties/dataframecolormapproperty.cpp
+    src/properties/filterlistproperty.cpp
     src/properties/optionconverter.cpp
     src/util/dataframeutil.cpp
+    src/util/filters.cpp
 )
 ivw_group("Source Files" ${SOURCE_FILES})
 

--- a/modules/dataframe/include/inviwo/dataframe/io/csvreader.h
+++ b/modules/dataframe/include/inviwo/dataframe/io/csvreader.h
@@ -93,6 +93,10 @@ public:
     CSVReader& setRowComment(std::string_view comment);
     const std::string& getRowComment() const;
 
+    /** @see CSVReader::defaultKeepOnly */
+    CSVReader& setKeepOnly(std::string_view only);
+    const std::string& getKeepOnly() const;
+
     /** @see CSVReader::defaultLocale */
     CSVReader& setLocale(std::string_view loc);
     const std::string& getLocale() const;
@@ -181,6 +185,8 @@ public:
     static constexpr size_t defaultNumberOfExampleRows = 50;
     /** @see CSVReader::setRowComment */
     static constexpr std::string_view defaultRowComment = "";
+    /** @see CSVReader::setKeepOnly */
+    static constexpr std::string_view defaultKeepOnly = "";
     /** @see CSVReader::setLocale */
     static constexpr std::string_view defaultLocale = "C";
     /** @see CSVReader::setHandleEmptyFields */
@@ -209,6 +215,7 @@ private:
     bool doublePrecision_;
     size_t exampleRows_;
     std::string rowComment_;
+    std::string keepOnly_;
     std::string locale_;
     EmptyField emptyField_;
 };

--- a/modules/dataframe/include/inviwo/dataframe/io/csvreader.h
+++ b/modules/dataframe/include/inviwo/dataframe/io/csvreader.h
@@ -152,6 +152,7 @@ public:
      * * NumberOfExampleRows (size_t)
      * * Locale (string)
      * * HandleEmptyFields (EmptyField)
+     * * Filters (csvfilters::Filters)
      */
     virtual bool setOption(std::string_view key, std::any value) override;
 
@@ -166,6 +167,7 @@ public:
      * * NumberOfExampleRows (size_t)
      * * Locale (string)
      * * HandleEmptyFields (EmptyField)
+     * * Filters (csvfilters::Filters)
      */
     virtual std::any getOption(std::string_view key) override;
 

--- a/modules/dataframe/include/inviwo/dataframe/io/csvreader.h
+++ b/modules/dataframe/include/inviwo/dataframe/io/csvreader.h
@@ -89,11 +89,17 @@ public:
     CSVReader& setNumberOfExampleRows(size_t rows);
     size_t getNumberOfExamplesRows() const;
 
-    /** @see CSVReader::defaultRowComment */
+    /** 
+    * sets the string that indicates that a row should be commented/removed
+    * @see CSVReader::defaultRowComment 
+    */
     CSVReader& setRowComment(std::string_view comment);
     const std::string& getRowComment() const;
 
-    /** @see CSVReader::defaultKeepOnly */
+    /** 
+    * sets the string that indicates that a row should be kept
+    * @see CSVReader::defaultKeepOnly 
+    */
     CSVReader& setKeepOnly(std::string_view only);
     const std::string& getKeepOnly() const;
 

--- a/modules/dataframe/include/inviwo/dataframe/io/csvreader.h
+++ b/modules/dataframe/include/inviwo/dataframe/io/csvreader.h
@@ -34,6 +34,7 @@
 #include <inviwo/core/io/datareader.h>
 #include <inviwo/core/io/datareaderexception.h>
 #include <inviwo/dataframe/datastructures/dataframe.h>
+#include <inviwo/dataframe/util/filters.h>
 
 namespace inviwo {
 
@@ -41,9 +42,9 @@ namespace inviwo {
  * \class CSVReader
  * \ingroup dataio
  *
- * \brief A reader for comma separated value (CSV) files with customizable delimiters.
+ * \brief A reader for comma separated value (CSV) files with customizable delimiters and filters.
  * The default delimiter is ',' and headers are included. Floating point values are stored as
- * float32.
+ * float32 unless double precision is enabled.
  */
 class IVW_MODULE_DATAFRAME_API CSVReader : public DataReaderType<DataFrame> {
 public:
@@ -78,7 +79,7 @@ public:
     const std::string& getUnitRegexp() const;
 
     /**
-     * sets the precision for columns containing floating point values. If @p useDoublePrecision is
+     * Sets the precision for columns containing floating point values. If @p useDoublePrecision is
      * true, values are stored as double (64 bits), otherwise float (32 bits) is used.
      * @see CSVReader::defaultDoublePrecision
      */
@@ -89,23 +90,16 @@ public:
     CSVReader& setNumberOfExampleRows(size_t rows);
     size_t getNumberOfExamplesRows() const;
 
-    /** 
-    * sets the string that indicates that a row should be commented/removed
-    * @see CSVReader::defaultRowComment 
-    */
-    CSVReader& setRowComment(std::string_view comment);
-    const std::string& getRowComment() const;
-
-    /** 
-    * sets the string that indicates that a row should be kept
-    * @see CSVReader::defaultKeepOnly 
-    */
-    CSVReader& setKeepOnly(std::string_view only);
-    const std::string& getKeepOnly() const;
-
     /** @see CSVReader::defaultLocale */
     CSVReader& setLocale(std::string_view loc);
     const std::string& getLocale() const;
+
+    /**
+     * Sets row and column filters.
+     * @see Filters
+     */
+    CSVReader& setFilters(const csvfilters::Filters& filters);
+    const csvfilters::Filters& getFilters() const;
 
     /**
      * How to handle missing / empty data
@@ -189,10 +183,6 @@ public:
     static constexpr bool defaultDoublePrecision = false;
     /** @see CSVReader::setNumberOfExampleRows */
     static constexpr size_t defaultNumberOfExampleRows = 50;
-    /** @see CSVReader::setRowComment */
-    static constexpr std::string_view defaultRowComment = "";
-    /** @see CSVReader::setKeepOnly */
-    static constexpr std::string_view defaultKeepOnly = "";
     /** @see CSVReader::setLocale */
     static constexpr std::string_view defaultLocale = "C";
     /** @see CSVReader::setHandleEmptyFields */
@@ -213,6 +203,8 @@ private:
         DataFrame& df, const std::vector<TypeCounts>& types,
         const std::vector<std::string>& headers) const;
 
+    bool skipRow(std::string_view row, size_t lineNumber, bool filterOnHeader) const;
+
     std::string delimiters_;
     bool stripQuotes_;
     bool firstRowHeader_;
@@ -220,10 +212,9 @@ private:
     std::string unitRegexp_;
     bool doublePrecision_;
     size_t exampleRows_;
-    std::string rowComment_;
-    std::string keepOnly_;
     std::string locale_;
     EmptyField emptyField_;
+    csvfilters::Filters filters_;
 };
 
 }  // namespace inviwo

--- a/modules/dataframe/include/inviwo/dataframe/io/csvreader.h
+++ b/modules/dataframe/include/inviwo/dataframe/io/csvreader.h
@@ -89,6 +89,10 @@ public:
     CSVReader& setNumberOfExampleRows(size_t rows);
     size_t getNumberOfExamplesRows() const;
 
+    /** @see CSVReader::defaultRowComment */
+    CSVReader& setRowComment(std::string_view comment);
+    const std::string& getRowComment() const;
+
     /** @see CSVReader::defaultLocale */
     CSVReader& setLocale(std::string_view loc);
     const std::string& getLocale() const;
@@ -175,6 +179,8 @@ public:
     static constexpr bool defaultDoublePrecision = false;
     /** @see CSVReader::setNumberOfExampleRows */
     static constexpr size_t defaultNumberOfExampleRows = 50;
+    /** @see CSVReader::setRowComment */
+    static constexpr std::string_view defaultRowComment = "";
     /** @see CSVReader::setLocale */
     static constexpr std::string_view defaultLocale = "C";
     /** @see CSVReader::setHandleEmptyFields */
@@ -202,6 +208,7 @@ private:
     std::string unitRegexp_;
     bool doublePrecision_;
     size_t exampleRows_;
+    std::string rowComment_;
     std::string locale_;
     EmptyField emptyField_;
 };

--- a/modules/dataframe/include/inviwo/dataframe/processors/csvsource.h
+++ b/modules/dataframe/include/inviwo/dataframe/processors/csvsource.h
@@ -84,7 +84,6 @@ private:
     BoolProperty doublePrecision_;
     IntSizeTProperty exampleRows_;
     StringProperty rowComment_;
-    StringProperty keepOnly_;
     FilterListProperty includeFilters_;
     FilterListProperty excludeFilters_;
     StringProperty locale_;

--- a/modules/dataframe/include/inviwo/dataframe/processors/csvsource.h
+++ b/modules/dataframe/include/inviwo/dataframe/processors/csvsource.h
@@ -80,6 +80,7 @@ private:
     BoolProperty stripQuotes_;
     BoolProperty doublePrecision_;
     IntSizeTProperty exampleRows_;
+    StringProperty rowComment_;
     StringProperty locale_;
     TemplateOptionProperty<CSVReader::EmptyField> emptyField_;
     ButtonProperty reloadData_;

--- a/modules/dataframe/include/inviwo/dataframe/processors/csvsource.h
+++ b/modules/dataframe/include/inviwo/dataframe/processors/csvsource.h
@@ -81,6 +81,7 @@ private:
     BoolProperty doublePrecision_;
     IntSizeTProperty exampleRows_;
     StringProperty rowComment_;
+    StringProperty keepOnly_;
     StringProperty locale_;
     TemplateOptionProperty<CSVReader::EmptyField> emptyField_;
     ButtonProperty reloadData_;

--- a/modules/dataframe/include/inviwo/dataframe/processors/csvsource.h
+++ b/modules/dataframe/include/inviwo/dataframe/processors/csvsource.h
@@ -33,6 +33,7 @@
 
 #include <inviwo/dataframe/datastructures/dataframe.h>
 #include <inviwo/dataframe/properties/columnmetadatalistproperty.h>
+#include <inviwo/dataframe/properties/filterlistproperty.h>
 #include <inviwo/core/processors/processor.h>
 #include <inviwo/core/ports/dataoutport.h>
 #include <inviwo/core/properties/fileproperty.h>
@@ -71,6 +72,8 @@ public:
     virtual void deserialize(Deserializer& d) override;
 
 private:
+    csvfilters::Filters createFilters() const;
+
     DataOutport<DataFrame> data_;
     FileProperty inputFile_;
     BoolProperty firstRowIsHeaders_;
@@ -82,6 +85,8 @@ private:
     IntSizeTProperty exampleRows_;
     StringProperty rowComment_;
     StringProperty keepOnly_;
+    FilterListProperty includeFilters_;
+    FilterListProperty excludeFilters_;
     StringProperty locale_;
     TemplateOptionProperty<CSVReader::EmptyField> emptyField_;
     ButtonProperty reloadData_;

--- a/modules/dataframe/include/inviwo/dataframe/properties/filterlistproperty.h
+++ b/modules/dataframe/include/inviwo/dataframe/properties/filterlistproperty.h
@@ -1,0 +1,84 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2022 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <inviwo/dataframe/dataframemoduledefine.h>
+#include <inviwo/core/properties/listproperty.h>
+
+namespace inviwo {
+
+/**
+ * @class FilterListProperty
+ * @brief A list property with different sub-properties for defining row and item filters.
+ *
+ * This property has a number of prefab objects for adding row and item filter properties
+ * (BoolCompositeProperty). A row filter is applied to the entire row of a dataset. Item filters, in
+ * contrast, are applied to the individual data items, that is columns. The distinction between row
+ * and item filters is based on the property identifiers.
+ *
+ * Identifiers of the properties for row filters begin with the following names and hold the listed
+ * sub-properties:
+ *  - @p "rowBegin":   StringProperty @p match for matching the beginning of a row
+ *  - @p "lineRange":  IntMinMaxProperty @p range for a line range (inclusive)
+ *
+ * Row filter properties also own a BoolProperty @p filterOnHeader. If true, the filter should be
+ * applied to all rows including headers where applicable (for example in the CSVReader).
+ *
+ * Item filters own an IntProperty @column defining the target column. Identifiers begin with:
+ *  - @p "stringItem":      StringProperty @match for matching strings and a
+ *                          TemplateOptionProperty<filters::StringComp> @comp for the comparison
+ *  - @p "intItem":         IntProperty @value, TemplateOptionProperty<filters::NumberComp> @comp
+ *                          for the comparison
+ *  - @p "floatItem":       FloatProperty @value and FloatProperty @epsilon,
+ *                          TemplateOptionProperty<filters::NumberComp> @comp for the comparison
+ *  - @p "doubleItem":      DoubleProperty @value and DoubleProperty @epsilon,
+ *                          TemplateOptionProperty<filters::NumberComp> @comp for the comparison
+ *  - @p "intRangeItem":    IntMinMaxProperty @range for an inclusive range [min, max]
+ *  - @p "floatRangeItem":  FloatMinMaxProperty @range for an inclusive range [min, max]
+ *  - @p "doubleRangeItem": DoubleMinMaxProperty @range for an inclusive range [min, max]
+ *
+ * @see CSVReader
+ */
+class IVW_MODULE_DATAFRAME_API FilterListProperty : public ListProperty {
+public:
+    virtual std::string getClassIdentifier() const override;
+    static const std::string classIdentifier;
+
+    FilterListProperty(std::string_view identifier, std::string_view displayName,
+                       bool supportsFilterOnHeader = false, size_t maxNumberOfElements = 0,
+                       ListPropertyUIFlags uiFlags = ListPropertyUIFlag::Add |
+                                                     ListPropertyUIFlag::Remove,
+                       InvalidationLevel invalidationLevel = InvalidationLevel::InvalidResources,
+                       PropertySemantics semantics = PropertySemantics::Default);
+    virtual ~FilterListProperty() = default;
+
+    virtual FilterListProperty* clone() const override;
+};
+
+}  // namespace inviwo

--- a/modules/dataframe/include/inviwo/dataframe/properties/filterlistproperty.h
+++ b/modules/dataframe/include/inviwo/dataframe/properties/filterlistproperty.h
@@ -31,19 +31,35 @@
 #include <inviwo/dataframe/dataframemoduledefine.h>
 #include <inviwo/core/properties/listproperty.h>
 
+#include <flags/flags.h>
+
 namespace inviwo {
 
+enum class FilterType {
+    Rows,
+    StringItem,
+    IntItem,
+    FloatItem,
+    DoubleItem,
+    IntRange,
+    FloatRange,
+    DoubleRange
+};
+
+ALLOW_FLAGS_FOR_ENUM(FilterType)
+using FilterTypes = flags::flags<FilterType>;
+
 /**
- * @class FilterListProperty
  * @brief A list property with different sub-properties for defining row and item filters.
  *
  * This property has a number of prefab objects for adding row and item filter properties
  * (BoolCompositeProperty). A row filter is applied to the entire row of a dataset. Item filters, in
- * contrast, are applied to the individual data items, that is columns. The distinction between row
- * and item filters is based on the property identifiers.
+ * contrast, are applied to the individual data items. The distinction between row and item filters
+ * is based on the property identifiers.
  *
  * Identifiers of the properties for row filters begin with the following names and hold the listed
  * sub-properties:
+ *  - @p "emptyLines": Matches empty lines
  *  - @p "rowBegin":   StringProperty @p match for matching the beginning of a row
  *  - @p "lineRange":  IntMinMaxProperty @p range for a line range (inclusive)
  *
@@ -71,7 +87,9 @@ public:
     static const std::string classIdentifier;
 
     FilterListProperty(std::string_view identifier, std::string_view displayName,
-                       bool supportsFilterOnHeader = false, size_t maxNumberOfElements = 0,
+                       bool supportsFilterOnHeader = false,
+                       FilterTypes supportedFilters = FilterTypes(flags::any),
+                       size_t maxNumberOfElements = 0,
                        ListPropertyUIFlags uiFlags = ListPropertyUIFlag::Add |
                                                      ListPropertyUIFlag::Remove,
                        InvalidationLevel invalidationLevel = InvalidationLevel::InvalidResources,

--- a/modules/dataframe/include/inviwo/dataframe/util/dataframeutil.h
+++ b/modules/dataframe/include/inviwo/dataframe/util/dataframeutil.h
@@ -38,6 +38,9 @@
 
 namespace inviwo {
 
+/**
+ * Utility functions for DataFrame operations
+ */
 namespace dataframe {
 
 IVW_MODULE_DATAFRAME_API std::shared_ptr<BufferBase> cloneBufferRange(

--- a/modules/dataframe/include/inviwo/dataframe/util/filters.h
+++ b/modules/dataframe/include/inviwo/dataframe/util/filters.h
@@ -45,6 +45,9 @@ enum class NumberComp { Equal, NotEqual, Less, LessEqual, Greater, GreaterEqual 
 
 }  // namespace filters
 
+/**
+ * CSV-specific filters when parsing CSV files
+ */
 namespace csvfilters {
 /**
  * Predicate functor for filtering rows.

--- a/modules/dataframe/include/inviwo/dataframe/util/filters.h
+++ b/modules/dataframe/include/inviwo/dataframe/util/filters.h
@@ -1,0 +1,135 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2022 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <inviwo/dataframe/dataframemoduledefine.h>
+
+#include <string_view>
+#include <functional>
+#include <variant>
+#include <vector>
+
+namespace inviwo {
+
+namespace filters {
+
+enum class StringComp { Equal, NotEqual, Regex, RegexPartial };
+
+enum class NumberComp { Equal, NotEqual, Less, LessEqual, Greater, GreaterEqual };
+
+}  // namespace filters
+
+namespace csvfilters {
+/**
+ * Predicate functor for filtering rows.
+ * @p RowFilter::filter is called once per row.
+ * If @p RowFilter::filterOnHeader is true, then this filter is applied before the header row is
+ * extracted.
+ */
+struct RowFilter {
+    /**
+     * Predicate function for rows. The first argument is the content of the entire row, the
+     * second argument holds the line number.
+     */
+    std::function<bool(std::string_view, size_t)> filter;
+    bool filterOnHeader;
+};
+/**
+ * Predicate functor for filtering items in a specific column of a row. Column indices are
+ * zero-based.
+ * @p ItemFilter::filter is called once for the data item in @p ItemFilter::column of each row.
+ * If @p ItemFilter::filterOnHeader is true, then this filter is applied before the header row
+ * is extracted.
+ */
+struct ItemFilter {
+    using FilterFunc = std::variant<std::function<bool(std::string_view)>, std::function<bool(int)>,
+                                    std::function<bool(float)>, std::function<bool(double)>>;
+
+    /**
+     * Predicate function for filtering a column. The data item of @ItemFilter::column is
+     * converted from std::string to the corresponding type of the predicate function before
+     * @p filter is called, that is @p std::string_view, @p int, @p float, or @p double.
+     * @see FilterFunc
+     */
+    FilterFunc filter;
+    int column;  //!< zero-based column index
+    bool filterOnHeader;
+};
+
+/**
+ * Filters to be applied per row while parsing the CSV file.
+ * All respective filter predicates are combined using a union operation.
+ * First, rows are filtered for includes and then excludes. Secondly, individual data items of
+ * the remaining rows are filtered for includes and excludes.
+ */
+struct Filters {
+    std::vector<RowFilter> includeRows;
+    std::vector<RowFilter> excludeRows;
+    std::vector<ItemFilter> includeItems;
+    std::vector<ItemFilter> excludeItems;
+};
+
+/// create a filter matching empty rows
+IVW_MODULE_DATAFRAME_API RowFilter emptyLines(bool filterOnHeader = true);
+
+/// create a filter matching rows starting with @p begin, for example comment rows starting with '#'
+IVW_MODULE_DATAFRAME_API RowFilter rowBegin(std::string_view begin, bool filterOnHeader);
+
+/// create a filter matching an inclusive line range [@p min, @p max]
+IVW_MODULE_DATAFRAME_API RowFilter lineRange(int min, int max, bool filterOnHeader);
+
+/// create an item filter matching strings with @p match based on @p op
+IVW_MODULE_DATAFRAME_API ItemFilter stringMatch(int column, filters::StringComp op,
+                                                std::string_view match);
+
+/// create an item filter matching integers with @p value using @p op
+IVW_MODULE_DATAFRAME_API ItemFilter intMatch(int column, filters::NumberComp op, int value);
+
+/// create an item filter matching floats with @p value using @p op, @epsilon is used for equal and
+/// not equal comparisons
+IVW_MODULE_DATAFRAME_API ItemFilter floatMatch(int column, filters::NumberComp op, float value,
+                                               float epsilon);
+
+/// create an item filter matching doubles with @p value using @p op, @epsilon is used for equal and
+/// not equal comparisons
+IVW_MODULE_DATAFRAME_API ItemFilter doubleMatch(int column, filters::NumberComp op, double value,
+                                                double epsilon);
+
+/// create an item filter matching an inclusive integer range [@p min, @p max]
+IVW_MODULE_DATAFRAME_API ItemFilter intRange(int column, int min, int max);
+
+/// create an item filter matching an inclusive float range [@p min, @p max]
+IVW_MODULE_DATAFRAME_API ItemFilter floatRange(int column, float min, float max);
+
+/// create an item filter matching an inclusive double range [@p min, @p max]
+IVW_MODULE_DATAFRAME_API ItemFilter doubleRange(int column, double min, double max);
+
+}  // namespace csvfilters
+
+}  // namespace inviwo

--- a/modules/dataframe/src/dataframemodule.cpp
+++ b/modules/dataframe/src/dataframemodule.cpp
@@ -44,6 +44,7 @@
 #include <inviwo/dataframe/properties/columnmetadataproperty.h>
 #include <inviwo/dataframe/properties/columnmetadatalistproperty.h>
 #include <inviwo/dataframe/properties/optionconverter.h>
+#include <inviwo/dataframe/properties/filterlistproperty.h>
 
 #include <inviwo/dataframe/io/csvreader.h>
 #include <inviwo/dataframe/io/jsonreader.h>
@@ -95,6 +96,7 @@ DataFrameModule::DataFrameModule(InviwoApplication* app) : InviwoModule(app, "Da
     registerProperty<ColumnOptionProperty>();
     registerProperty<ColumnMetaDataProperty>();
     registerProperty<ColumnMetaDataListProperty>();
+    registerProperty<FilterListProperty>();
 
     // Readers and writes
     registerDataReader(std::make_unique<CSVReader>());

--- a/modules/dataframe/src/io/csvreader.cpp
+++ b/modules/dataframe/src/io/csvreader.cpp
@@ -524,7 +524,8 @@ std::shared_ptr<DataFrame> CSVReader::readData(std::istream& stream) const {
         std::remove_if(rows.begin(), rows.end(), [](const auto& row) { return row.first.empty(); }),
         rows.end());
 
-    // Ignore comment lines
+    // Ignore comment lines 
+    // The row must start with the comment character. Applied before keep only
     if (!rowComment_.empty()) {
         rows.erase(std::remove_if(rows.begin(), rows.end(),
                                   [this](const auto& row) {

--- a/modules/dataframe/src/processors/csvsource.cpp
+++ b/modules/dataframe/src/processors/csvsource.cpp
@@ -33,6 +33,15 @@
 #include <inviwo/core/datastructures/buffer/bufferramprecision.h>
 #include <inviwo/core/util/stdextensions.h>
 #include <inviwo/core/util/zip.h>
+#include <inviwo/core/util/exception.h>
+
+#include <inviwo/core/properties/boolcompositeproperty.h>
+#include <inviwo/core/properties/boolproperty.h>
+#include <inviwo/core/properties/optionproperty.h>
+#include <inviwo/core/properties/ordinalproperty.h>
+#include <inviwo/core/properties/minmaxproperty.h>
+
+#include <type_traits>
 
 namespace inviwo {
 
@@ -59,8 +68,10 @@ CSVSource::CSVSource(const std::string& file)
     , stripQuotes_("stripQuotes", "Strip surrounding quotes", CSVReader::defaultStripQuotes)
     , doublePrecision_("doublePrecision", "Double Precision", CSVReader::defaultDoublePrecision)
     , exampleRows_("exampleRows", "Example Rows", CSVReader::defaultNumberOfExampleRows, 0, 10000)
-    , rowComment_("rowComment", "Comment marker", CSVReader::defaultRowComment)
-    , keepOnly_("keepOnly", "Keeping marker", CSVReader::defaultKeepOnly)
+    , rowComment_("rowComment", "Comment marker", "")
+    , keepOnly_("keepOnly", "Keeping marker", "")
+    , includeFilters_("includeFilters", "Include Filters", true)
+    , excludeFilters_("excludeFilters", "Exclude Filters", true)
     , locale_("locale", "Locale", CSVReader::defaultLocale)
     , emptyField_("emptyField", "Missing Data Mode",
                   {{"throw", "Throw Exception", CSVReader::EmptyField::Throw},
@@ -78,13 +89,17 @@ CSVSource::CSVSource(const std::string& file)
 
     unitsInHeaders_.addProperty(unitRegexp_);
     addProperties(inputFile_, firstRowIsHeaders_, unitsInHeaders_, delimiters_, stripQuotes_,
-                  doublePrecision_, exampleRows_, rowComment_, keepOnly_, locale_, emptyField_, reloadData_,
-                  columns_);
+                  doublePrecision_, exampleRows_, rowComment_, keepOnly_, locale_, emptyField_,
+                  reloadData_, includeFilters_, excludeFilters_, columns_);
+
+    includeFilters_.setCollapsed(true);
+    excludeFilters_.setCollapsed(true);
 
     isReady_.setUpdate(
         [this]() { return !loadingFailed_ && filesystem::fileExists(inputFile_.get()); });
-    for (auto&& item : util::ref<Property>(inputFile_, reloadData_, delimiters_, stripQuotes_,
-                                           firstRowIsHeaders_, unitsInHeaders_, unitRegexp_, doublePrecision_, exampleRows_,
+    for (auto&& item :
+         util::ref<Property>(inputFile_, reloadData_, delimiters_, stripQuotes_, firstRowIsHeaders_,
+                             unitsInHeaders_, unitRegexp_, doublePrecision_, exampleRows_,
                              rowComment_, keepOnly_, locale_, emptyField_)) {
         std::invoke(&Property::onChange, item, [this]() {
             loadingFailed_ = false;
@@ -106,20 +121,22 @@ void CSVSource::process() {
         const auto overwrite = deserialized_ ? util::OverwriteState::No : util::OverwriteState::Yes;
         deserialized_ = false;
 
-        if (util::any_of(util::ref<Property>(inputFile_, reloadData_, delimiters_, stripQuotes_,
-                                             firstRowIsHeaders_, unitsInHeaders_, unitRegexp_,
-                                             doublePrecision_, exampleRows_, rowComment_, keepOnly_, locale_,
-                                             emptyField_),
-                         &Property::isModified)) {
+        if (util::any_of(
+                util::ref<Property>(inputFile_, reloadData_, delimiters_, stripQuotes_,
+                                    firstRowIsHeaders_, unitsInHeaders_, unitRegexp_,
+                                    doublePrecision_, exampleRows_, rowComment_, keepOnly_,
+                                    includeFilters_, excludeFilters_, locale_, emptyField_),
+                &Property::isModified)) {
             CSVReader reader(delimiters_, firstRowIsHeaders_, doublePrecision_);
             reader.setLocale(locale_)
                 .setStripQuotes(stripQuotes_)
                 .setNumberOfExampleRows(exampleRows_)
                 .setHandleEmptyFields(emptyField_)
                 .setUnitsInHeaders(unitsInHeaders_)
-                .setUnitRegexp(unitRegexp_)
-                .setRowComment(rowComment_)
-                .setKeepOnly(keepOnly_);
+                .setUnitRegexp(unitRegexp_);
+
+            reader.setFilters(createFilters());
+
             loadedData_ = reader.readData(inputFile_.get());
             columns_.updateForNewDataFrame(*loadedData_, overwrite);
         }
@@ -137,6 +154,94 @@ void CSVSource::process() {
 void CSVSource::deserialize(Deserializer& d) {
     Processor::deserialize(d);
     deserialized_ = true;
+}
+
+namespace detail {
+
+template <typename T>
+decltype(std::declval<T&>().get()) getValue(PropertyOwner* parent, std::string_view identifier) {
+    if (auto p = dynamic_cast<T*>(parent->getPropertyByIdentifier(identifier))) {
+        return p->get();
+    } else {
+        throw Exception(IVW_CONTEXT_CUSTOM("CSVSource::createFilters"),
+                        "Invalid filter property '{}', missing sub-property '{}'",
+                        parent->getIdentifier(), identifier);
+    }
+}
+
+}  // namespace detail
+
+csvfilters::Filters CSVSource::createFilters() const {
+
+    auto startsWith = [](std::string_view str, std::string_view prefix) {
+        return str.substr(0, prefix.size()) == prefix;
+    };
+
+    auto parse = [&](const auto& filterProp, auto& rowFilters, auto& itemFilters) {
+        for (auto prop : filterProp) {
+            if (auto cp = dynamic_cast<BoolCompositeProperty*>(prop)) {
+                if (!cp->isChecked()) continue;
+
+                const auto& identifier = cp->getIdentifier();
+
+                if (startsWith(identifier, "rowBegin")) {
+                    rowFilters.push_back(csvfilters::rowBegin(
+                        std::string_view{detail::getValue<StringProperty>(cp, "match")},
+                        detail::getValue<BoolProperty>(cp, "filterOnHeader")));
+                } else if (startsWith(identifier, "lineRange")) {
+                    const auto& range = detail::getValue<IntMinMaxProperty>(cp, "range");
+                    rowFilters.push_back(csvfilters::lineRange(
+                        range.x, range.y, detail::getValue<BoolProperty>(cp, "filterOnHeader")));
+                } else if (startsWith(identifier, "stringItem")) {
+                    itemFilters.push_back(csvfilters::stringMatch(
+                        detail::getValue<IntProperty>(cp, "column"),
+                        detail::getValue<TemplateOptionProperty<filters::StringComp>>(cp, "comp"),
+                        detail::getValue<StringProperty>(cp, "match")));
+                } else if (startsWith(identifier, "intItem")) {
+                    itemFilters.push_back(csvfilters::intMatch(
+                        detail::getValue<IntProperty>(cp, "column"),
+                        detail::getValue<TemplateOptionProperty<filters::NumberComp>>(cp, "comp"),
+                        detail::getValue<IntProperty>(cp, "value")));
+                } else if (startsWith(identifier, "floatItem")) {
+                    itemFilters.push_back(csvfilters::floatMatch(
+                        detail::getValue<IntProperty>(cp, "column"),
+                        detail::getValue<TemplateOptionProperty<filters::NumberComp>>(cp, "comp"),
+                        detail::getValue<FloatProperty>(cp, "value"),
+                        detail::getValue<FloatProperty>(cp, "epsilon")));
+                } else if (startsWith(identifier, "doubleItem")) {
+                    itemFilters.push_back(csvfilters::doubleMatch(
+                        detail::getValue<IntProperty>(cp, "column"),
+                        detail::getValue<TemplateOptionProperty<filters::NumberComp>>(cp, "comp"),
+                        detail::getValue<DoubleProperty>(cp, "value"),
+                        detail::getValue<DoubleProperty>(cp, "epsilon")));
+                } else if (startsWith(identifier, "intRangeItem")) {
+                    const auto& range = detail::getValue<IntMinMaxProperty>(cp, "range");
+                    itemFilters.push_back(csvfilters::intRange(
+                        detail::getValue<IntProperty>(cp, "column"), range.x, range.y));
+                } else if (startsWith(identifier, "floatRangeItem")) {
+                    const auto& range = detail::getValue<FloatMinMaxProperty>(cp, "range");
+                    itemFilters.push_back(csvfilters::floatRange(
+                        detail::getValue<IntProperty>(cp, "column"), range.x, range.y));
+                } else if (startsWith(identifier, "doubleRangeItem")) {
+                    const auto& range = detail::getValue<DoubleMinMaxProperty>(cp, "range");
+                    itemFilters.push_back(csvfilters::doubleRange(
+                        detail::getValue<IntProperty>(cp, "column"), range.x, range.y));
+                }
+            }
+        }
+    };
+
+    csvfilters::Filters filters;
+    parse(includeFilters_, filters.includeRows, filters.includeItems);
+    parse(excludeFilters_, filters.excludeRows, filters.excludeItems);
+
+    if (!rowComment_.get().empty()) {
+        filters.excludeRows.push_back(csvfilters::rowBegin(rowComment_, true));
+    }
+    if (!keepOnly_.get().empty()) {
+        filters.includeRows.push_back(csvfilters::rowBegin(keepOnly_, false));
+    }
+    return filters;
 }
 
 }  // namespace inviwo

--- a/modules/dataframe/src/properties/filterlistproperty.cpp
+++ b/modules/dataframe/src/properties/filterlistproperty.cpp
@@ -61,7 +61,7 @@ FilterListProperty::FilterListProperty(std::string_view identifier, std::string_
         return p;
     };
 
-    if (supportedFilters & FilterType::Rows) {
+    if (supportedFilters.contains(FilterType::Rows)) {
         {
             auto emptyLines =
                 std::make_unique<BoolCompositeProperty>("emptyLines", "Empty Lines", true);
@@ -94,7 +94,7 @@ FilterListProperty::FilterListProperty(std::string_view identifier, std::string_
             InvalidationLevel::InvalidOutput, PropertySemantics::Text);
     };
 
-    if (supportedFilters & FilterType::StringItem) {
+    if (supportedFilters.contains(FilterType::StringItem)) {
         auto stringItem =
             std::make_unique<BoolCompositeProperty>("stringItem", "String Match", true);
         stringItem->addProperty(columnProp());
@@ -110,7 +110,7 @@ FilterListProperty::FilterListProperty(std::string_view identifier, std::string_
 
         addPrefab(std::move(stringItem));
     }
-    if (supportedFilters & FilterType::IntItem) {
+    if (supportedFilters.contains(FilterType::IntItem)) {
         auto intItem =
             std::make_unique<BoolCompositeProperty>("intItem", "Integer Comparison", true);
         intItem->addProperty(columnProp());
@@ -130,7 +130,7 @@ FilterListProperty::FilterListProperty(std::string_view identifier, std::string_
 
         addPrefab(std::move(intItem));
     }
-    if (supportedFilters & FilterType::FloatItem) {
+    if (supportedFilters.contains(FilterType::FloatItem)) {
         auto floatItem =
             std::make_unique<BoolCompositeProperty>("floatItem", "Float Comparison", true);
         floatItem->addProperty(columnProp());
@@ -154,7 +154,7 @@ FilterListProperty::FilterListProperty(std::string_view identifier, std::string_
 
         addPrefab(std::move(floatItem));
     }
-    if (supportedFilters & FilterType::DoubleItem) {
+    if (supportedFilters.contains(FilterType::DoubleItem)) {
         auto doubleItem =
             std::make_unique<BoolCompositeProperty>("doubleItem", "Double Comparison", true);
         doubleItem->addProperty(columnProp());
@@ -178,7 +178,7 @@ FilterListProperty::FilterListProperty(std::string_view identifier, std::string_
 
         addPrefab(std::move(doubleItem));
     }
-    if (supportedFilters & FilterType::IntRange) {
+    if (supportedFilters.contains(FilterType::IntRange)) {
         auto intRange = std::make_unique<BoolCompositeProperty>("intRangeItem", "Int Range", true);
         intRange->addProperty(columnProp());
         intRange->addProperty(std::make_unique<IntMinMaxProperty>(
@@ -188,7 +188,7 @@ FilterListProperty::FilterListProperty(std::string_view identifier, std::string_
 
         addPrefab(std::move(intRange));
     }
-    if (supportedFilters & FilterType::FloatRange) {
+    if (supportedFilters.contains(FilterType::FloatRange)) {
         auto floatRange =
             std::make_unique<BoolCompositeProperty>("floatRangeItem", "Float Range", true);
         floatRange->addProperty(columnProp());
@@ -199,7 +199,7 @@ FilterListProperty::FilterListProperty(std::string_view identifier, std::string_
 
         addPrefab(std::move(floatRange));
     }
-    if (supportedFilters & FilterType::DoubleRange) {
+    if (supportedFilters.contains(FilterType::DoubleRange)) {
         auto doubleRange =
             std::make_unique<BoolCompositeProperty>("doubleRangeItem", "Double Range", true);
         doubleRange->addProperty(columnProp());

--- a/modules/dataframe/src/properties/filterlistproperty.cpp
+++ b/modules/dataframe/src/properties/filterlistproperty.cpp
@@ -1,0 +1,207 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2022 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/dataframe/properties/filterlistproperty.h>
+#include <inviwo/core/properties/boolcompositeproperty.h>
+#include <inviwo/core/properties/stringproperty.h>
+#include <inviwo/core/properties/boolproperty.h>
+#include <inviwo/core/properties/ordinalproperty.h>
+#include <inviwo/core/properties/minmaxproperty.h>
+#include <inviwo/core/properties/optionproperty.h>
+
+#include <inviwo/dataframe/util/filters.h>
+
+#include <limits>
+#include <regex>
+#include <functional>
+#include <algorithm>
+
+namespace inviwo {
+
+const std::string FilterListProperty::classIdentifier = "org.inviwo.FilterListProperty";
+std::string FilterListProperty::getClassIdentifier() const { return classIdentifier; }
+
+FilterListProperty::FilterListProperty(std::string_view identifier, std::string_view displayName,
+                                       bool supportsFilterOnHeader, size_t maxNumberOfElements,
+                                       ListPropertyUIFlags uiFlags,
+                                       InvalidationLevel invalidationLevel,
+                                       PropertySemantics semantics)
+    : ListProperty(identifier, displayName, maxNumberOfElements, uiFlags, invalidationLevel,
+                   semantics) {
+
+    auto onHeaderProp = [enable = supportsFilterOnHeader]() {
+        auto p = std::make_unique<BoolProperty>("filterOnHeader", "Filter on Header", enable);
+        p->setVisible(enable);
+        return p;
+    };
+
+    {
+        auto rowBegin = std::make_unique<BoolCompositeProperty>("rowBegin", "Row Begin", true);
+        rowBegin->addProperty(onHeaderProp());
+        rowBegin->addProperty(std::make_unique<StringProperty>("match", "Matching String", ""));
+
+        addPrefab(std::move(rowBegin));
+    }
+    {
+        auto lineRange = std::make_unique<BoolCompositeProperty>("lineRange", "Line Range", true);
+        lineRange->addProperty(onHeaderProp());
+        lineRange->addProperty(std::make_unique<IntMinMaxProperty>(
+            "range", "Line Range", 0, 100, 0, std::numeric_limits<int>::max(), 1, 0,
+            InvalidationLevel::InvalidOutput, PropertySemantics::Text));
+
+        addPrefab(std::move(lineRange));
+    }
+
+    auto columnProp = []() {
+        return std::make_unique<IntProperty>(
+            "column", "Column", 0, 0, std::numeric_limits<int>::max(), 1,
+            InvalidationLevel::InvalidOutput, PropertySemantics::Text);
+    };
+
+    {
+        auto stringItem =
+            std::make_unique<BoolCompositeProperty>("stringItem", "String Match", true);
+        stringItem->addProperty(columnProp());
+        stringItem->addProperty(std::make_unique<TemplateOptionProperty<filters::StringComp>>(
+            "comp", "Comparison",
+            std::vector<OptionPropertyOption<filters::StringComp>>{
+                {"equal", "equal (==)", filters::StringComp::Equal},
+                {"notEqual", "Not Equal (!=)", filters::StringComp::NotEqual},
+                {"regex", "Regex", filters::StringComp::Regex},
+                {"regexPartial", "Regex (Partial)", filters::StringComp::RegexPartial}},
+            0));
+        stringItem->addProperty(std::make_unique<StringProperty>("match", "Matching String", ""));
+
+        addPrefab(std::move(stringItem));
+    }
+    {
+        auto intItem =
+            std::make_unique<BoolCompositeProperty>("intItem", "Integer Comparison", true);
+        intItem->addProperty(columnProp());
+        intItem->addProperty(std::make_unique<TemplateOptionProperty<filters::NumberComp>>(
+            "comp", "Comparison",
+            std::vector<OptionPropertyOption<filters::NumberComp>>{
+                {"equal", "equal (==)", filters::NumberComp::Equal},
+                {"notEqual", "Not Equal (!=)", filters::NumberComp::NotEqual},
+                {"less", "Less (<)", filters::NumberComp::Less},
+                {"lessEqual", "Less Equal (<=)", filters::NumberComp::LessEqual},
+                {"greater", "greater (>)", filters::NumberComp::Greater},
+                {"greaterEqual", "Greater Equal (>=)", filters::NumberComp::GreaterEqual}},
+            0));
+        intItem->addProperty(std::make_unique<IntProperty>(
+            "value", "Value", 0, std::numeric_limits<int>::min(), std::numeric_limits<int>::max(),
+            1, InvalidationLevel::InvalidOutput, PropertySemantics::Text));
+
+        addPrefab(std::move(intItem));
+    }
+    {
+        auto floatItem =
+            std::make_unique<BoolCompositeProperty>("floatItem", "Float Comparison", true);
+        floatItem->addProperty(columnProp());
+        floatItem->addProperty(std::make_unique<TemplateOptionProperty<filters::NumberComp>>(
+            "comp", "Comparison",
+            std::vector<OptionPropertyOption<filters::NumberComp>>{
+                {"equal", "equal (==)", filters::NumberComp::Equal},
+                {"notEqual", "Not Equal (!=)", filters::NumberComp::NotEqual},
+                {"less", "Less (<)", filters::NumberComp::Less},
+                {"lessEqual", "Less Equal (<=)", filters::NumberComp::LessEqual},
+                {"greater", "greater (>)", filters::NumberComp::Greater},
+                {"greaterEqual", "Greater Equal (>=)", filters::NumberComp::GreaterEqual}},
+            0));
+        floatItem->addProperty(std::make_unique<FloatProperty>(
+            "value", "Value", 0.0f, std::numeric_limits<float>::lowest(),
+            std::numeric_limits<float>::max(), 0.1f, InvalidationLevel::InvalidOutput,
+            PropertySemantics::Text));
+        floatItem->addProperty(std::make_unique<FloatProperty>(
+            "epsilon", "Epsilon", 0.0f, 0.0f, std::numeric_limits<float>::max(), 0.1f,
+            InvalidationLevel::InvalidOutput, PropertySemantics::Text));
+
+        addPrefab(std::move(floatItem));
+    }
+    {
+        auto doubleItem =
+            std::make_unique<BoolCompositeProperty>("doubleItem", "Double Comparison", true);
+        doubleItem->addProperty(columnProp());
+        doubleItem->addProperty(std::make_unique<TemplateOptionProperty<filters::NumberComp>>(
+            "comp", "Comparison",
+            std::vector<OptionPropertyOption<filters::NumberComp>>{
+                {"equal", "equal (==)", filters::NumberComp::Equal},
+                {"notEqual", "Not Equal (!=)", filters::NumberComp::NotEqual},
+                {"less", "Less (<)", filters::NumberComp::Less},
+                {"lessEqual", "Less Equal (<=)", filters::NumberComp::LessEqual},
+                {"greater", "greater (>)", filters::NumberComp::Greater},
+                {"greaterEqual", "Greater Equal (>=)", filters::NumberComp::GreaterEqual}},
+            0));
+        doubleItem->addProperty(std::make_unique<DoubleProperty>(
+            "value", "Value", 0.0, std::numeric_limits<double>::lowest(),
+            std::numeric_limits<double>::max(), 0.1, InvalidationLevel::InvalidOutput,
+            PropertySemantics::Text));
+        doubleItem->addProperty(std::make_unique<DoubleProperty>(
+            "epsilon", "Epsilon", 0.0, 0.0, std::numeric_limits<double>::max(), 0.1,
+            InvalidationLevel::InvalidOutput, PropertySemantics::Text));
+
+        addPrefab(std::move(doubleItem));
+    }
+    {
+        auto intRange = std::make_unique<BoolCompositeProperty>("intRangeItem", "Int Range", true);
+        intRange->addProperty(columnProp());
+        intRange->addProperty(std::make_unique<IntMinMaxProperty>(
+            "range", "Integer Range", 0, 100, std::numeric_limits<int>::min(),
+            std::numeric_limits<int>::max(), 1, 0, InvalidationLevel::InvalidOutput,
+            PropertySemantics::Text));
+
+        addPrefab(std::move(intRange));
+    }
+    {
+        auto floatRange =
+            std::make_unique<BoolCompositeProperty>("floatRangeItem", "Float Range", true);
+        floatRange->addProperty(columnProp());
+        floatRange->addProperty(std::make_unique<FloatMinMaxProperty>(
+            "range", "Float Range", 0.0f, 100.0f, std::numeric_limits<float>::lowest(),
+            std::numeric_limits<float>::max(), 0.1f, 0.0f, InvalidationLevel::InvalidOutput,
+            PropertySemantics::Text));
+
+        addPrefab(std::move(floatRange));
+    }
+    {
+        auto doubleRange =
+            std::make_unique<BoolCompositeProperty>("doubleRangeItem", "Ddouble Range", true);
+        doubleRange->addProperty(columnProp());
+        doubleRange->addProperty(std::make_unique<DoubleMinMaxProperty>(
+            "range", "Double Range", 0.0, 100.0, std::numeric_limits<double>::min(),
+            std::numeric_limits<double>::max(), 0.1, 0.0, InvalidationLevel::InvalidOutput,
+            PropertySemantics::Text));
+
+        addPrefab(std::move(doubleRange));
+    }
+}
+
+FilterListProperty* FilterListProperty::clone() const { return new FilterListProperty(*this); }
+
+}  // namespace inviwo

--- a/modules/dataframe/src/util/filters.cpp
+++ b/modules/dataframe/src/util/filters.cpp
@@ -1,0 +1,175 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2022 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/dataframe/util/filters.h>
+
+#include <functional>
+#include <algorithm>
+#include <regex>
+
+namespace inviwo {
+
+namespace csvfilters {
+
+RowFilter emptyLines(bool filterOnHeader) {
+    return RowFilter{[](std::string_view row, size_t) { return row.empty(); }, filterOnHeader};
+}
+
+RowFilter rowBegin(std::string_view begin, bool filterOnHeader) {
+    return RowFilter{[str = std::string{begin}](std::string_view row, size_t) {
+                         return row.substr(0, str.size()) == str;
+                     },
+                     filterOnHeader};
+}
+
+RowFilter lineRange(int min, int max, bool filterOnHeader) {
+    return RowFilter{
+        [min = static_cast<size_t>(std::max(min, 0)), max = static_cast<size_t>(std::max(max, 0))](
+            std::string_view, size_t line) { return (line >= min) && (line <= max); },
+        filterOnHeader};
+}
+
+ItemFilter stringMatch(int column, filters::StringComp op, std::string_view match) {
+    switch (op) {
+        case filters::StringComp::Equal:
+            return ItemFilter{[str = match](std::string_view item) { return item == str; }, column,
+                              false};
+        case filters::StringComp::NotEqual:
+            return ItemFilter{[str = match](std::string_view item) { return item != str; }, column,
+                              false};
+        case filters::StringComp::Regex:
+            return ItemFilter{[re = std::regex(std::string{match})](std::string_view item) {
+                                  return std::regex_match(item.begin(), item.end(), re);
+                              },
+                              column, false};
+        case filters::StringComp::RegexPartial:
+            return ItemFilter{[re = std::regex(std::string{match})](std::string_view item) {
+                                  return std::regex_search(item.begin(), item.end(), re);
+                              },
+                              column, false};
+        default:
+            return ItemFilter{[str = match](std::string_view item) { return item == str; }, column,
+                              false};
+    }
+}
+
+namespace detail {
+
+template <typename T>
+ItemFilter epsilonComparison(int column, filters::NumberComp op, T value, T epsilon) {
+    auto createFilter = [v = value, column](auto comp) {
+        return ItemFilter{
+            std::function<bool(T)>([v, column, comp](T value) { return comp(value, v); }), column,
+            false};
+    };
+
+    switch (op) {
+        case filters::NumberComp::Equal:
+            return ItemFilter{std::function<bool(T)>([v = value, eps = epsilon](T value) {
+                                  return std::abs(value - v) <= eps;
+                              }),
+                              column, false};
+        case filters::NumberComp::NotEqual:
+            return ItemFilter{std::function<bool(T)>([v = value, eps = epsilon](T value) {
+                                  return std::abs(value - v) > eps;
+                              }),
+                              column, false};
+        case filters::NumberComp::Less:
+            return createFilter(std::less<T>());
+        case filters::NumberComp::LessEqual:
+            return createFilter(std::less_equal<T>());
+        case filters::NumberComp::Greater:
+            return createFilter(std::greater<T>());
+        case filters::NumberComp::GreaterEqual:
+            return createFilter(std::greater_equal<T>());
+        default:
+            return ItemFilter{std::function<bool(T)>([v = value, eps = epsilon](T value) {
+                                  return std::abs(value - v) <= eps;
+                              }),
+                              column, false};
+    }
+}
+
+template <typename T>
+ItemFilter rangeComparison(int column, T min, T max) {
+    return ItemFilter{
+        std::function<bool(T)>([min, max](T value) { return (value >= min) && (value <= max); }),
+        column, false};
+}
+
+}  // namespace detail
+
+ItemFilter intMatch(int column, filters::NumberComp op, int value) {
+    auto createFilter = [v = value, column](auto comp) {
+        return ItemFilter{
+            std::function<bool(int)>([v, column, comp](int value) { return comp(value, v); }),
+            column, false};
+    };
+
+    switch (op) {
+        case filters::NumberComp::Equal:
+            return createFilter(std::equal_to<int>());
+        case filters::NumberComp::NotEqual:
+            return createFilter(std::not_equal_to<int>());
+        case filters::NumberComp::Less:
+            return createFilter(std::less<int>());
+        case filters::NumberComp::LessEqual:
+            return createFilter(std::less_equal<int>());
+        case filters::NumberComp::Greater:
+            return createFilter(std::greater<int>());
+        case filters::NumberComp::GreaterEqual:
+            return createFilter(std::greater_equal<int>());
+        default:
+            return createFilter(std::equal_to<int>());
+    }
+}
+
+ItemFilter floatMatch(int column, filters::NumberComp op, float value, float epsilon) {
+    return detail::epsilonComparison(column, op, value, epsilon);
+}
+
+ItemFilter doubleMatch(int column, filters::NumberComp op, double value, double epsilon) {
+    return detail::epsilonComparison(column, op, value, epsilon);
+}
+
+ItemFilter intRange(int column, int min, int max) {
+    return detail::rangeComparison(column, min, max);
+}
+
+ItemFilter floatRange(int column, float min, float max) {
+    return detail::rangeComparison(column, min, max);
+}
+
+ItemFilter doubleRange(int column, double min, double max) {
+    return detail::rangeComparison(column, min, max);
+}
+
+}  // namespace csvfilters
+
+}  // namespace inviwo

--- a/modules/dataframe/tests/unittests/csvreader-test.cpp
+++ b/modules/dataframe/tests/unittests/csvreader-test.cpp
@@ -102,12 +102,14 @@ TEST(CSVdata, emptyRowAtEnd) {
 
 TEST(CSVdata, emptyRowsAtEnd) {
     // test for empty rows at the end
-    std::istringstream ss("1\n2\n\n\n\n");
+    std::istringstream ss("1\n2\n  \n\n  \n");
 
     CSVReader reader;
     reader.setFirstRowHeader(false);
 
-    EXPECT_THROW(reader.readData(ss), DataReaderException);
+    auto dataframe = reader.readData(ss);
+    ASSERT_EQ(2, dataframe->getNumberOfColumns()) << "column count does not match";
+    ASSERT_EQ(2, dataframe->getNumberOfRows()) << "row count does not match";
 }
 
 TEST(CSVdata, emptyFields) {
@@ -255,23 +257,6 @@ TEST(CSVheader, missingHeader) {
     EXPECT_EQ("1", dataframe->getColumn(1)->getHeader());
     EXPECT_EQ("2", dataframe->getColumn(2)->getHeader());
     EXPECT_EQ("3", dataframe->getColumn(3)->getHeader());
-}
-
-TEST(CSVheader, duplicateHeader) {
-    const std::string data = "1,2,3,4,5\n6,7,8,9,10";
-    std::istringstream ss("First,Second,First,Second,First\n" + data);
-
-    CSVReader reader;
-    reader.setFirstRowHeader(true);
-    auto dataframe = reader.readData(ss);
-
-    // dataFrame should have 4 columns, three for data + 1 index
-    ASSERT_EQ(6, dataframe->getNumberOfColumns()) << "column count does not match";
-    EXPECT_EQ("First", dataframe->getColumn(1)->getHeader());
-    EXPECT_EQ("Second", dataframe->getColumn(2)->getHeader());
-    EXPECT_EQ("First.1", dataframe->getColumn(3)->getHeader());
-    EXPECT_EQ("Second.1", dataframe->getColumn(4)->getHeader());
-    EXPECT_EQ("First.2", dataframe->getColumn(5)->getHeader());
 }
 
 TEST(CSVdelimiter, comma) {
@@ -580,7 +565,7 @@ TEST(CSVFilters, keepLines) {
 TEST(CSVFilters, emptyRows) {
     // test for empty rows in between
     std::istringstream ss("1\n2\n\n\n3\n4\n\n\5\n6");
-    
+
     csvfilters::Filters filters;
     filters.excludeRows.push_back(csvfilters::emptyLines());
 
@@ -596,7 +581,7 @@ TEST(CSVFilters, emptyRows) {
 TEST(CSVFilters, emptyRowsAtEnd) {
     // test for empty rows at the end
     std::istringstream ss("1\n2\n\n\n\n");
-    
+
     csvfilters::Filters filters;
     filters.excludeRows.push_back(csvfilters::emptyLines());
 

--- a/modules/plottinggl/src/processors/scatterplotmatrixprocessor.cpp
+++ b/modules/plottinggl/src/processors/scatterplotmatrixprocessor.cpp
@@ -115,9 +115,10 @@ ScatterPlotMatrixProcessor::ScatterPlotMatrixProcessor()
 
     color_.onChange([&]() {
         if (dataFrame_.hasData()) {
-            auto colorCol = dataFrame_.getData()->getColumn(color_.getSelectedValue());
+            auto index = color_.getSelectedValue();
+            auto colorCol = index >= 0 ? dataFrame_.getData()->getColumn(index).get() : nullptr;
             for (auto& p : plots_) {
-                p->setColorData(colorCol.get());
+                p->setColorData(colorCol);
             }
             scatterPlotproperties_.tf_.setVisible(colorCol != nullptr);
             scatterPlotproperties_.color_.setVisible(colorCol == nullptr);

--- a/src/core/io/datareader.cpp
+++ b/src/core/io/datareader.cpp
@@ -48,7 +48,7 @@ std::ifstream DataReader::open(std::string_view path, std::ios_base::openmode mo
     if (auto file = filesystem::ifstream(path, mode)) {
         return file;
     } else {
-        throw FileException(IVW_CONTEXT, "Could not open file: {)", path);
+        throw FileException(IVW_CONTEXT, "Could not open file: {}", path);
     }
 }
 


### PR DESCRIPTION
* added some generic filtering for CSV files to filter rows and columns
    - removing/including rows starting with strings
    - line ranges
    - string, int, float, and double comparisons
    - int, float, and double ranges
* most of the filters should be applicable to DataFrames as well (future PR)