### PR TITLE
Feature/threadpool

### DIFF
--- a/include/inviwo/core/common/inviwoapplication.h
+++ b/include/inviwo/core/common/inviwoapplication.h
@@ -244,6 +244,11 @@ public:
      */
     virtual void resizePool(size_t newSize);
 
+    /**
+     * Check whether the active thread is managed by the thread pool.
+     */
+    bool isPoolThread() const;
+
     void waitForPool();
     void setPostEnqueueFront(std::function<void()> func);
     void setProgressCallback(std::function<void(std::string)> progressCallback);

--- a/include/inviwo/core/util/threadpool.h
+++ b/include/inviwo/core/util/threadpool.h
@@ -98,6 +98,12 @@ public:
 
     size_t getQueueSize();
 
+    /**
+     * Check whether the active thread is managed by this thread pool.
+     * @return true if current thread is a pool thread
+     */
+    bool isPoolThread() const;
+
 private:
     enum class State {
         Free,     //< Worker is waiting for tasks.

--- a/src/core/common/inviwoapplication.cpp
+++ b/src/core/common/inviwoapplication.cpp
@@ -411,6 +411,8 @@ void InviwoApplication::setProgressCallback(std::function<void(std::string)> pro
 
 ThreadPool& InviwoApplication::getThreadPool() { return pool_; }
 
+bool InviwoApplication::isPoolThread() const { return pool_.isPoolThread(); }
+
 void InviwoApplication::waitForPool() {
     size_t old_size = pool_.getSize();
     resizePool(0);  // This will wait until all tasks are done;


### PR DESCRIPTION
Fixes:
* potential deadlock in `forEachVoxel`

Changes proposed in this PR:
 * added `ThreadPool::isPoolThread()` to check whether current thread is a pool thread

> Thank you for contributing to the Inviwo repository! Please ensure the following: 
> - Code is error and warning free
> - Code follows the Inviwo coding guidelines: 
>   https://github.com/inviwo/inviwo/wiki/Coding-Conventions
> - New Code / Processors follows the Inviwo documentation guidelines: 
>   https://github.com/inviwo/inviwo/wiki/Documentation-guide
> - New Code / processors are tested in a unittest and / or regression test: 
>   https://github.com/inviwo/inviwo/wiki/Manual#testing
> 
> Please remember to specify the environment this code been compiled and tested on:
> Operating System / Compiler / IDE / QT / CMake / Python versions.
