### PR TITLE
Feature/imagelayoutfix

### DIFF
--- a/modules/basegl/src/processors/imageprocessing/imagelayoutgl.cpp
+++ b/modules/basegl/src/processors/imageprocessing/imagelayoutgl.cpp
@@ -88,15 +88,11 @@ ImageLayoutGL::ImageLayoutGL()
 
     addPort(multiinport_);
     multiinport_.setIsReadyUpdater([this]() {
-        // Ports with zero dimensions will not be active,
-        // so disregard them when considering ready status
+        const auto& outports = multiinport_.getConnectedOutports();
+        size_t minNum = std::min(outports.size(), viewManager_.size());
         return multiinport_.isConnected() &&
-               util::all_of(multiinport_.getConnectedOutports(), [](Outport* p) {
-                   auto ip = static_cast<ImageOutport*>(p);
-                   return (ip->hasData() && glm::any(glm::equal(ip->getDimensions(), size2_t(0))))
-                              ? true
-                              : p->isReady();
-               });
+               util::all_of(outports.begin(), outports.begin() + minNum,
+                            [](Outport* p) { return p->isReady(); });
     });
     // Ensure that viewports are up-to-date
     // before isConnectionActive is called
@@ -481,6 +477,8 @@ void ImageLayoutGL::updateViewports(ivec2 dim, bool force) {
 
     currentDim_ = dim;
     currentLayout_ = layout_.get();
+
+    isReady_.update();
 }
 
 }  // namespace inviwo

--- a/src/core/util/imagecache.cpp
+++ b/src/core/util/imagecache.cpp
@@ -45,7 +45,7 @@ void ImageCache::setMaster(std::shared_ptr<const Image> master) {
 }
 
 std::shared_ptr<const Image> ImageCache::getImage(const size2_t dimensions) const {
-    if (!master_) return std::shared_ptr<const Image>();
+    if (!master_ || (glm::compMul(dimensions) == 0)) return std::shared_ptr<const Image>();
 
     if (master_->getDimensions() == dimensions) return master_;
 


### PR DESCRIPTION
Fixes #1153

Changes proposed in this PR:
 * ImageCache returns empty Image for dimensions `(0,0)`
 * isReady of the `ImageLayout` processor only considers inports which are used in the layout

This has been tested on: Windows
