### PR TITLE
Webbrowser: Linux compile fix

### DIFF
--- a/modules/webbrowser/src/webbrowserutil.cpp
+++ b/modules/webbrowser/src/webbrowserutil.cpp
@@ -36,10 +36,12 @@ namespace cefutil {
 
 std::tuple<CefWindowInfo, CefBrowserSettings> getDefaultBrowserSettings() {
     CefWindowInfo windowInfo;
-    // in linux set a gtk widget, in windows a hwnd. If not available set nullptr
-    // - may cause
-    // some render errors, in context-menu and plugins.
+    
+#if defined(WIN32) || defined(__APPLE__)
     windowInfo.SetAsWindowless(nullptr);  // nullptr means no transparency (site background colour)
+#else
+    windowInfo.SetAsWindowless(0);
+#endif
 
     CefBrowserSettings browserSettings;
 

--- a/modules/webbrowser/src/webbrowserutil.cpp
+++ b/modules/webbrowser/src/webbrowserutil.cpp
@@ -36,7 +36,7 @@ namespace cefutil {
 
 std::tuple<CefWindowInfo, CefBrowserSettings> getDefaultBrowserSettings() {
     CefWindowInfo windowInfo;
-    
+
 #if defined(WIN32) || defined(__APPLE__)
     windowInfo.SetAsWindowless(nullptr);  // nullptr means no transparency (site background colour)
 #else


### PR DESCRIPTION
Fixes 

> inviwo/modules/webbrowser/src/webbrowserutil.cpp:42:32: error: cannot convert ‘std::nullptr_t’ to ‘long unsigned int’
   42 |     windowInfo.SetAsWindowless(nullptr);  // nullptr means no transparency (site background colour)
      |                                ^~~~~~~
      |                                |
      |                                std::nullptr_t
