### PR TITLE
Feature/fmt9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Here we document changes that affect the public API or changes that needs to be communicated to other developers. 
 
+## 2022-08-15 FMT Version 9.0.0
+The fmt library was updated to the recent version 9.0.0. There are major breaking change in the update with respect to using ostream operators and fmt. Previosly you could just include `fmt/ostream.h` and any type that was streamable was not also printable with fmt. That behavious as removed and now you either as to wrapp the object with `fmt::streamed(x)` or add a specialization of fmt::formatter for the type. Most core types in inviwo that used std::ostream operators has been updated with fmt formatters. 
+
 ## 2022-08-12 Include changes in core/util/
 Optimized includes in `core/util` with some functions being moved to separate header files.
 Functions moved from `core/util/stringconversion.h` include

--- a/include/inviwo/core/common/version.h
+++ b/include/inviwo/core/common/version.h
@@ -34,7 +34,7 @@
 #include <inviwo/core/util/exception.h>
 
 #include <string>
-#include <ostream>
+#include <iosfwd>
 #include <tuple>
 #include <array>
 
@@ -114,12 +114,7 @@ public:
         return (lhs < rhs) || (lhs == rhs);
     }
 
-    template <class Elem, class Traits>
-    friend std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                                        const Version& v) {
-        ss << v.major << "." << v.minor << "." << v.patch << "." << v.build;
-        return ss;
-    }
+    IVW_CORE_API friend std::ostream& operator<<(std::ostream& ss, const Version& v);
 
     unsigned int major = 0;  ///< Increases when you make incompatible API changes
     unsigned int minor =

--- a/include/inviwo/core/datastructures/geometry/geometrytype.h
+++ b/include/inviwo/core/datastructures/geometry/geometrytype.h
@@ -30,14 +30,10 @@
 #pragma once
 
 #include <inviwo/core/util/ostreamjoiner.h>
+#include <inviwo/core/util/fmtutils.h>
 
-#include <flags/flags.h>
-
-#include <iterator>
-#include <ostream>
+#include <iosfwd>
 #include <string_view>
-
-#include <fmt/format.h>
 
 namespace inviwo {
 
@@ -59,187 +55,44 @@ enum class BufferType {
     RadiiAttrib,
     PickingAttrib,
     ScalarMetaAttrib,
-    NumberOfBufferTypes
+    Unknown
 };
-
-ALLOW_FLAGS_FOR_ENUM(BufferType)
-using BufferTypes = flags::flags<BufferType>;
 
 enum class BufferUsage { Static, Dynamic };
 
 enum class BufferTarget {
-    Data,
-    Index
-};  // Index maps to GL_ELEMENT_ARRAY_BUFFER, Data maps to GL_ARRAY_BUFFER
-
-enum class DrawType { NotSpecified = 0, Points, Lines, Triangles, NumberOfDrawTypes };
-
-enum class ConnectivityType {
-    None = 0,
-    Strip,
-    Loop,
-    Fan,
-    Adjacency,
-    StripAdjacency,
-    NumberOfConnectivityTypes
+    Data,  // Data maps to GL_ARRAY_BUFFER
+    Index  // Index maps to GL_ELEMENT_ARRAY_BUFFER
 };
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, DrawType dt) {
-    switch (dt) {
-        case DrawType::Points:
-            ss << "Points";
-            break;
-        case DrawType::Lines:
-            ss << "Lines";
-            break;
-        case DrawType::Triangles:
-            ss << "Triangles";
-            break;
-        case DrawType::NotSpecified:
-        case DrawType::NumberOfDrawTypes:
-        default:
-            ss << "Not specified";
-    }
-    return ss;
-}
+enum class DrawType { NotSpecified = 0, Points, Lines, Triangles };
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             ConnectivityType ct) {
-    switch (ct) {
-        case ConnectivityType::None:
-            ss << "None";
-            break;
-        case ConnectivityType::Strip:
-            ss << "Strip";
-            break;
-        case ConnectivityType::Loop:
-            ss << "Loop";
-            break;
-        case ConnectivityType::Fan:
-            ss << "Fan";
-            break;
-        case ConnectivityType::Adjacency:
-            ss << "Adjacency";
-            break;
-        case ConnectivityType::StripAdjacency:
-            ss << "Strip adjacency";
-            break;
-        case ConnectivityType::NumberOfConnectivityTypes:
-        default:
-            ss << "Not specified";
-    }
-    return ss;
-}
+enum class ConnectivityType { None = 0, Strip, Loop, Fan, Adjacency, StripAdjacency };
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, BufferType bt) {
-    switch (bt) {
-        case BufferType::PositionAttrib:
-            ss << "Position";
-            break;
-        case BufferType::NormalAttrib:
-            ss << "Normal";
-            break;
-        case BufferType::ColorAttrib:
-            ss << "Color";
-            break;
-        case BufferType::TexCoordAttrib:
-            ss << "TexCoord";
-            break;
-        case BufferType::CurvatureAttrib:
-            ss << "Curvature";
-            break;
-        case BufferType::IndexAttrib:
-            ss << "Index";
-            break;
-        case BufferType::RadiiAttrib:
-            ss << "Radii";
-            break;
-        case BufferType::PickingAttrib:
-            ss << "Picking";
-            break;
-        case BufferType::ScalarMetaAttrib:
-            ss << "ScalarMeta";
-            break;
-        case BufferType::NumberOfBufferTypes:
-            ss << "NumberOfBufferTypes";
-            break;
-        default:
-            ss << "Type not specified";
-            break;
-    }
-    return ss;
-}
+namespace util {
+IVW_CORE_API std::string_view name(DrawType dt);
+IVW_CORE_API std::string_view name(ConnectivityType ct);
+IVW_CORE_API std::string_view name(BufferType bt);
+IVW_CORE_API std::string_view name(BufferUsage bu);
+IVW_CORE_API std::string_view name(BufferTarget bt);
+}  // namespace util
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, BufferUsage bu) {
-    switch (bu) {
-        case BufferUsage::Static:
-            ss << "Static";
-            break;
-        case BufferUsage::Dynamic:
-            ss << "Dynamic";
-            break;
-        default:
-            ss << "Usage not specified";
-    }
-    return ss;
-}
-
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             BufferTarget bt) {
-    switch (bt) {
-        case BufferTarget::Data:
-            ss << "Data";
-            break;
-        case BufferTarget::Index:
-            ss << "Index";
-            break;
-        default:
-            ss << "Target not specified";
-    }
-    return ss;
-}
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, DrawType dt);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, ConnectivityType ct);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, BufferType bt);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, BufferUsage bu);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, BufferTarget bt);
 
 }  // namespace inviwo
 
-namespace fmt {
 template <>
-struct formatter<::inviwo::BufferType> : formatter<string_view> {
-    // parse is inherited from formatter<string_view>.
-    template <typename FormatContext>
-    auto format(::inviwo::BufferType bt, FormatContext& ctx) {
-        using namespace std::literals;
-        const std::string_view str = [&]() {
-            switch (bt) {
-                case ::inviwo::BufferType::PositionAttrib:
-                    return "Position"sv;
-                case ::inviwo::BufferType::NormalAttrib:
-                    return "Normal"sv;
-                case ::inviwo::BufferType::ColorAttrib:
-                    return "Color"sv;
-                case ::inviwo::BufferType::TexCoordAttrib:
-                    return "TexCoord"sv;
-                case ::inviwo::BufferType::CurvatureAttrib:
-                    return "Curvature"sv;
-                case ::inviwo::BufferType::IndexAttrib:
-                    return "Index"sv;
-                case ::inviwo::BufferType::RadiiAttrib:
-                    return "Radii"sv;
-                case ::inviwo::BufferType::PickingAttrib:
-                    return "Picking"sv;
-                case ::inviwo::BufferType::ScalarMetaAttrib:
-                    return "ScalarMeta"sv;
-                case ::inviwo::BufferType::NumberOfBufferTypes:
-                    return "NumberOfBufferTypes"sv;
-                default:
-                    return "Type not specified"sv;
-            }
-        }();
-        return formatter<string_view>::format(str, ctx);
-    }
+struct fmt::formatter<inviwo::DrawType> : inviwo::FlagFormatter<inviwo::DrawType> {};
+template <>
+struct fmt::formatter<inviwo::ConnectivityType> : inviwo::FlagFormatter<inviwo::ConnectivityType> {
 };
-}  // namespace fmt
+template <>
+struct fmt::formatter<inviwo::BufferType> : inviwo::FlagFormatter<inviwo::BufferType> {};
+template <>
+struct fmt::formatter<inviwo::BufferUsage> : inviwo::FlagFormatter<inviwo::BufferUsage> {};
+template <>
+struct fmt::formatter<inviwo::BufferTarget> : inviwo::FlagFormatter<inviwo::BufferTarget> {};

--- a/include/inviwo/core/datastructures/geometry/mesh.h
+++ b/include/inviwo/core/datastructures/geometry/mesh.h
@@ -53,19 +53,21 @@ class IVW_CORE_API Mesh : public DataGroup<Mesh, MeshRepresentation>,
                           public SpatialEntity<3>,
                           public MetaDataOwner {
 public:
-    struct MeshInfo {
+    struct IVW_CORE_API MeshInfo {
         MeshInfo() : dt(DrawType::Points), ct(ConnectivityType::None) {}
         MeshInfo(DrawType d, ConnectivityType c) : dt(d), ct(c) {}
         DrawType dt;
         ConnectivityType ct;
     };
-    struct BufferInfo {
+    struct IVW_CORE_API BufferInfo {
         BufferInfo(BufferType atype) : type(atype), location(static_cast<int>(atype)) {}
         BufferInfo() : BufferInfo(BufferType::PositionAttrib) {}
         BufferInfo(BufferType atype, int alocation) : type(atype), location(alocation) {}
 
         BufferType type;
         int location;  //<! attribute location of buffer in GLSL shader
+
+        IVW_CORE_API friend std::ostream& operator<<(std::ostream& ss, Mesh::BufferInfo info);
     };
 
     using IndexVector = std::vector<std::pair<MeshInfo, std::shared_ptr<IndexBuffer>>>;
@@ -273,13 +275,6 @@ inline bool operator==(const Mesh::MeshInfo& a, const Mesh::MeshInfo& b) {
     return (a.ct == b.ct) && (a.dt == b.dt);
 }
 inline bool operator!=(const Mesh::MeshInfo& a, const Mesh::MeshInfo& b) { return !(a == b); }
-
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             Mesh::BufferInfo info) {
-    ss << info.type << " (location = " << info.location << ")";
-    return ss;
-}
 
 namespace meshutil {
 

--- a/include/inviwo/core/datastructures/image/imagetypes.h
+++ b/include/inviwo/core/datastructures/image/imagetypes.h
@@ -32,6 +32,7 @@
 #include <inviwo/core/common/inviwocoredefine.h>
 #include <inviwo/core/util/ostreamjoiner.h>
 #include <inviwo/core/util/stringconversion.h>
+#include <inviwo/core/util/fmtutils.h>
 
 #include <array>
 #include <ostream>
@@ -59,202 +60,33 @@ enum class ImageChannel : unsigned char { Red, Green, Blue, Alpha, Zero, One };
 
 using SwizzleMask = std::array<ImageChannel, 4>;
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, ImageType type) {
-    switch (type) {
-        case ImageType::ColorOnly:
-            ss << "Color Only";
-            break;
-        case ImageType::ColorDepth:
-            ss << "Color + Depth";
-            break;
-        case ImageType::ColorPicking:
-            ss << "Color + Picking";
-            break;
-        case ImageType::ColorDepthPicking:
-        default:
-            ss << "Color + Depth + Picking";
-            break;
-    }
-    return ss;
-}
+namespace util {
+IVW_CORE_API std::string_view name(ImageType b);
+IVW_CORE_API std::string_view name(LayerType b);
+IVW_CORE_API std::string_view name(ImageChannel b);
+IVW_CORE_API std::string_view name(InterpolationType b);
+IVW_CORE_API std::string_view name(Wrapping b);
+}  // namespace util
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, LayerType type) {
-    switch (type) {
-        case LayerType::Color:
-            ss << "Color";
-            break;
-        case LayerType::Depth:
-            ss << "Depth";
-            break;
-        case LayerType::Picking:
-            ss << "Picking";
-            break;
-        default:
-            ss << "Unknown";
-            break;
-    }
-    return ss;
-}
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, ImageType type);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, LayerType type);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, ImageChannel channel);
+IVW_CORE_API std::istream& operator>>(std::istream& ss, ImageChannel& channel);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, SwizzleMask mask);
+IVW_CORE_API std::istream& operator>>(std::istream& ss, SwizzleMask& mask);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, InterpolationType type);
+IVW_CORE_API std::istream& operator>>(std::istream& ss, InterpolationType& interpolation);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, Wrapping type);
+IVW_CORE_API std::istream& operator>>(std::istream& ss, Wrapping& wrapping);
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             ImageChannel channel) {
-    switch (channel) {
-        case ImageChannel::Red:
-            ss << 'r';
-            break;
-        case ImageChannel::Green:
-            ss << 'g';
-            break;
-        case ImageChannel::Blue:
-            ss << 'b';
-            break;
-        case ImageChannel::Alpha:
-            ss << 'a';
-            break;
-        case ImageChannel::Zero:
-            ss << '0';
-            break;
-        case ImageChannel::One:
-        default:
-            ss << '1';
-            break;
-    }
-    return ss;
-}
-
-template <class Elem, class Traits>
-std::basic_istream<Elem, Traits>& operator>>(std::basic_istream<Elem, Traits>& ss,
-                                             ImageChannel& channel) {
-    char c{0};
-    ss >> c;
-    switch (c) {
-        case 'r':
-            channel = ImageChannel::Red;
-            break;
-        case 'g':
-            channel = ImageChannel::Green;
-            break;
-        case 'b':
-            channel = ImageChannel::Blue;
-            break;
-        case 'a':
-            channel = ImageChannel::Alpha;
-            break;
-        case '0':
-            channel = ImageChannel::Zero;
-            break;
-        case '1':
-            channel = ImageChannel::One;
-            break;
-        default:
-            ss.setstate(std::ios_base::failbit);
-            break;
-    }
-    return ss;
-}
-
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             SwizzleMask mask) {
-    for (const auto c : mask) {
-        ss << c;
-    }
-    return ss;
-}
-
-template <class Elem, class Traits>
-std::basic_istream<Elem, Traits>& operator>>(std::basic_istream<Elem, Traits>& ss,
-                                             SwizzleMask& mask) {
-    for (auto& c : mask) {
-        ss >> c;
-        if (!ss) return ss;
-    }
-    return ss;
-}
-
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             InterpolationType type) {
-    switch (type) {
-        case InterpolationType::Nearest:
-            ss << "Nearest";
-            break;
-        case InterpolationType::Linear:
-        default:
-            ss << "Linear";
-            break;
-    }
-    return ss;
-}
-
-template <class Elem, class Traits>
-std::basic_istream<Elem, Traits>& operator>>(std::basic_istream<Elem, Traits>& ss,
-                                             InterpolationType& interpolation) {
-    std::string str;
-    ss >> str;
-    str = toLower(str);
-
-    if (str == toLower(toString(InterpolationType::Nearest))) {
-        interpolation = InterpolationType::Nearest;
-    } else if (str == toLower(toString(InterpolationType::Linear))) {
-        interpolation = InterpolationType::Linear;
-    } else {
-        ss.setstate(std::ios_base::failbit);
-    }
-
-    return ss;
-}
-
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, Wrapping type) {
-    switch (type) {
-        case Wrapping::Mirror:
-            ss << "Mirror";
-            break;
-        case Wrapping::Repeat:
-            ss << "Repeat";
-            break;
-        case Wrapping::Clamp:
-        default:
-            ss << "Clamp";
-            break;
-    }
-    return ss;
-}
-
-template <class Elem, class Traits>
-std::basic_istream<Elem, Traits>& operator>>(std::basic_istream<Elem, Traits>& ss,
-                                             Wrapping& wrapping) {
-    std::string str;
-    ss >> str;
-    str = toLower(str);
-
-    if (str == toLower(toString(Wrapping::Mirror))) {
-        wrapping = Wrapping::Mirror;
-    } else if (str == toLower(toString(Wrapping::Repeat))) {
-        wrapping = Wrapping::Repeat;
-    } else if (str == toLower(toString(Wrapping::Clamp))) {
-        wrapping = Wrapping::Clamp;
-    } else {
-        ss.setstate(std::ios_base::failbit);
-    }
-
-    return ss;
-}
-
-template <class Elem, class Traits, size_t N>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             const std::array<Wrapping, N>& wrapping) {
+template <size_t N>
+std::ostream& operator<<(std::ostream& ss, const std::array<Wrapping, N>& wrapping) {
     std::copy(wrapping.begin(), wrapping.end(), util::make_ostream_joiner(ss, ", "));
     return ss;
 }
 
-template <class Elem, class Traits, size_t N>
-std::basic_istream<Elem, Traits>& operator>>(std::basic_istream<Elem, Traits>& ss,
-                                             std::array<Wrapping, N>& wrapping) {
+template <size_t N>
+std::istream& operator>>(std::istream& ss, std::array<Wrapping, N>& wrapping) {
     for (auto& w : wrapping) {
         ss >> w;
         if (!ss) return ss;
@@ -263,27 +95,19 @@ std::basic_istream<Elem, Traits>& operator>>(std::basic_istream<Elem, Traits>& s
 }
 
 namespace swizzlemasks {
-
 constexpr SwizzleMask rgb = {
     {ImageChannel::Red, ImageChannel::Green, ImageChannel::Blue, ImageChannel::One}};
-
 constexpr SwizzleMask rgba = {
     {ImageChannel::Red, ImageChannel::Green, ImageChannel::Blue, ImageChannel::Alpha}};
-
 constexpr SwizzleMask rgbZeroAlpha = {
     {ImageChannel::Red, ImageChannel::Green, ImageChannel::Blue, ImageChannel::Zero}};
-
 constexpr SwizzleMask luminance = {
     {ImageChannel::Red, ImageChannel::Red, ImageChannel::Red, ImageChannel::One}};
-
 constexpr SwizzleMask luminanceAlpha = {
     {ImageChannel::Red, ImageChannel::Red, ImageChannel::Red, ImageChannel::Green}};
-
 constexpr SwizzleMask redGreen = {
     {ImageChannel::Red, ImageChannel::Green, ImageChannel::Zero, ImageChannel::Zero}};
-
 constexpr SwizzleMask depth = luminance;
-
 }  // namespace swizzlemasks
 
 namespace wrapping2d {
@@ -291,6 +115,7 @@ constexpr Wrapping2D clampAll = {Wrapping::Clamp, Wrapping::Clamp};
 constexpr Wrapping2D repeatAll = {Wrapping::Repeat, Wrapping::Repeat};
 constexpr Wrapping2D mirrorAll = {Wrapping::Mirror, Wrapping::Mirror};
 }  // namespace wrapping2d
+
 namespace wrapping3d {
 constexpr Wrapping3D clampAll = {Wrapping::Clamp, Wrapping::Clamp, Wrapping::Clamp};
 constexpr Wrapping3D repeatAll = {Wrapping::Repeat, Wrapping::Repeat, Wrapping::Repeat};
@@ -299,18 +124,39 @@ constexpr Wrapping3D mirrorAll = {Wrapping::Mirror, Wrapping::Mirror, Wrapping::
 
 #include <warn/push>
 #include <warn/ignore/unused-function>
-inline bool IVW_CORE_API typeContainsColor(ImageType type) {
+inline bool typeContainsColor(ImageType type) {
     return (type == ImageType::ColorOnly || type == ImageType::ColorDepth ||
             type == ImageType::ColorPicking || type == ImageType::ColorDepthPicking);
 }
 
-inline bool IVW_CORE_API typeContainsDepth(ImageType type) {
+inline bool typeContainsDepth(ImageType type) {
     return (type == ImageType::ColorDepth || type == ImageType::ColorDepthPicking);
 }
 
-inline bool IVW_CORE_API typeContainsPicking(ImageType type) {
+inline bool typeContainsPicking(ImageType type) {
     return (type == ImageType::ColorPicking || type == ImageType::ColorDepthPicking);
 }
 #include <warn/pop>
 
 }  // namespace inviwo
+
+template <>
+struct fmt::formatter<inviwo::ImageType> : inviwo::FlagFormatter<inviwo::ImageType> {};
+template <>
+struct fmt::formatter<inviwo::LayerType> : inviwo::FlagFormatter<inviwo::LayerType> {};
+template <>
+struct fmt::formatter<inviwo::ImageChannel> : inviwo::FlagFormatter<inviwo::ImageChannel> {};
+template <>
+struct fmt::formatter<inviwo::InterpolationType>
+    : inviwo::FlagFormatter<inviwo::InterpolationType> {};
+template <>
+struct fmt::formatter<inviwo::Wrapping> : inviwo::FlagFormatter<inviwo::Wrapping> {};
+
+template <>
+struct fmt::formatter<inviwo::SwizzleMask> : inviwo::FlagsFormatter<inviwo::SwizzleMask> {};
+template <>
+struct fmt::formatter<inviwo::Wrapping1D> : inviwo::FlagsFormatter<inviwo::Wrapping1D> {};
+template <>
+struct fmt::formatter<inviwo::Wrapping2D> : inviwo::FlagsFormatter<inviwo::Wrapping2D> {};
+template <>
+struct fmt::formatter<inviwo::Wrapping3D> : inviwo::FlagsFormatter<inviwo::Wrapping3D> {};

--- a/include/inviwo/core/interaction/events/gesturestate.h
+++ b/include/inviwo/core/interaction/events/gesturestate.h
@@ -30,12 +30,10 @@
 #pragma once
 
 #include <inviwo/core/common/inviwocoredefine.h>
-#include <inviwo/core/util/ostreamjoiner.h>
+#include <inviwo/core/util/fmtutils.h>
 
 #include <flags/flags.h>
-
-#include <iterator>
-#include <ostream>
+#include <iosfwd>
 
 namespace inviwo {
 
@@ -55,53 +53,23 @@ enum class GestureState {
 ALLOW_FLAGS_FOR_ENUM(GestureState)
 using GestureStates = flags::flags<GestureState>;
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, GestureType t) {
-    switch (t) {
-        case GestureType::Pan:
-            ss << "Pan";
-            break;
-        case GestureType::Pinch:
-            ss << "Pinch";
-            break;
-        case GestureType::Swipe:
-            ss << "Swipe";
-            break;
-    }
-    return ss;
-}
+namespace util {
+IVW_CORE_API std::string_view name(GestureType b);
+IVW_CORE_API std::string_view name(GestureState b);
+}  // namespace util
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, GestureState s) {
-    switch (s) {
-        case GestureState::NoGesture:
-            ss << "NoGesture";
-            break;
-        case GestureState::Started:
-            ss << "Started";
-            break;
-        case GestureState::Updated:
-            ss << "Updated";
-            break;
-        case GestureState::Finished:
-            ss << "Finished";
-            break;
-        case GestureState::Canceled:
-            ss << "Canceled";
-            break;
-    }
-    return ss;
-}
-
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, GestureTypes s) {
-    std::copy(s.begin(), s.end(), util::make_ostream_joiner(ss, "+"));
-}
-
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             GestureStates s) {
-    std::copy(s.begin(), s.end(), util::make_ostream_joiner(ss, "+"));
-}
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, GestureType t);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, GestureState s);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, GestureTypes s);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, GestureStates s);
 
 }  // namespace inviwo
+
+template <>
+struct fmt::formatter<inviwo::GestureType> : inviwo::FlagFormatter<inviwo::GestureType> {};
+template <>
+struct fmt::formatter<inviwo::GestureTypes> : inviwo::FlagsFormatter<inviwo::GestureTypes> {};
+template <>
+struct fmt::formatter<inviwo::GestureState> : inviwo::FlagFormatter<inviwo::GestureState> {};
+template <>
+struct fmt::formatter<inviwo::GestureStates> : inviwo::FlagsFormatter<inviwo::GestureStates> {};

--- a/include/inviwo/core/interaction/events/keyboardkeys.h
+++ b/include/inviwo/core/interaction/events/keyboardkeys.h
@@ -30,12 +30,14 @@
 #pragma once
 
 #include <inviwo/core/common/inviwocoredefine.h>
-#include <inviwo/core/util/ostreamjoiner.h>
+#include <inviwo/core/util/fmtutils.h>
 
+#include <string_view>
 #include <flags/flags.h>
+#include <iosfwd>
 
-#include <iterator>
-#include <ostream>
+#include <fmt/core.h>
+
 
 namespace inviwo {
 
@@ -51,66 +53,12 @@ enum class KeyModifier {
 ALLOW_FLAGS_FOR_ENUM(KeyModifier)
 using KeyModifiers = flags::flags<KeyModifier>;
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, KeyModifier m) {
-    switch (m) {
-        case KeyModifier::None:
-            ss << "None";
-            break;
-        case KeyModifier::Control:
-            ss << "Control";
-            break;
-        case KeyModifier::Shift:
-            ss << "Shift";
-            break;
-        case KeyModifier::Alt:
-            ss << "Alt";
-            break;
-        case KeyModifier::Super:
-            ss << "Super";
-            break;
-        case KeyModifier::Menu:
-            ss << "Menu";
-            break;
-        case KeyModifier::Meta:
-            ss << "Meta";
-            break;
-        default:
-            break;
-    }
-    return ss;
-}
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             KeyModifiers ms) {
-    std::copy(ms.begin(), ms.end(), util::make_ostream_joiner(ss, "+"));
-    return ss;
-}
-
 enum class KeyState {
     Press = 1 << 0,
     Release = 1 << 1,
 };
 ALLOW_FLAGS_FOR_ENUM(KeyState)
 using KeyStates = flags::flags<KeyState>;
-
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, KeyState s) {
-    switch (s) {
-        case KeyState::Press:
-            ss << "Press";
-            break;
-        case KeyState::Release:
-            ss << "Release";
-            break;
-    }
-    return ss;
-}
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, KeyStates s) {
-    std::copy(s.begin(), s.end(), util::make_ostream_joiner(ss, "+"));
-    return ss;
-}
 
 enum class IvwKey {
     Undefined = -2,
@@ -266,445 +214,29 @@ enum class IvwKey {
     RightMeta = 350,
 };
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, IvwKey k) {
-    switch (k) {
-        case IvwKey::Undefined:
-            ss << "Undefined";
-            break;
-        case IvwKey::Unknown:
-            ss << "Unknown";
-            break;
-        case IvwKey::Space:
-            ss << "Space";
-            break;
-        case IvwKey::Exclam:
-            ss << "Exclam";
-            break;
-        case IvwKey::QuoteDbl:
-            ss << "QuoteDbl";
-            break;
-        case IvwKey::NumberSign:
-            ss << "NumberSign";
-            break;
-        case IvwKey::Dollar:
-            ss << "Dollar";
-            break;
-        case IvwKey::Percent:
-            ss << "Percent";
-            break;
-        case IvwKey::Ampersand:
-            ss << "Ampersand";
-            break;
-        case IvwKey::Apostrophe:
-            ss << "Apostrophe";
-            break;
-        case IvwKey::ParenLeft:
-            ss << "ParenLeft";
-            break;
-        case IvwKey::ParenRight:
-            ss << "ParenRight";
-            break;
-        case IvwKey::Asterisk:
-            ss << "Asterisk";
-            break;
-        case IvwKey::Plus:
-            ss << "Plus";
-            break;
-        case IvwKey::Comma:
-            ss << "Comma";
-            break;
-        case IvwKey::Minus:
-            ss << "Minus";
-            break;
-        case IvwKey::Period:
-            ss << "Period";
-            break;
-        case IvwKey::Slash:
-            ss << "Slash";
-            break;
-        case IvwKey::Num0:
-            ss << "Num0";
-            break;
-        case IvwKey::Num1:
-            ss << "Num1";
-            break;
-        case IvwKey::Num2:
-            ss << "Num2";
-            break;
-        case IvwKey::Num3:
-            ss << "Num3";
-            break;
-        case IvwKey::Num4:
-            ss << "Num4";
-            break;
-        case IvwKey::Num5:
-            ss << "Num5";
-            break;
-        case IvwKey::Num6:
-            ss << "Num6";
-            break;
-        case IvwKey::Num7:
-            ss << "Num7";
-            break;
-        case IvwKey::Num8:
-            ss << "Num8";
-            break;
-        case IvwKey::Num9:
-            ss << "Num9";
-            break;
-        case IvwKey::Colon:
-            ss << "Colon";
-            break;
-        case IvwKey::Semicolon:
-            ss << "Semicolon";
-            break;
-        case IvwKey::Less:
-            ss << "Less";
-            break;
-        case IvwKey::Equal:
-            ss << "Equal";
-            break;
-        case IvwKey::Greater:
-            ss << "Greater";
-            break;
-        case IvwKey::Question:
-            ss << "Question";
-            break;
-        case IvwKey::A:
-            ss << "A";
-            break;
-        case IvwKey::B:
-            ss << "B";
-            break;
-        case IvwKey::C:
-            ss << "C";
-            break;
-        case IvwKey::D:
-            ss << "D";
-            break;
-        case IvwKey::E:
-            ss << "E";
-            break;
-        case IvwKey::F:
-            ss << "F";
-            break;
-        case IvwKey::G:
-            ss << "G";
-            break;
-        case IvwKey::H:
-            ss << "H";
-            break;
-        case IvwKey::I:
-            ss << "I";
-            break;
-        case IvwKey::J:
-            ss << "J";
-            break;
-        case IvwKey::K:
-            ss << "K";
-            break;
-        case IvwKey::L:
-            ss << "L";
-            break;
-        case IvwKey::M:
-            ss << "M";
-            break;
-        case IvwKey::N:
-            ss << "N";
-            break;
-        case IvwKey::O:
-            ss << "O";
-            break;
-        case IvwKey::P:
-            ss << "P";
-            break;
-        case IvwKey::Q:
-            ss << "Q";
-            break;
-        case IvwKey::R:
-            ss << "R";
-            break;
-        case IvwKey::S:
-            ss << "S";
-            break;
-        case IvwKey::T:
-            ss << "T";
-            break;
-        case IvwKey::U:
-            ss << "U";
-            break;
-        case IvwKey::V:
-            ss << "V";
-            break;
-        case IvwKey::W:
-            ss << "W";
-            break;
-        case IvwKey::X:
-            ss << "X";
-            break;
-        case IvwKey::Y:
-            ss << "Y";
-            break;
-        case IvwKey::Z:
-            ss << "Z";
-            break;
-        case IvwKey::BracketLeft:
-            ss << "BracketLeft";
-            break;
-        case IvwKey::Backslash:
-            ss << "Backslash";
-            break;
-        case IvwKey::BracketRight:
-            ss << "BracketRight";
-            break;
-        case IvwKey::GraveAccent:
-            ss << "GraveAccent";
-            break;
-        case IvwKey::AsciiCircum:
-            ss << "AsciiCircum";
-            break;
-        case IvwKey::Underscore:
-            ss << "Underscore";
-            break;
-        case IvwKey::BraceLeft:
-            ss << "BraceLeft";
-            break;
-        case IvwKey::Bar:
-            ss << "Bar";
-            break;
-        case IvwKey::BraceRight:
-            ss << "BraceRight";
-            break;
-        case IvwKey::AsciiTilde:
-            ss << "AsciiTilde";
-            break;
-        case IvwKey::World1:
-            ss << "World1";
-            break;
-        case IvwKey::World2:
-            ss << "World2";
-            break;
-        case IvwKey::Escape:
-            ss << "Escape";
-            break;
-        case IvwKey::Enter:
-            ss << "Enter";
-            break;
-        case IvwKey::Tab:
-            ss << "Tab";
-            break;
-        case IvwKey::Backspace:
-            ss << "Backspace";
-            break;
-        case IvwKey::Insert:
-            ss << "Insert";
-            break;
-        case IvwKey::Delete:
-            ss << "Delete";
-            break;
-        case IvwKey::Right:
-            ss << "Right";
-            break;
-        case IvwKey::Left:
-            ss << "Left";
-            break;
-        case IvwKey::Down:
-            ss << "Down";
-            break;
-        case IvwKey::Up:
-            ss << "Up";
-            break;
-        case IvwKey::PageUp:
-            ss << "PageUp";
-            break;
-        case IvwKey::PageDown:
-            ss << "PageDown";
-            break;
-        case IvwKey::Home:
-            ss << "Home";
-            break;
-        case IvwKey::End:
-            ss << "End";
-            break;
-        case IvwKey::CapsLock:
-            ss << "CapsLock";
-            break;
-        case IvwKey::ScrollLock:
-            ss << "ScrollLock";
-            break;
-        case IvwKey::NumLock:
-            ss << "NumLock";
-            break;
-        case IvwKey::PrintScreen:
-            ss << "PrintScreen";
-            break;
-        case IvwKey::Pause:
-            ss << "Pause";
-            break;
-        case IvwKey::F1:
-            ss << "F1";
-            break;
-        case IvwKey::F2:
-            ss << "F2";
-            break;
-        case IvwKey::F3:
-            ss << "F3";
-            break;
-        case IvwKey::F4:
-            ss << "F4";
-            break;
-        case IvwKey::F5:
-            ss << "F5";
-            break;
-        case IvwKey::F6:
-            ss << "F6";
-            break;
-        case IvwKey::F7:
-            ss << "F7";
-            break;
-        case IvwKey::F8:
-            ss << "F8";
-            break;
-        case IvwKey::F9:
-            ss << "F9";
-            break;
-        case IvwKey::F10:
-            ss << "F10";
-            break;
-        case IvwKey::F11:
-            ss << "F11";
-            break;
-        case IvwKey::F12:
-            ss << "F12";
-            break;
-        case IvwKey::F13:
-            ss << "F13";
-            break;
-        case IvwKey::F14:
-            ss << "F14";
-            break;
-        case IvwKey::F15:
-            ss << "F15";
-            break;
-        case IvwKey::F16:
-            ss << "F16";
-            break;
-        case IvwKey::F17:
-            ss << "F17";
-            break;
-        case IvwKey::F18:
-            ss << "F18";
-            break;
-        case IvwKey::F19:
-            ss << "F19";
-            break;
-        case IvwKey::F20:
-            ss << "F20";
-            break;
-        case IvwKey::F21:
-            ss << "F21";
-            break;
-        case IvwKey::F22:
-            ss << "F22";
-            break;
-        case IvwKey::F23:
-            ss << "F23";
-            break;
-        case IvwKey::F24:
-            ss << "F24";
-            break;
-        case IvwKey::F25:
-            ss << "F25";
-            break;
-        case IvwKey::KP0:
-            ss << "KP0";
-            break;
-        case IvwKey::KP1:
-            ss << "KP1";
-            break;
-        case IvwKey::KP2:
-            ss << "KP2";
-            break;
-        case IvwKey::KP3:
-            ss << "KP3";
-            break;
-        case IvwKey::KP4:
-            ss << "KP4";
-            break;
-        case IvwKey::KP5:
-            ss << "KP5";
-            break;
-        case IvwKey::KP6:
-            ss << "KP6";
-            break;
-        case IvwKey::KP7:
-            ss << "KP7";
-            break;
-        case IvwKey::KP8:
-            ss << "KP8";
-            break;
-        case IvwKey::KP9:
-            ss << "KP9";
-            break;
-        case IvwKey::KPDecimal:
-            ss << "KPDecimal";
-            break;
-        case IvwKey::KPDivide:
-            ss << "KPDivide";
-            break;
-        case IvwKey::KPMultiply:
-            ss << "KPMultiply";
-            break;
-        case IvwKey::KPSubtract:
-            ss << "KPSubtract";
-            break;
-        case IvwKey::KPAdd:
-            ss << "KPAdd";
-            break;
-        case IvwKey::KPEnter:
-            ss << "KPEnter";
-            break;
-        case IvwKey::KPEqual:
-            ss << "KPEqual";
-            break;
-        case IvwKey::LeftShift:
-            ss << "LeftShift";
-            break;
-        case IvwKey::LeftControl:
-            ss << "LeftControl";
-            break;
-        case IvwKey::LeftAlt:
-            ss << "LeftAlt";
-            break;
-        case IvwKey::LeftSuper:
-            ss << "LeftSuper";
-            break;
-        case IvwKey::RightShift:
-            ss << "RightShift";
-            break;
-        case IvwKey::RightControl:
-            ss << "RightControl";
-            break;
-        case IvwKey::RightAlt:
-            ss << "RightAlt";
-            break;
-        case IvwKey::RightSuper:
-            ss << "RightSuper";
-            break;
-        case IvwKey::Menu:
-            ss << "Menu";
-            break;
-        case IvwKey::LeftMeta:
-            ss << "LeftMeta";
-            break;
-        case IvwKey::RightMeta:
-            ss << "RightMeta";
-            break;
-        default:
-            break;
-    }
-    return ss;
-}
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, KeyModifier m);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, KeyModifiers ms);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, KeyState s);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, KeyStates s);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, IvwKey k);
+
+namespace util {
+IVW_CORE_API std::string_view name(KeyModifier m);
+IVW_CORE_API std::string_view name(KeyState s);
+IVW_CORE_API std::string_view name(IvwKey k);
+}  // namespace util
 
 }  // namespace inviwo
