### PR TITLE
Feature/qt fixes

### DIFF
--- a/modules/dataframeqt/src/dataframemodel.cpp
+++ b/modules/dataframeqt/src/dataframemodel.cpp
@@ -217,12 +217,17 @@ QVariant DataFrameModel::headerData(int section, Qt::Orientation orientation, in
         }
     } else if ((role == Qt::ToolTipRole) && (orientation == Qt::Horizontal)) {
         const Column* col = data_->getColumn(section).get();
-        auto tooltip = [col]() {
+        auto tooltip = [col, section]() {
             if (col->getColumnType() == ColumnType::Categorical) {
-                return QString("Categorical (%0 categories)")
+                return QString("<b>%0</b> (Column %1)\nCategorical (%2 categories)")
+                    .arg(utilqt::toQString(col->getHeader()))
+                    .arg(section)
                     .arg(static_cast<const CategoricalColumn*>(col)->getCategories().size());
             } else {
-                return QString("Ordinal (%0)").arg(col->getBuffer()->getDataFormat()->getString());
+                return QString("<b>%0</b> (Column %1)\nOrdinal (%2)")
+                    .arg(utilqt::toQString(col->getHeader()))
+                    .arg(section)
+                    .arg(col->getBuffer()->getDataFormat()->getString());
             }
         }();
         if (col->getCustomRange()) {

--- a/modules/dataframeqt/src/dataframetableview.cpp
+++ b/modules/dataframeqt/src/dataframetableview.cpp
@@ -47,14 +47,32 @@
 #include <QHeaderView>
 #include <QSortFilterProxyModel>
 #include <QAbstractButton>
+#include <QStyledItemDelegate>
 #include <warn/pop>
 
 namespace inviwo {
+
+// Custom style delegate to prevent the drawing of the default selection, which is drawn on top of
+// the background of the table cells
+class HideSelectionDelegate : public QStyledItemDelegate {
+public:
+    HideSelectionDelegate(QObject* parent = nullptr) : QStyledItemDelegate(parent) {}
+
+    virtual void paint(QPainter* painter, const QStyleOptionViewItem& option,
+                       const QModelIndex& index) const override {
+        QStyleOptionViewItem style(option);
+        // get rid of selected state so that the default selection overlay is not drawn
+        style.state &= ~QStyle::State_Selected;
+        QStyledItemDelegate::paint(painter, style, index);
+    }
+};
 
 DataFrameTableView::DataFrameTableView(QWidget* parent)
     : QTableView(parent)
     , model_(new DataFrameModel(this))
     , sortProxy_(new DataFrameSortFilterProxy(this)) {
+
+    setItemDelegate(new HideSelectionDelegate(this));
 
     sortProxy_->setSourceModel(model_);
     setModel(sortProxy_);

--- a/src/qt/editor/inviwomainwindow.cpp
+++ b/src/qt/editor/inviwomainwindow.cpp
@@ -1029,8 +1029,8 @@ bool InviwoMainWindow::openExample(QString exampleFileName) {
 void InviwoMainWindow::openLastWorkspace(std::string workspace) {
     QSettings settings;
     const bool showWelcomePage = settings.value("WelcomeWidget/showWelcomePage", true).toBool();
-    settings.beginGroup(objectName());
-    const bool loadlastWorkspace = settings.value("autoloadLastWorkspace", true).toBool();
+    const bool loadlastWorkspace =
+        settings.value("WelcomeWidget/autoloadLastWorkspace", false).toBool();
 
     const auto loadSuccessful = [&]() {
         workspace = filesystem::cleanupPath(workspace);

--- a/src/qt/editor/welcomewidget.cpp
+++ b/src/qt/editor/welcomewidget.cpp
@@ -490,7 +490,7 @@ WelcomeWidget::WelcomeWidget(InviwoApplication* app, QWidget* parent)
 
         {
             auto autoloadWorkspace = new QCheckBox("&Auto-load last workspace", rightColumn);
-            autoloadWorkspace->setChecked(getSetting("autoloadLastWorkspace", true).toBool());
+            autoloadWorkspace->setChecked(getSetting("autoloadLastWorkspace", false).toBool());
             QObject::connect(autoloadWorkspace, &QCheckBox::toggled, this, [this](bool checked) {
                 setSetting("autoloadLastWorkspace", checked);
             });


### PR DESCRIPTION
Fixes
* Without any existing settings (Qt), Inviwo starts with the Boron dataset and does not show the welcome widget
* Brushing highlight in `DataFrame Table` was not visible due to regular selection drawn on top

Changes proposed in this PR:
 * the Welcome widget is shown by default and "Load last workspace" is disabled
 * DataFrameTableView with custom style delegate to prevent drawing of the regular selection since this is handled with the background role
 * added tooltips with column index and data format to DataFrame Table