+
+template <>
+struct fmt::formatter<inviwo::KeyModifier> : inviwo::FlagFormatter<inviwo::KeyModifier> {};
+template <>
+struct fmt::formatter<inviwo::KeyModifiers> : inviwo::FlagsFormatter<inviwo::KeyModifiers> {};
+
+template <>
+struct fmt::formatter<inviwo::KeyState> : inviwo::FlagFormatter<inviwo::KeyState> {};
+template <>
+struct fmt::formatter<inviwo::KeyStates> : inviwo::FlagsFormatter<inviwo::KeyStates> {};
+
+template <>
+struct fmt::formatter<inviwo::IvwKey> : inviwo::FlagFormatter<inviwo::IvwKey> {};

--- a/include/inviwo/core/interaction/events/mousebuttons.h
+++ b/include/inviwo/core/interaction/events/mousebuttons.h
@@ -30,12 +30,14 @@
 #pragma once
 
 #include <inviwo/core/common/inviwocoredefine.h>
-#include <inviwo/core/util/ostreamjoiner.h>
+#include <inviwo/core/util/fmtutils.h>
+
+#include <string_view>
+#include <iosfwd>
+#include <array>
 
 #include <flags/flags.h>
-
-#include <iterator>
-#include <ostream>
+#include <fmt/format.h>
 
 namespace inviwo {
 
@@ -47,53 +49,23 @@ enum class MouseState { Press = 1 << 0, Move = 1 << 1, Release = 1 << 2, DoubleC
 ALLOW_FLAGS_FOR_ENUM(MouseState)
 using MouseStates = flags::flags<MouseState>;
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, MouseButton b) {
-    switch (b) {
-        case MouseButton::None:
-            ss << "None";
-            break;
-        case MouseButton::Left:
-            ss << "Left";
-            break;
-        case MouseButton::Middle:
-            ss << "Middle";
-            break;
-        case MouseButton::Right:
-            ss << "Right";
-            break;
-    }
-    return ss;
-}
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, MouseState s) {
-    switch (s) {
-        case MouseState::Move:
-            ss << "Move";
-            break;
-        case MouseState::Press:
-            ss << "Press";
-            break;
-        case MouseState::Release:
-            ss << "Release";
-            break;
-        case MouseState::DoubleClick:
-            ss << "DoubleClick";
-            break;
-    }
-    return ss;
-}
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, MouseButton b);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, MouseState s);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, MouseButtons bs);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, MouseStates s);
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             MouseButtons bs) {
-    std::copy(bs.begin(), bs.end(), util::make_ostream_joiner(ss, "+"));
-    return ss;
-}
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, MouseStates s) {
-    std::copy(s.begin(), s.end(), util::make_ostream_joiner(ss, "+"));
-    return ss;
-}
+namespace util {
+IVW_CORE_API std::string_view name(MouseButton b);
+IVW_CORE_API std::string_view name(MouseState b);
+}  // namespace util
 
 }  // namespace inviwo
+
+template <>
+struct fmt::formatter<inviwo::MouseButton> : inviwo::FlagFormatter<inviwo::MouseButton> {};
+template <>
+struct fmt::formatter<inviwo::MouseButtons> : inviwo::FlagsFormatter<inviwo::MouseButtons> {};
+template <>
+struct fmt::formatter<inviwo::MouseState> : inviwo::FlagFormatter<inviwo::MouseState> {};
+template <>
+struct fmt::formatter<inviwo::MouseStates> : inviwo::FlagsFormatter<inviwo::MouseStates> {};

--- a/include/inviwo/core/interaction/events/mousecursors.h
+++ b/include/inviwo/core/interaction/events/mousecursors.h
@@ -30,9 +30,10 @@
 #pragma once
 
 #include <inviwo/core/common/inviwocoredefine.h>
+#include <inviwo/core/util/fmtutils.h>
 
-#include <iterator>
-#include <ostream>
+#include <string_view>
+#include <iosfwd>
 
 namespace inviwo {
 
@@ -59,68 +60,13 @@ enum class MouseCursor {
     Busy
 };
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, MouseCursor c) {
-    switch (c) {
-        case MouseCursor::Arrow:
-            ss << "Arrow";
-            break;
-        case MouseCursor::UpArrow:
-            ss << "UpArrow";
-            break;
-        case MouseCursor::Cross:
-            ss << "Cross";
-            break;
-        case MouseCursor::Wait:
-            ss << "Wait";
-            break;
-        case MouseCursor::IBeam:
-            ss << "IBeam";
-            break;
-        case MouseCursor::SizeVer:
-            ss << "SizeVer";
-            break;
-        case MouseCursor::SizeHor:
-            ss << "SizeHor";
-            break;
-        case MouseCursor::SizeBDiag:
-            ss << "SizeBDiag";
-            break;
-        case MouseCursor::SizeFDiag:
-            ss << "SizeFDiag";
-            break;
-        case MouseCursor::SizeAll:
-            ss << "SizeAll";
-            break;
-        case MouseCursor::Blank:
-            ss << "Blank";
-            break;
-        case MouseCursor::SplitV:
-            ss << "SplitV";
-            break;
-        case MouseCursor::SplitH:
-            ss << "SplitH";
-            break;
-        case MouseCursor::PointingHand:
-            ss << "PointingHand";
-            break;
-        case MouseCursor::Forbidden:
-            ss << "Forbidden";
-            break;
-        case MouseCursor::OpenHand:
-            ss << "OpenHand";
-            break;
-        case MouseCursor::ClosedHand:
-            ss << "ClosedHand";
-            break;
-        case MouseCursor::WhatsThis:
-            ss << "WhatsThis";
-            break;
-        case MouseCursor::Busy:
-            ss << "Busy";
-            break;
-    }
-    return ss;
-}
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, MouseCursor c);
+
+namespace util {
+IVW_CORE_API std::string_view name(MouseCursor b);
+}  // namespace util
 
 }  // namespace inviwo
+
+template <>
+struct fmt::formatter<inviwo::MouseCursor> : inviwo::FlagFormatter<inviwo::MouseCursor> {};

--- a/include/inviwo/core/interaction/events/touchstate.h
+++ b/include/inviwo/core/interaction/events/touchstate.h
@@ -30,12 +30,11 @@
 #pragma once
 
 #include <inviwo/core/common/inviwocoredefine.h>
-#include <inviwo/core/util/ostreamjoiner.h>
+#include <inviwo/core/util/fmtutils.h>
 
 #include <flags/flags.h>
-
-#include <iterator>
-#include <ostream>
+#include <string_view>
+#include <iosfwd>
 
 namespace inviwo {
 
@@ -50,31 +49,17 @@ enum class TouchState {
 ALLOW_FLAGS_FOR_ENUM(TouchState)
 using TouchStates = flags::flags<TouchState>;
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, TouchState s) {
-    switch (s) {
-        case TouchState::None:
-            ss << "None";
-            break;
-        case TouchState::Started:
-            ss << "Started";
-            break;
-        case TouchState::Updated:
-            ss << "Updated";
-            break;
-        case TouchState::Stationary:
-            ss << "Stationary";
-            break;
-        case TouchState::Finished:
-            ss << "Finished";
-            break;
-    }
-    return ss;
-}
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, TouchStates s) {
-    std::copy(s.begin(), s.end(), util::make_ostream_joiner(ss, "+"));
-    return ss;
-}
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, TouchState s);
+
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, TouchStates s);
+
+namespace util {
+IVW_CORE_API std::string_view name(TouchState b);
+}  // namespace util
 
 }  // namespace inviwo
+
+template <>
+struct fmt::formatter<inviwo::TouchState> : inviwo::FlagFormatter<inviwo::TouchState> {};
+template <>
+struct fmt::formatter<inviwo::TouchStates> : inviwo::FlagsFormatter<inviwo::TouchStates> {};

--- a/include/inviwo/core/interaction/pickingstate.h
+++ b/include/inviwo/core/interaction/pickingstate.h
@@ -30,12 +30,11 @@
 #pragma once
 
 #include <inviwo/core/common/inviwocoredefine.h>
-#include <inviwo/core/util/ostreamjoiner.h>
+#include <inviwo/core/util/fmtutils.h>
 
 #include <flags/flags.h>
 
-#include <iterator>
-#include <ostream>
+#include <iosfwd>
 
 namespace inviwo {
 
@@ -71,110 +70,46 @@ enum class PickingHoverState { None = 0, Enter = 1 << 0, Move = 1 << 1, Exit = 1
 ALLOW_FLAGS_FOR_ENUM(PickingHoverState)
 using PickingHoverStates = flags::flags<PickingHoverState>;
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, PickingState s) {
-    switch (s) {
-        case PickingState::None:
-            ss << "None";
-            break;
-        case PickingState::Started:
-            ss << "Started";
-            break;
-        case PickingState::Updated:
-            ss << "Updated";
-            break;
-        case PickingState::Finished:
-            ss << "Finished";
-            break;
-    }
-    return ss;
-}
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             PickingStates s) {
-    std::copy(s.begin(), s.end(), util::make_ostream_joiner(ss, "+"));
-    return ss;
-}
+namespace util {
+IVW_CORE_API std::string_view name(PickingState b);
+IVW_CORE_API std::string_view name(PickingPressItem b);
+IVW_CORE_API std::string_view name(PickingPressState b);
+IVW_CORE_API std::string_view name(PickingHoverState b);
+}  // namespace util
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             PickingPressItem s) {
-    switch (s) {
-        case PickingPressItem::None:
-            ss << "None";
-            break;
-        case PickingPressItem::Primary:
-            ss << "Primary";
-            break;
-        case PickingPressItem::Secondary:
-            ss << "Secondary";
-            break;
-        case PickingPressItem::Tertiary:
-            ss << "Tertiary";
-            break;
-    }
-    return ss;
-}
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             PickingPressItems s) {
-    std::copy(s.begin(), s.end(), util::make_ostream_joiner(ss, "+"));
-    return ss;
-}
-
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             PickingPressState s) {
-    switch (s) {
-        case PickingPressState::None:
-            ss << "None";
-            break;
-        case PickingPressState::Press:
-            ss << "Press";
-            break;
-        case PickingPressState::Move:
-            ss << "Move";
-            break;
-        case PickingPressState::Release:
-            ss << "Release";
-            break;
-        case PickingPressState::DoubleClick:
-            ss << "DoubleClick";
-            break;
-    }
-    return ss;
-}
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             PickingPressStates s) {
-    std::copy(s.begin(), s.end(), util::make_ostream_joiner(ss, "+"));
-    return ss;
-}
-
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             PickingHoverState s) {
-    switch (s) {
-        case PickingHoverState::None:
-            ss << "None";
-            break;
-        case PickingHoverState::Enter:
-            ss << "Enter";
-            break;
-        case PickingHoverState::Move:
-            ss << "Move";
-            break;
-        case PickingHoverState::Exit:
-            ss << "Exit";
-            break;
-    }
-    return ss;
-}
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             PickingHoverStates s) {
-    std::copy(s.begin(), s.end(), util::make_ostream_joiner(ss, "+"));
-    return ss;
-}
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, PickingState s);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, PickingStates s);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, PickingPressItem s);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, PickingPressItems s);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, PickingPressState s);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, PickingPressStates s);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, PickingHoverState s);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, PickingHoverStates s);
 
 }  // namespace inviwo
+
+template <>
+struct fmt::formatter<inviwo::PickingState> : inviwo::FlagFormatter<inviwo::PickingState> {};
+template <>
+struct fmt::formatter<inviwo::PickingStates> : inviwo::FlagsFormatter<inviwo::PickingStates> {};
+
+template <>
+struct fmt::formatter<inviwo::PickingPressItem> : inviwo::FlagFormatter<inviwo::PickingPressItem> {
+};
+template <>
+struct fmt::formatter<inviwo::PickingPressItems>
+    : inviwo::FlagsFormatter<inviwo::PickingPressItems> {};
+
+template <>
+struct fmt::formatter<inviwo::PickingPressState>
+    : inviwo::FlagFormatter<inviwo::PickingPressState> {};
+template <>
+struct fmt::formatter<inviwo::PickingPressStates>
+    : inviwo::FlagsFormatter<inviwo::PickingPressStates> {};
+
+template <>
+struct fmt::formatter<inviwo::PickingHoverState>
+    : inviwo::FlagFormatter<inviwo::PickingHoverState> {};
+template <>
+struct fmt::formatter<inviwo::PickingHoverStates>
+    : inviwo::FlagsFormatter<inviwo::PickingHoverStates> {};

--- a/include/inviwo/core/io/serialization/deserializer.h
+++ b/include/inviwo/core/io/serialization/deserializer.h
@@ -263,6 +263,7 @@ public:
               typename = std::enable_if_t<util::is_detected_exact_v<void, HasDeserialize, T>>>
     void deserialize(std::string_view key, T& sObj);
 
+    using ExceptionHandler = std::function<void(ExceptionContext)>;
     void setExceptionHandler(ExceptionHandler handler);
     void handleError(const ExceptionContext& context);
 

--- a/include/inviwo/core/network/workspacemanager.h
+++ b/include/inviwo/core/network/workspacemanager.h
@@ -62,6 +62,9 @@ using WorkspaceSaveModes = flags::flags<WorkspaceSaveMode>;
  * The workspace manager is owned by the InviwoApplication.
  */
 class IVW_CORE_API WorkspaceManager {
+public:
+    using ExceptionHandler = std::function<void(ExceptionContext)>;
+private:
     using ClearDispatcher = Dispatcher<void()>;
     using SerializationDispatcher =
         Dispatcher<void(Serializer&, const ExceptionHandler&, WorkspaceSaveMode mode)>;
@@ -76,7 +79,7 @@ public:
 
     using DeserializationCallback = std::function<void(Deserializer&)>;
     using DeserializationHandle = typename DeserializationDispatcher::Handle;
-
+    
     WorkspaceManager(InviwoApplication* app);
     ~WorkspaceManager();
 

--- a/include/inviwo/core/ports/datainport.h
+++ b/include/inviwo/core/ports/datainport.h
@@ -91,19 +91,21 @@ using FlatMultiDataInport = DataInport<T, 0, true>;
 template <typename T, size_t N, bool Flat>
 struct PortTraits<DataInport<T, N, Flat>> {
     static std::string classIdentifier() {
-        std::string postfix = +(Flat ? ".flat" : "");
-        switch (N) {
-            case 0:
-                postfix += ".multi.inport";
-                break;
-            case 1:
-                postfix += ".inport";
-                break;
-            default:
-                postfix += "." + toString(N) + ".inport";
-                break;
+        auto&& classId = DataTraits<T>::classIdentifier();
+        if (classId.empty()) return {};
+
+        StrBuffer name;
+        name.append("{}", classId);
+        if constexpr (Flat) {
+            name.append(".flat");
         }
-        return util::appendIfNotEmpty(DataTraits<T>::classIdentifier(), postfix);
+        if constexpr (N == 0) {
+            name.append(".multi");
+        } else if constexpr (N != 1) {
+            name.append(".{}", N);
+        }
+        name.append(".inport");
+        return std::string{name.view()};
     }
 };
 

--- a/include/inviwo/core/ports/dataoutport.h
+++ b/include/inviwo/core/ports/dataoutport.h
@@ -96,7 +96,9 @@ protected:
 template <typename T>
 struct PortTraits<DataOutport<T>> {
     static std::string classIdentifier() {
-        return util::appendIfNotEmpty(DataTraits<T>::classIdentifier(), ".outport");
+        auto&& classId = DataTraits<T>::classIdentifier();
+        if (classId.empty()) return {};
+        return fmt::format("{}.outport", classId);
     }
 };
 

--- a/include/inviwo/core/processors/compositesink.h
+++ b/include/inviwo/core/processors/compositesink.h
@@ -98,7 +98,8 @@ struct ProcessorTraits<CompositeSink<InportType, OutportType>> {
         using intype = typename InportType::type;
         using outtype = typename InportType::type;
         static_assert(std::is_same<intype, outtype>::value, "type mismatch");
-        auto name = util::cleanIdentifier(DataTraits<intype>::dataName() + " Meta Sink", " ");
+        auto name =
+            util::cleanIdentifier(fmt::format("{} Meta Sink", DataTraits<intype>::dataName()), " ");
         auto id = util::appendIfNotEmpty(PortTraits<OutportType>::classIdentifier(), ".metasink");
         return {
             id,                 // Class identifier

--- a/include/inviwo/core/processors/compositesource.h
+++ b/include/inviwo/core/processors/compositesource.h
@@ -100,7 +100,8 @@ struct ProcessorTraits<CompositeSource<InportType, OutportType>> {
         using intype = typename InportType::type;
         using outtype = typename InportType::type;
         static_assert(std::is_same<intype, outtype>::value, "type mismatch");
-        auto name = util::cleanIdentifier(DataTraits<intype>::dataName() + " Meta Source", " ");
+        auto name = util::cleanIdentifier(
+            fmt::format("{} Meta Source", DataTraits<intype>::dataName()), " ");
         auto id = util::appendIfNotEmpty(PortTraits<OutportType>::classIdentifier(), ".metasource");
         return {
             id,                 // Class identifier

--- a/include/inviwo/core/processors/processorstate.h
+++ b/include/inviwo/core/processors/processorstate.h
@@ -30,31 +30,20 @@
 #pragma once
 
 #include <inviwo/core/common/inviwocoredefine.h>
-#include <ostream>
+#include <inviwo/core/util/fmtutils.h>
+#include <iosfwd>
 
 namespace inviwo {
 
 enum class CodeState { Broken, Experimental, Stable, Deprecated };
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, CodeState cs) {
-    switch (cs) {
-        case CodeState::Broken:
-            ss << "Broken";
-            break;
-        case CodeState::Experimental:
-            ss << "Experimental";
-            break;
-        case CodeState::Stable:
-            ss << "Stable";
-            break;
-        case CodeState::Deprecated:
-            ss << "Deprecated";
-            break;
-        default:
-            ss << "Not specified";
-    }
-    return ss;
+namespace util {
+IVW_CORE_API std::string_view name(CodeState cs);
 }
 
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, CodeState cs);
+
 }  // namespace inviwo
+
+template <>
+struct fmt::formatter<inviwo::CodeState> : inviwo::FlagFormatter<inviwo::CodeState> {};

--- a/include/inviwo/core/properties/constraintbehavior.h
+++ b/include/inviwo/core/properties/constraintbehavior.h
@@ -30,8 +30,9 @@
 #pragma once
 
 #include <inviwo/core/common/inviwocoredefine.h>
-
-#include <ostream>
+#include <inviwo/core/util/fmtutils.h>
+#include <iosfwd>
+#include <string_view>
 
 namespace inviwo {
 
@@ -72,26 +73,14 @@ enum class ConstraintBehavior {
 
 };
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             ConstraintBehavior cb) {
-    switch (cb) {
-        case ConstraintBehavior::Editable:
-            ss << "Editable";
-            break;
-        case ConstraintBehavior::Mutable:
-            ss << "Mutable";
-            break;
-        case ConstraintBehavior::Immutable:
-            ss << "Immutable";
-            break;
-        case ConstraintBehavior::Ignore:
-            ss << "Ignore";
-            break;
-        default:
-            break;
-    }
-    return ss;
+namespace util {
+IVW_CORE_API std::string_view name(ConstraintBehavior cb);
 }
 
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, ConstraintBehavior cb);
+
 }  // namespace inviwo
+
+template <>
+struct fmt::formatter<inviwo::ConstraintBehavior>
+    : inviwo::FlagFormatter<inviwo::ConstraintBehavior> {};

--- a/include/inviwo/core/properties/invalidationlevel.h
+++ b/include/inviwo/core/properties/invalidationlevel.h
@@ -30,7 +30,7 @@
 #pragma once
 
 #include <inviwo/core/common/inviwocoredefine.h>
-
+#include <inviwo/core/util/fmtutils.h>
 #include <iosfwd>
 
 namespace inviwo {
@@ -45,25 +45,14 @@ enum class InvalidationLevel {
     InvalidResources  // Trigger a call to initializeResources and then process.
 };
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             const InvalidationLevel& level) {
-    switch (level) {
-        case InvalidationLevel::Valid:
-            ss << "Valid";
-            break;
-        case InvalidationLevel::InvalidOutput:
-            ss << "Invalid output";
-            break;
-        case InvalidationLevel::InvalidResources:
-            ss << "Invalid resources";
-            break;
-        default:
-            ss << "Unknown";
-            break;
-    }
-
-    return ss;
+namespace util {
+IVW_CORE_API std::string_view name(InvalidationLevel level);
 }
 
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, InvalidationLevel level);
+
 }  // namespace inviwo
+
+template <>
+struct fmt::formatter<inviwo::InvalidationLevel>
+    : inviwo::FlagFormatter<inviwo::InvalidationLevel> {};

--- a/include/inviwo/core/properties/propertypresetmanager.h
+++ b/include/inviwo/core/properties/propertypresetmanager.h
@@ -31,14 +31,15 @@
 
 #include <inviwo/core/common/inviwocoredefine.h>
 #include <inviwo/core/io/serialization/serializable.h>
-#include <inviwo/core/util/ostreamjoiner.h>
 #include <inviwo/core/util/raiiutils.h>
+#include <inviwo/core/util/fmtutils.h>
+
 #include <flags/flags.h>
 
 #include <map>
 #include <string>
 #include <vector>
-#include <algorithm>
+#include <iosfwd>
 
 namespace inviwo {
 class InviwoApplication;
@@ -110,29 +111,19 @@ private:
     std::vector<Preset> workspacePresets_;
 };
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             PropertyPresetType p) {
-    switch (p) {
-        case PropertyPresetType::Property:
-            ss << "Property";
-            break;
-        case PropertyPresetType::Workspace:
-            ss << "Workspace";
-            break;
-        case PropertyPresetType::Application:
-            ss << "Application";
-            break;
-        default:
-            break;
-    }
-    return ss;
-}
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             PropertyPresetTypes ps) {
-    std::copy(ps.begin(), ps.end(), util::make_ostream_joiner(ss, ", "));
-    return ss;
+namespace util {
+IVW_CORE_API std::string_view name(PropertyPresetType p);
 }
 
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, PropertyPresetType p);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, PropertyPresetTypes ps);
+
 }  // namespace inviwo
+
+template <>
+struct fmt::formatter<inviwo::PropertyPresetType>
+    : inviwo::FlagFormatter<inviwo::PropertyPresetType> {};
+
+template <>
+struct fmt::formatter<inviwo::PropertyPresetTypes>
+    : inviwo::FlagsFormatter<inviwo::PropertyPresetTypes> {};

--- a/include/inviwo/core/properties/propertysemantics.h
+++ b/include/inviwo/core/properties/propertysemantics.h
@@ -32,11 +32,11 @@
 #include <inviwo/core/common/inviwocoredefine.h>
 #include <inviwo/core/io/serialization/serializable.h>
 #include <string>
-#include <ostream>
+#include <iosfwd>
 
 namespace inviwo {
 
-class IVW_CORE_API PropertySemantics : public Serializable {
+class IVW_CORE_API PropertySemantics {
 public:
     PropertySemantics();
     PropertySemantics(std::string semantic);
@@ -44,10 +44,10 @@ public:
     PropertySemantics(PropertySemantics&& rhs) noexcept = default;
     PropertySemantics& operator=(const PropertySemantics& that) = default;
     PropertySemantics& operator=(PropertySemantics&& that) noexcept = default;
-    virtual ~PropertySemantics() noexcept = default;
+    ~PropertySemantics() noexcept = default;
 
-    virtual void serialize(Serializer& s) const;
-    virtual void deserialize(Deserializer& d);
+    void serialize(Serializer& s) const;
+    void deserialize(Deserializer& d);
 
     const std::string& getString() const;
 
@@ -81,15 +81,10 @@ public:
         return !operator<(lhs, rhs);
     }
 
+    IVW_CORE_API friend std::ostream& operator<<(std::ostream& ss, const PropertySemantics& obj);
+
 private:
     std::string semantic_;
 };
-
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             const PropertySemantics& obj) {
-    ss << obj.getString();
-    return ss;
-}
 
 }  // namespace inviwo

--- a/include/inviwo/core/properties/propertyvisibility.h
+++ b/include/inviwo/core/properties/propertyvisibility.h
@@ -30,8 +30,7 @@
 #pragma once
 
 #include <inviwo/core/common/inviwocoredefine.h>
-
-#include <iosfwd>
+#include <ostream>
 
 namespace inviwo {
 
@@ -40,9 +39,7 @@ enum class UsageMode {
     Development = 1,  // Default, Only show in developer mode
 };
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             const UsageMode& mode) {
+inline std::ostream& operator<<(std::ostream& ss, const UsageMode& mode) {
     switch (mode) {
         case UsageMode::Application:
             ss << "Application";

--- a/include/inviwo/core/properties/valuewrapper.h
+++ b/include/inviwo/core/properties/valuewrapper.h
@@ -49,7 +49,7 @@ struct ValueWrapper {
         return *this;
     }
 
-    operator const T&() const { return value; }
+    operator const T &() const { return value; }
 
     bool isDefault() const { return value == defaultValue; }
 
@@ -138,3 +138,11 @@ struct ValueWrapper {
 };
 
 }  // namespace inviwo
+
+template <typename T>
+struct fmt::formatter<inviwo::ValueWrapper<T>> : fmt::formatter<T> {
+    template <typename FormatContext>
+    auto format(const inviwo::ValueWrapper<T>& val, FormatContext& ctx) const {
+        return fmt::formatter<T>::format(val.value, ctx);
+    }
+};

--- a/include/inviwo/core/util/colorbrewer-generated.h
+++ b/include/inviwo/core/util/colorbrewer-generated.h
@@ -35,10 +35,12 @@ tools/codegen/colorbrewer/colorbrewer.py
 #pragma once
 
 #include <inviwo/core/common/inviwocoredefine.h>
-#include <inviwo/core/util/glm.h>
+#include <inviwo/core/util/glmvec.h>
 
 #include <vector>
 #include <ostream>
+#include <fmt/core.h>
+#include <fmt/ostream.h>
 
 namespace inviwo {
 namespace colorbrewer {
@@ -94,368 +96,34 @@ enum class Family {
     NumberOfColormapFamilies, Undefined
 };
 // clang-format on
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& os,
-                                             Colormap colormap) {
-    switch (colormap) {
-        // clang-format off
-        case Colormap::Accent_1: os << "Accent_1"; break;
-        case Colormap::Accent_2: os << "Accent_2"; break;
-        case Colormap::Accent_3: os << "Accent_3"; break;
-        case Colormap::Accent_4: os << "Accent_4"; break;
-        case Colormap::Accent_5: os << "Accent_5"; break;
-        case Colormap::Accent_6: os << "Accent_6"; break;
-        case Colormap::Accent_7: os << "Accent_7"; break;
-        case Colormap::Accent_8: os << "Accent_8"; break;
-        case Colormap::Blues_3: os << "Blues_3"; break;
-        case Colormap::Blues_4: os << "Blues_4"; break;
-        case Colormap::Blues_5: os << "Blues_5"; break;
-        case Colormap::Blues_6: os << "Blues_6"; break;
-        case Colormap::Blues_7: os << "Blues_7"; break;
-        case Colormap::Blues_8: os << "Blues_8"; break;
-        case Colormap::Blues_9: os << "Blues_9"; break;
-        case Colormap::BrBG_3: os << "BrBG_3"; break;
-        case Colormap::BrBG_4: os << "BrBG_4"; break;
-        case Colormap::BrBG_5: os << "BrBG_5"; break;
-        case Colormap::BrBG_6: os << "BrBG_6"; break;
-        case Colormap::BrBG_7: os << "BrBG_7"; break;
-        case Colormap::BrBG_8: os << "BrBG_8"; break;
-        case Colormap::BrBG_9: os << "BrBG_9"; break;
-        case Colormap::BrBG_10: os << "BrBG_10"; break;
-        case Colormap::BrBG_11: os << "BrBG_11"; break;
-        case Colormap::BuGn_3: os << "BuGn_3"; break;
-        case Colormap::BuGn_4: os << "BuGn_4"; break;
-        case Colormap::BuGn_5: os << "BuGn_5"; break;
-        case Colormap::BuGn_6: os << "BuGn_6"; break;
-        case Colormap::BuGn_7: os << "BuGn_7"; break;
-        case Colormap::BuGn_8: os << "BuGn_8"; break;
-        case Colormap::BuGn_9: os << "BuGn_9"; break;
-        case Colormap::BuPu_3: os << "BuPu_3"; break;
-        case Colormap::BuPu_4: os << "BuPu_4"; break;
-        case Colormap::BuPu_5: os << "BuPu_5"; break;
-        case Colormap::BuPu_6: os << "BuPu_6"; break;
-        case Colormap::BuPu_7: os << "BuPu_7"; break;
-        case Colormap::BuPu_8: os << "BuPu_8"; break;
-        case Colormap::BuPu_9: os << "BuPu_9"; break;
-        case Colormap::Dark2_3: os << "Dark2_3"; break;
-        case Colormap::Dark2_4: os << "Dark2_4"; break;
-        case Colormap::Dark2_5: os << "Dark2_5"; break;
-        case Colormap::Dark2_6: os << "Dark2_6"; break;
-        case Colormap::Dark2_7: os << "Dark2_7"; break;
-        case Colormap::Dark2_8: os << "Dark2_8"; break;
-        case Colormap::GnBu_3: os << "GnBu_3"; break;
-        case Colormap::GnBu_4: os << "GnBu_4"; break;
-        case Colormap::GnBu_5: os << "GnBu_5"; break;
-        case Colormap::GnBu_6: os << "GnBu_6"; break;
-        case Colormap::GnBu_7: os << "GnBu_7"; break;
-        case Colormap::GnBu_8: os << "GnBu_8"; break;
-        case Colormap::GnBu_9: os << "GnBu_9"; break;
-        case Colormap::Greens_3: os << "Greens_3"; break;
-        case Colormap::Greens_4: os << "Greens_4"; break;
-        case Colormap::Greens_5: os << "Greens_5"; break;
-        case Colormap::Greens_6: os << "Greens_6"; break;
-        case Colormap::Greens_7: os << "Greens_7"; break;
-        case Colormap::Greens_8: os << "Greens_8"; break;
-        case Colormap::Greens_9: os << "Greens_9"; break;
-        case Colormap::Greys_3: os << "Greys_3"; break;
-        case Colormap::Greys_4: os << "Greys_4"; break;
-        case Colormap::Greys_5: os << "Greys_5"; break;
-        case Colormap::Greys_6: os << "Greys_6"; break;
-        case Colormap::Greys_7: os << "Greys_7"; break;
-        case Colormap::Greys_8: os << "Greys_8"; break;
-        case Colormap::Greys_9: os << "Greys_9"; break;
-        case Colormap::OrRd_3: os << "OrRd_3"; break;
-        case Colormap::OrRd_4: os << "OrRd_4"; break;
-        case Colormap::OrRd_5: os << "OrRd_5"; break;
-        case Colormap::OrRd_6: os << "OrRd_6"; break;
-        case Colormap::OrRd_7: os << "OrRd_7"; break;
-        case Colormap::OrRd_8: os << "OrRd_8"; break;
-        case Colormap::OrRd_9: os << "OrRd_9"; break;
-        case Colormap::Oranges_3: os << "Oranges_3"; break;
-        case Colormap::Oranges_4: os << "Oranges_4"; break;
-        case Colormap::Oranges_5: os << "Oranges_5"; break;
-        case Colormap::Oranges_6: os << "Oranges_6"; break;
-        case Colormap::Oranges_7: os << "Oranges_7"; break;
-        case Colormap::Oranges_8: os << "Oranges_8"; break;
-        case Colormap::Oranges_9: os << "Oranges_9"; break;
-        case Colormap::PRGn_3: os << "PRGn_3"; break;
-        case Colormap::PRGn_4: os << "PRGn_4"; break;
-        case Colormap::PRGn_5: os << "PRGn_5"; break;
-        case Colormap::PRGn_6: os << "PRGn_6"; break;
-        case Colormap::PRGn_7: os << "PRGn_7"; break;
-        case Colormap::PRGn_8: os << "PRGn_8"; break;
-        case Colormap::PRGn_9: os << "PRGn_9"; break;
-        case Colormap::PRGn_10: os << "PRGn_10"; break;
-        case Colormap::PRGn_11: os << "PRGn_11"; break;
-        case Colormap::Paired_1: os << "Paired_1"; break;
-        case Colormap::Paired_2: os << "Paired_2"; break;
-        case Colormap::Paired_3: os << "Paired_3"; break;
-        case Colormap::Paired_4: os << "Paired_4"; break;
-        case Colormap::Paired_5: os << "Paired_5"; break;
-        case Colormap::Paired_6: os << "Paired_6"; break;
-        case Colormap::Paired_7: os << "Paired_7"; break;
-        case Colormap::Paired_8: os << "Paired_8"; break;
-        case Colormap::Paired_9: os << "Paired_9"; break;
-        case Colormap::Paired_10: os << "Paired_10"; break;
-        case Colormap::Paired_11: os << "Paired_11"; break;
-        case Colormap::Paired_12: os << "Paired_12"; break;
-        case Colormap::Pastel1_3: os << "Pastel1_3"; break;
-        case Colormap::Pastel1_4: os << "Pastel1_4"; break;
-        case Colormap::Pastel1_5: os << "Pastel1_5"; break;
-        case Colormap::Pastel1_6: os << "Pastel1_6"; break;
-        case Colormap::Pastel1_7: os << "Pastel1_7"; break;
-        case Colormap::Pastel1_8: os << "Pastel1_8"; break;
-        case Colormap::Pastel1_9: os << "Pastel1_9"; break;
-        case Colormap::Pastel2_3: os << "Pastel2_3"; break;
-        case Colormap::Pastel2_4: os << "Pastel2_4"; break;
-        case Colormap::Pastel2_5: os << "Pastel2_5"; break;
-        case Colormap::Pastel2_6: os << "Pastel2_6"; break;
-        case Colormap::Pastel2_7: os << "Pastel2_7"; break;
-        case Colormap::Pastel2_8: os << "Pastel2_8"; break;
-        case Colormap::PiYG_3: os << "PiYG_3"; break;
-        case Colormap::PiYG_4: os << "PiYG_4"; break;
-        case Colormap::PiYG_5: os << "PiYG_5"; break;
-        case Colormap::PiYG_6: os << "PiYG_6"; break;
-        case Colormap::PiYG_7: os << "PiYG_7"; break;
-        case Colormap::PiYG_8: os << "PiYG_8"; break;
-        case Colormap::PiYG_9: os << "PiYG_9"; break;
-        case Colormap::PiYG_10: os << "PiYG_10"; break;
-        case Colormap::PiYG_11: os << "PiYG_11"; break;
-        case Colormap::PuBu_3: os << "PuBu_3"; break;
-        case Colormap::PuBu_4: os << "PuBu_4"; break;
-        case Colormap::PuBu_5: os << "PuBu_5"; break;
-        case Colormap::PuBu_6: os << "PuBu_6"; break;
-        case Colormap::PuBu_7: os << "PuBu_7"; break;
-        case Colormap::PuBu_8: os << "PuBu_8"; break;
-        case Colormap::PuBu_9: os << "PuBu_9"; break;
-        case Colormap::PuBuGn_3: os << "PuBuGn_3"; break;
-        case Colormap::PuBuGn_4: os << "PuBuGn_4"; break;
-        case Colormap::PuBuGn_5: os << "PuBuGn_5"; break;
-        case Colormap::PuBuGn_6: os << "PuBuGn_6"; break;
-        case Colormap::PuBuGn_7: os << "PuBuGn_7"; break;
-        case Colormap::PuBuGn_8: os << "PuBuGn_8"; break;
-        case Colormap::PuBuGn_9: os << "PuBuGn_9"; break;
-        case Colormap::PuOr_3: os << "PuOr_3"; break;
-        case Colormap::PuOr_4: os << "PuOr_4"; break;
-        case Colormap::PuOr_5: os << "PuOr_5"; break;
-        case Colormap::PuOr_6: os << "PuOr_6"; break;
-        case Colormap::PuOr_7: os << "PuOr_7"; break;
-        case Colormap::PuOr_8: os << "PuOr_8"; break;
-        case Colormap::PuOr_9: os << "PuOr_9"; break;
-        case Colormap::PuOr_10: os << "PuOr_10"; break;
-        case Colormap::PuOr_11: os << "PuOr_11"; break;
-        case Colormap::PuRd_3: os << "PuRd_3"; break;
-        case Colormap::PuRd_4: os << "PuRd_4"; break;
-        case Colormap::PuRd_5: os << "PuRd_5"; break;
-        case Colormap::PuRd_6: os << "PuRd_6"; break;
-        case Colormap::PuRd_7: os << "PuRd_7"; break;
-        case Colormap::PuRd_8: os << "PuRd_8"; break;
-        case Colormap::PuRd_9: os << "PuRd_9"; break;
-        case Colormap::Purples_3: os << "Purples_3"; break;
-        case Colormap::Purples_4: os << "Purples_4"; break;
-        case Colormap::Purples_5: os << "Purples_5"; break;
-        case Colormap::Purples_6: os << "Purples_6"; break;
-        case Colormap::Purples_7: os << "Purples_7"; break;
-        case Colormap::Purples_8: os << "Purples_8"; break;
-        case Colormap::Purples_9: os << "Purples_9"; break;
-        case Colormap::RdBu_3: os << "RdBu_3"; break;
-        case Colormap::RdBu_4: os << "RdBu_4"; break;
-        case Colormap::RdBu_5: os << "RdBu_5"; break;
-        case Colormap::RdBu_6: os << "RdBu_6"; break;
-        case Colormap::RdBu_7: os << "RdBu_7"; break;
-        case Colormap::RdBu_8: os << "RdBu_8"; break;
-        case Colormap::RdBu_9: os << "RdBu_9"; break;
-        case Colormap::RdBu_10: os << "RdBu_10"; break;
-        case Colormap::RdBu_11: os << "RdBu_11"; break;
-        case Colormap::RdGy_3: os << "RdGy_3"; break;
-        case Colormap::RdGy_4: os << "RdGy_4"; break;
-        case Colormap::RdGy_5: os << "RdGy_5"; break;
-        case Colormap::RdGy_6: os << "RdGy_6"; break;
-        case Colormap::RdGy_7: os << "RdGy_7"; break;
-        case Colormap::RdGy_8: os << "RdGy_8"; break;
-        case Colormap::RdGy_9: os << "RdGy_9"; break;
-        case Colormap::RdGy_10: os << "RdGy_10"; break;
-        case Colormap::RdGy_11: os << "RdGy_11"; break;
-        case Colormap::RdPu_3: os << "RdPu_3"; break;
-        case Colormap::RdPu_4: os << "RdPu_4"; break;
-        case Colormap::RdPu_5: os << "RdPu_5"; break;
-        case Colormap::RdPu_6: os << "RdPu_6"; break;
-        case Colormap::RdPu_7: os << "RdPu_7"; break;
-        case Colormap::RdPu_8: os << "RdPu_8"; break;
-        case Colormap::RdPu_9: os << "RdPu_9"; break;
-        case Colormap::RdYlBu_3: os << "RdYlBu_3"; break;
-        case Colormap::RdYlBu_4: os << "RdYlBu_4"; break;
-        case Colormap::RdYlBu_5: os << "RdYlBu_5"; break;
-        case Colormap::RdYlBu_6: os << "RdYlBu_6"; break;
-        case Colormap::RdYlBu_7: os << "RdYlBu_7"; break;
-        case Colormap::RdYlBu_8: os << "RdYlBu_8"; break;
-        case Colormap::RdYlBu_9: os << "RdYlBu_9"; break;
-        case Colormap::RdYlBu_10: os << "RdYlBu_10"; break;
-        case Colormap::RdYlBu_11: os << "RdYlBu_11"; break;
-        case Colormap::RdYlGn_3: os << "RdYlGn_3"; break;
-        case Colormap::RdYlGn_4: os << "RdYlGn_4"; break;
-        case Colormap::RdYlGn_5: os << "RdYlGn_5"; break;
-        case Colormap::RdYlGn_6: os << "RdYlGn_6"; break;
-        case Colormap::RdYlGn_7: os << "RdYlGn_7"; break;
-        case Colormap::RdYlGn_8: os << "RdYlGn_8"; break;
-        case Colormap::RdYlGn_9: os << "RdYlGn_9"; break;
-        case Colormap::RdYlGn_10: os << "RdYlGn_10"; break;
-        case Colormap::RdYlGn_11: os << "RdYlGn_11"; break;
-        case Colormap::Reds_3: os << "Reds_3"; break;
-        case Colormap::Reds_4: os << "Reds_4"; break;
-        case Colormap::Reds_5: os << "Reds_5"; break;
-        case Colormap::Reds_6: os << "Reds_6"; break;
-        case Colormap::Reds_7: os << "Reds_7"; break;
-        case Colormap::Reds_8: os << "Reds_8"; break;
-        case Colormap::Reds_9: os << "Reds_9"; break;
-        case Colormap::Set1_1: os << "Set1_1"; break;
-        case Colormap::Set1_2: os << "Set1_2"; break;
-        case Colormap::Set1_3: os << "Set1_3"; break;
-        case Colormap::Set1_4: os << "Set1_4"; break;
-        case Colormap::Set1_5: os << "Set1_5"; break;
-        case Colormap::Set1_6: os << "Set1_6"; break;
-        case Colormap::Set1_7: os << "Set1_7"; break;
-        case Colormap::Set1_8: os << "Set1_8"; break;
-        case Colormap::Set1_9: os << "Set1_9"; break;
-        case Colormap::Set2_1: os << "Set2_1"; break;
-        case Colormap::Set2_2: os << "Set2_2"; break;
-        case Colormap::Set2_3: os << "Set2_3"; break;
-        case Colormap::Set2_4: os << "Set2_4"; break;
-        case Colormap::Set2_5: os << "Set2_5"; break;
-        case Colormap::Set2_6: os << "Set2_6"; break;
-        case Colormap::Set2_7: os << "Set2_7"; break;
-        case Colormap::Set2_8: os << "Set2_8"; break;
-        case Colormap::Set3_3: os << "Set3_3"; break;
-        case Colormap::Set3_4: os << "Set3_4"; break;
-        case Colormap::Set3_5: os << "Set3_5"; break;
-        case Colormap::Set3_6: os << "Set3_6"; break;
-        case Colormap::Set3_7: os << "Set3_7"; break;
-        case Colormap::Set3_8: os << "Set3_8"; break;
-        case Colormap::Set3_9: os << "Set3_9"; break;
-        case Colormap::Set3_10: os << "Set3_10"; break;
-        case Colormap::Set3_11: os << "Set3_11"; break;
-        case Colormap::Set3_12: os << "Set3_12"; break;
-        case Colormap::Spectral_3: os << "Spectral_3"; break;
-        case Colormap::Spectral_4: os << "Spectral_4"; break;
-        case Colormap::Spectral_5: os << "Spectral_5"; break;
-        case Colormap::Spectral_6: os << "Spectral_6"; break;
-        case Colormap::Spectral_7: os << "Spectral_7"; break;
-        case Colormap::Spectral_8: os << "Spectral_8"; break;
-        case Colormap::Spectral_9: os << "Spectral_9"; break;
-        case Colormap::Spectral_10: os << "Spectral_10"; break;
-        case Colormap::Spectral_11: os << "Spectral_11"; break;
-        case Colormap::YlGn_3: os << "YlGn_3"; break;
-        case Colormap::YlGn_4: os << "YlGn_4"; break;
-        case Colormap::YlGn_5: os << "YlGn_5"; break;
-        case Colormap::YlGn_6: os << "YlGn_6"; break;
-        case Colormap::YlGn_7: os << "YlGn_7"; break;
-        case Colormap::YlGn_8: os << "YlGn_8"; break;
-        case Colormap::YlGn_9: os << "YlGn_9"; break;
-        case Colormap::YlGnBu_3: os << "YlGnBu_3"; break;
-        case Colormap::YlGnBu_4: os << "YlGnBu_4"; break;
-        case Colormap::YlGnBu_5: os << "YlGnBu_5"; break;
-        case Colormap::YlGnBu_6: os << "YlGnBu_6"; break;
-        case Colormap::YlGnBu_7: os << "YlGnBu_7"; break;
-        case Colormap::YlGnBu_8: os << "YlGnBu_8"; break;
-        case Colormap::YlGnBu_9: os << "YlGnBu_9"; break;
-        case Colormap::YlOrBr_3: os << "YlOrBr_3"; break;
-        case Colormap::YlOrBr_4: os << "YlOrBr_4"; break;
-        case Colormap::YlOrBr_5: os << "YlOrBr_5"; break;
-        case Colormap::YlOrBr_6: os << "YlOrBr_6"; break;
-        case Colormap::YlOrBr_7: os << "YlOrBr_7"; break;
-        case Colormap::YlOrBr_8: os << "YlOrBr_8"; break;
-        case Colormap::YlOrBr_9: os << "YlOrBr_9"; break;
-        case Colormap::YlOrRd_3: os << "YlOrRd_3"; break;
-        case Colormap::YlOrRd_4: os << "YlOrRd_4"; break;
-        case Colormap::YlOrRd_5: os << "YlOrRd_5"; break;
-        case Colormap::YlOrRd_6: os << "YlOrRd_6"; break;
-        case Colormap::YlOrRd_7: os << "YlOrRd_7"; break;
-        case Colormap::YlOrRd_8: os << "YlOrRd_8"; break;
-            // clang-format on
-    }
-    return os;
-}
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& os,
-                                             Category category) {
-    switch (category) {
-        // clang-format off
-        case Category::Diverging: os << "Diverging"; break;
-        case Category::Qualitative: os << "Qualitative"; break;
-        case Category::Sequential: os << "Sequential"; break;
-        case Category::NumberOfColormapCategories: os << "NumberOfColormapCategories"; break;
-        case Category::Undefined: os << "Undefined"; break;
-            // clang-format on
-    }
-    return os;
-}
-
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& os, Family family) {
-    switch (family) {
-        // clang-format off
-        case Family::Accent: os << "Accent"; break;
-        case Family::Blues: os << "Blues"; break;
-        case Family::BrBG: os << "BrBG"; break;
-        case Family::BuGn: os << "BuGn"; break;
-        case Family::BuPu: os << "BuPu"; break;
-        case Family::Dark2: os << "Dark2"; break;
-        case Family::GnBu: os << "GnBu"; break;
-        case Family::Greens: os << "Greens"; break;
-        case Family::Greys: os << "Greys"; break;
-        case Family::OrRd: os << "OrRd"; break;
-        case Family::Oranges: os << "Oranges"; break;
-        case Family::PRGn: os << "PRGn"; break;
-        case Family::Paired: os << "Paired"; break;
-        case Family::Pastel1: os << "Pastel1"; break;
-        case Family::Pastel2: os << "Pastel2"; break;
-        case Family::PiYG: os << "PiYG"; break;
-        case Family::PuBu: os << "PuBu"; break;
-        case Family::PuBuGn: os << "PuBuGn"; break;
-        case Family::PuOr: os << "PuOr"; break;
-        case Family::PuRd: os << "PuRd"; break;
-        case Family::Purples: os << "Purples"; break;
-        case Family::RdBu: os << "RdBu"; break;
-        case Family::RdGy: os << "RdGy"; break;
-        case Family::RdPu: os << "RdPu"; break;
-        case Family::RdYlBu: os << "RdYlBu"; break;
-        case Family::RdYlGn: os << "RdYlGn"; break;
-        case Family::Reds: os << "Reds"; break;
-        case Family::Set1: os << "Set1"; break;
-        case Family::Set2: os << "Set2"; break;
-        case Family::Set3: os << "Set3"; break;
-        case Family::Spectral: os << "Spectral"; break;
-        case Family::YlGn: os << "YlGn"; break;
-        case Family::YlGnBu: os << "YlGnBu"; break;
-        case Family::YlOrBr: os << "YlOrBr"; break;
-        case Family::YlOrRd: os << "YlOrRd"; break;
-        case Family::NumberOfColormapFamilies: os << "NumberOfColormapFamilies"; break;
-        case Family::Undefined: os << "Undefined"; break;
-            // clang-format on
-    }
-    return os;
-}
+IVW_CORE_API std::ostream& operator<<(std::ostream& os, Colormap colormap);
+IVW_CORE_API std::ostream& operator<<(std::ostream& os, Category category);
+IVW_CORE_API std::ostream& operator<<(std::ostream& os, Family family);
 
 /**
  * Returns the specified colormap. For reference see http://colorbrewer2.org/
  **/
-IVW_CORE_API const std::vector<dvec4>& getColormap(Colormap colormap);
+IVW_CORE_API const std::vector<dvec4> &getColormap(Colormap colormap);
 
 /**
  * Returns the minimum number of colors for which the requested family is available.
  **/
-IVW_CORE_API glm::uint8 getMinNumberOfColorsForFamily(const Family& family);
+IVW_CORE_API glm::uint8 getMinNumberOfColorsForFamily(const Family &family);
 
 /**
  * Returns the maximum number of colors for which the requested family is available.
  **/
-IVW_CORE_API glm::uint8 getMaxNumberOfColorsForFamily(const Family& family);
+IVW_CORE_API glm::uint8 getMaxNumberOfColorsForFamily(const Family &family);
 
 /**
  * Returns all families contained in the specified category.
  **/
-IVW_CORE_API std::vector<Family> getFamiliesForCategory(const Category& category);
+IVW_CORE_API std::vector<Family> getFamiliesForCategory(const Category &category);
 
 }  // namespace colorbrewer
 }  // namespace inviwo
+
+template <> struct fmt::formatter<inviwo::colorbrewer::Colormap> : ostream_formatter {};
+template <> struct fmt::formatter<inviwo::colorbrewer::Category> : ostream_formatter {};
+template <> struct fmt::formatter<inviwo::colorbrewer::Family> : ostream_formatter {};

--- a/include/inviwo/core/util/document.h
+++ b/include/inviwo/core/util/document.h
@@ -126,9 +126,7 @@ public:
 
         ElemVec::const_iterator operator()(const ElemVec& elements) const;
 
-        template <class Elem, class Traits>
-        friend std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                                            const Document::PathComponent& path) {
+        friend std::ostream& operator<<(std::ostream& ss, const Document::PathComponent& path) {
             ss << path.strrep_;
             return ss;
         }
@@ -215,40 +213,7 @@ public:
         for (const auto& e : root_->children_) traverser(e.get(), stack);
     }
 
-    template <class Elem, class Traits>
-    friend std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                                        const Document& doc) {
-        doc.visit(
-            [&](Element* elem, std::vector<Element*>& stack) {
-                if (elem->isNode()) {
-                    ss << std::setw(stack.size() * 4) << ' ' << '<' << elem->name();
-                    for (const auto& item : elem->attributes()) {
-                        ss << ' ' << item.first << "='" << item.second << '\'';
-                    }
-                    ss << '>';
-                    if (!elem->noIndent()) ss << '\n';
-                } else if (elem->isText() && !elem->content().empty()) {
-                    if (!stack.empty() && !stack.back()->noIndent()) {
-                        ss << std::setw(stack.size() * 4) << ' ' << elem->content() << '\n';
-                    } else if (!stack.empty() && stack.back()->noIndent()) {
-                        ss << elem->content();
-                    } else {
-                        ss << elem->content() << '\n';
-                    }
-                }
-            },
-            [&](Element* elem, std::vector<Element*>& stack) {
-                if (elem->isNode() && !elem->emptyTag()) {
-                    if (!elem->noIndent()) {
-                        ss << std::setw(stack.size() * 4) << ' ' << "</" << elem->name() << ">\n";
-                    } else {
-                        ss << "</" << elem->name() << ">\n";
-                    }
-                }
-            });
-
-        return ss;
-    }
+    IVW_CORE_API friend std::ostream& operator<<(std::ostream& ss, const Document& doc);
 
     std::string str() const;
     operator std::string() const;

--- a/include/inviwo/core/util/exception.h
+++ b/include/inviwo/core/util/exception.h
@@ -32,12 +32,10 @@
 #include <inviwo/core/common/inviwocoredefine.h>
 #include <inviwo/core/util/sourcecontext.h>
 
+#include <stdexcept>
 #include <string_view>
 #include <string>
-#include <exception>
-#include <stdexcept>
 #include <vector>
-#include <ostream>
 
 #include <fmt/format.h>
 
@@ -48,7 +46,6 @@
 namespace inviwo {
 
 using ExceptionContext = SourceContext;
-using ExceptionHandler = std::function<void(ExceptionContext)>;
 
 class IVW_CORE_API Exception : public std::runtime_error {
 public:
@@ -56,7 +53,7 @@ public:
     Exception(std::string_view format, fmt::format_args&& args, ExceptionContext context);
     template <typename... Args>
     Exception(ExceptionContext context, std::string_view format, Args&&... args)
-        : Exception{format, fmt::make_args_checked<Args...>(format, std::forward<Args>(args)...),
+        : Exception{format, fmt::make_format_args(format, std::forward<Args>(args)...),
                     std::move(context)} {}
     virtual ~Exception() noexcept;
     virtual std::string getMessage() const;
@@ -66,17 +63,12 @@ public:
     const std::vector<std::string>& getStack() const;
     void getStack(std::ostream& os, int maxFrames = -1) const;
 
+    IVW_CORE_API friend std::ostream& operator<<(std::ostream& ss, const Exception& e);
+
 private:
     ExceptionContext context_;
     std::vector<std::string> stack_;
 };
-
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             const Exception& e) {
-    e.getFullMessage(ss);
-    return ss;
-}
 
 class IVW_CORE_API RangeException : public Exception {
 public:

--- a/include/inviwo/core/util/filedialogstate.h
+++ b/include/inviwo/core/util/filedialogstate.h
@@ -30,7 +30,7 @@
 #pragma once
 
 #include <inviwo/core/common/inviwocoredefine.h>
-
+#include <inviwo/core/util/fmtutils.h>
 #include <iosfwd>
 
 namespace inviwo {
@@ -38,40 +38,18 @@ namespace inviwo {
 enum class AcceptMode { Open, Save };
 enum class FileMode { AnyFile, ExistingFile, Directory, ExistingFiles, DirectoryOnly };
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             AcceptMode& mode) {
-    switch (mode) {
-        case AcceptMode::Open:
-            ss << "Open";
-            break;
-        case AcceptMode::Save:
-            ss << "Save";
-            break;
-    }
-    return ss;
-}
+namespace util {
+IVW_CORE_API std::string_view name(AcceptMode mode);
+IVW_CORE_API std::string_view name(FileMode mode);
+}  // namespace util
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, FileMode& mode) {
-    switch (mode) {
-        case FileMode::AnyFile:
-            ss << "Any File";
-            break;
-        case FileMode::ExistingFile:
-            ss << "Existing File";
-            break;
-        case FileMode::Directory:
-            ss << "Directory";
-            break;
-        case FileMode::ExistingFiles:
-            ss << "Existing Files";
-            break;
-        case FileMode::DirectoryOnly:
-            ss << "Directory Only";
-            break;
-    }
-    return ss;
-}
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, AcceptMode& mode);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, FileMode& mode);
 
 }  // namespace inviwo
+
+template <>
+struct fmt::formatter<inviwo::AcceptMode> : inviwo::FlagFormatter<inviwo::AcceptMode> {};
+
+template <>
+struct fmt::formatter<inviwo::FileMode> : inviwo::FlagFormatter<inviwo::FileMode> {};

--- a/include/inviwo/core/util/fileextension.h
+++ b/include/inviwo/core/util/fileextension.h
@@ -87,30 +87,17 @@ public:
 
     std::string extension_;  ///< File extension in lower case letters.
     std::string description_;
+
+    IVW_CORE_API friend std::ostream& operator<<(std::ostream& ss, const FileExtension& ext);
+
+    IVW_CORE_API friend bool operator==(const FileExtension&, const FileExtension&);
+    IVW_CORE_API friend bool operator!=(const FileExtension&, const FileExtension&);
+
+    IVW_CORE_API friend bool operator<(const FileExtension&, const FileExtension&);
+    IVW_CORE_API friend bool operator<=(const FileExtension&, const FileExtension&);
+    IVW_CORE_API friend bool operator>(const FileExtension&, const FileExtension&);
+    IVW_CORE_API friend bool operator>=(const FileExtension&, const FileExtension&);
 };
-
-IVW_CORE_API bool operator==(const FileExtension&, const FileExtension&);
-IVW_CORE_API bool operator!=(const FileExtension&, const FileExtension&);
-
-IVW_CORE_API bool operator<(const FileExtension&, const FileExtension&);
-IVW_CORE_API bool operator<=(const FileExtension&, const FileExtension&);
-IVW_CORE_API bool operator>(const FileExtension&, const FileExtension&);
-IVW_CORE_API bool operator>=(const FileExtension&, const FileExtension&);
-
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             const FileExtension& ext) {
-    if (ext.extension_.empty()) {
-        return ss;
-    }
-    ss << ext.description_ << " ";
-    if (ext.extension_ == "*") {
-        ss << "(*)";
-    } else {
-        ss << "(*." << ext.extension_ << ")";
-    }
-    return ss;
-}
 
 template <>
 struct PropertyTraits<OptionProperty<FileExtension>> {

--- a/include/inviwo/core/util/fmtutils.h
+++ b/include/inviwo/core/util/fmtutils.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2013-2021 Inviwo Foundation
+ * Copyright (c) 2022 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,41 +26,32 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  *********************************************************************************/
+#pragma once
 
-#include <inviwo/core/properties/propertysemantics.h>
-#include <inviwo/core/io/serialization/serialization.h>
-
-#include <ostream>
+#include <fmt/format.h>
 
 namespace inviwo {
 
-PropertySemantics::PropertySemantics() : semantic_("Default") {}
-PropertySemantics::PropertySemantics(std::string semantic) : semantic_(std::move(semantic)) {}
+template <typename T>
+struct FlagsFormatter : fmt::formatter<fmt::string_view> {
+    template <typename FormatContext>
+    auto format(T val, FormatContext& ctx) const {
+        fmt::memory_buffer buff;
+        fmt::format_to(std::back_inserter(buff), "{}", fmt::join(val, "+"));
+        return formatter<fmt::string_view>::format(fmt::string_view(buff.data(), buff.size()), ctx);
+    }
+};
+template <typename T>
+struct FlagFormatter : fmt::formatter<fmt::string_view> {
+    template <typename U>
+    static std::string_view name(U val) {
+        return name(val);
+    }
 
-const std::string& PropertySemantics::getString() const { return semantic_; }
-
-void PropertySemantics::serialize(Serializer& s) const {
-    s.serialize("semantics", semantic_, SerializationTarget::Attribute);
-}
-
-void PropertySemantics::deserialize(Deserializer& d) {
-    d.deserialize("semantics", semantic_, SerializationTarget::Attribute);
-}
-
-const PropertySemantics PropertySemantics::Default("Default");
-const PropertySemantics PropertySemantics::Text("Text");
-const PropertySemantics PropertySemantics::SpinBox("SpinBox");
-const PropertySemantics PropertySemantics::Color("Color");
-const PropertySemantics PropertySemantics::LightPosition("LightPosition");
-const PropertySemantics PropertySemantics::Multiline("Multiline");
-const PropertySemantics PropertySemantics::TextEditor("TextEditor");
-const PropertySemantics PropertySemantics::PythonEditor("PythonEditor");
-const PropertySemantics PropertySemantics::ImageEditor("ImageEditor");
-const PropertySemantics PropertySemantics::ShaderEditor("ShaderEditor");
-
-std::ostream& operator<<(std::ostream& ss, const PropertySemantics& obj) {
-    ss << obj.getString();
-    return ss;
-}
+    template <typename FormatContext>
+    auto format(T val, FormatContext& ctx) const {
+        return formatter<fmt::string_view>::format(name<T>(val), ctx);
+    }
+};
 
 }  // namespace inviwo

--- a/include/inviwo/core/util/formats.h
+++ b/include/inviwo/core/util/formats.h
@@ -39,7 +39,6 @@
 #include <array>
 #include <memory>
 
-
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
 #define M_PI_2 1.57079632679489661923
@@ -231,7 +230,7 @@ public:
     static constexpr double minToDouble();
     static constexpr double lowestToDouble();
     static std::string_view str();
-    static constexpr const auto& staticStr();
+    static constexpr auto staticStr();
 
     // Converter functions
     virtual double valueToDouble(void* val) const override;
@@ -341,16 +340,16 @@ constexpr NumericType DataFormat<T>::numericType() {
 }
 
 template <typename T>
-constexpr const auto& DataFormat<T>::staticStr() {
-    constexpr auto pre = []() {
-        if constexpr (components() == 0) {
+constexpr auto DataFormat<T>::staticStr() {
+    constexpr auto prefix = []() {
+        if constexpr (components() == 1) {
             return StaticString{""};
-        } else if constexpr (components() == 1) {
-            return StaticString{"Vec1"};
         } else if constexpr (components() == 2) {
             return StaticString{"Vec2"};
         } else if constexpr (components() == 3) {
             return StaticString{"Vec3"};
+        } else if constexpr (components() == 4) {
+            return StaticString{"Vec4"};
         } else {
             throw DataFormatException("Invalid format", IVW_CONTEXT_CUSTOM("DataFormat"));
         }
@@ -382,7 +381,7 @@ constexpr const auto& DataFormat<T>::staticStr() {
         }
     };
 
-    return pre() + type() + prec();
+    return prefix() + type() + prec();
 }
 
 template <typename T>

--- a/include/inviwo/core/util/glm.h
+++ b/include/inviwo/core/util/glm.h
@@ -66,6 +66,9 @@
 #include <type_traits>
 #include <utility>
 
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
 namespace inviwo {
 
 static_assert(std::is_standard_layout<half_float::half>::value, "");
@@ -990,3 +993,12 @@ template <std::size_t N, glm::length_t L, typename T, glm::qualifier Q>
 struct std::tuple_element<N, glm::vec<L, T, Q>> {
     using type = T;
 };
+
+template <glm::length_t L, typename T, glm::qualifier Q>
+struct fmt::formatter<glm::vec<L, T, Q>> : fmt::ostream_formatter {};
+
+template <glm::length_t C, glm::length_t R, typename T, glm::qualifier Q>
+struct fmt::formatter<glm::mat<C, R, T, Q>> : fmt::ostream_formatter {};
+
+template <typename T, glm::qualifier Q>
+struct fmt::formatter<glm::qua<T, Q>> : fmt::ostream_formatter {};

--- a/include/inviwo/core/util/logcentral.h
+++ b/include/inviwo/core/util/logcentral.h
@@ -32,10 +32,12 @@
 #include <inviwo/core/common/inviwocoredefine.h>
 #include <inviwo/core/util/singleton.h>
 #include <inviwo/core/util/exception.h>
+#include <inviwo/core/util/fmtutils.h>
 #include <inviwo/core/util/demangle.h>
 
 #include <ostream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace inviwo {
@@ -61,54 +63,15 @@ IVW_CORE_API bool operator>(const LogVerbosity& lhs, const LogLevel& rhs);
 IVW_CORE_API bool operator<=(const LogVerbosity& lhs, const LogLevel& rhs);
 IVW_CORE_API bool operator>=(const LogVerbosity& lhs, const LogLevel& rhs);
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, LogLevel ll) {
-    switch (ll) {
-        case LogLevel::Info:
-            ss << "Info";
-            break;
-        case LogLevel::Warn:
-            ss << "Warn";
-            break;
-        case LogLevel::Error:
-            ss << "Error";
-            break;
-    }
-    return ss;
-}
+namespace util {
+IVW_CORE_API std::string_view name(LogLevel ll);
+IVW_CORE_API std::string_view name(LogAudience la);
+IVW_CORE_API std::string_view name(MessageBreakLevel ll);
+}  // namespace util
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, LogAudience la) {
-    switch (la) {
-        case LogAudience::User:
-            ss << "User";
-            break;
-        case LogAudience::Developer:
-            ss << "Developer";
-            break;
-    }
-    return ss;
-}
-
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             MessageBreakLevel ll) {
-    switch (ll) {
-        case MessageBreakLevel::Info:
-            ss << "Info";
-            break;
-        case MessageBreakLevel::Warn:
-            ss << "Warn";
-            break;
-        case MessageBreakLevel::Error:
-            ss << "Error";
-            break;
-        case MessageBreakLevel::Off:
-            ss << "Off";
-            break;
-    }
-    return ss;
-}
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, LogLevel ll);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, LogAudience la);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, MessageBreakLevel ll);
 
 #define LogSpecial(logger, logLevel, message)                                                   \
     {                                                                                           \
@@ -254,3 +217,11 @@ IVW_CORE_API void log(Logger* logger, ExceptionContext context, std::string_view
 }  // namespace util
 
 }  // namespace inviwo
+
+template <>
+struct fmt::formatter<inviwo::LogLevel> : inviwo::FlagFormatter<inviwo::LogLevel> {};
+template <>
+struct fmt::formatter<inviwo::LogAudience> : inviwo::FlagFormatter<inviwo::LogAudience> {};
+template <>
+struct fmt::formatter<inviwo::MessageBreakLevel>
+    : inviwo::FlagFormatter<inviwo::MessageBreakLevel> {};

--- a/include/inviwo/core/util/spatial4dsampler.h
+++ b/include/inviwo/core/util/spatial4dsampler.h
@@ -82,10 +82,11 @@ extern template class IVW_CORE_TMPL_EXP Spatial4DSampler<4, float>;
 template <unsigned DataDims, typename T>
 struct DataTraits<Spatial4DSampler<DataDims, T>> {
     static std::string classIdentifier() {
-        return "org.inviwo.Spatial4DSampler." + DataFormat<Vector<DataDims, T>>::str();
+        return fmt::format("org.inviwo.Spatial4DSampler.{}",
+                           DataFormat<Vector<DataDims, T>>::str());
     }
     static std::string dataName() {
-        return "Spatial4DSampler<" + DataFormat<Vector<DataDims, T>>::str() + ">";
+        return fmt::format("Spatial4DSampler<{}>", DataFormat<Vector<DataDims, T>>::str());
     }
     static uvec3 colorCode() { return uvec3(153, 0, 76); }
     static Document info(const Spatial4DSampler<DataDims, T>&) {

--- a/include/inviwo/core/util/spatialsampler.h
+++ b/include/inviwo/core/util/spatialsampler.h
@@ -78,12 +78,12 @@ protected:
 template <unsigned int SpatialDims, unsigned int DataDims, typename T>
 struct DataTraits<SpatialSampler<SpatialDims, DataDims, T>> {
     static std::string classIdentifier() {
-        return "org.inviwo.SpatialSampler." + toString(SpatialDims) + "D." +
-               DataFormat<Vector<DataDims, T>>::str();
+        return fmt::format("org.inviwo.SpatialSampler.{}D.{}", SpatialDims,
+                           DataFormat<Vector<DataDims, T>>::str());
     }
     static std::string dataName() {
-        return "SpatialSampler<" + toString(SpatialDims) + "D" +
-               DataFormat<Vector<DataDims, T>>::str() + ">";
+        return fmt::format("SpatialSampler<{}D{}>", SpatialDims,
+                           DataFormat<Vector<DataDims, T>>::str());
     }
     static uvec3 colorCode() { return uvec3(153, 0, 76); }
     static Document info(const SpatialSampler<SpatialDims, DataDims, T>&) {

--- a/modules/animation/include/modules/animation/datastructures/easing.h
+++ b/modules/animation/include/modules/animation/datastructures/easing.h
@@ -33,6 +33,8 @@
 #include <inviwo/core/util/formats.h>
 #include <inviwo/core/util/assertion.h>
 
+#include <iosfwd>
+
 namespace inviwo {
 
 namespace animation {
@@ -95,114 +97,7 @@ IVW_MODULE_ANIMATION_API EasingType& operator++(EasingType& e);
 
 IVW_MODULE_ANIMATION_API EasingType operator++(EasingType& e, int);
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& os,
-                                             EasingType type) {
-    switch (type) {
-        case inviwo::animation::easing::EasingType::None:
-            os << "None";
-            break;
-        case inviwo::animation::easing::EasingType::Linear:
-            os << "Linear";
-            break;
-        case inviwo::animation::easing::EasingType::InQuadratic:
-            os << "InQuadratic";
-            break;
-        case inviwo::animation::easing::EasingType::InCubic:
-            os << "InCubic";
-            break;
-        case inviwo::animation::easing::EasingType::InQuartic:
-            os << "InQuartic";
-            break;
-        case inviwo::animation::easing::EasingType::InQuintic:
-            os << "InQuintic";
-            break;
-        case inviwo::animation::easing::EasingType::OutQuadratic:
-            os << "OutQuadratic";
-            break;
-        case inviwo::animation::easing::EasingType::OutCubic:
-            os << "OutCubic";
-            break;
-        case inviwo::animation::easing::EasingType::OutQuartic:
-            os << "OutQuartic";
-            break;
-        case inviwo::animation::easing::EasingType::OutQuintic:
-            os << "OutQuintic";
-            break;
-        case inviwo::animation::easing::EasingType::InOutQuadratic:
-            os << "InOutQuadratic";
-            break;
-        case inviwo::animation::easing::EasingType::InOutCubic:
-            os << "InOutCubic";
-            break;
-        case inviwo::animation::easing::EasingType::InOutQuartic:
-            os << "InOutQuartic";
-            break;
-        case inviwo::animation::easing::EasingType::InOutQuintic:
-            os << "InOutQuintic";
-            break;
-        case inviwo::animation::easing::EasingType::InSine:
-            os << "InSine";
-            break;
-        case inviwo::animation::easing::EasingType::OutSine:
-            os << "OutSine";
-            break;
-        case inviwo::animation::easing::EasingType::InOutSine:
-            os << "InOutSine";
-            break;
-        case inviwo::animation::easing::EasingType::InExp:
-            os << "InExp";
-            break;
-        case inviwo::animation::easing::EasingType::OutExp:
-            os << "OutExp";
-            break;
-        case inviwo::animation::easing::EasingType::InOutExp:
-            os << "InOutExp";
-            break;
-        case inviwo::animation::easing::EasingType::InCircular:
-            os << "InCircular";
-            break;
-        case inviwo::animation::easing::EasingType::OutCircular:
-            os << "OutCircular";
-            break;
-        case inviwo::animation::easing::EasingType::InOutCircular:
-            os << "InOutCircular";
-            break;
-        case inviwo::animation::easing::EasingType::InBack:
-            os << "InBack";
-            break;
-        case inviwo::animation::easing::EasingType::OutBack:
-            os << "OutBack";
-            break;
-        case inviwo::animation::easing::EasingType::InOutBack:
-            os << "InOutBack";
-            break;
-        case inviwo::animation::easing::EasingType::InElastic:
-            os << "InElastic";
-            break;
-        case inviwo::animation::easing::EasingType::OutElastic:
-            os << "OutElastic";
-            break;
-        case inviwo::animation::easing::EasingType::InOutElastic:
-            os << "InOutElastic";
-            break;
-        case inviwo::animation::easing::EasingType::InBounce:
-            os << "InBounce";
-            break;
-        case inviwo::animation::easing::EasingType::OutBounce:
-            os << "OutBounce";
-            break;
-        case inviwo::animation::easing::EasingType::InOutBounce:
-            os << "InOutBounce";
-            break;
-        default:
-            throw inviwo::Exception("Unknown Easing type",
-                                    IVW_CONTEXT_CUSTOM("Easing::operator<<"));
-            break;
-    }
-
-    return os;
-}
+IVW_MODULE_ANIMATION_API std::ostream& operator<<(std::ostream& os, EasingType type);
 
 /// Polynomial In-Easing
 inline double inPolynomial(const double t, const double Exponent) { return pow(t, Exponent); }

--- a/modules/animation/include/modules/animation/interpolation/constantinterpolation.h
+++ b/modules/animation/include/modules/animation/interpolation/constantinterpolation.h
@@ -31,6 +31,8 @@
 #include <modules/animation/animationmoduledefine.h>
 #include <modules/animation/interpolation/interpolation.h>
 
+#include <inviwo/core/util/defaultvalues.h>
+
 #include <algorithm>
 
 namespace inviwo {

--- a/modules/animation/src/datastructures/easing.cpp
+++ b/modules/animation/src/datastructures/easing.cpp
@@ -29,6 +29,8 @@
 
 #include <modules/animation/datastructures/easing.h>
 
+#include <ostream>
+
 namespace inviwo {
 namespace animation {
 
@@ -44,6 +46,111 @@ EasingType operator++(EasingType& e, int) {
     EasingType result = e;
     ++e;
     return result;
+}
+
+std::ostream& operator<<(std::ostream& os, EasingType type) {
+    switch (type) {
+        case EasingType::None:
+            os << "None";
+            break;
+        case EasingType::Linear:
+            os << "Linear";
+            break;
+        case EasingType::InQuadratic:
+            os << "InQuadratic";
+            break;
+        case EasingType::InCubic:
+            os << "InCubic";
+            break;
+        case EasingType::InQuartic:
+            os << "InQuartic";
+            break;
+        case EasingType::InQuintic:
+            os << "InQuintic";
+            break;
+        case EasingType::OutQuadratic:
+            os << "OutQuadratic";
+            break;
+        case EasingType::OutCubic:
+            os << "OutCubic";
+            break;
+        case EasingType::OutQuartic:
+            os << "OutQuartic";
+            break;
+        case EasingType::OutQuintic:
+            os << "OutQuintic";
+            break;
+        case EasingType::InOutQuadratic:
+            os << "InOutQuadratic";
+            break;
+        case EasingType::InOutCubic:
+            os << "InOutCubic";
+            break;
+        case EasingType::InOutQuartic:
+            os << "InOutQuartic";
+            break;
+        case EasingType::InOutQuintic:
+            os << "InOutQuintic";
+            break;
+        case EasingType::InSine:
+            os << "InSine";
+            break;
+        case EasingType::OutSine:
+            os << "OutSine";
+            break;
+        case EasingType::InOutSine:
+            os << "InOutSine";
+            break;
+        case EasingType::InExp:
+            os << "InExp";
+            break;
+        case EasingType::OutExp:
+            os << "OutExp";
+            break;
+        case EasingType::InOutExp:
+            os << "InOutExp";
+            break;
+        case EasingType::InCircular:
+            os << "InCircular";
+            break;
+        case EasingType::OutCircular:
+            os << "OutCircular";
+            break;
+        case EasingType::InOutCircular:
+            os << "InOutCircular";
+            break;
+        case EasingType::InBack:
+            os << "InBack";
+            break;
+        case EasingType::OutBack:
+            os << "OutBack";
+            break;
+        case EasingType::InOutBack:
+            os << "InOutBack";
+            break;
+        case EasingType::InElastic:
+            os << "InElastic";
+            break;
+        case EasingType::OutElastic:
+            os << "OutElastic";
+            break;
+        case EasingType::InOutElastic:
+            os << "InOutElastic";
+            break;
+        case EasingType::InBounce:
+            os << "InBounce";
+            break;
+        case EasingType::OutBounce:
+            os << "OutBounce";
+            break;
+        case EasingType::InOutBounce:
+            os << "InOutBounce";
+            break;
+        default:
+            throw Exception("Unknown Easing type", IVW_CONTEXT_CUSTOM("Easing::operator<<"));
+    }
+
+    return os;
 }
 
 }  // namespace easing

--- a/modules/assimp/src/assimpreader.cpp
+++ b/modules/assimp/src/assimpreader.cpp
@@ -369,7 +369,7 @@ std::shared_ptr<Mesh> AssimpReader::readData(std::string_view filePath) {
     }
 
     // use additional unused attribute locations for extra color channels and texture coords
-    int auxLocation = static_cast<int>(BufferType::NumberOfBufferTypes);
+    int auxLocation = static_cast<int>(BufferType::Unknown);
     for (size_t i = 0; i < color_channels; ++i) {
         int location = (i == 0 ? static_cast<int>(BufferType::ColorAttrib) : auxLocation++);
         mesh->addBuffer(Mesh::BufferInfo(BufferType::ColorAttrib, location), cbuff[i]);

--- a/modules/base/include/modules/base/processors/distancetransformram.h
+++ b/modules/base/include/modules/base/processors/distancetransformram.h
@@ -45,6 +45,8 @@
 #include <inviwo/core/processors/progressbarowner.h>
 #include <inviwo/core/datastructures/volume/volume.h>
 
+#include <iosfwd>
+
 namespace inviwo {
 
 class IVW_MODULE_BASE_API DistanceTransformRAM : public PoolProcessor {
@@ -77,23 +79,7 @@ private:
     DoubleMinMaxProperty customDataRange_;
 };
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             DistanceTransformRAM::DataRangeMode m) {
-    switch (m) {
-        case DistanceTransformRAM::DataRangeMode::Diagonal:
-            ss << "Diagonal";
-            break;
-        case DistanceTransformRAM::DataRangeMode::MinMax:
-            ss << "MinMax";
-            break;
-        case DistanceTransformRAM::DataRangeMode::Custom:
-            ss << "Custom";
-            break;
-        default:
-            break;
-    }
-    return ss;
-}
+IVW_MODULE_BASE_API std::ostream& operator<<(std::ostream& ss,
+                                             DistanceTransformRAM::DataRangeMode m);
 
 }  // namespace inviwo

--- a/modules/base/include/modules/base/processors/layerdistancetransformram.h
+++ b/modules/base/include/modules/base/processors/layerdistancetransformram.h
@@ -47,6 +47,8 @@
 
 #include <modules/base/datastructures/imagereusecache.h>
 
+#include <iosfwd>
+
 namespace inviwo {
 
 /** \docpage{org.inviwo.LayerDistanceTransformRAM, Layer Distance Transform}
@@ -107,23 +109,7 @@ private:
     IntSize2Property upsampleFactorVec2_;  // non-uniform upscaling of the output field
 };
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             LayerDistanceTransformRAM::DataRangeMode m) {
-    switch (m) {
-        case LayerDistanceTransformRAM::DataRangeMode::Diagonal:
-            ss << "Diagonal";
-            break;
-        case LayerDistanceTransformRAM::DataRangeMode::MinMax:
-            ss << "MinMax";
-            break;
-        case LayerDistanceTransformRAM::DataRangeMode::Custom:
-            ss << "Custom";
-            break;
-        default:
-            break;
-    }
-    return ss;
-}
+IVW_MODULE_BASE_API std::ostream& operator<<(std::ostream& ss,
+                                             LayerDistanceTransformRAM::DataRangeMode m);
 
 }  // namespace inviwo

--- a/modules/base/include/modules/base/processors/ordinalpropertyanimator.h
+++ b/modules/base/include/modules/base/processors/ordinalpropertyanimator.h
@@ -30,23 +30,23 @@
 #pragma once
 
 #include <modules/base/basemoduledefine.h>
-#include <inviwo/core/processors/processor.h>
-#include <inviwo/core/util/timer.h>
 #include <inviwo/core/common/inviwoapplication.h>
+#include <inviwo/core/processors/processor.h>
 #include <inviwo/core/properties/propertyfactory.h>
 #include <inviwo/core/properties/optionproperty.h>
 #include <inviwo/core/properties/boolproperty.h>
 #include <inviwo/core/properties/buttonproperty.h>
 #include <inviwo/core/properties/ordinalproperty.h>
 #include <inviwo/core/properties/compositeproperty.h>
+#include <inviwo/core/util/timer.h>
 
 #include <glm/vector_relational.hpp>
-
+#include <iosfwd>
 #include <tuple>
 
 namespace inviwo {
 
-class BaseOrdinalAnimationProperty : public CompositeProperty {
+class IVW_MODULE_BASE_API BaseOrdinalAnimationProperty : public CompositeProperty {
 public:
     using CompositeProperty::CompositeProperty;
     virtual ~BaseOrdinalAnimationProperty() = default;
@@ -54,6 +54,7 @@ public:
 };
 
 enum class BoundaryType { Stop, Periodic, Mirror };
+IVW_MODULE_BASE_API std::ostream& operator<<(std::ostream& ss, BoundaryType bt);
 
 template <typename T>
 class OrdinalAnimationProperty : public BaseOrdinalAnimationProperty {
@@ -76,25 +77,6 @@ public:
     OptionProperty<BoundaryType> boundary_;
     BoolProperty active_;
 };
-
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             BoundaryType bt) {
-    switch (bt) {
-        case BoundaryType::Stop:
-            ss << "Stop";
-            break;
-        case BoundaryType::Periodic:
-            ss << "Periodic";
-            break;
-        case BoundaryType::Mirror:
-            ss << "Mirror";
-            break;
-        default:
-            break;
-    }
-    return ss;
-}
 
 template <typename T>
 OrdinalAnimationProperty<T>::OrdinalAnimationProperty(std::string_view identifier,

--- a/modules/base/src/algorithm/mesh/meshconverter.cpp
+++ b/modules/base/src/algorithm/mesh/meshconverter.cpp
@@ -148,7 +148,6 @@ std::unique_ptr<Mesh> toLineMesh(const Mesh& mesh) {
                     break;
                 }
                 case ConnectivityType::Loop:
-                case ConnectivityType::NumberOfConnectivityTypes:
                 default:
                     break;
             }

--- a/modules/base/src/processors/distancetransformram.cpp
+++ b/modules/base/src/processors/distancetransformram.cpp
@@ -32,6 +32,8 @@
 #include <modules/base/algorithm/volume/volumeramdistancetransform.h>
 #include <inviwo/core/datastructures/volume/volumeramprecision.h>
 
+#include <ostream>
+
 namespace inviwo {
 
 const ProcessorInfo DistanceTransformRAM::processorInfo_{
@@ -162,6 +164,23 @@ void DistanceTransformRAM::process() {
         outport_.setData(result);
         newResults();
     });
+}
+
+std::ostream& operator<<(std::ostream& ss, DistanceTransformRAM::DataRangeMode m) {
+    switch (m) {
+        case DistanceTransformRAM::DataRangeMode::Diagonal:
+            ss << "Diagonal";
+            break;
+        case DistanceTransformRAM::DataRangeMode::MinMax:
+            ss << "MinMax";
+            break;
+        case DistanceTransformRAM::DataRangeMode::Custom:
+            ss << "Custom";
+            break;
+        default:
+            break;
+    }
+    return ss;
 }
 
 }  // namespace inviwo

--- a/modules/base/src/processors/layerdistancetransformram.cpp
+++ b/modules/base/src/processors/layerdistancetransformram.cpp
@@ -103,4 +103,21 @@ void LayerDistanceTransformRAM::process() {
     });
 }
 
+std::ostream& operator<<(std::ostream& ss, LayerDistanceTransformRAM::DataRangeMode m) {
+    switch (m) {
+        case LayerDistanceTransformRAM::DataRangeMode::Diagonal:
+            ss << "Diagonal";
+            break;
+        case LayerDistanceTransformRAM::DataRangeMode::MinMax:
+            ss << "MinMax";
+            break;
+        case LayerDistanceTransformRAM::DataRangeMode::Custom:
+            ss << "Custom";
+            break;
+        default:
+            break;
+    }
+    return ss;
+}
+
 }  // namespace inviwo

--- a/modules/base/src/processors/ordinalpropertyanimator.cpp
+++ b/modules/base/src/processors/ordinalpropertyanimator.cpp
@@ -32,6 +32,8 @@
 #include <inviwo/core/util/exception.h>
 #include <inviwo/core/network/networklock.h>
 
+#include <ostream>
+
 namespace inviwo {
 
 const ProcessorInfo OrdinalPropertyAnimator::processorInfo_{
@@ -107,6 +109,23 @@ void OrdinalPropertyAnimator::deserialize(Deserializer& d) {
             props_.push_back(p);
         }
     }
+}
+
+std::ostream& operator<<(std::ostream& ss, BoundaryType bt) {
+    switch (bt) {
+        case BoundaryType::Stop:
+            ss << "Stop";
+            break;
+        case BoundaryType::Periodic:
+            ss << "Periodic";
+            break;
+        case BoundaryType::Mirror:
+            ss << "Mirror";
+            break;
+        default:
+            break;
+    }
+    return ss;
 }
 
 }  // namespace inviwo

--- a/modules/brushingandlinking/src/datastructures/brushingaction.cpp
+++ b/modules/brushingandlinking/src/datastructures/brushingaction.cpp
@@ -28,6 +28,7 @@
  *********************************************************************************/
 
 #include <modules/brushingandlinking/datastructures/brushingaction.h>
+#include <inviwo/core/util/exception.h>
 
 #include <iostream>
 #include <mutex>
@@ -50,6 +51,52 @@ std::string_view BrushingTarget::findOrAdd(std::string_view target) {
     } else {
         return std::string_view{**it};
     }
+}
+
+std::string_view util::name(BrushingAction action) {
+    switch (action) {
+        case BrushingAction::Filter:
+            return "Filter";
+        case BrushingAction::Select:
+            return "Select";
+        case BrushingAction::Highlight:
+            return "Highlight";
+        case BrushingAction::NumberOfActions:
+            break;
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid BrushingAction enum value '{}'",
+                    static_cast<int>(action));
+}
+
+std::string_view util::name(BrushingModification bm) {
+    switch (bm) {
+        case BrushingModification::Filtered:
+            return "Filtered";
+        case BrushingModification::Selected:
+            return "Selected";
+        case BrushingModification::Highlighted:
+            return "Highlighted";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"),
+                    "Found invalid BrushingModification enum value '{}'", static_cast<int>(bm));
+}
+
+std::ostream& operator<<(std::ostream& ss, BrushingAction action) {
+    return ss << util::name(action);
+}
+std::ostream& operator<<(std::ostream& ss, BrushingModification action) {
+    return ss << util::name(action);
+}
+std::ostream& operator<<(std::ostream& ss, BrushingModifications action) {
+    std::copy(action.begin(), action.end(), util::make_ostream_joiner(ss, "+"));
+    return ss;
+}
+
+std::istream& operator>>(std::istream& ss, BrushingTarget& bt) {
+    std::string str;
+    ss >> str;
+    bt = BrushingTarget(str);
+    return ss;
 }
 
 }  // namespace inviwo

--- a/modules/dataframe/include/inviwo/dataframe/datastructures/column.h
+++ b/modules/dataframe/include/inviwo/dataframe/datastructures/column.h
@@ -37,12 +37,13 @@
 #include <inviwo/core/util/exception.h>
 #include <inviwo/core/util/transformiterator.h>
 #include <inviwo/core/util/stdextensions.h>
+#include <inviwo/core/util/fmtutils.h>
 #include <inviwo/core/metadata/metadataowner.h>
 
 #include <modules/base/algorithm/dataminmax.h>
 
 #include <optional>
-#include <iostream>
+#include <iosfwd>
 
 namespace inviwo {
 
@@ -57,25 +58,10 @@ public:
 };
 
 enum class ColumnType { Index, Ordinal, Categorical };
-
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss,
-                                             ColumnType type) {
-    switch (type) {
-        case ColumnType::Index:
-            ss << "Index";
-            break;
-        case ColumnType::Ordinal:
-            ss << "Ordinal";
-            break;
-        case ColumnType::Categorical:
-            ss << "Categorical";
-            break;
-        default:
-            ss << "Invalid";
-    }
-    return ss;
-}
+namespace util {
+IVW_CORE_API std::string_view name(ColumnType b);
+}  // namespace util
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, ColumnType type);
 
 /**
  * @brief Pure interface for representing a data column with a header, optional units, and data
@@ -725,3 +711,6 @@ inline auto CategoricalColumn::values() const -> util::iter_range<ConstIterator>
 #endif
 
 }  // namespace inviwo
+
+template <>
+struct fmt::formatter<inviwo::ColumnType> : inviwo::FlagFormatter<inviwo::ColumnType> {};

--- a/modules/dataframe/include/inviwo/dataframe/properties/colormapproperty.h
+++ b/modules/dataframe/include/inviwo/dataframe/properties/colormapproperty.h
@@ -38,6 +38,8 @@
 #include <inviwo/core/properties/optionproperty.h>
 #include <inviwo/core/util/colorbrewer.h>
 
+#include <iosfwd>
+
 namespace inviwo {
 /**
  * Continuous is suitable for ordered/sequential data.
@@ -46,18 +48,7 @@ namespace inviwo {
  */
 enum class ColormapType { Continuous, Categorical };
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& os,
-                                             ColormapType colormap) {
-    // clang-format off
-    switch (colormap) {
-        case ColormapType::Continuous: os << "Continuous"; break;
-        case ColormapType::Categorical: os << "Categorical"; break;
-    }
-    // clang-format on
-    return os;
-}
-
+IVW_MODULE_DATAFRAME_API std::ostream& operator<<(std::ostream& os, ColormapType colormap);
 /**
  * \brief Selection of pre-defined color maps based on data type.
  *

--- a/modules/dataframe/src/datastructures/column.cpp
+++ b/modules/dataframe/src/datastructures/column.cpp
@@ -34,6 +34,7 @@
 #include <inviwo/core/util/exception.h>
 
 #include <unordered_map>
+#include <ostream>
 
 namespace inviwo {
 
@@ -232,5 +233,19 @@ std::shared_ptr<Buffer<std::uint32_t>> CategoricalColumn::getTypedBuffer() { ret
 std::shared_ptr<const Buffer<std::uint32_t>> CategoricalColumn::getTypedBuffer() const {
     return buffer_;
 }
+
+std::string_view util::name(ColumnType type) {
+    switch (type) {
+        case ColumnType::Index:
+            return "Index";
+        case ColumnType::Ordinal:
+            return "Ordinal";
+        case ColumnType::Categorical:
+            return "Categorical";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid ColumnType enum value '{}'",
+                    static_cast<int>(type));
+}
+std::ostream& operator<<(std::ostream& ss, ColumnType type) { return ss << util::name(type); }
 
 }  // namespace inviwo

--- a/modules/dataframe/src/properties/colormapproperty.cpp
+++ b/modules/dataframe/src/properties/colormapproperty.cpp
@@ -32,6 +32,8 @@
 
 #include <modules/base/algorithm/dataminmax.h>
 
+#include <ostream>
+
 namespace inviwo {
 
 const std::string ColormapProperty::classIdentifier = "org.inviwo.ColormapProperty";
@@ -182,6 +184,14 @@ void ColormapProperty::updateColormaps() {
         diverging = false;
         discrete = true;
     }
+}
+
+std::ostream& operator<<(std::ostream& os, ColormapType colormap) {
+    switch (colormap) {
+        case ColormapType::Continuous: os << "Continuous"; break;
+        case ColormapType::Categorical: os << "Categorical"; break;
+    }
+    return os;
 }
 
 }  // namespace inviwo

--- a/modules/opengl/include/modules/opengl/debugmessages.h
+++ b/modules/opengl/include/modules/opengl/debugmessages.h
@@ -34,6 +34,8 @@
 #include <inviwo/core/util/canvas.h>
 #include <inviwo/core/util/logcentral.h>
 
+#include <iosfwd>
+
 namespace inviwo {
 
 namespace utilgl {
@@ -94,47 +96,9 @@ inline LogLevel toLogLevel(Severity s) {
     }
 }
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, Mode m) {
-    switch (m) {
-        case Mode::Off:
-            ss << "Off";
-            break;
-        case Mode::Debug:
-            ss << "Debug";
-            break;
-        case Mode::DebugSynchronous:
-            ss << "DebugSynchronous";
-            break;
-        default:
-            break;
-    }
-    return ss;
-}
+IVW_MODULE_OPENGL_API std::ostream& operator<<(std::ostream& ss, Mode m);
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, BreakLevel b) {
-    switch (b) {
-        case BreakLevel::Off:
-            ss << "Off";
-            break;
-        case BreakLevel::High:
-            ss << "High";
-            break;
-        case BreakLevel::Medium:
-            ss << "Medium";
-            break;
-        case BreakLevel::Low:
-            ss << "Low";
-            break;
-        case BreakLevel::Notification:
-            ss << "Notification";
-            break;
-        default:
-            break;
-    }
-    return ss;
-}
+IVW_MODULE_OPENGL_API std::ostream& operator<<(std::ostream& ss, BreakLevel b);
 
 namespace detail {
 
@@ -195,98 +159,11 @@ inline bool operator<=(const BreakLevel& b, const Severity& s) { return s >= b; 
 inline bool operator>(const BreakLevel& b, const Severity& s) { return s < b; }
 inline bool operator>=(const BreakLevel& b, const Severity& s) { return s <= b; }
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, Source s) {
-    switch (s) {
-        case Source::Api:
-            ss << "Api";
-            break;
-        case Source::WindowSystem:
-            ss << "WindowSystem";
-            break;
-        case Source::ShaderCompiler:
-            ss << "ShaderCompiler";
-            break;
-        case Source::ThirdParty:
-            ss << "ThirdParty";
-            break;
-        case Source::Application:
-            ss << "Application";
-            break;
-        case Source::Other:
-            ss << "Other";
-            break;
-        case Source::DontCare:
-            ss << "DontCare";
-            break;
-        default:
-            break;
-    }
-    return ss;
-}
+IVW_MODULE_OPENGL_API std::ostream& operator<<(std::ostream& ss, Source s);
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, Type t) {
-    switch (t) {
-        case Type::Error:
-            ss << "Error";
-            break;
-        case Type::DeprecatedBehavior:
-            ss << "DeprecatedBehavior";
-            break;
-        case Type::UndefinedBehavior:
-            ss << "UndefinedBehavior";
-            break;
-        case Type::Portability:
-            ss << "Portability";
-            break;
-        case Type::Performance:
-            ss << "Performance";
-            break;
-        case Type::Marker:
-            ss << "Marker";
-            break;
-        case Type::PushGroup:
-            ss << "PushGroup";
-            break;
-        case Type::PopGroup:
-            ss << "PopGroup";
-            break;
-        case Type::Other:
-            ss << "Other";
-            break;
-        case Type::DontCare:
-            ss << "DontCare";
-            break;
-        default:
-            break;
-    }
-    return ss;
-}
+IVW_MODULE_OPENGL_API std::ostream& operator<<(std::ostream& ss, Type t);
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& ss, Severity s) {
-    switch (s) {
-        case Severity::Low:
-            ss << "Low";
-            break;
-        case Severity::Medium:
-            ss << "Medium";
-            break;
-        case Severity::High:
-            ss << "High";
-            break;
-        case Severity::Notification:
-            ss << "Notification";
-            break;
-        case Severity::DontCare:
-            ss << "DontCare";
-            break;
-        default:
-            break;
-    }
-    return ss;
-}
+IVW_MODULE_OPENGL_API std::ostream& operator<<(std::ostream& ss, Severity s);
 
 }  // namespace debug
 

--- a/modules/opengl/src/debugmessages.cpp
+++ b/modules/opengl/src/debugmessages.cpp
@@ -135,7 +135,7 @@ void setOpenGLDebugMode(debug::Mode mode, debug::Severity severity) {
     }
 }
 
-IVW_MODULE_OPENGL_API void handleOpenGLDebugMessagesChange(utilgl::debug::Severity severity) {
+void handleOpenGLDebugMessagesChange(utilgl::debug::Severity severity) {
     if (RenderContext::getPtr()->hasDefaultRenderContext()) {
         RenderContext::getPtr()->forEachContext(
             [severity](Canvas::ContextID id, const std::string& /*name*/, ContextHolder* canvas,
@@ -154,7 +154,7 @@ IVW_MODULE_OPENGL_API void handleOpenGLDebugMessagesChange(utilgl::debug::Severi
     }
 }
 
-IVW_MODULE_OPENGL_API void configureOpenGLDebugMessages(utilgl::debug::Severity severity) {
+void configureOpenGLDebugMessages(utilgl::debug::Severity severity) {
     if (!glDebugMessageControl) return;
 
     using namespace debug;
@@ -198,6 +198,136 @@ void handleOpenGLDebugMode(Canvas::ContextID context) {
         logDebugMode(mode, severity, context);
     }
 }
+
+namespace debug {
+
+std::ostream& operator<<(std::ostream& ss, Mode m) {
+    switch (m) {
+        case Mode::Off:
+            ss << "Off";
+            break;
+        case Mode::Debug:
+            ss << "Debug";
+            break;
+        case Mode::DebugSynchronous:
+            ss << "DebugSynchronous";
+            break;
+        default:
+            break;
+    }
+    return ss;
+}
+std::ostream& operator<<(std::ostream& ss, BreakLevel b) {
+    switch (b) {
+        case BreakLevel::Off:
+            ss << "Off";
+            break;
+        case BreakLevel::High:
+            ss << "High";
+            break;
+        case BreakLevel::Medium:
+            ss << "Medium";
+            break;
+        case BreakLevel::Low:
+            ss << "Low";
+            break;
+        case BreakLevel::Notification:
+            ss << "Notification";
+            break;
+        default:
+            break;
+    }
+    return ss;
+}
+std::ostream& operator<<(std::ostream& ss, Source s) {
+    switch (s) {
+        case Source::Api:
+            ss << "Api";
+            break;
+        case Source::WindowSystem:
+            ss << "WindowSystem";
+            break;
+        case Source::ShaderCompiler:
+            ss << "ShaderCompiler";
+            break;
+        case Source::ThirdParty:
+            ss << "ThirdParty";
+            break;
+        case Source::Application:
+            ss << "Application";
+            break;
+        case Source::Other:
+            ss << "Other";
+            break;
+        case Source::DontCare:
+            ss << "DontCare";
+            break;
+        default:
+            break;
+    }
+    return ss;
+}
+std::ostream& operator<<(std::ostream& ss, Type t) {
+    switch (t) {
+        case Type::Error:
+            ss << "Error";
+            break;
+        case Type::DeprecatedBehavior:
+            ss << "DeprecatedBehavior";
+            break;
+        case Type::UndefinedBehavior:
+            ss << "UndefinedBehavior";
+            break;
+        case Type::Portability:
+            ss << "Portability";
+            break;
+        case Type::Performance:
+            ss << "Performance";
+            break;
+        case Type::Marker:
+            ss << "Marker";
+            break;
+        case Type::PushGroup:
+            ss << "PushGroup";
+            break;
+        case Type::PopGroup:
+            ss << "PopGroup";
+            break;
+        case Type::Other:
+            ss << "Other";
+            break;
+        case Type::DontCare:
+            ss << "DontCare";
+            break;
+        default:
+            break;
+    }
+    return ss;
+}
+std::ostream& operator<<(std::ostream& ss, Severity s) {
+    switch (s) {
+        case Severity::Low:
+            ss << "Low";
+            break;
+        case Severity::Medium:
+            ss << "Medium";
+            break;
+        case Severity::High:
+            ss << "High";
+            break;
+        case Severity::Notification:
+            ss << "Notification";
+            break;
+        case Severity::DontCare:
+            ss << "DontCare";
+            break;
+        default:
+            break;
+    }
+    return ss;
+}
+
+}  // namespace debug
 
 }  // namespace utilgl
 

--- a/modules/opengl/src/rendering/meshdrawergl.cpp
+++ b/modules/opengl/src/rendering/meshdrawergl.cpp
@@ -120,7 +120,6 @@ MeshDrawerGL::DrawMode MeshDrawerGL::getDrawMode(DrawType dt, ConnectivityType c
                     return DrawMode::TriangleStripAdjacency;
 
                 case ConnectivityType::Loop:
-                case ConnectivityType::NumberOfConnectivityTypes:
                 default:
                     return DrawMode::Points;
             }
@@ -143,14 +142,12 @@ MeshDrawerGL::DrawMode MeshDrawerGL::getDrawMode(DrawType dt, ConnectivityType c
                     return DrawMode::LineStripAdjacency;
 
                 case ConnectivityType::Fan:
-                case ConnectivityType::NumberOfConnectivityTypes:
                 default:
                     return DrawMode::Points;
             }
 
         case DrawType::Points:
         case DrawType::NotSpecified:
-        case DrawType::NumberOfDrawTypes:
         default:
             return DrawMode::Points;
     }

--- a/modules/plotting/include/modules/plotting/utils/statsutils.h
+++ b/modules/plotting/include/modules/plotting/utils/statsutils.h
@@ -32,7 +32,7 @@
 #include <modules/plotting/plottingmoduledefine.h>
 #include <inviwo/core/datastructures/buffer/buffer.h>
 #include <inviwo/core/util/formatdispatching.h>
-#include <ostream>
+#include <iosfwd>
 
 namespace inviwo {
 
@@ -46,13 +46,7 @@ struct RegresionResult {
 
 IVW_MODULE_PLOTTING_API RegresionResult linearRegresion(const BufferBase& X, const BufferBase& Y);
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& os,
-                                             RegresionResult res) {
-    os << "y = " << res.k << "x + " << res.m << "(r2: " << res.r2 << ", corr: " << res.corr;
-
-    return os;
-}
+IVW_MODULE_PLOTTING_API std::ostream& operator<<(std::ostream& os, RegresionResult res);
 
 /**
  * \brief Compute value below a percentage of observations in the data.

--- a/modules/plotting/src/utils/statsutils.cpp
+++ b/modules/plotting/src/utils/statsutils.cpp
@@ -117,6 +117,12 @@ RegresionResult linearRegresion(const BufferBase& X, const BufferBase& Y) {
         });
 }
 
+std::ostream& operator<<(std::ostream& os, RegresionResult res) {
+    os << "y = " << res.k << "x + " << res.m << "(r2: " << res.r2 << ", corr: " << res.corr;
+
+    return os;
+}
+
 }  // namespace statsutil
 
 }  // namespace inviwo

--- a/modules/python3/bindings/src/pybuffer.cpp
+++ b/modules/python3/bindings/src/pybuffer.cpp
@@ -97,7 +97,7 @@ void exposeBuffer(pybind11::module& m) {
         .value("RadiiAttrib", BufferType::RadiiAttrib)
         .value("PickingAttrib", BufferType::PickingAttrib)
         .value("ScalarMetaAttrib", BufferType::ScalarMetaAttrib)
-        .value("NumberOfBufferTypes", BufferType::NumberOfBufferTypes);
+        .value("Unknown", BufferType::Unknown);
 
     py::enum_<BufferUsage>(m, "BufferUsage")
         .value("Static", BufferUsage::Static)

--- a/modules/python3/bindings/src/pydataformat.cpp
+++ b/modules/python3/bindings/src/pydataformat.cpp
@@ -38,9 +38,9 @@ struct DataFormatHelper {
     template <typename DataFormat>
     auto operator()(pybind11::module& m) {
         namespace py = pybind11;
-        m.attr(("Data" + DataFormat::str()).c_str()) =
-            py::cast(static_cast<const DataFormatBase*>(DataFormat::get()),
-                     py::return_value_policy::reference);
+        constexpr auto name = StaticString{"Data"} + DataFormat::staticStr();
+        m.attr(name.c_str()) = py::cast(static_cast<const DataFormatBase*>(DataFormat::get()),
+                                        py::return_value_policy::reference);
     }
 };
 

--- a/modules/vectorfieldvisualization/include/modules/vectorfieldvisualization/datastructures/integralline.h
+++ b/modules/vectorfieldvisualization/include/modules/vectorfieldvisualization/datastructures/integralline.h
@@ -37,6 +37,7 @@
 #include <inviwo/core/util/interpolation.h>
 
 #include <map>
+#include <iosfwd>
 
 namespace inviwo {
 
@@ -198,29 +199,7 @@ T IntegralLine::getMetaDataAtDistance(std::string md, double d) const {
         Interpolation<TV, double>::linear(static_cast<TV>(*prevMD), static_cast<TV>(*nextMD), x));
 }
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits>& operator<<(std::basic_ostream<Elem, Traits>& os,
-                                             IntegralLine::TerminationReason reason) {
-    switch (reason) {
-        case IntegralLine::TerminationReason::StartPoint:
-            os << "Seed Point";
-            break;
-        case IntegralLine::TerminationReason::OutOfBounds:
-            os << "Out of Bounds";
-            break;
-        case IntegralLine::TerminationReason::ZeroVelocity:
-            os << "Zero Velocity";
-            break;
-        case IntegralLine::TerminationReason::Steps:
-            os << "Steps";
-            break;
-        default:
-        case IntegralLine::TerminationReason::Unknown:
-            os << "Unknown";
-            break;
-    }
-
-    return os;
-}
+IVW_MODULE_VECTORFIELDVISUALIZATION_API std::ostream& operator<<(
+    std::ostream& os, IntegralLine::TerminationReason reason);
 
 }  // namespace inviwo

--- a/modules/vectorfieldvisualization/src/datastructures/integralline.cpp
+++ b/modules/vectorfieldvisualization/src/datastructures/integralline.cpp
@@ -30,6 +30,8 @@
 #include <modules/vectorfieldvisualization/datastructures/integralline.h>
 #include <inviwo/core/util/interpolation.h>
 
+#include <iosfwd>
+
 namespace inviwo {
 
 const std::vector<dvec3>& IntegralLine::getPositions() const { return positions_; }
@@ -157,6 +159,29 @@ double IntegralLine::calcLength(std::vector<dvec3>::const_iterator start,
         }
     }
     return length;
+}
+
+std::ostream& operator<<(std::ostream& os, IntegralLine::TerminationReason reason) {
+    switch (reason) {
+        case IntegralLine::TerminationReason::StartPoint:
+            os << "Seed Point";
+            break;
+        case IntegralLine::TerminationReason::OutOfBounds:
+            os << "Out of Bounds";
+            break;
+        case IntegralLine::TerminationReason::ZeroVelocity:
+            os << "Zero Velocity";
+            break;
+        case IntegralLine::TerminationReason::Steps:
+            os << "Steps";
+            break;
+        default:
+        case IntegralLine::TerminationReason::Unknown:
+            os << "Unknown";
+            break;
+    }
+
+    return os;
 }
 
 }  // namespace inviwo

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -315,6 +315,7 @@ set(HEADER_FILES
     ${IVW_INCLUDE_DIR}/inviwo/core/util/fileobserver.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/filesystem.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/filesystemobserver.h
+    ${IVW_INCLUDE_DIR}/inviwo/core/util/fmtutils.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/foreach.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/foreacharg.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/formatconversion.h
@@ -423,6 +424,7 @@ set(SOURCE_FILES
     datastructures/datarepresentation.cpp
     datastructures/datatraits.cpp
     datastructures/geometry/basicmesh.cpp
+    datastructures/geometry/geometrytype.cpp
     datastructures/geometry/mesh.cpp
     datastructures/geometry/meshram.cpp
     datastructures/geometry/meshrepresentation.cpp
@@ -434,6 +436,7 @@ set(SOURCE_FILES
     datastructures/image/image.cpp
     datastructures/image/imageram.cpp
     datastructures/image/imagerepresentation.cpp
+    datastructures/image/imagetypes.cpp
     datastructures/image/layer.cpp
     datastructures/image/layerdisk.cpp
     datastructures/image/layerram.cpp
@@ -473,14 +476,18 @@ set(SOURCE_FILES
     interaction/events/eventmatcher.cpp
     interaction/events/eventutil.cpp
     interaction/events/gestureevent.cpp
+    interaction/events/gesturestate.cpp
     interaction/events/interactionevent.cpp
     interaction/events/keyboardevent.cpp
+    interaction/events/keyboardkeys.cpp
+    interaction/events/mousebuttons.cpp
     interaction/events/mousecursors.cpp
     interaction/events/mouseevent.cpp
     interaction/events/mouseinteractionevent.cpp
     interaction/events/pickingevent.cpp
     interaction/events/resizeevent.cpp
     interaction/events/touchevent.cpp
+    interaction/events/touchstate.cpp
     interaction/events/viewevent.cpp
     interaction/events/wheelevent.cpp
     interaction/interactionhandler.cpp
@@ -490,6 +497,7 @@ set(SOURCE_FILES
     interaction/pickingcontrollertouchstate.cpp
     interaction/pickingmanager.cpp
     interaction/pickingmapper.cpp
+    interaction/pickingstate.cpp
     interaction/trackball.cpp
     io/bytereaderutil.cpp
     io/datareader.cpp
@@ -561,6 +569,7 @@ set(SOURCE_FILES
     processors/processorfactory.cpp
     processors/processorinfo.cpp
     processors/processorpair.cpp
+    processors/processorstate.cpp
     processors/processortags.cpp
     processors/processorutils.cpp
     processors/processorwidget.cpp
@@ -581,6 +590,7 @@ set(SOURCE_FILES
     properties/eventproperty.cpp
     properties/filepatternproperty.cpp
     properties/fileproperty.cpp
+    properties/invalidationlevel.cpp
     properties/imageeditorproperty.cpp
     properties/isotfproperty.cpp
     properties/isovalueproperty.cpp
@@ -642,11 +652,13 @@ set(SOURCE_FILES
     util/exception.cpp
     util/factory.cpp
     util/filedialog.cpp
+    util/filedialogstate.cpp
     util/fileextension.cpp
     util/filelogger.cpp
     util/fileobserver.cpp
     util/filesystem.cpp
     util/filesystemobserver.cpp
+    util/fmtutils.cpp
     util/foreacharg.cpp
     util/formatconversion.cpp
     util/formatdispatching.cpp

--- a/src/core/common/version.cpp
+++ b/src/core/common/version.cpp
@@ -29,6 +29,8 @@
 
 #include <inviwo/core/common/version.h>
 
+#include <ostream>
+
 namespace inviwo {
 
 namespace {
@@ -38,5 +40,10 @@ static_assert(ver.minor == 8);
 static_assert(ver.patch == 3);
 static_assert(ver.build == 21);
 }  // namespace
+
+std::ostream& operator<<(std::ostream& ss, const Version& v) {
+    ss << v.major << "." << v.minor << "." << v.patch << "." << v.build;
+    return ss;
+}
 
 }  // namespace inviwo

--- a/src/core/datastructures/coordinatetransformer.cpp
+++ b/src/core/datastructures/coordinatetransformer.cpp
@@ -29,6 +29,8 @@
 
 #include <inviwo/core/datastructures/coordinatetransformer.h>
 
+#include <ostream>
+
 namespace inviwo {
 
 template class IVW_CORE_TMPL_INST SpatialCoordinateTransformer<2>;
@@ -40,5 +42,26 @@ template class IVW_CORE_TMPL_INST StructuredCoordinateTransformer<2>;
 template class IVW_CORE_TMPL_INST StructuredCoordinateTransformer<3>;
 template class IVW_CORE_TMPL_INST StructuredCameraCoordinateTransformer<2>;
 template class IVW_CORE_TMPL_INST StructuredCameraCoordinateTransformer<3>;
+
+std::string_view util::name(CoordinateSpace s) {
+    switch (s) {
+        case CoordinateSpace::Data:
+            return "Data";
+        case CoordinateSpace::Model:
+            return "Model";
+        case CoordinateSpace::World:
+            return "World";
+        case CoordinateSpace::Index:
+            return "Index";
+        case CoordinateSpace::Clip:
+            return "Clip";
+        case CoordinateSpace::View:
+            return "View";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid CoordinateSpace enum value '{}'",
+                    static_cast<int>(s));
+}
+
+std::ostream& operator<<(std::ostream& ss, CoordinateSpace s) { return ss << util::name(s); }
 
 }  // namespace inviwo

--- a/src/core/datastructures/datatraits.cpp
+++ b/src/core/datastructures/datatraits.cpp
@@ -85,11 +85,11 @@ uvec3 util::getDataFormatColor(NumericType t, size_t comp, size_t size) {
     return color;
 }
 
-std::string util::appendIfNotEmpty(const std::string& a, const std::string& b) {
+std::string util::appendIfNotEmpty(std::string_view a, std::string_view b) {
     if (a.empty() || b.empty()) {
-        return a;
+        return std::string{a};
     } else {
-        return a + b;
+        return std::string{a}.append(b);
     }
 }
 

--- a/src/core/datastructures/geometry/geometrytype.cpp
+++ b/src/core/datastructures/geometry/geometrytype.cpp
@@ -1,0 +1,120 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2022 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/core/datastructures/geometry/geometrytype.h>
+#include <inviwo/core/util/exception.h>
+
+namespace inviwo {
+
+std::string_view util::name(DrawType dt) {
+    switch (dt) {
+        case DrawType::Points:
+            return "Points";
+        case DrawType::Lines:
+            return "Lines";
+        case DrawType::Triangles:
+            return "Triangles";
+        case DrawType::NotSpecified:
+            return "Not specified";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid DrawType enum value '{}'",
+                    static_cast<int>(dt));
+}
+std::string_view util::name(ConnectivityType ct) {
+    switch (ct) {
+        case ConnectivityType::None:
+            return "None";
+        case ConnectivityType::Strip:
+            return "Strip";
+        case ConnectivityType::Loop:
+            return "Loop";
+        case ConnectivityType::Fan:
+            return "Fan";
+        case ConnectivityType::Adjacency:
+            return "Adjacency";
+        case ConnectivityType::StripAdjacency:
+            return "Strip adjacency";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"),
+                    "Found invalid ConnectivityType enum value '{}'", static_cast<int>(ct));
+}
+std::string_view util::name(BufferType bt) {
+    switch (bt) {
+        case BufferType::PositionAttrib:
+            return "Position";
+        case BufferType::NormalAttrib:
+            return "Normal";
+        case BufferType::ColorAttrib:
+            return "Color";
+        case BufferType::TexCoordAttrib:
+            return "TexCoord";
+        case BufferType::CurvatureAttrib:
+            return "Curvature";
+        case BufferType::IndexAttrib:
+            return "Index";
+        case BufferType::RadiiAttrib:
+            return "Radii";
+        case BufferType::PickingAttrib:
+            return "Picking";
+        case BufferType::ScalarMetaAttrib:
+            return "ScalarMeta";
+        case BufferType::Unknown:
+            return "Unknown";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid BufferType enum value '{}'",
+                    static_cast<int>(bt));
+}
+std::string_view util::name(BufferUsage bu) {
+    switch (bu) {
+        case BufferUsage::Static:
+            return "Static";
+        case BufferUsage::Dynamic:
+            return "Dynamic";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid BufferUsage enum value '{}'",
+                    static_cast<int>(bu));
+}
+std::string_view util::name(BufferTarget bt) {
+    switch (bt) {
+        case BufferTarget::Data:
+            return "Data";
+        case BufferTarget::Index:
+            return "Index";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid BufferTarget enum value '{}'",
+                    static_cast<int>(bt));
+}
+
+std::ostream& operator<<(std::ostream& ss, DrawType dt) { return ss << util::name(dt); }
+std::ostream& operator<<(std::ostream& ss, ConnectivityType ct) { return ss << util::name(ct); }
+std::ostream& operator<<(std::ostream& ss, BufferType bt) { return ss << util::name(bt); }
+std::ostream& operator<<(std::ostream& ss, BufferUsage bu) { return ss << util::name(bu); }
+std::ostream& operator<<(std::ostream& ss, BufferTarget bt) { return ss << util::name(bt); }
+
+}  // namespace inviwo

--- a/src/core/datastructures/geometry/mesh.cpp
+++ b/src/core/datastructures/geometry/mesh.cpp
@@ -31,6 +31,7 @@
 #include <inviwo/core/util/document.h>
 
 #include <fmt/format.h>
+#include <ostream>
 
 namespace inviwo {
 
@@ -402,6 +403,11 @@ Document Mesh::getInfo() const {
     }
 
     return doc;
+}
+
+std::ostream& operator<<(std::ostream& ss, Mesh::BufferInfo info) {
+    ss << info.type << " (location = " << info.location << ")";
+    return ss;
 }
 
 template class IVW_CORE_TMPL_INST DataReaderType<Mesh>;

--- a/src/core/datastructures/image/imagetypes.cpp
+++ b/src/core/datastructures/image/imagetypes.cpp
@@ -1,0 +1,195 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2022 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/core/datastructures/image/imagetypes.h>
+#include <inviwo/core/util/exception.h>
+
+namespace inviwo {
+
+std::string_view util::name(ImageType type) {
+    switch (type) {
+        case ImageType::ColorOnly:
+            return "Color Only";
+        case ImageType::ColorDepth:
+            return "Color + Depth";
+        case ImageType::ColorPicking:
+            return "Color + Picking";
+        case ImageType::ColorDepthPicking:
+            return "Color + Depth + Picking";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid ImageType enum value '{}'",
+                    static_cast<int>(type));
+}
+std::string_view util::name(LayerType type) {
+    switch (type) {
+        case LayerType::Color:
+            return "Color";
+        case LayerType::Depth:
+            return "Depth";
+        case LayerType::Picking:
+            return "Picking";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid LayerType enum value '{}'",
+                    static_cast<int>(type));
+}
+std::string_view util::name(ImageChannel channel) {
+    switch (channel) {
+        case ImageChannel::Red:
+            return "r";
+        case ImageChannel::Green:
+            return "g";
+        case ImageChannel::Blue:
+            return "b";
+        case ImageChannel::Alpha:
+            return "a";
+        case ImageChannel::Zero:
+            return "0";
+        case ImageChannel::One:
+            return "1";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid ImageChannel enum value '{}'",
+                    static_cast<int>(channel));
+}
+
+std::string_view util::name(InterpolationType type) {
+    switch (type) {
+        case InterpolationType::Nearest:
+            return "Nearest";
+        case InterpolationType::Linear:
+            return "Linear";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"),
+                    "Found invalid InterpolationType enum value '{}'", static_cast<int>(type));
+}
+std::string_view util::name(Wrapping type) {
+    switch (type) {
+        case Wrapping::Mirror:
+            return "Mirror";
+        case Wrapping::Repeat:
+            return "Repeat";
+        case Wrapping::Clamp:
+            return "Clamp";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid Wrapping enum value '{}'",
+                    static_cast<int>(type));
+}
+
+std::ostream& operator<<(std::ostream& ss, ImageType type) { return ss << util::name(type); }
+
+std::ostream& operator<<(std::ostream& ss, LayerType type) { return ss << util::name(type); }
+
+std::ostream& operator<<(std::ostream& ss, ImageChannel channel) {
+    return ss << util::name(channel);
+}
+
+std::istream& operator>>(std::istream& ss, ImageChannel& channel) {
+    char c{0};
+    ss >> c;
+    switch (c) {
+        case 'r':
+            channel = ImageChannel::Red;
+            break;
+        case 'g':
+            channel = ImageChannel::Green;
+            break;
+        case 'b':
+            channel = ImageChannel::Blue;
+            break;
+        case 'a':
+            channel = ImageChannel::Alpha;
+            break;
+        case '0':
+            channel = ImageChannel::Zero;
+            break;
+        case '1':
+            channel = ImageChannel::One;
+            break;
+        default:
+            ss.setstate(std::ios_base::failbit);
+            break;
+    }
+    return ss;
+}
+
+std::ostream& operator<<(std::ostream& ss, SwizzleMask mask) {
+    for (const auto c : mask) {
+        ss << c;
+    }
+    return ss;
+}
+
+std::istream& operator>>(std::istream& ss, SwizzleMask& mask) {
+    for (auto& c : mask) {
+        ss >> c;
+        if (!ss) return ss;
+    }
+    return ss;
+}
+
+std::ostream& operator<<(std::ostream& ss, InterpolationType type) {
+    return ss << util::name(type);
+}
+
+std::istream& operator>>(std::istream& ss, InterpolationType& interpolation) {
+    std::string str;
+    ss >> str;
+    str = toLower(str);
+
+    if (str == toLower(toString(InterpolationType::Nearest))) {
+        interpolation = InterpolationType::Nearest;
+    } else if (str == toLower(toString(InterpolationType::Linear))) {
+        interpolation = InterpolationType::Linear;
+    } else {
+        ss.setstate(std::ios_base::failbit);
+    }
+
+    return ss;
+}
+
+std::ostream& operator<<(std::ostream& ss, Wrapping type) { return ss << util::name(type); }
+
+std::istream& operator>>(std::istream& ss, Wrapping& wrapping) {
+    std::string str;
+    ss >> str;
+    str = toLower(str);
+
+    if (str == toLower(toString(Wrapping::Mirror))) {
+        wrapping = Wrapping::Mirror;
+    } else if (str == toLower(toString(Wrapping::Repeat))) {
+        wrapping = Wrapping::Repeat;
+    } else if (str == toLower(toString(Wrapping::Clamp))) {
+        wrapping = Wrapping::Clamp;
+    } else {
+        ss.setstate(std::ios_base::failbit);
+    }
+
+    return ss;
+}
+
+}  // namespace inviwo

--- a/src/core/interaction/events/gesturestate.cpp
+++ b/src/core/interaction/events/gesturestate.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2013-2021 Inviwo Foundation
+ * Copyright (c) 2022 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,39 +27,51 @@
  *
  *********************************************************************************/
 
-#include <inviwo/core/properties/propertysemantics.h>
-#include <inviwo/core/io/serialization/serialization.h>
+#include <inviwo/core/interaction/events/gesturestate.h>
+#include <inviwo/core/util/ostreamjoiner.h>
+#include <inviwo/core/util/exception.h>
 
+#include <iterator>
 #include <ostream>
 
 namespace inviwo {
 
-PropertySemantics::PropertySemantics() : semantic_("Default") {}
-PropertySemantics::PropertySemantics(std::string semantic) : semantic_(std::move(semantic)) {}
-
-const std::string& PropertySemantics::getString() const { return semantic_; }
-
-void PropertySemantics::serialize(Serializer& s) const {
-    s.serialize("semantics", semantic_, SerializationTarget::Attribute);
+std::string_view util::name(GestureType t) {
+    switch (t) {
+        case GestureType::Pan:
+            return "Pan";
+        case GestureType::Pinch:
+            return "Pinch";
+        case GestureType::Swipe:
+            return "Swipe";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid GestureType enum value '{}'", static_cast<int>(t));
+}
+std::string_view util::name(GestureState s) {
+    switch (s) {
+        case GestureState::NoGesture:
+            return "NoGesture";
+        case GestureState::Started:
+            return "Started";
+        case GestureState::Updated:
+            return "Updated";
+        case GestureState::Finished:
+            return "Finished";
+        case GestureState::Canceled:
+            return "Canceled";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid GestureState enum value '{}'",
+                    static_cast<int>(s));
 }
 
-void PropertySemantics::deserialize(Deserializer& d) {
-    d.deserialize("semantics", semantic_, SerializationTarget::Attribute);
+std::ostream& operator<<(std::ostream& ss, GestureType t) { return ss << util::name(t); }
+std::ostream& operator<<(std::ostream& ss, GestureState s) { return ss << util::name(s); }
+std::ostream& operator<<(std::ostream& ss, GestureTypes s) {
+    std::copy(s.begin(), s.end(), util::make_ostream_joiner(ss, "+"));
+    return ss;
 }
-
-const PropertySemantics PropertySemantics::Default("Default");
-const PropertySemantics PropertySemantics::Text("Text");
-const PropertySemantics PropertySemantics::SpinBox("SpinBox");
-const PropertySemantics PropertySemantics::Color("Color");
-const PropertySemantics PropertySemantics::LightPosition("LightPosition");
-const PropertySemantics PropertySemantics::Multiline("Multiline");
-const PropertySemantics PropertySemantics::TextEditor("TextEditor");
-const PropertySemantics PropertySemantics::PythonEditor("PythonEditor");
-const PropertySemantics PropertySemantics::ImageEditor("ImageEditor");
-const PropertySemantics PropertySemantics::ShaderEditor("ShaderEditor");
-
-std::ostream& operator<<(std::ostream& ss, const PropertySemantics& obj) {
-    ss << obj.getString();
+std::ostream& operator<<(std::ostream& ss, GestureStates s) {
+    std::copy(s.begin(), s.end(), util::make_ostream_joiner(ss, "+"));
     return ss;
 }
 

--- a/src/core/interaction/events/keyboardkeys.cpp
+++ b/src/core/interaction/events/keyboardkeys.cpp
@@ -1,0 +1,374 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2022 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/core/interaction/events/keyboardkeys.h>
+#include <inviwo/core/util/ostreamjoiner.h>
+#include <inviwo/core/util/exception.h>
+#include <ostream>
+
+namespace inviwo {
+
+std::string_view util::name(KeyModifier m) {
+    switch (m) {
+        case KeyModifier::None:
+            return "None";
+        case KeyModifier::Control:
+            return "Control";
+        case KeyModifier::Shift:
+            return "Shift";
+        case KeyModifier::Alt:
+            return "Alt";
+        case KeyModifier::Super:
+            return "Super";
+        case KeyModifier::Menu:
+            return "Menu";
+        case KeyModifier::Meta:
+            return "Meta";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid KeyModifier enum value '{}'",
+                    static_cast<int>(m));
+}
+std::string_view util::name(KeyState s) {
+    switch (s) {
+        case KeyState::Press:
+            return "Press";
+        case KeyState::Release:
+            return "Release";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid KeyState enum value '{}'",
+                    static_cast<int>(s));
+}
+std::string_view util::name(IvwKey k) {
+    switch (k) {
+        case IvwKey::Undefined:
+            return "Undefined";
+        case IvwKey::Unknown:
+            return "Unknown";
+        case IvwKey::Space:
+            return "Space";
+        case IvwKey::Exclam:
+            return "Exclam";
+        case IvwKey::QuoteDbl:
+            return "QuoteDbl";
+        case IvwKey::NumberSign:
+            return "NumberSign";
+        case IvwKey::Dollar:
+            return "Dollar";
+        case IvwKey::Percent:
+            return "Percent";
+        case IvwKey::Ampersand:
+            return "Ampersand";
+        case IvwKey::Apostrophe:
+            return "Apostrophe";
+        case IvwKey::ParenLeft:
+            return "ParenLeft";
+        case IvwKey::ParenRight:
+            return "ParenRight";
+        case IvwKey::Asterisk:
+            return "Asterisk";
+        case IvwKey::Plus:
+            return "Plus";
+        case IvwKey::Comma:
+            return "Comma";
+        case IvwKey::Minus:
+            return "Minus";
+        case IvwKey::Period:
+            return "Period";
+        case IvwKey::Slash:
+            return "Slash";
+        case IvwKey::Num0:
+            return "Num0";
+        case IvwKey::Num1:
+            return "Num1";
+        case IvwKey::Num2:
+            return "Num2";
+        case IvwKey::Num3:
+            return "Num3";
+        case IvwKey::Num4:
+            return "Num4";
+        case IvwKey::Num5:
+            return "Num5";
+        case IvwKey::Num6:
+            return "Num6";
+        case IvwKey::Num7:
+            return "Num7";
+        case IvwKey::Num8:
+            return "Num8";
+        case IvwKey::Num9:
+            return "Num9";
+        case IvwKey::Colon:
+            return "Colon";
+        case IvwKey::Semicolon:
+            return "Semicolon";
+        case IvwKey::Less:
+            return "Less";
+        case IvwKey::Equal:
+            return "Equal";
+        case IvwKey::Greater:
+            return "Greater";
+        case IvwKey::Question:
+            return "Question";
+        case IvwKey::A:
+            return "A";
+        case IvwKey::B:
+            return "B";
+        case IvwKey::C:
+            return "C";
+        case IvwKey::D:
+            return "D";
+        case IvwKey::E:
+            return "E";
+        case IvwKey::F:
+            return "F";
+        case IvwKey::G:
+            return "G";
+        case IvwKey::H:
+            return "H";
+        case IvwKey::I:
+            return "I";
+        case IvwKey::J:
+            return "J";
+        case IvwKey::K:
+            return "K";
+        case IvwKey::L:
+            return "L";
+        case IvwKey::M:
+            return "M";
+        case IvwKey::N:
+            return "N";
+        case IvwKey::O:
+            return "O";
+        case IvwKey::P:
+            return "P";
+        case IvwKey::Q:
+            return "Q";
+        case IvwKey::R:
+            return "R";
+        case IvwKey::S:
+            return "S";
+        case IvwKey::T:
+            return "T";
+        case IvwKey::U:
+            return "U";
+        case IvwKey::V:
+            return "V";
+        case IvwKey::W:
+            return "W";
+        case IvwKey::X:
+            return "X";
+        case IvwKey::Y:
+            return "Y";
+        case IvwKey::Z:
+            return "Z";
+        case IvwKey::BracketLeft:
+            return "BracketLeft";
+        case IvwKey::Backslash:
+            return "Backslash";
+        case IvwKey::BracketRight:
+            return "BracketRight";
+        case IvwKey::GraveAccent:
+            return "GraveAccent";
+        case IvwKey::AsciiCircum:
+            return "AsciiCircum";
+        case IvwKey::Underscore:
+            return "Underscore";
+        case IvwKey::BraceLeft:
+            return "BraceLeft";
+        case IvwKey::Bar:
+            return "Bar";
+        case IvwKey::BraceRight:
+            return "BraceRight";
+        case IvwKey::AsciiTilde:
+            return "AsciiTilde";
+        case IvwKey::World1:
+            return "World1";
+        case IvwKey::World2:
+            return "World2";
+        case IvwKey::Escape:
+            return "Escape";
+        case IvwKey::Enter:
+            return "Enter";
+        case IvwKey::Tab:
+            return "Tab";
+        case IvwKey::Backspace:
+            return "Backspace";
+        case IvwKey::Insert:
+            return "Insert";
+        case IvwKey::Delete:
+            return "Delete";
+        case IvwKey::Right:
+            return "Right";
+        case IvwKey::Left:
+            return "Left";
+        case IvwKey::Down:
+            return "Down";
+        case IvwKey::Up:
+            return "Up";
+        case IvwKey::PageUp:
+            return "PageUp";
+        case IvwKey::PageDown:
+            return "PageDown";
+        case IvwKey::Home:
+            return "Home";
+        case IvwKey::End:
+            return "End";
+        case IvwKey::CapsLock:
+            return "CapsLock";
+        case IvwKey::ScrollLock:
+            return "ScrollLock";
+        case IvwKey::NumLock:
+            return "NumLock";
+        case IvwKey::PrintScreen:
+            return "PrintScreen";
+        case IvwKey::Pause:
+            return "Pause";
+        case IvwKey::F1:
+            return "F1";
+        case IvwKey::F2:
+            return "F2";
+        case IvwKey::F3:
+            return "F3";
+        case IvwKey::F4:
+            return "F4";
+        case IvwKey::F5:
+            return "F5";
+        case IvwKey::F6:
+            return "F6";
+        case IvwKey::F7:
+            return "F7";
+        case IvwKey::F8:
+            return "F8";
+        case IvwKey::F9:
+            return "F9";
+        case IvwKey::F10:
+            return "F10";
+        case IvwKey::F11:
+            return "F11";
+        case IvwKey::F12:
+            return "F12";
+        case IvwKey::F13:
+            return "F13";
+        case IvwKey::F14:
+            return "F14";
+        case IvwKey::F15:
+            return "F15";
+        case IvwKey::F16:
+            return "F16";
+        case IvwKey::F17:
+            return "F17";
+        case IvwKey::F18:
+            return "F18";
+        case IvwKey::F19:
+            return "F19";
+        case IvwKey::F20:
+            return "F20";
+        case IvwKey::F21:
+            return "F21";
+        case IvwKey::F22:
+            return "F22";
+        case IvwKey::F23:
+            return "F23";
+        case IvwKey::F24:
+            return "F24";
+        case IvwKey::F25:
+            return "F25";
+        case IvwKey::KP0:
+            return "KP0";
+        case IvwKey::KP1:
+            return "KP1";
+        case IvwKey::KP2:
+            return "KP2";
+        case IvwKey::KP3:
+            return "KP3";
+        case IvwKey::KP4:
+            return "KP4";
+        case IvwKey::KP5:
+            return "KP5";
+        case IvwKey::KP6:
+            return "KP6";
+        case IvwKey::KP7:
+            return "KP7";
+        case IvwKey::KP8:
+            return "KP8";
+        case IvwKey::KP9:
+            return "KP9";
+        case IvwKey::KPDecimal:
+            return "KPDecimal";
+        case IvwKey::KPDivide:
+            return "KPDivide";
+        case IvwKey::KPMultiply:
+            return "KPMultiply";
+        case IvwKey::KPSubtract:
+            return "KPSubtract";
+        case IvwKey::KPAdd:
+            return "KPAdd";
+        case IvwKey::KPEnter:
+            return "KPEnter";
+        case IvwKey::KPEqual:
+            return "KPEqual";
+        case IvwKey::LeftShift:
+            return "LeftShift";
+        case IvwKey::LeftControl:
+            return "LeftControl";
+        case IvwKey::LeftAlt:
+            return "LeftAlt";
+        case IvwKey::LeftSuper:
+            return "LeftSuper";
+        case IvwKey::RightShift:
+            return "RightShift";
+        case IvwKey::RightControl:
+            return "RightControl";
+        case IvwKey::RightAlt:
+            return "RightAlt";
+        case IvwKey::RightSuper:
+            return "RightSuper";
+        case IvwKey::Menu:
+            return "Menu";
+        case IvwKey::LeftMeta:
+            return "LeftMeta";
+        case IvwKey::RightMeta:
+            return "RightMeta";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid IvwKey enum value '{}'",
+                    static_cast<int>(k));
+}
+
+std::ostream& operator<<(std::ostream& ss, KeyModifier m) { return ss << util::name(m); }
+std::ostream& operator<<(std::ostream& ss, KeyModifiers ms) {
+    std::copy(ms.begin(), ms.end(), util::make_ostream_joiner(ss, "+"));
+    return ss;
+}
+std::ostream& operator<<(std::ostream& ss, KeyState s) { return ss << util::name(s); }
+std::ostream& operator<<(std::ostream& ss, KeyStates s) {
+    std::copy(s.begin(), s.end(), util::make_ostream_joiner(ss, "+"));
+    return ss;
+}
+std::ostream& operator<<(std::ostream& ss, IvwKey k) { return ss << util::name(k); }
+
+}  // namespace inviwo

--- a/src/core/interaction/events/mousebuttons.cpp
+++ b/src/core/interaction/events/mousebuttons.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2013-2021 Inviwo Foundation
+ * Copyright (c) 2012-2021 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,39 +27,50 @@
  *
  *********************************************************************************/
 
-#include <inviwo/core/properties/propertysemantics.h>
-#include <inviwo/core/io/serialization/serialization.h>
+#include <inviwo/core/interaction/events/mousebuttons.h>
 
+#include <inviwo/core/util/ostreamjoiner.h>
+#include <inviwo/core/util/exception.h>
 #include <ostream>
 
 namespace inviwo {
 
-PropertySemantics::PropertySemantics() : semantic_("Default") {}
-PropertySemantics::PropertySemantics(std::string semantic) : semantic_(std::move(semantic)) {}
-
-const std::string& PropertySemantics::getString() const { return semantic_; }
-
-void PropertySemantics::serialize(Serializer& s) const {
-    s.serialize("semantics", semantic_, SerializationTarget::Attribute);
+std::string_view util::name(MouseButton b) {
+    switch (b) {
+        case MouseButton::None:
+            return "None";
+        case MouseButton::Left:
+            return "Left";
+        case MouseButton::Middle:
+            return "Middle";
+        case MouseButton::Right:
+            return "Right";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid MouseButton enum value '{}'", static_cast<int>(b));
 }
 
-void PropertySemantics::deserialize(Deserializer& d) {
-    d.deserialize("semantics", semantic_, SerializationTarget::Attribute);
+std::string_view util::name(MouseState s) {
+    switch (s) {
+        case MouseState::Move:
+            return "Move";
+        case MouseState::Press:
+            return "Press";
+        case MouseState::Release:
+            return "Release";
+        case MouseState::DoubleClick:
+            return "DoubleClick";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid MouseState enum value '{}'", static_cast<int>(s));
 }
 
-const PropertySemantics PropertySemantics::Default("Default");
-const PropertySemantics PropertySemantics::Text("Text");
-const PropertySemantics PropertySemantics::SpinBox("SpinBox");
-const PropertySemantics PropertySemantics::Color("Color");
-const PropertySemantics PropertySemantics::LightPosition("LightPosition");
-const PropertySemantics PropertySemantics::Multiline("Multiline");
-const PropertySemantics PropertySemantics::TextEditor("TextEditor");
-const PropertySemantics PropertySemantics::PythonEditor("PythonEditor");
-const PropertySemantics PropertySemantics::ImageEditor("ImageEditor");
-const PropertySemantics PropertySemantics::ShaderEditor("ShaderEditor");
-
-std::ostream& operator<<(std::ostream& ss, const PropertySemantics& obj) {
-    ss << obj.getString();
+std::ostream& operator<<(std::ostream& ss, MouseButton b) { return ss << util::name(b); }
+std::ostream& operator<<(std::ostream& ss, MouseState s) { return ss << util::name(s); }
+std::ostream& operator<<(std::ostream& ss, MouseButtons bs) {
+    std::copy(bs.begin(), bs.end(), util::make_ostream_joiner(ss, "+"));
+    return ss;
+}
+std::ostream& operator<<(std::ostream& ss, MouseStates s) {
+    std::copy(s.begin(), s.end(), util::make_ostream_joiner(ss, "+"));
     return ss;
 }
 

--- a/src/core/interaction/events/mousecursors.cpp
+++ b/src/core/interaction/events/mousecursors.cpp
@@ -29,4 +29,56 @@
 
 #include <inviwo/core/interaction/events/mousecursors.h>
 
-namespace inviwo {}
+#include <inviwo/core/util/exception.h>
+#include <ostream>
+
+namespace inviwo {
+
+std::string_view util::name(MouseCursor b) {
+    switch (b) {
+        case MouseCursor::Arrow:
+            return "Arrow";
+        case MouseCursor::UpArrow:
+            return "UpArrow";
+        case MouseCursor::Cross:
+            return "Cross";
+        case MouseCursor::Wait:
+            return "Wait";
+        case MouseCursor::IBeam:
+            return "IBeam";
+        case MouseCursor::SizeVer:
+            return "SizeVer";
+        case MouseCursor::SizeHor:
+            return "SizeHor";
+        case MouseCursor::SizeBDiag:
+            return "SizeBDiag";
+        case MouseCursor::SizeFDiag:
+            return "SizeFDiag";
+        case MouseCursor::SizeAll:
+            return "SizeAll";
+        case MouseCursor::Blank:
+            return "Blank";
+        case MouseCursor::SplitV:
+            return "SplitV";
+        case MouseCursor::SplitH:
+            return "SplitH";
+        case MouseCursor::PointingHand:
+            return "PointingHand";
+        case MouseCursor::Forbidden:
+            return "Forbidden";
+        case MouseCursor::OpenHand:
+            return "OpenHand";
+        case MouseCursor::ClosedHand:
+            return "ClosedHand";
+        case MouseCursor::WhatsThis:
+            return "WhatsThis";
+        case MouseCursor::Busy:
+            return "Busy";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid MouseCursor enum value '{}'",
+                    static_cast<int>(b));
+}
+
+std::ostream& operator<<(std::ostream& ss, MouseCursor c) { return ss << util::name(c); }
+
+}  // namespace inviwo

--- a/src/core/interaction/events/touchstate.cpp
+++ b/src/core/interaction/events/touchstate.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2013-2021 Inviwo Foundation
+ * Copyright (c) 2022 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,39 +27,34 @@
  *
  *********************************************************************************/
 
-#include <inviwo/core/properties/propertysemantics.h>
-#include <inviwo/core/io/serialization/serialization.h>
+#include <inviwo/core/interaction/events/touchstate.h>
+#include <inviwo/core/util/ostreamjoiner.h>
 
+#include <inviwo/core/util/exception.h>
 #include <ostream>
 
 namespace inviwo {
 
-PropertySemantics::PropertySemantics() : semantic_("Default") {}
-PropertySemantics::PropertySemantics(std::string semantic) : semantic_(std::move(semantic)) {}
-
-const std::string& PropertySemantics::getString() const { return semantic_; }
-
-void PropertySemantics::serialize(Serializer& s) const {
-    s.serialize("semantics", semantic_, SerializationTarget::Attribute);
+std::string_view util::name(TouchState s) {
+    switch (s) {
+        case TouchState::None:
+            return "None";
+        case TouchState::Started:
+            return "Started";
+        case TouchState::Updated:
+            return "Updated";
+        case TouchState::Stationary:
+            return "Stationary";
+        case TouchState::Finished:
+            return "Finished";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid TouchState enum value '{}'", static_cast<int>(s));
 }
 
-void PropertySemantics::deserialize(Deserializer& d) {
-    d.deserialize("semantics", semantic_, SerializationTarget::Attribute);
-}
+std::ostream& operator<<(std::ostream& ss, TouchState s) { return ss << util::name(s); }
 
-const PropertySemantics PropertySemantics::Default("Default");
-const PropertySemantics PropertySemantics::Text("Text");
-const PropertySemantics PropertySemantics::SpinBox("SpinBox");
-const PropertySemantics PropertySemantics::Color("Color");
-const PropertySemantics PropertySemantics::LightPosition("LightPosition");
-const PropertySemantics PropertySemantics::Multiline("Multiline");
-const PropertySemantics PropertySemantics::TextEditor("TextEditor");
-const PropertySemantics PropertySemantics::PythonEditor("PythonEditor");
-const PropertySemantics PropertySemantics::ImageEditor("ImageEditor");
-const PropertySemantics PropertySemantics::ShaderEditor("ShaderEditor");
-
-std::ostream& operator<<(std::ostream& ss, const PropertySemantics& obj) {
-    ss << obj.getString();
+std::ostream& operator<<(std::ostream& ss, TouchStates s) {
+    std::copy(s.begin(), s.end(), util::make_ostream_joiner(ss, "+"));
     return ss;
 }
 

--- a/src/core/interaction/pickingstate.cpp
+++ b/src/core/interaction/pickingstate.cpp
@@ -1,0 +1,123 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2022 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/core/interaction/pickingstate.h>
+#include <inviwo/core/interaction/events/pickingevent.h>
+#include <inviwo/core/interaction/pickingaction.h>
+#include <inviwo/core/util/assertion.h>
+
+#include <inviwo/core/util/ostreamjoiner.h>
+#include <inviwo/core/util/exception.h>
+
+namespace inviwo {
+
+std::string_view util::name(PickingState s) {
+    switch (s) {
+        case PickingState::None:
+            return "None";
+        case PickingState::Started:
+            return "Started";
+        case PickingState::Updated:
+            return "Updated";
+        case PickingState::Finished:
+            return "Finished";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid PickingState enum value '{}'",
+                    static_cast<int>(s));
+}
+std::string_view util::name(PickingPressItem s) {
+    switch (s) {
+        case PickingPressItem::None:
+            return "None";
+        case PickingPressItem::Primary:
+            return "Primary";
+        case PickingPressItem::Secondary:
+            return "Secondary";
+        case PickingPressItem::Tertiary:
+            return "Tertiary";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"),
+                    "Found invalid PickingPressItem enum value '{}'", static_cast<int>(s));
+}
+std::string_view util::name(PickingPressState s) {
+    switch (s) {
+        case PickingPressState::None:
+            return "None";
+        case PickingPressState::Press:
+            return "Press";
+        case PickingPressState::Move:
+            return "Move";
+        case PickingPressState::Release:
+            return "Release";
+        case PickingPressState::DoubleClick:
+            return "DoubleClick";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"),
+                    "Found invalid PickingPressState enum value '{}'", static_cast<int>(s));
+}
+std::string_view util::name(PickingHoverState s) {
+    switch (s) {
+        case PickingHoverState::None:
+            return "None";
+        case PickingHoverState::Enter:
+            return "Enter";
+        case PickingHoverState::Move:
+            return "Move";
+        case PickingHoverState::Exit:
+            return "Exit";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"),
+                    "Found invalid PickingHoverState enum value '{}'", static_cast<int>(s));
+}
+
+std::ostream& operator<<(std::ostream& ss, PickingState s) { return ss << util::name(s); }
+std::ostream& operator<<(std::ostream& ss, PickingStates s) {
+    std::copy(s.begin(), s.end(), util::make_ostream_joiner(ss, "+"));
+    return ss;
+}
+
+std::ostream& operator<<(std::ostream& ss, PickingPressItem s) { return ss << util::name(s); }
+std::ostream& operator<<(std::ostream& ss, PickingPressItems s) {
+    std::copy(s.begin(), s.end(), util::make_ostream_joiner(ss, "+"));
+    return ss;
+}
+
+std::ostream& operator<<(std::ostream& ss, PickingPressState s) { return ss << util::name(s); }
+std::ostream& operator<<(std::ostream& ss, PickingPressStates s) {
+    std::copy(s.begin(), s.end(), util::make_ostream_joiner(ss, "+"));
+    return ss;
+}
+
+std::ostream& operator<<(std::ostream& ss, PickingHoverState s) { return ss << util::name(s); }
+std::ostream& operator<<(std::ostream& ss, PickingHoverStates s) {
+    std::copy(s.begin(), s.end(), util::make_ostream_joiner(ss, "+"));
+    return ss;
+}
+
+}  // namespace inviwo

--- a/src/core/processors/processorstate.cpp
+++ b/src/core/processors/processorstate.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2013-2021 Inviwo Foundation
+ * Copyright (c) 2022 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,40 +27,27 @@
  *
  *********************************************************************************/
 
-#include <inviwo/core/properties/propertysemantics.h>
-#include <inviwo/core/io/serialization/serialization.h>
-
+#include <inviwo/core/processors/processorstate.h>
+#include <inviwo/core/util/exception.h>
 #include <ostream>
 
 namespace inviwo {
 
-PropertySemantics::PropertySemantics() : semantic_("Default") {}
-PropertySemantics::PropertySemantics(std::string semantic) : semantic_(std::move(semantic)) {}
-
-const std::string& PropertySemantics::getString() const { return semantic_; }
-
-void PropertySemantics::serialize(Serializer& s) const {
-    s.serialize("semantics", semantic_, SerializationTarget::Attribute);
+std::string_view util::name(CodeState cs) {
+    switch (cs) {
+        case CodeState::Broken:
+            return "Broken";
+        case CodeState::Experimental:
+            return "Experimental";
+        case CodeState::Stable:
+            return "Stable";
+        case CodeState::Deprecated:
+            return "Deprecated";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid CodeState enum value '{}'",
+                    static_cast<int>(cs));
 }
 
-void PropertySemantics::deserialize(Deserializer& d) {
-    d.deserialize("semantics", semantic_, SerializationTarget::Attribute);
-}
-
-const PropertySemantics PropertySemantics::Default("Default");
-const PropertySemantics PropertySemantics::Text("Text");
-const PropertySemantics PropertySemantics::SpinBox("SpinBox");
-const PropertySemantics PropertySemantics::Color("Color");
-const PropertySemantics PropertySemantics::LightPosition("LightPosition");
-const PropertySemantics PropertySemantics::Multiline("Multiline");
-const PropertySemantics PropertySemantics::TextEditor("TextEditor");
-const PropertySemantics PropertySemantics::PythonEditor("PythonEditor");
-const PropertySemantics PropertySemantics::ImageEditor("ImageEditor");
-const PropertySemantics PropertySemantics::ShaderEditor("ShaderEditor");
-
-std::ostream& operator<<(std::ostream& ss, const PropertySemantics& obj) {
-    ss << obj.getString();
-    return ss;
-}
+std::ostream& operator<<(std::ostream& ss, CodeState cs) { return ss << util::name(cs); }
 
 }  // namespace inviwo

--- a/src/core/properties/constraintbehavior.cpp
+++ b/src/core/properties/constraintbehavior.cpp
@@ -28,5 +28,26 @@
  *********************************************************************************/
 
 #include <inviwo/core/properties/constraintbehavior.h>
+#include <inviwo/core/util/exception.h>
+#include <ostream>
 
-namespace inviwo {}  // namespace inviwo
+namespace inviwo {
+
+std::string_view util::name(ConstraintBehavior cb) {
+    switch (cb) {
+        case ConstraintBehavior::Editable:
+            return "Editable";
+        case ConstraintBehavior::Mutable:
+            return "Mutable";
+        case ConstraintBehavior::Immutable:
+            return "Immutable";
+        case ConstraintBehavior::Ignore:
+            return "Ignore";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"),
+                    "Found invalid ConstraintBehavior enum value '{}'", static_cast<int>(cb));
+}
+
+std::ostream& operator<<(std::ostream& ss, ConstraintBehavior cb) { return ss << util::name(cb); }
+
+}  // namespace inviwo

--- a/src/core/properties/invalidationlevel.cpp
+++ b/src/core/properties/invalidationlevel.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2013-2021 Inviwo Foundation
+ * Copyright (c) 2020-2021 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,40 +27,27 @@
  *
  *********************************************************************************/
 
-#include <inviwo/core/properties/propertysemantics.h>
-#include <inviwo/core/io/serialization/serialization.h>
-
+#include <inviwo/core/properties/invalidationlevel.h>
+#include <inviwo/core/util/exception.h>
 #include <ostream>
 
 namespace inviwo {
 
-PropertySemantics::PropertySemantics() : semantic_("Default") {}
-PropertySemantics::PropertySemantics(std::string semantic) : semantic_(std::move(semantic)) {}
-
-const std::string& PropertySemantics::getString() const { return semantic_; }
-
-void PropertySemantics::serialize(Serializer& s) const {
-    s.serialize("semantics", semantic_, SerializationTarget::Attribute);
+std::string_view util::name(InvalidationLevel level) {
+    switch (level) {
+        case InvalidationLevel::Valid:
+            return "Valid";
+        case InvalidationLevel::InvalidOutput:
+            return "Invalid output";
+        case InvalidationLevel::InvalidResources:
+            return "Invalid resources";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"),
+                    "Found invalid InvalidationLevel enum value '{}'", static_cast<int>(level));
 }
 
-void PropertySemantics::deserialize(Deserializer& d) {
-    d.deserialize("semantics", semantic_, SerializationTarget::Attribute);
-}
-
-const PropertySemantics PropertySemantics::Default("Default");
-const PropertySemantics PropertySemantics::Text("Text");
-const PropertySemantics PropertySemantics::SpinBox("SpinBox");
-const PropertySemantics PropertySemantics::Color("Color");
-const PropertySemantics PropertySemantics::LightPosition("LightPosition");
-const PropertySemantics PropertySemantics::Multiline("Multiline");
-const PropertySemantics PropertySemantics::TextEditor("TextEditor");
-const PropertySemantics PropertySemantics::PythonEditor("PythonEditor");
-const PropertySemantics PropertySemantics::ImageEditor("ImageEditor");
-const PropertySemantics PropertySemantics::ShaderEditor("ShaderEditor");
-
-std::ostream& operator<<(std::ostream& ss, const PropertySemantics& obj) {
-    ss << obj.getString();
-    return ss;
+std::ostream& operator<<(std::ostream& ss, InvalidationLevel level) {
+    return ss << util::name(level);
 }
 
 }  // namespace inviwo

--- a/src/core/properties/propertypresetmanager.cpp
+++ b/src/core/properties/propertypresetmanager.cpp
@@ -37,6 +37,11 @@
 #include <inviwo/core/common/inviwoapplication.h>
 #include <inviwo/core/properties/propertyfactory.h>
 #include <inviwo/core/metadata/metadatafactory.h>
+#include <inviwo/core/util/ostreamjoiner.h>
+
+#include <algorithm>
+#include <ostream>
+#include <sstream>
 
 namespace inviwo {
 
@@ -281,6 +286,26 @@ void PropertyPresetManager::Preset::deserialize(Deserializer& d) {
 std::map<std::string, std::string>& PropertyPresetManager::getPropertyPresets(Property* property) {
     using MT = StdUnorderedMapMetaData<std::string, std::string>;
     return property->createMetaData<MT>("SavedState")->getMap();
+}
+
+std::string_view util::name(PropertyPresetType p) {
+    switch (p) {
+        case PropertyPresetType::Property:
+            return "Property";
+        case PropertyPresetType::Workspace:
+            return "Workspace";
+        case PropertyPresetType::Application:
+            return "Application";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"),
+                    "Found invalid PropertyPresetType enum value '{}'", static_cast<int>(p));
+}
+
+std::ostream& operator<<(std::ostream& ss, PropertyPresetType p) { return ss << util::name(p); }
+
+std::ostream& operator<<(std::ostream& ss, PropertyPresetTypes ps) {
+    std::copy(ps.begin(), ps.end(), util::make_ostream_joiner(ss, ", "));
+    return ss;
 }
 
 }  // namespace inviwo

--- a/src/core/util/colorbrewer-generated.cpp
+++ b/src/core/util/colorbrewer-generated.cpp
@@ -38,7 +38,7 @@ tools/codegen/colorbrewer/colorbrewer.py
 namespace inviwo {
 namespace colorbrewer {
 
-const std::vector<dvec4>& getColormap(Colormap colormap) {
+const std::vector<dvec4> &getColormap(Colormap colormap) {
     switch (colormap) {
         // clang-format off
         case Colormap::Accent_1: {
@@ -2822,15 +2822,15 @@ const std::vector<dvec4>& getColormap(Colormap colormap) {
             return ylorrd_8;
         }
 
-            // clang-format on
+        // clang-format on
     }
     IVW_ASSERT(false, "Unhandled enum value");
     static const std::vector<dvec4> dummy{};
     return dummy;
 }
 
-glm::uint8 getMinNumberOfColorsForFamily(const Family& family) {
-    // clang-format off
+glm::uint8 getMinNumberOfColorsForFamily(const Family &family) { 
+        // clang-format off
     if (family == Family::Accent || family == Family::Paired || 
         family == Family::Set1 || family == Family::Set2) {
         return 1;
@@ -2857,7 +2857,7 @@ glm::uint8 getMinNumberOfColorsForFamily(const Family& family) {
     return 0;
 }
 
-glm::uint8 getMaxNumberOfColorsForFamily(const Family& family) {
+glm::uint8 getMaxNumberOfColorsForFamily(const Family &family) {
     // clang-format off
     if (family == Family::Accent || family == Family::Dark2 || 
         family == Family::Pastel2 || family == Family::Set2 || 
@@ -2891,7 +2891,7 @@ glm::uint8 getMaxNumberOfColorsForFamily(const Family& family) {
     return 0;
 }
 
-std::vector<Family> getFamiliesForCategory(const Category& category) {
+std::vector<Family> getFamiliesForCategory(const Category &category) {
     std::vector<Family> v;
     switch (category) {
         // clang-format off
@@ -2941,6 +2941,344 @@ std::vector<Family> getFamiliesForCategory(const Category& category) {
             // clang-format on
     }
     return v;
+}
+
+std::ostream& operator<<(std::ostream& os, Colormap colormap) {
+    switch (colormap) {
+        // clang-format off
+        case Colormap::Accent_1: os << "Accent_1"; break;
+        case Colormap::Accent_2: os << "Accent_2"; break;
+        case Colormap::Accent_3: os << "Accent_3"; break;
+        case Colormap::Accent_4: os << "Accent_4"; break;
+        case Colormap::Accent_5: os << "Accent_5"; break;
+        case Colormap::Accent_6: os << "Accent_6"; break;
+        case Colormap::Accent_7: os << "Accent_7"; break;
+        case Colormap::Accent_8: os << "Accent_8"; break;
+        case Colormap::Blues_3: os << "Blues_3"; break;
+        case Colormap::Blues_4: os << "Blues_4"; break;
+        case Colormap::Blues_5: os << "Blues_5"; break;
+        case Colormap::Blues_6: os << "Blues_6"; break;
+        case Colormap::Blues_7: os << "Blues_7"; break;
+        case Colormap::Blues_8: os << "Blues_8"; break;
+        case Colormap::Blues_9: os << "Blues_9"; break;
+        case Colormap::BrBG_3: os << "BrBG_3"; break;
+        case Colormap::BrBG_4: os << "BrBG_4"; break;
+        case Colormap::BrBG_5: os << "BrBG_5"; break;
+        case Colormap::BrBG_6: os << "BrBG_6"; break;
+        case Colormap::BrBG_7: os << "BrBG_7"; break;
+        case Colormap::BrBG_8: os << "BrBG_8"; break;
+        case Colormap::BrBG_9: os << "BrBG_9"; break;
+        case Colormap::BrBG_10: os << "BrBG_10"; break;
+        case Colormap::BrBG_11: os << "BrBG_11"; break;
+        case Colormap::BuGn_3: os << "BuGn_3"; break;
+        case Colormap::BuGn_4: os << "BuGn_4"; break;
+        case Colormap::BuGn_5: os << "BuGn_5"; break;
+        case Colormap::BuGn_6: os << "BuGn_6"; break;
+        case Colormap::BuGn_7: os << "BuGn_7"; break;
+        case Colormap::BuGn_8: os << "BuGn_8"; break;
+        case Colormap::BuGn_9: os << "BuGn_9"; break;
+        case Colormap::BuPu_3: os << "BuPu_3"; break;
+        case Colormap::BuPu_4: os << "BuPu_4"; break;
+        case Colormap::BuPu_5: os << "BuPu_5"; break;
+        case Colormap::BuPu_6: os << "BuPu_6"; break;
+        case Colormap::BuPu_7: os << "BuPu_7"; break;
+        case Colormap::BuPu_8: os << "BuPu_8"; break;
+        case Colormap::BuPu_9: os << "BuPu_9"; break;
+        case Colormap::Dark2_3: os << "Dark2_3"; break;
+        case Colormap::Dark2_4: os << "Dark2_4"; break;
+        case Colormap::Dark2_5: os << "Dark2_5"; break;
+        case Colormap::Dark2_6: os << "Dark2_6"; break;
+        case Colormap::Dark2_7: os << "Dark2_7"; break;
+        case Colormap::Dark2_8: os << "Dark2_8"; break;
+        case Colormap::GnBu_3: os << "GnBu_3"; break;
+        case Colormap::GnBu_4: os << "GnBu_4"; break;
+        case Colormap::GnBu_5: os << "GnBu_5"; break;
+        case Colormap::GnBu_6: os << "GnBu_6"; break;
+        case Colormap::GnBu_7: os << "GnBu_7"; break;
+        case Colormap::GnBu_8: os << "GnBu_8"; break;
+        case Colormap::GnBu_9: os << "GnBu_9"; break;
+        case Colormap::Greens_3: os << "Greens_3"; break;
+        case Colormap::Greens_4: os << "Greens_4"; break;
+        case Colormap::Greens_5: os << "Greens_5"; break;
+        case Colormap::Greens_6: os << "Greens_6"; break;
+        case Colormap::Greens_7: os << "Greens_7"; break;
+        case Colormap::Greens_8: os << "Greens_8"; break;
+        case Colormap::Greens_9: os << "Greens_9"; break;
+        case Colormap::Greys_3: os << "Greys_3"; break;
+        case Colormap::Greys_4: os << "Greys_4"; break;
+        case Colormap::Greys_5: os << "Greys_5"; break;
+        case Colormap::Greys_6: os << "Greys_6"; break;
+        case Colormap::Greys_7: os << "Greys_7"; break;
+        case Colormap::Greys_8: os << "Greys_8"; break;
+        case Colormap::Greys_9: os << "Greys_9"; break;
+        case Colormap::OrRd_3: os << "OrRd_3"; break;
+        case Colormap::OrRd_4: os << "OrRd_4"; break;
+        case Colormap::OrRd_5: os << "OrRd_5"; break;
+        case Colormap::OrRd_6: os << "OrRd_6"; break;
+        case Colormap::OrRd_7: os << "OrRd_7"; break;
+        case Colormap::OrRd_8: os << "OrRd_8"; break;
+        case Colormap::OrRd_9: os << "OrRd_9"; break;
+        case Colormap::Oranges_3: os << "Oranges_3"; break;
+        case Colormap::Oranges_4: os << "Oranges_4"; break;
+        case Colormap::Oranges_5: os << "Oranges_5"; break;
+        case Colormap::Oranges_6: os << "Oranges_6"; break;
+        case Colormap::Oranges_7: os << "Oranges_7"; break;
+        case Colormap::Oranges_8: os << "Oranges_8"; break;
+        case Colormap::Oranges_9: os << "Oranges_9"; break;
+        case Colormap::PRGn_3: os << "PRGn_3"; break;
+        case Colormap::PRGn_4: os << "PRGn_4"; break;
+        case Colormap::PRGn_5: os << "PRGn_5"; break;
+        case Colormap::PRGn_6: os << "PRGn_6"; break;
+        case Colormap::PRGn_7: os << "PRGn_7"; break;
+        case Colormap::PRGn_8: os << "PRGn_8"; break;
+        case Colormap::PRGn_9: os << "PRGn_9"; break;
+        case Colormap::PRGn_10: os << "PRGn_10"; break;
+        case Colormap::PRGn_11: os << "PRGn_11"; break;
+        case Colormap::Paired_1: os << "Paired_1"; break;
+        case Colormap::Paired_2: os << "Paired_2"; break;
+        case Colormap::Paired_3: os << "Paired_3"; break;
+        case Colormap::Paired_4: os << "Paired_4"; break;
+        case Colormap::Paired_5: os << "Paired_5"; break;
+        case Colormap::Paired_6: os << "Paired_6"; break;
+        case Colormap::Paired_7: os << "Paired_7"; break;
+        case Colormap::Paired_8: os << "Paired_8"; break;
+        case Colormap::Paired_9: os << "Paired_9"; break;
+        case Colormap::Paired_10: os << "Paired_10"; break;
+        case Colormap::Paired_11: os << "Paired_11"; break;
+        case Colormap::Paired_12: os << "Paired_12"; break;
+        case Colormap::Pastel1_3: os << "Pastel1_3"; break;
+        case Colormap::Pastel1_4: os << "Pastel1_4"; break;
+        case Colormap::Pastel1_5: os << "Pastel1_5"; break;
+        case Colormap::Pastel1_6: os << "Pastel1_6"; break;
+        case Colormap::Pastel1_7: os << "Pastel1_7"; break;
+        case Colormap::Pastel1_8: os << "Pastel1_8"; break;
+        case Colormap::Pastel1_9: os << "Pastel1_9"; break;
+        case Colormap::Pastel2_3: os << "Pastel2_3"; break;
+        case Colormap::Pastel2_4: os << "Pastel2_4"; break;
+        case Colormap::Pastel2_5: os << "Pastel2_5"; break;
+        case Colormap::Pastel2_6: os << "Pastel2_6"; break;
+        case Colormap::Pastel2_7: os << "Pastel2_7"; break;
+        case Colormap::Pastel2_8: os << "Pastel2_8"; break;
+        case Colormap::PiYG_3: os << "PiYG_3"; break;
+        case Colormap::PiYG_4: os << "PiYG_4"; break;
+        case Colormap::PiYG_5: os << "PiYG_5"; break;
+        case Colormap::PiYG_6: os << "PiYG_6"; break;
+        case Colormap::PiYG_7: os << "PiYG_7"; break;
+        case Colormap::PiYG_8: os << "PiYG_8"; break;
+        case Colormap::PiYG_9: os << "PiYG_9"; break;
+        case Colormap::PiYG_10: os << "PiYG_10"; break;
+        case Colormap::PiYG_11: os << "PiYG_11"; break;
+        case Colormap::PuBu_3: os << "PuBu_3"; break;
+        case Colormap::PuBu_4: os << "PuBu_4"; break;
+        case Colormap::PuBu_5: os << "PuBu_5"; break;
+        case Colormap::PuBu_6: os << "PuBu_6"; break;
+        case Colormap::PuBu_7: os << "PuBu_7"; break;
+        case Colormap::PuBu_8: os << "PuBu_8"; break;
+        case Colormap::PuBu_9: os << "PuBu_9"; break;
+        case Colormap::PuBuGn_3: os << "PuBuGn_3"; break;
+        case Colormap::PuBuGn_4: os << "PuBuGn_4"; break;
+        case Colormap::PuBuGn_5: os << "PuBuGn_5"; break;
+        case Colormap::PuBuGn_6: os << "PuBuGn_6"; break;
+        case Colormap::PuBuGn_7: os << "PuBuGn_7"; break;
+        case Colormap::PuBuGn_8: os << "PuBuGn_8"; break;
+        case Colormap::PuBuGn_9: os << "PuBuGn_9"; break;
+        case Colormap::PuOr_3: os << "PuOr_3"; break;
+        case Colormap::PuOr_4: os << "PuOr_4"; break;
+        case Colormap::PuOr_5: os << "PuOr_5"; break;
+        case Colormap::PuOr_6: os << "PuOr_6"; break;
+        case Colormap::PuOr_7: os << "PuOr_7"; break;
+        case Colormap::PuOr_8: os << "PuOr_8"; break;
+        case Colormap::PuOr_9: os << "PuOr_9"; break;
+        case Colormap::PuOr_10: os << "PuOr_10"; break;
+        case Colormap::PuOr_11: os << "PuOr_11"; break;
+        case Colormap::PuRd_3: os << "PuRd_3"; break;
+        case Colormap::PuRd_4: os << "PuRd_4"; break;
+        case Colormap::PuRd_5: os << "PuRd_5"; break;
+        case Colormap::PuRd_6: os << "PuRd_6"; break;
+        case Colormap::PuRd_7: os << "PuRd_7"; break;
+        case Colormap::PuRd_8: os << "PuRd_8"; break;
+        case Colormap::PuRd_9: os << "PuRd_9"; break;
+        case Colormap::Purples_3: os << "Purples_3"; break;
+        case Colormap::Purples_4: os << "Purples_4"; break;
+        case Colormap::Purples_5: os << "Purples_5"; break;
+        case Colormap::Purples_6: os << "Purples_6"; break;
+        case Colormap::Purples_7: os << "Purples_7"; break;
+        case Colormap::Purples_8: os << "Purples_8"; break;
+        case Colormap::Purples_9: os << "Purples_9"; break;
+        case Colormap::RdBu_3: os << "RdBu_3"; break;
+        case Colormap::RdBu_4: os << "RdBu_4"; break;
+        case Colormap::RdBu_5: os << "RdBu_5"; break;
+        case Colormap::RdBu_6: os << "RdBu_6"; break;
+        case Colormap::RdBu_7: os << "RdBu_7"; break;
+        case Colormap::RdBu_8: os << "RdBu_8"; break;
+        case Colormap::RdBu_9: os << "RdBu_9"; break;
+        case Colormap::RdBu_10: os << "RdBu_10"; break;
+        case Colormap::RdBu_11: os << "RdBu_11"; break;
+        case Colormap::RdGy_3: os << "RdGy_3"; break;
+        case Colormap::RdGy_4: os << "RdGy_4"; break;
+        case Colormap::RdGy_5: os << "RdGy_5"; break;
+        case Colormap::RdGy_6: os << "RdGy_6"; break;
+        case Colormap::RdGy_7: os << "RdGy_7"; break;
+        case Colormap::RdGy_8: os << "RdGy_8"; break;
+        case Colormap::RdGy_9: os << "RdGy_9"; break;
+        case Colormap::RdGy_10: os << "RdGy_10"; break;
+        case Colormap::RdGy_11: os << "RdGy_11"; break;
+        case Colormap::RdPu_3: os << "RdPu_3"; break;
+        case Colormap::RdPu_4: os << "RdPu_4"; break;
+        case Colormap::RdPu_5: os << "RdPu_5"; break;
+        case Colormap::RdPu_6: os << "RdPu_6"; break;
+        case Colormap::RdPu_7: os << "RdPu_7"; break;
+        case Colormap::RdPu_8: os << "RdPu_8"; break;
+        case Colormap::RdPu_9: os << "RdPu_9"; break;
+        case Colormap::RdYlBu_3: os << "RdYlBu_3"; break;
+        case Colormap::RdYlBu_4: os << "RdYlBu_4"; break;
+        case Colormap::RdYlBu_5: os << "RdYlBu_5"; break;
+        case Colormap::RdYlBu_6: os << "RdYlBu_6"; break;
+        case Colormap::RdYlBu_7: os << "RdYlBu_7"; break;
+        case Colormap::RdYlBu_8: os << "RdYlBu_8"; break;
+        case Colormap::RdYlBu_9: os << "RdYlBu_9"; break;
+        case Colormap::RdYlBu_10: os << "RdYlBu_10"; break;
+        case Colormap::RdYlBu_11: os << "RdYlBu_11"; break;
+        case Colormap::RdYlGn_3: os << "RdYlGn_3"; break;
+        case Colormap::RdYlGn_4: os << "RdYlGn_4"; break;
+        case Colormap::RdYlGn_5: os << "RdYlGn_5"; break;
+        case Colormap::RdYlGn_6: os << "RdYlGn_6"; break;
+        case Colormap::RdYlGn_7: os << "RdYlGn_7"; break;
+        case Colormap::RdYlGn_8: os << "RdYlGn_8"; break;
+        case Colormap::RdYlGn_9: os << "RdYlGn_9"; break;
+        case Colormap::RdYlGn_10: os << "RdYlGn_10"; break;
+        case Colormap::RdYlGn_11: os << "RdYlGn_11"; break;
+        case Colormap::Reds_3: os << "Reds_3"; break;
+        case Colormap::Reds_4: os << "Reds_4"; break;
+        case Colormap::Reds_5: os << "Reds_5"; break;
+        case Colormap::Reds_6: os << "Reds_6"; break;
+        case Colormap::Reds_7: os << "Reds_7"; break;
+        case Colormap::Reds_8: os << "Reds_8"; break;
+        case Colormap::Reds_9: os << "Reds_9"; break;
+        case Colormap::Set1_1: os << "Set1_1"; break;
+        case Colormap::Set1_2: os << "Set1_2"; break;
+        case Colormap::Set1_3: os << "Set1_3"; break;
+        case Colormap::Set1_4: os << "Set1_4"; break;
+        case Colormap::Set1_5: os << "Set1_5"; break;
+        case Colormap::Set1_6: os << "Set1_6"; break;
+        case Colormap::Set1_7: os << "Set1_7"; break;
+        case Colormap::Set1_8: os << "Set1_8"; break;
+        case Colormap::Set1_9: os << "Set1_9"; break;
+        case Colormap::Set2_1: os << "Set2_1"; break;
+        case Colormap::Set2_2: os << "Set2_2"; break;
+        case Colormap::Set2_3: os << "Set2_3"; break;
+        case Colormap::Set2_4: os << "Set2_4"; break;
+        case Colormap::Set2_5: os << "Set2_5"; break;
+        case Colormap::Set2_6: os << "Set2_6"; break;
+        case Colormap::Set2_7: os << "Set2_7"; break;
+        case Colormap::Set2_8: os << "Set2_8"; break;
+        case Colormap::Set3_3: os << "Set3_3"; break;
+        case Colormap::Set3_4: os << "Set3_4"; break;
+        case Colormap::Set3_5: os << "Set3_5"; break;
+        case Colormap::Set3_6: os << "Set3_6"; break;
+        case Colormap::Set3_7: os << "Set3_7"; break;
+        case Colormap::Set3_8: os << "Set3_8"; break;
+        case Colormap::Set3_9: os << "Set3_9"; break;
+        case Colormap::Set3_10: os << "Set3_10"; break;
+        case Colormap::Set3_11: os << "Set3_11"; break;
+        case Colormap::Set3_12: os << "Set3_12"; break;
+        case Colormap::Spectral_3: os << "Spectral_3"; break;
+        case Colormap::Spectral_4: os << "Spectral_4"; break;
+        case Colormap::Spectral_5: os << "Spectral_5"; break;
+        case Colormap::Spectral_6: os << "Spectral_6"; break;
+        case Colormap::Spectral_7: os << "Spectral_7"; break;
+        case Colormap::Spectral_8: os << "Spectral_8"; break;
+        case Colormap::Spectral_9: os << "Spectral_9"; break;
+        case Colormap::Spectral_10: os << "Spectral_10"; break;
+        case Colormap::Spectral_11: os << "Spectral_11"; break;
+        case Colormap::YlGn_3: os << "YlGn_3"; break;
+        case Colormap::YlGn_4: os << "YlGn_4"; break;
+        case Colormap::YlGn_5: os << "YlGn_5"; break;
+        case Colormap::YlGn_6: os << "YlGn_6"; break;
+        case Colormap::YlGn_7: os << "YlGn_7"; break;
+        case Colormap::YlGn_8: os << "YlGn_8"; break;
+        case Colormap::YlGn_9: os << "YlGn_9"; break;
+        case Colormap::YlGnBu_3: os << "YlGnBu_3"; break;
+        case Colormap::YlGnBu_4: os << "YlGnBu_4"; break;
+        case Colormap::YlGnBu_5: os << "YlGnBu_5"; break;
+        case Colormap::YlGnBu_6: os << "YlGnBu_6"; break;
+        case Colormap::YlGnBu_7: os << "YlGnBu_7"; break;
+        case Colormap::YlGnBu_8: os << "YlGnBu_8"; break;
+        case Colormap::YlGnBu_9: os << "YlGnBu_9"; break;
+        case Colormap::YlOrBr_3: os << "YlOrBr_3"; break;
+        case Colormap::YlOrBr_4: os << "YlOrBr_4"; break;
+        case Colormap::YlOrBr_5: os << "YlOrBr_5"; break;
+        case Colormap::YlOrBr_6: os << "YlOrBr_6"; break;
+        case Colormap::YlOrBr_7: os << "YlOrBr_7"; break;
+        case Colormap::YlOrBr_8: os << "YlOrBr_8"; break;
+        case Colormap::YlOrBr_9: os << "YlOrBr_9"; break;
+        case Colormap::YlOrRd_3: os << "YlOrRd_3"; break;
+        case Colormap::YlOrRd_4: os << "YlOrRd_4"; break;
+        case Colormap::YlOrRd_5: os << "YlOrRd_5"; break;
+        case Colormap::YlOrRd_6: os << "YlOrRd_6"; break;
+        case Colormap::YlOrRd_7: os << "YlOrRd_7"; break;
+        case Colormap::YlOrRd_8: os << "YlOrRd_8"; break;
+        // clang-format on
+    }
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, Category category) {
+    switch (category) {
+        // clang-format off
+        case Category::Diverging: os << "Diverging"; break;
+        case Category::Qualitative: os << "Qualitative"; break;
+        case Category::Sequential: os << "Sequential"; break;
+        case Category::NumberOfColormapCategories: os << "NumberOfColormapCategories"; break;
+        case Category::Undefined: os << "Undefined"; break;
+        // clang-format on
+    }
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, Family family) {
+    switch (family) {
+        // clang-format off
+        case Family::Accent: os << "Accent"; break;
+        case Family::Blues: os << "Blues"; break;
+        case Family::BrBG: os << "BrBG"; break;
+        case Family::BuGn: os << "BuGn"; break;
+        case Family::BuPu: os << "BuPu"; break;
+        case Family::Dark2: os << "Dark2"; break;
+        case Family::GnBu: os << "GnBu"; break;
+        case Family::Greens: os << "Greens"; break;
+        case Family::Greys: os << "Greys"; break;
+        case Family::OrRd: os << "OrRd"; break;
+        case Family::Oranges: os << "Oranges"; break;
+        case Family::PRGn: os << "PRGn"; break;
+        case Family::Paired: os << "Paired"; break;
+        case Family::Pastel1: os << "Pastel1"; break;
+        case Family::Pastel2: os << "Pastel2"; break;
+        case Family::PiYG: os << "PiYG"; break;
+        case Family::PuBu: os << "PuBu"; break;
+        case Family::PuBuGn: os << "PuBuGn"; break;
+        case Family::PuOr: os << "PuOr"; break;
+        case Family::PuRd: os << "PuRd"; break;
+        case Family::Purples: os << "Purples"; break;
+        case Family::RdBu: os << "RdBu"; break;
+        case Family::RdGy: os << "RdGy"; break;
+        case Family::RdPu: os << "RdPu"; break;
+        case Family::RdYlBu: os << "RdYlBu"; break;
+        case Family::RdYlGn: os << "RdYlGn"; break;
+        case Family::Reds: os << "Reds"; break;
+        case Family::Set1: os << "Set1"; break;
+        case Family::Set2: os << "Set2"; break;
+        case Family::Set3: os << "Set3"; break;
+        case Family::Spectral: os << "Spectral"; break;
+        case Family::YlGn: os << "YlGn"; break;
+        case Family::YlGnBu: os << "YlGnBu"; break;
+        case Family::YlOrBr: os << "YlOrBr"; break;
+        case Family::YlOrRd: os << "YlOrRd"; break;
+        case Family::NumberOfColormapFamilies: os << "NumberOfColormapFamilies"; break;
+        case Family::Undefined: os << "Undefined"; break;
+        // clang-format on
+    }
+    return os;
 }
 
 }  // namespace colorbrewer

--- a/src/core/util/consolelogger.cpp
+++ b/src/core/util/consolelogger.cpp
@@ -32,6 +32,7 @@
 #include <inviwo/core/util/stdextensions.h>
 
 #include <sstream>
+#include <iostream>
 #include <iomanip>
 #include <chrono>
 #include <array>

--- a/src/core/util/exception.cpp
+++ b/src/core/util/exception.cpp
@@ -129,4 +129,9 @@ void StandardExceptionHandler::operator()(ExceptionContext context) {
     }
 }
 
+std::ostream& operator<<(std::ostream& ss, const Exception& e) {
+    e.getFullMessage(ss);
+    return ss;
+}
+
 }  // namespace inviwo

--- a/src/core/util/filedialogstate.cpp
+++ b/src/core/util/filedialogstate.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2013-2021 Inviwo Foundation
+ * Copyright (c) 2022 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,40 +27,41 @@
  *
  *********************************************************************************/
 
-#include <inviwo/core/properties/propertysemantics.h>
-#include <inviwo/core/io/serialization/serialization.h>
+#include <inviwo/core/util/filedialogstate.h>
+#include <inviwo/core/util/exception.h>
 
 #include <ostream>
 
 namespace inviwo {
 
-PropertySemantics::PropertySemantics() : semantic_("Default") {}
-PropertySemantics::PropertySemantics(std::string semantic) : semantic_(std::move(semantic)) {}
-
-const std::string& PropertySemantics::getString() const { return semantic_; }
-
-void PropertySemantics::serialize(Serializer& s) const {
-    s.serialize("semantics", semantic_, SerializationTarget::Attribute);
+std::string_view util::name(AcceptMode mode) {
+    switch (mode) {
+        case AcceptMode::Open:
+            return "Open";
+        case AcceptMode::Save:
+            return "Save";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid AcceptMode enum value '{}'",
+                    static_cast<int>(mode));
+}
+std::string_view util::name(FileMode mode) {
+    switch (mode) {
+        case FileMode::AnyFile:
+            return "Any File";
+        case FileMode::ExistingFile:
+            return "Existing File";
+        case FileMode::Directory:
+            return "Directory";
+        case FileMode::ExistingFiles:
+            return "Existing Files";
+        case FileMode::DirectoryOnly:
+            return "Directory Only";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid FileMode enum value '{}'",
+                    static_cast<int>(mode));
 }
 
-void PropertySemantics::deserialize(Deserializer& d) {
-    d.deserialize("semantics", semantic_, SerializationTarget::Attribute);
-}
-
-const PropertySemantics PropertySemantics::Default("Default");
-const PropertySemantics PropertySemantics::Text("Text");
-const PropertySemantics PropertySemantics::SpinBox("SpinBox");
-const PropertySemantics PropertySemantics::Color("Color");
-const PropertySemantics PropertySemantics::LightPosition("LightPosition");
-const PropertySemantics PropertySemantics::Multiline("Multiline");
-const PropertySemantics PropertySemantics::TextEditor("TextEditor");
-const PropertySemantics PropertySemantics::PythonEditor("PythonEditor");
-const PropertySemantics PropertySemantics::ImageEditor("ImageEditor");
-const PropertySemantics PropertySemantics::ShaderEditor("ShaderEditor");
-
-std::ostream& operator<<(std::ostream& ss, const PropertySemantics& obj) {
-    ss << obj.getString();
-    return ss;
-}
+std::ostream& operator<<(std::ostream& ss, AcceptMode& mode) { return ss << util::name(mode); }
+std::ostream& operator<<(std::ostream& ss, FileMode& mode) { return ss << util::name(mode); }
 
 }  // namespace inviwo

--- a/src/core/util/fileextension.cpp
+++ b/src/core/util/fileextension.cpp
@@ -33,6 +33,8 @@
 #include <inviwo/core/util/stringconversion.h>
 #include <inviwo/core/util/filesystem.h>
 
+#include <ostream>
+
 namespace inviwo {
 
 FileExtension::FileExtension() : extension_(), description_() {}
@@ -127,5 +129,18 @@ bool operator<=(const FileExtension& lhs, const FileExtension& rhs) { return !op
 bool operator>=(const FileExtension& lhs, const FileExtension& rhs) { return !operator<(lhs, rhs); }
 
 FileExtension FileExtension::all() { return FileExtension("*", "All Files"); }
+
+std::ostream& operator<<(std::ostream& ss, const FileExtension& ext) {
+    if (ext.extension_.empty()) {
+        return ss;
+    }
+    ss << ext.description_ << " ";
+    if (ext.extension_ == "*") {
+        ss << "(*)";
+    } else {
+        ss << "(*." << ext.extension_ << ")";
+    }
+    return ss;
+}
 
 }  // namespace inviwo

--- a/src/core/util/fmtutils.cpp
+++ b/src/core/util/fmtutils.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2013-2021 Inviwo Foundation
+ * Copyright (c) 2022 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,40 +27,6 @@
  *
  *********************************************************************************/
 
-#include <inviwo/core/properties/propertysemantics.h>
-#include <inviwo/core/io/serialization/serialization.h>
+#include <inviwo/core/util/fmtutils.h>
 
-#include <ostream>
-
-namespace inviwo {
-
-PropertySemantics::PropertySemantics() : semantic_("Default") {}
-PropertySemantics::PropertySemantics(std::string semantic) : semantic_(std::move(semantic)) {}
-
-const std::string& PropertySemantics::getString() const { return semantic_; }
-
-void PropertySemantics::serialize(Serializer& s) const {
-    s.serialize("semantics", semantic_, SerializationTarget::Attribute);
-}
-
-void PropertySemantics::deserialize(Deserializer& d) {
-    d.deserialize("semantics", semantic_, SerializationTarget::Attribute);
-}
-
-const PropertySemantics PropertySemantics::Default("Default");
-const PropertySemantics PropertySemantics::Text("Text");
-const PropertySemantics PropertySemantics::SpinBox("SpinBox");
-const PropertySemantics PropertySemantics::Color("Color");
-const PropertySemantics PropertySemantics::LightPosition("LightPosition");
-const PropertySemantics PropertySemantics::Multiline("Multiline");
-const PropertySemantics PropertySemantics::TextEditor("TextEditor");
-const PropertySemantics PropertySemantics::PythonEditor("PythonEditor");
-const PropertySemantics PropertySemantics::ImageEditor("ImageEditor");
-const PropertySemantics PropertySemantics::ShaderEditor("ShaderEditor");
-
-std::ostream& operator<<(std::ostream& ss, const PropertySemantics& obj) {
-    ss << obj.getString();
-    return ss;
-}
-
-}  // namespace inviwo
+namespace inviwo {}  // namespace inviwo

--- a/src/core/util/logcentral.cpp
+++ b/src/core/util/logcentral.cpp
@@ -203,4 +203,47 @@ void util::log(Logger* logger, ExceptionContext context, std::string_view messag
                 context.getLine(), message);
 }
 
+std::string_view util::name(LogLevel ll) {
+    switch (ll) {
+        case LogLevel::Info:
+            return "Info";
+        case LogLevel::Warn:
+            return "Warn";
+        case LogLevel::Error:
+            return "Error";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid LogLevel enum value '{}'",
+                    static_cast<int>(ll));
+}
+
+std::string_view util::name(LogAudience la) {
+    switch (la) {
+        case LogAudience::User:
+            return "User";
+        case LogAudience::Developer:
+            return "Developer";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid LogAudience enum value '{}'",
+                    static_cast<int>(la));
+}
+
+std::string_view util::name(MessageBreakLevel ll) {
+    switch (ll) {
+        case MessageBreakLevel::Info:
+            return "Info";
+        case MessageBreakLevel::Warn:
+            return "Warn";
+        case MessageBreakLevel::Error:
+            return "Error";
+        case MessageBreakLevel::Off:
+            return "Off";
+    }
+    throw Exception(IVW_CONTEXT_CUSTOM("enumName"),
+                    "Found invalid MessageBreakLevel enum value '{}'", static_cast<int>(ll));
+}
+
+std::ostream& operator<<(std::ostream& ss, LogLevel ll) { return ss << util::name(ll); }
+std::ostream& operator<<(std::ostream& ss, LogAudience la) { return ss << util::name(la); }
+std::ostream& operator<<(std::ostream& ss, MessageBreakLevel ll) { return ss << util::name(ll); }
+
 }  // namespace inviwo

--- a/src/core/util/sourcecontext.cpp
+++ b/src/core/util/sourcecontext.cpp
@@ -28,5 +28,18 @@
  *********************************************************************************/
 
 #include <inviwo/core/util/sourcecontext.h>
+#include <ostream>
 
-namespace inviwo {}  // namespace inviwo
+namespace inviwo {
+
+std::ostream& operator<<(std::ostream& ss, const SourceContext& ec) {
+    ss << ec.getCaller() << " (" << ec.getFile() << ":" << ec.getLine() << ")";
+    return ss;
+}
+
+std::ostream& operator<<(std::ostream& ss, const SourceLocation& ec) {
+    ss << ec.getFunction() << " (" << ec.getFile() << ":" << ec.getLine() << ")";
+    return ss;
+}
+
+}  // namespace inviwo

--- a/src/qt/editor/editorgrapicsitem.cpp
+++ b/src/qt/editor/editorgrapicsitem.cpp
@@ -89,8 +89,6 @@ void EditorGraphicsItem::showPortInfo(QGraphicsSceneHelpEvent* e, Port* port) co
     bool inspector = settings->enablePortInspectors_.get();
     size_t portInspectorSize = static_cast<size_t>(settings->portInspectorSize_.get());
 
-    using P = Document::PathComponent;
-
     Document desc{};
     auto html = desc.append("html");
     html.append("head").append("style", R"(

--- a/tools/codegen/colorbrewer/colorbrewer.py
+++ b/tools/codegen/colorbrewer/colorbrewer.py
@@ -1,173 +1,171 @@
-﻿import json 
-import re
-import sys
+﻿import json
 import argparse
-sys.path.append('../../')
-import ivwpy.ivwpaths 
+
 
 def dictToOrderedList(d):
-    for a,b in sorted(d.items()):
+    for a, b in sorted(d.items()):
         yield b
 
+
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Generate C++ source and header files exposing colorbrewer colors', 
-                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument("-i", "--inviwo", type=str, default="", dest="ivwpath", 
-                        help="Path to the inviwo repository. If ommited, tries to find it in the current path")
+    parser = argparse.ArgumentParser(
+        description='Generate C++ source and header files exposing colorbrewer colors',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("-i", "--inviwo", type=str, dest="ivwpath",
+                        help="Path to the inviwo repository")
+
     args = parser.parse_args()
-    if args.ivwpath == "":
-        ivwpath = ivwpy.ivwpaths.find_inv_path()
-    else:
-        ivwpath = args.ivwpath
+    ivwpath = args.ivwpath
 
-    enum = "enum class Colormap {";
+    enum = "enum class Colormap {"
 
-    cat = [];
-    categories = "enum class Category { ";
+    cat = []
+    categories = "enum class Category { "
 
-    families = "enum class Family {";
+    families = "enum class Family {"
 
-    familiesInCategory = dict();
-    getFamiliesForCategoryImpl = "";
+    familiesInCategory = dict()
+    getFamiliesForCategoryImpl = ""
 
-    minElementsForFamily = dict();
-    maxElementsForFamily = dict();
-    getMinNumberOfColorsForFamilyImpl = "";
-    getMaxNumberOfColorsForFamilyImpl = "";
-    
-    impls = "";
-    names = "";
-    families_os = "";
-    categories_os = "";
+    minElementsForFamily = dict()
+    maxElementsForFamily = dict()
+    getMinNumberOfColorsForFamilyImpl = ""
+    getMaxNumberOfColorsForFamilyImpl = ""
 
-    lastEnum = "";
-    firstEnum = "";
+    impls = ""
+    names = ""
+    families_os = ""
+    categories_os = ""
 
-	#colorbrewer.json is downlaoded from http://colorbrewer2.org/# 
+    lastEnum = ""
+    firstEnum = ""
 
-    with open('colorbrewer.json','r') as cb_file:
-        cb = json.load(cb_file);
-        famID = 0;
-        for fam,arr in sorted(cb.items()):
+    # colorbrewer.json is downlaoded from http://colorbrewer2.org/#
+
+    with open('colorbrewer.json', 'r') as cb_file:
+        cb = json.load(cb_file)
+        famID = 0
+        for fam, arr in sorted(cb.items()):
             if famID % 7 == 0:
                 families += "\n\t"
-            famID += 1    
-            families_os += "\t\tcase Family::" + fam + ": os << \"" + fam + "\"; break;\n";
-            families +=  fam + ", "
+            famID += 1
+            families_os += "\t\tcase Family::" + fam + ": os << \"" + fam + "\"; break;\n"
+            families += fam + ", "
             arrs = {}
-            for a,b in arr.items():
+            for a, b in arr.items():
                 try:
                     arrs[int(a)] = b
                 except:
                     pass
             if not arr["type"] in cat:
-                familiesInCategory[arr["type"]] = [];
+                familiesInCategory[arr["type"]] = []
 
-            cat.append(arr["type"]);
-            familiesInCategory[arr["type"]].append(fam);
+            cat.append(arr["type"])
+            familiesInCategory[arr["type"]].append(fam)
 
             enum += "\n\t"
             imp = []
-            i=0;
-            for a,b in sorted(arrs.items()):
+            i = 0
+            for a, b in sorted(arrs.items()):
                 if i == len(sorted(arrs.items())) - 1:
-                    if not a in maxElementsForFamily:
-                        maxElementsForFamily[a] = [];
-                    maxElementsForFamily[a].append(fam);
+                    if a not in maxElementsForFamily:
+                        maxElementsForFamily[a] = []
+                    maxElementsForFamily[a].append(fam)
                 if i == 0:
-                    if not a in minElementsForFamily:
-                        minElementsForFamily[a] = [];
-                    minElementsForFamily[a].append(fam);
-                i+=1;
-                enumname = fam +"_" + str(a);
-                enum += enumname + ", ";
-                lastEnum = enumname;
+                    if a not in minElementsForFamily:
+                        minElementsForFamily[a] = []
+                    minElementsForFamily[a].append(fam)
+                i += 1
+                enumname = fam + "_" + str(a)
+                enum += enumname + ", "
+                lastEnum = enumname
                 if len(firstEnum) == 0:
-                    firstEnum = enumname;
+                    firstEnum = enumname
 
                 impls += "\t\tcase Colormap::" + enumname + ": {"
                 colors = []
                 for color in b:
-                    r,g,b = color[4:-1].split(',')
-                    r = int(r) / 255;
-                    g = int(g) / 255;
-                    b = int(b) / 255;
-                    c = ', '.join([str(r),str(g),str(b),"1.0"]);
-                    colors.append('dvec4('+c+')');
+                    r, g, b = color[4:-1].split(',')
+                    r = int(r) / 255
+                    g = int(g) / 255
+                    b = int(b) / 255
+                    c = ', '.join([str(r), str(g), str(b), "1.0"])
+                    colors.append('dvec4(' + c + ')')
 
-                vector = "std::vector<dvec4> "+ enumname.lower()  +"(\n\t\t\t\t{"+',\n\t\t\t\t '.join(colors)+"});"
+                vector = "std::vector<dvec4> " + \
+                    enumname.lower() + "(\n\t\t\t\t{" + ',\n\t\t\t\t '.join(colors) + "});"
 
-                impls += "\n\t\t\tstatic const " + vector + "\n\t\t\treturn "+ enumname.lower() +";\n\t\t}\n"
+                impls += "\n\t\t\tstatic const " + vector + "\n\t\t\treturn " + enumname.lower() + ";\n\t\t}\n"
 
-                names += "\t\tcase Colormap::" + enumname + ": os << \"" + enumname + "\"; break;\n";
-                
+                names += "\t\tcase Colormap::" + enumname + ": os << \"" + enumname + "\"; break;\n"
+
         families += "\n\tNumberOfColormapFamilies, Undefined\n};"
         families_os += "\t\tcase Family::NumberOfColormapFamilies: os << \"NumberOfColormapFamilies\"; break;\n"
         families_os += "\t\tcase Family::Undefined: os << \"Undefined\"; break;"
-        catset = set(cat);
-        catlist = list(catset);
+        catset = set(cat)
+        catlist = list(catset)
 
         for c in sorted(catlist):
-            categories += c + ", ";
-            getFamiliesForCategoryImpl += "\t\tcase Category::";
+            categories += c + ", "
+            getFamiliesForCategoryImpl += "\t\tcase Category::"
             if c == "div":
                 getFamiliesForCategoryImpl += "Diverging:\n"
-                categories_os += "\t\tcase Category::Diverging: os << \"Diverging\"; break;\n";
+                categories_os += "\t\tcase Category::Diverging: os << \"Diverging\"; break;\n"
             if c == "qual":
                 getFamiliesForCategoryImpl += "Qualitative:\n"
-                categories_os += "\t\tcase Category::Qualitative: os << \"Qualitative\"; break;\n";
+                categories_os += "\t\tcase Category::Qualitative: os << \"Qualitative\"; break;\n"
             if c == "seq":
                 getFamiliesForCategoryImpl += "Sequential:\n"
-                categories_os += "\t\tcase Category::Sequential: os << \"Sequential\"; break;\n";
+                categories_os += "\t\tcase Category::Sequential: os << \"Sequential\"; break;\n"
             for f in sorted(familiesInCategory[c]):
-                getFamiliesForCategoryImpl += "\t\t\tv.emplace_back(Family::" + f + ");\n";
-            getFamiliesForCategoryImpl += "\t\t\tbreak;\n";
-        getFamiliesForCategoryImpl += "\t\tdefault:\n\t\t\tbreak;";
+                getFamiliesForCategoryImpl += "\t\t\tv.emplace_back(Family::" + f + ");\n"
+            getFamiliesForCategoryImpl += "\t\t\tbreak;\n"
+        getFamiliesForCategoryImpl += "\t\tdefault:\n\t\t\tbreak;"
 
-        categories_os += "\t\tcase Category::NumberOfColormapCategories: os << \"NumberOfColormapCategories\"; break;\n";
-        categories_os += "\t\tcase Category::Undefined: os << \"Undefined\"; break;";
+        categories_os += "\t\tcase Category::NumberOfColormapCategories: os << \"NumberOfColormapCategories\"; break;\n"
+        categories_os += "\t\tcase Category::Undefined: os << \"Undefined\"; break;"
 
         r = 0
         for a in maxElementsForFamily:
-            getMaxNumberOfColorsForFamilyImpl += "\tif (";
+            getMaxNumberOfColorsForFamilyImpl += "\tif ("
             for z in maxElementsForFamily[a]:
                 getMaxNumberOfColorsForFamilyImpl += "family == Family::" + z + " || "
                 if r % 2:
-                    getMaxNumberOfColorsForFamilyImpl += "\n\t\t";
-                r=r+1
+                    getMaxNumberOfColorsForFamilyImpl += "\n\t\t"
+                r = r + 1
             if not r % 2:
-                getMaxNumberOfColorsForFamilyImpl = getMaxNumberOfColorsForFamilyImpl[:-7];
+                getMaxNumberOfColorsForFamilyImpl = getMaxNumberOfColorsForFamilyImpl[:-7]
             else:
-                getMaxNumberOfColorsForFamilyImpl = getMaxNumberOfColorsForFamilyImpl[:-4];
-            getMaxNumberOfColorsForFamilyImpl += ") {\n\t\treturn " + str(a) + ";\n\t}\n";
+                getMaxNumberOfColorsForFamilyImpl = getMaxNumberOfColorsForFamilyImpl[:-4]
+            getMaxNumberOfColorsForFamilyImpl += ") {\n\t\treturn " + str(a) + ";\n\t}\n"
         r = 0
         for a in minElementsForFamily:
-            getMinNumberOfColorsForFamilyImpl += "\tif (";
+            getMinNumberOfColorsForFamilyImpl += "\tif ("
             for z in minElementsForFamily[a]:
                 getMinNumberOfColorsForFamilyImpl += "family == Family::" + z + " || "
                 if r % 2:
-                    getMinNumberOfColorsForFamilyImpl += "\n\t\t";
-                r=r+1
+                    getMinNumberOfColorsForFamilyImpl += "\n\t\t"
+                r = r + 1
             if not r % 2:
-                getMinNumberOfColorsForFamilyImpl = getMinNumberOfColorsForFamilyImpl[:-7];
+                getMinNumberOfColorsForFamilyImpl = getMinNumberOfColorsForFamilyImpl[:-7]
             else:
-                getMinNumberOfColorsForFamilyImpl = getMinNumberOfColorsForFamilyImpl[:-4];
-            getMinNumberOfColorsForFamilyImpl += ") {\n\t\treturn " + str(a) + ";\n\t}\n";
+                getMinNumberOfColorsForFamilyImpl = getMinNumberOfColorsForFamilyImpl[:-4]
+            getMinNumberOfColorsForFamilyImpl += ") {\n\t\treturn " + str(a) + ";\n\t}\n"
 
-    categories += "NumberOfColormapCategories, Undefined };\n";
+    categories += "NumberOfColormapCategories, Undefined };\n"
 
-    categories = categories.replace("seq", "Sequential");
-    categories = categories.replace("div", "Diverging");
-    categories = categories.replace("qual", "Qualitative");
+    categories = categories.replace("seq", "Sequential")
+    categories = categories.replace("div", "Diverging")
+    categories = categories.replace("qual", "Qualitative")
 
     enum += "\n\tFirstMap=" + firstEnum + ", LastMap=" + lastEnum + "\n};\n\n"
 
     header = ""
     src = ""
-    with open('colorbrewer_tmpl.h','r') as template_h:
-        header = template_h.read();
-    with open('colorbrewer_tmpl.cpp','r') as template_cpp:
-        src = template_cpp.read();
+    with open('colorbrewer_tmpl.h', 'r') as template_h:
+        header = template_h.read()
+    with open('colorbrewer_tmpl.cpp', 'r') as template_cpp:
+        src = template_cpp.read()
 
     while names.endswith("\n"):
         names = names[0:-1]
@@ -177,24 +175,22 @@ if __name__ == '__main__':
     while getMinNumberOfColorsForFamilyImpl.endswith("\n"):
         getMinNumberOfColorsForFamilyImpl = getMinNumberOfColorsForFamilyImpl[0:-1]
 
-    
-
-    header = header.replace("##PLACEHOLDER##",enum + categories + "\n" + families);
-    src = src.replace("##PLACEHOLDER##",impls);
-    src = src.replace("##GETFAMILIESIMPL##", getFamiliesForCategoryImpl);
-    src = src.replace("##GETMINIMPL##", getMinNumberOfColorsForFamilyImpl);
-    src = src.replace("##GETMAXIMPL##", getMaxNumberOfColorsForFamilyImpl);
-    header = header.replace("##PLACEHOLDER_NAMES##",names);
-    header = header.replace("##PLACEHOLDER_CATEGORIES##",categories_os);
-    header = header.replace("##PLACEHOLDER_FAMILIES##",families_os);
+    header = header.replace("##PLACEHOLDER##", enum + categories + "\n" + families)
+    src = src.replace("##PLACEHOLDER##", impls)
+    src = src.replace("##GETFAMILIESIMPL##", getFamiliesForCategoryImpl)
+    src = src.replace("##GETMINIMPL##", getMinNumberOfColorsForFamilyImpl)
+    src = src.replace("##GETMAXIMPL##", getMaxNumberOfColorsForFamilyImpl)
+    src = src.replace("##PLACEHOLDER_NAMES##", names)
+    src = src.replace("##PLACEHOLDER_CATEGORIES##", categories_os)
+    src = src.replace("##PLACEHOLDER_FAMILIES##", families_os)
 
     # replace tabs with spaces
-    src = src.replace("\t","    ");
-    header = header.replace("\t","    ");
+    src = src.replace("\t", "    ")
+    header = header.replace("\t", "    ")
 
-    with open(ivwpath + '/include/inviwo/core/util/colorbrewer-generated.h','w') as header_file:
+    with open(ivwpath + '/include/inviwo/core/util/colorbrewer-generated.h', 'w') as header_file:
         print(header, file=header_file, end='')
-        header_file.close();
-    with open(ivwpath + '/src/core/util/colorbrewer-generated.cpp','w') as source_file:
+        header_file.close()
+    with open(ivwpath + '/src/core/util/colorbrewer-generated.cpp', 'w') as source_file:
         print(src, file=source_file, end='')
-        source_file.close();
+        source_file.close()

--- a/tools/codegen/colorbrewer/colorbrewer_tmpl.cpp
+++ b/tools/codegen/colorbrewer/colorbrewer_tmpl.cpp
@@ -73,6 +73,33 @@ std::vector<Family> getFamiliesForCategory(const Category &category) {
     return v;
 }
 
+std::ostream& operator<<(std::ostream& os, Colormap colormap) {
+    switch (colormap) {
+        // clang-format off
+##PLACEHOLDER_NAMES##
+        // clang-format on
+    }
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, Category category) {
+    switch (category) {
+        // clang-format off
+##PLACEHOLDER_CATEGORIES##
+        // clang-format on
+    }
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, Family family) {
+    switch (family) {
+        // clang-format off
+##PLACEHOLDER_FAMILIES##
+        // clang-format on
+    }
+    return os;
+}
+
 }  // namespace colorbrewer
 
 }  // namespace inviwo

--- a/tools/codegen/colorbrewer/colorbrewer_tmpl.h
+++ b/tools/codegen/colorbrewer/colorbrewer_tmpl.h
@@ -35,10 +35,12 @@ tools/codegen/colorbrewer/colorbrewer.py
 #pragma once
 
 #include <inviwo/core/common/inviwocoredefine.h>
-#include <inviwo/core/util/glm.h>
+#include <inviwo/core/util/glmvec.h>
 
 #include <vector>
 #include <ostream>
+#include <fmt/core.h>
+#include <fmt/ostream.h>
 
 namespace inviwo {
 namespace colorbrewer {
@@ -46,37 +48,10 @@ namespace colorbrewer {
 // clang-format off
 ##PLACEHOLDER##
 // clang-format on
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits> &operator<<(std::basic_ostream<Elem, Traits> &os,
-                                             Colormap colormap) {
-    switch (colormap) {
-        // clang-format off
-##PLACEHOLDER_NAMES##
-            // clang-format on
-    }
-    return os;
-}
 
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits> &operator<<(std::basic_ostream<Elem, Traits> &os,
-                                             Category category) {
-    switch (category) {
-        // clang-format off
-##PLACEHOLDER_CATEGORIES##
-            // clang-format on
-    }
-    return os;
-}
-
-template <class Elem, class Traits>
-std::basic_ostream<Elem, Traits> &operator<<(std::basic_ostream<Elem, Traits> &os, Family family) {
-    switch (family) {
-        // clang-format off
-##PLACEHOLDER_FAMILIES##
-            // clang-format on
-    }
-    return os;
-}
+IVW_CORE_API std::ostream& operator<<(std::ostream& os, Colormap colormap);
+IVW_CORE_API std::ostream& operator<<(std::ostream& os, Category category);
+IVW_CORE_API std::ostream& operator<<(std::ostream& os, Family family);
 
 /**
  * Returns the specified colormap. For reference see http://colorbrewer2.org/
@@ -100,3 +75,7 @@ IVW_CORE_API std::vector<Family> getFamiliesForCategory(const Category &category
 
 }  // namespace colorbrewer
 }  // namespace inviwo
+
+template <> struct fmt::formatter<inviwo::colorbrewer::Colormap> : ostream_formatter {};
+template <> struct fmt::formatter<inviwo::colorbrewer::Category> : ostream_formatter {};
+template <> struct fmt::formatter<inviwo::colorbrewer::Family> : ostream_formatter {};


### PR DESCRIPTION
The fmt library was updated to the recent version 9.0.0. There are major breaking changes in the update with respect to using ostream operators and fmt. Previously you could just include `fmt/ostream.h` and any type that was streamable was not also printable with fmt. That behavior was removed and now you either have to wrap the object with `fmt::streamed(x)` or add a specialization of fmt::formatter for the type. Most core types in Inviwo that used std::ostream operators have been updated with fmt formatters. 
