### PR TITLE
Feature/qt welcomeappend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Here we document changes that affect the public API or changes that needs to be communicated to other developers. 
 
+## 2022-09-02 Append workspace on Welcome Screen
+Previously, the File menu received an "Append" functionality which appends a workspace to the current network by holding down Control/Command. This functionality is now also available in the Welcome Screen. The Welcome Screen also no longer immediately closes the current workspace, it is now possible to close the Welcome Screen and continue working without loosing any changes.
+
 ## 2022-08-16 New help system
 The old processor help system based on doxygen and qhp has been removed in favor of a runtime system where help text is added to processor/port/properties at runtime. To add a help text to a processor now you add a new element to the ProcessorInfo for that processor like this
 ```c++

--- a/include/inviwo/qt/editor/inviwomainwindow.h
+++ b/include/inviwo/qt/editor/inviwomainwindow.h
@@ -252,7 +252,6 @@ private:
     HelpWidget* helpWidget_;
     WelcomeWidget* welcomeWidget_ =
         nullptr;  ///< Use delayed initialization as it can be expensive.
-    std::vector<QDockWidget*> welcomeHidden_;
     AnnotationsWidget* annotationsWidget_ = nullptr;
     InviwoAboutWindow* inviwoAboutWindow_ = nullptr;
 
@@ -294,10 +293,10 @@ private:
         /**
          * show previously hidden processor and dock widgets
          */
-        void restore();
+        void show();
 
         std::vector<Processor*> processors;
-        std::vector<InviwoDockWidget*> dockwidgets;
+        std::vector<QDockWidget*> dockwidgets;
     };
     VisibleWidgets visibleWidgetState_;  //!< holds all processor and dock widgets that were visible
                                          //!< before showing the welcome widget

--- a/include/inviwo/qt/editor/inviwomainwindow.h
+++ b/include/inviwo/qt/editor/inviwomainwindow.h
@@ -141,8 +141,19 @@ public:
      */
     bool appendWorkspace();
 
-    void saveWorkspace();
-    void saveWorkspaceAs();
+    /**
+     * saves the current workspace. If the workspace does not have a name yet, a file dialog will be
+     * shown.
+     * @return true if the workspace was saved, otherwise false.
+     * @see saveWorkspaceAs
+     */
+    bool saveWorkspace();
+    /**
+     * saves the current workspace using a file dialog
+     * @return true if the workspace was saved, otherwise false.
+     * @see saveWorkspaceAs
+     */
+    bool saveWorkspaceAs();
 
     /*
      * Save the current workspace into a new workspace file,
@@ -191,7 +202,12 @@ private:
      * @see askToSaveWorkspaceChanges
      */
     bool openWorkspace(QString workspaceFileName, bool isExample);
-    void saveWorkspace(QString workspaceFileName);
+
+    /**
+     * saves the current workspace to the given \p workspaceFileName.
+     * @return true if the workspace was saved, otherwise false.
+     */
+    bool saveWorkspace(QString workspaceFileName);
     void appendWorkspace(const QString& workspaceFileName);
 
     std::optional<QString> askForWorkspaceToOpen();

--- a/include/inviwo/qt/editor/inviwomainwindow.h
+++ b/include/inviwo/qt/editor/inviwomainwindow.h
@@ -61,6 +61,7 @@ class HelpWidget;
 class WelcomeWidget;
 class AnnotationsWidget;
 class InviwoApplicationQt;
+class InviwoDockWidget;
 class InviwoEditMenu;
 class InviwoAboutWindow;
 class ResourceManagerDockWidget;
@@ -68,6 +69,7 @@ class FileAssociations;
 class ToolsMenu;
 class TextLabelOverlay;
 class MenuKeyboardEventFilter;
+class Processor;
 
 class IVW_QTEDITOR_API InviwoMainWindow : public QMainWindow, public NetworkEditorObserver {
 public:
@@ -283,6 +285,22 @@ private:
     TCLAP::ValueArg<std::string> updateWorkspacesInPath_;
 
     UndoManager undoManager_;
+
+    struct VisibleWidgets {
+        /**
+         * store all visible processor and dock widgets before hiding them
+         */
+        void hide(InviwoMainWindow* win);
+        /**
+         * show previously hidden processor and dock widgets
+         */
+        void restore();
+
+        std::vector<Processor*> processors;
+        std::vector<InviwoDockWidget*> dockwidgets;
+    };
+    VisibleWidgets visibleWidgetState_;  //!< holds all processor and dock widgets that were visible
+                                         //!< before showing the welcome widget
 };
 
 }  // namespace inviwo

--- a/include/inviwo/qt/editor/welcomewidget.h
+++ b/include/inviwo/qt/editor/welcomewidget.h
@@ -54,6 +54,7 @@ class WorkspaceGridView;
 class InviwoApplication;
 class ChangeLog;
 class WorkspaceFilter;
+class KeyboardEventFilter;
 
 class IVW_QTEDITOR_API WelcomeWidget : public QSplitter {
 #include <warn/push>
@@ -67,14 +68,18 @@ public:
     void updateRecentWorkspaces(const QStringList& list);
     void enableRestoreButton(bool hasRestoreWorkspace);
 
+    void updateLoadIcon(bool append, bool openWithPath);
+
 signals:
     void loadWorkspace(const QString& filename, bool isExample);
+    void appendWorkspace(const QString& filename);
     void newWorkspace();
     void openWorkspace();
     void restoreWorkspace();
 
 protected:
     virtual void showEvent(QShowEvent* event) override;
+    virtual void hideEvent(QHideEvent* event) override;
 
     virtual void keyPressEvent(QKeyEvent* event) override;
 
@@ -102,6 +107,8 @@ private:
     ChangeLog* changelog_;
     QToolButton* loadWorkspaceBtn_;
     QToolButton* restoreButton_;
+
+    KeyboardEventFilter* keyboardEventFilter_;
 };
 
 }  // namespace inviwo

--- a/include/inviwo/qt/editor/welcomewidget.h
+++ b/include/inviwo/qt/editor/welcomewidget.h
@@ -54,7 +54,6 @@ class WorkspaceGridView;
 class InviwoApplication;
 class ChangeLog;
 class WorkspaceFilter;
-class KeyboardEventFilter;
 
 class IVW_QTEDITOR_API WelcomeWidget : public QSplitter {
 #include <warn/push>
@@ -67,8 +66,6 @@ public:
 
     void updateRecentWorkspaces(const QStringList& list);
     void enableRestoreButton(bool hasRestoreWorkspace);
-
-    void updateLoadIcon(bool append, bool openWithPath);
 
 signals:
     void loadWorkspace(const QString& filename, bool isExample);
@@ -106,9 +103,8 @@ private:
     QTextEdit* details_;
     ChangeLog* changelog_;
     QToolButton* loadWorkspaceBtn_;
+    QToolButton* appendWorkspaceBtn_;
     QToolButton* restoreButton_;
-
-    KeyboardEventFilter* keyboardEventFilter_;
 };
 
 }  // namespace inviwo

--- a/include/inviwo/qt/editor/workspacegridview.h
+++ b/include/inviwo/qt/editor/workspacegridview.h
@@ -69,7 +69,7 @@ public:
     void collapseRecursively(const QModelIndex& index);
 
 signals:
-    void loadFile(QString filename, bool isExample);
+    void loadFile(const QString& filename, bool isExample);
     void selectFile(const QModelIndex& index);
 
 protected:

--- a/include/inviwo/qt/editor/workspacetreeview.h
+++ b/include/inviwo/qt/editor/workspacetreeview.h
@@ -63,7 +63,7 @@ public:
     void collapseRecursively(const QModelIndex& index);
 
 signals:
-    void loadFile(QString filename, bool isExample);
+    void loadFile(const QString& filename, bool isExample);
     void selectFile(const QModelIndex& index);
 };
 

--- a/modules/qtwidgets/include/modules/qtwidgets/keyboardutils.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/keyboardutils.h
@@ -40,13 +40,13 @@ class QKeyEvent;
 
 namespace inviwo {
 
-enum class ModifierAction { AppendWorkspace, OpenWithPath };
+enum class ModifierAction { None, AppendWorkspace, OpenWithPath };
 
 namespace util {
 
 IVW_MODULE_QTWIDGETS_API IvwKey mapKeyFromQt(const QKeyEvent* keyevent);
 
-IVW_MODULE_QTWIDGETS_API Qt::KeyboardModifier getKeyboardModifier(ModifierAction action);
+IVW_MODULE_QTWIDGETS_API ModifierAction getModifierAction(Qt::KeyboardModifiers modifiers);
 
 }  // namespace util
 

--- a/modules/qtwidgets/include/modules/qtwidgets/keyboardutils.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/keyboardutils.h
@@ -31,13 +31,22 @@
 #include <modules/qtwidgets/qtwidgetsmoduledefine.h>
 #include <inviwo/core/interaction/events/keyboardkeys.h>
 
+#include <warn/push>
+#include <warn/ignore/all>
+#include <QtCore/qnamespace.h>
+#include <warn/pop>
+
 class QKeyEvent;
 
 namespace inviwo {
 
+enum class ModifierAction { AppendWorkspace, OpenWithPath };
+
 namespace util {
 
 IVW_MODULE_QTWIDGETS_API IvwKey mapKeyFromQt(const QKeyEvent* keyevent);
+
+IVW_MODULE_QTWIDGETS_API Qt::KeyboardModifier getKeyboardModifier(ModifierAction action);
 
 }  // namespace util
 

--- a/modules/qtwidgets/include/modules/qtwidgets/properties/propertywidgetqt.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/properties/propertywidgetqt.h
@@ -123,7 +123,7 @@ private:
 
     const BaseCallBack* appModeCallback_;
 
-    const int maxNumNestedShades_;  //< This number has do match the number of shades in the qss.
+    const int maxNumNestedShades_;  //< This number has to match the number of shades in the qss.
     int nestedDepth_;
 };
 

--- a/modules/qtwidgets/src/keyboardutils.cpp
+++ b/modules/qtwidgets/src/keyboardutils.cpp
@@ -38,7 +38,6 @@
 // for Qt key codes
 #include <warn/push>
 #include <warn/ignore/all>
-#include <QtCore/qnamespace.h>
 #include <QKeyEvent>
 #include <warn/pop>
 
@@ -371,6 +370,17 @@ IvwKey mapKeyFromQt(const QKeyEvent* keyevent) {
 
         default:
             return IvwKey::Unknown;
+    }
+}
+
+Qt::KeyboardModifier getKeyboardModifier(ModifierAction action) {
+    switch (action) {
+        case ModifierAction::AppendWorkspace:
+            return Qt::ControlModifier;
+        case ModifierAction::OpenWithPath:
+            return Qt::ShiftModifier;
+        default:
+            return Qt::NoModifier;
     }
 }
 

--- a/modules/qtwidgets/src/keyboardutils.cpp
+++ b/modules/qtwidgets/src/keyboardutils.cpp
@@ -373,14 +373,13 @@ IvwKey mapKeyFromQt(const QKeyEvent* keyevent) {
     }
 }
 
-Qt::KeyboardModifier getKeyboardModifier(ModifierAction action) {
-    switch (action) {
-        case ModifierAction::AppendWorkspace:
-            return Qt::ControlModifier;
-        case ModifierAction::OpenWithPath:
-            return Qt::ShiftModifier;
-        default:
-            return Qt::NoModifier;
+ModifierAction getModifierAction(Qt::KeyboardModifiers modifiers) {
+    if (modifiers.testFlag(Qt::ControlModifier)) {
+        return ModifierAction::AppendWorkspace;
+    } else if (modifiers.testFlag(Qt::ShiftModifier)) {
+        return ModifierAction::OpenWithPath;
+    } else {
+        return ModifierAction::None;
     }
 }
 

--- a/resources/changelog.html
+++ b/resources/changelog.html
@@ -26,6 +26,8 @@
 </style>
 </head>
 <body>
+<h2>2022-09-02 Append workspace on Welcome Screen</h2>
+<p>Previously, the File menu received an "Append" functionality which appends a workspace to the current network by holding down Control/Command. This functionality is now also available in the Welcome Screen. The Welcome Screen also no longer immediately closes the current workspace, it is now possible to close the Welcome Screen and continue working without loosing any changes.</p>
 <h2>2022-08-16 New help system</h2>
 <p>The old processor help system based on doxygen and qhp has been removed in favor of a runtime system where help text is added to processor/port/properties at runtime. To add a help text to a processor now you add a new element to the ProcessorInfo for that processor like this</p>
 <div class="highlight highlight-source-c++"><pre><span class="pl-k">const</span> ProcessorInfo InstanceRenderer::processorInfo_{

--- a/resources/stylesheets/inviwo.qss
+++ b/resources/stylesheets/inviwo.qss
@@ -1038,11 +1038,11 @@ QSplitter#WelcomeWidget::handle:horizontal:pressed {
 }
 
 QSplitter#WelcomeWidget QToolButton {
-    font-size: 16pt;
+    font-size: 14pt;
 }
 QSplitter#WelcomeWidget QLineEdit {
     color: #c8ccd0;
-    font-size: 16pt;
+    font-size: 14pt;
     padding: 0.25em;
 }
 

--- a/src/qt/editor/inviwomainwindow.cpp
+++ b/src/qt/editor/inviwomainwindow.cpp
@@ -1267,7 +1267,7 @@ void InviwoMainWindow::appendWorkspace(const QString& file) {
     app_->processEvents();  // make sure the gui is ready before we unlock.
 }
 
-void InviwoMainWindow::saveWorkspace(QString workspaceFileName) {
+bool InviwoMainWindow::saveWorkspace(QString workspaceFileName) {
     std::string fileName{utilqt::fromQString(workspaceFileName)};
     fileName = filesystem::cleanupPath(fileName);
 
@@ -1284,22 +1284,24 @@ void InviwoMainWindow::saveWorkspace(QString workspaceFileName) {
         getNetworkEditor()->setModified(false);
         updateWindowTitle();
         LogInfo("Workspace saved to: " << fileName);
+        return true;
     } catch (const Exception& e) {
         util::log(e.getContext(),
                   "Unable to save network " + fileName + " due to " + e.getMessage(),
                   LogLevel::Error);
     }
+    return false;
 }
 
-void InviwoMainWindow::saveWorkspace() {
+bool InviwoMainWindow::saveWorkspace() {
     if (currentWorkspaceFileName_ == untitledWorkspaceName_)
-        saveWorkspaceAs();
+        return saveWorkspaceAs();
     else {
-        saveWorkspace(currentWorkspaceFileName_);
+        return saveWorkspace(currentWorkspaceFileName_);
     }
 }
 
-void InviwoMainWindow::saveWorkspaceAs() {
+bool InviwoMainWindow::saveWorkspaceAs() {
     InviwoFileDialog saveFileDialog(this, "Save Workspace ...", "workspace");
     saveFileDialog.setFileMode(FileMode::AnyFile);
     saveFileDialog.setAcceptMode(AcceptMode::Save);
@@ -1310,6 +1312,7 @@ void InviwoMainWindow::saveWorkspaceAs() {
 
     saveFileDialog.addExtension("inv", "Inviwo File");
 
+    bool savedWorkspace = false;
     if (saveFileDialog.exec()) {
         QString path = saveFileDialog.selectedFiles().at(0);
         if (!path.endsWith(".inv")) path.append(".inv");
@@ -1317,8 +1320,10 @@ void InviwoMainWindow::saveWorkspaceAs() {
         saveWorkspace(path);
         setCurrentWorkspace(path);
         addToRecentWorkspaces(path);
+        savedWorkspace = true;
     }
     saveWindowState();
+    return savedWorkspace;
 }
 
 void InviwoMainWindow::saveWorkspaceAsCopy() {
@@ -1337,8 +1342,9 @@ void InviwoMainWindow::saveWorkspaceAsCopy() {
 
         if (!path.endsWith(".inv")) path.append(".inv");
 
-        saveWorkspace(path);
-        addToRecentWorkspaces(path);
+        if (saveWorkspace(path)) {
+            addToRecentWorkspaces(path);
+        }
     }
     saveWindowState();
 }

--- a/src/qt/editor/welcomewidget.cpp
+++ b/src/qt/editor/welcomewidget.cpp
@@ -219,37 +219,11 @@ private:
     SearchDSL<QModelIndex> dsl_;
 };
 
-class KeyboardEventFilter : public QObject {
-public:
-    KeyboardEventFilter(WelcomeWidget* parent) : QObject(parent), widget_(parent) {}
-    virtual ~KeyboardEventFilter() = default;
-
-    virtual bool eventFilter(QObject*, QEvent* ev) override {
-        if (ev->type() == QEvent::KeyPress || ev->type() == QEvent::KeyRelease) {
-            update();
-        }
-        return false;
-    }
-
-    void update() {
-        const auto append = QApplication::queryKeyboardModifiers().testFlag(
-            util::getKeyboardModifier(ModifierAction::AppendWorkspace));
-        const auto openWithPath = QApplication::queryKeyboardModifiers().testFlag(
-            util::getKeyboardModifier(ModifierAction::OpenWithPath));
-
-        widget_->updateLoadIcon(append, openWithPath);
-    }
-
-private:
-    WelcomeWidget* widget_;
-};
-
 WelcomeWidget::WelcomeWidget(InviwoApplication* app, QWidget* parent)
     : QSplitter(parent)
     , app_(app)
     , model_(new WorkspaceTreeModel(app, this))
-    , filterModel_{new WorkspaceFilter{this}}
-    , keyboardEventFilter_{new KeyboardEventFilter(this)} {
+    , filterModel_{new WorkspaceFilter{this}} {
 
     setObjectName("WelcomeWidget");
 
@@ -302,16 +276,36 @@ WelcomeWidget::WelcomeWidget(InviwoApplication* app, QWidget* parent)
         leftSplitter->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
 
         {  // left column: workspace filter, list of recently used workspaces, and examples
-            auto load = [this](const QModelIndex& index) {
+
+            auto loadFile = [this](const QString& filename, bool isExample) {
+                auto action = util::getModifierAction(QApplication::keyboardModifiers());
+                switch (action) {
+                    case ModifierAction::AppendWorkspace:
+                        emit appendWorkspace(filename);
+                        break;
+                    case ModifierAction::OpenWithPath:
+                        emit loadWorkspace(filename, false);
+                        break;
+                    case ModifierAction::None:
+                    default:
+                        emit loadWorkspace(filename, isExample);
+                        break;
+                }
+            };
+            auto updateLoadButtons = [this](const QModelIndex& index) {
                 updateDetails(index);
                 loadWorkspaceBtn_->disconnect();
+                appendWorkspaceBtn_->disconnect();
 
                 if (index.isValid()) {
                     const auto filename = utilqt::getData(index, Role::FilePath).toString();
                     const auto isExample = utilqt::getData(index, Role::isExample).toBool();
+
                     QObject::connect(
                         loadWorkspaceBtn_, &QToolButton::clicked, this,
                         [this, filename, isExample]() { emit loadWorkspace(filename, isExample); });
+                    QObject::connect(appendWorkspaceBtn_, &QToolButton::clicked, this,
+                                     [this, filename]() { emit appendWorkspace(filename); });
                 }
             };
 
@@ -320,18 +314,18 @@ WelcomeWidget::WelcomeWidget(InviwoApplication* app, QWidget* parent)
             workspaceTreeView_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
             workspaceTreeView_->setVisible(!getSetting("showWorkSpaceGridView", true).toBool());
 
-            QObject::connect(workspaceTreeView_, &WorkspaceTreeView::loadFile, this,
-                             &WelcomeWidget::loadWorkspace);
-            QObject::connect(workspaceTreeView_, &WorkspaceTreeView::selectFile, this, load);
+            QObject::connect(workspaceTreeView_, &WorkspaceTreeView::loadFile, this, loadFile);
+            QObject::connect(workspaceTreeView_, &WorkspaceTreeView::selectFile, this,
+                             updateLoadButtons);
 
             workspaceGridView_ = new WorkspaceGridView(filterModel_, this);
             workspaceGridView_->setMinimumWidth(utilqt::emToPx(this, 25));
             workspaceGridView_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
             workspaceGridView_->setVisible(getSetting("showWorkSpaceGridView", true).toBool());
 
-            QObject::connect(workspaceGridView_, &WorkspaceGridView::loadFile, this,
-                             &WelcomeWidget::loadWorkspace);
-            QObject::connect(workspaceGridView_, &WorkspaceGridView::selectFile, this, load);
+            QObject::connect(workspaceGridView_, &WorkspaceGridView::loadFile, this, loadFile);
+            QObject::connect(workspaceGridView_, &WorkspaceGridView::selectFile, this,
+                             updateLoadButtons);
 
             auto toolbarLayout = new QHBoxLayout();
             filterLineEdit_ = new QLineEdit();
@@ -450,6 +444,10 @@ WelcomeWidget::WelcomeWidget(InviwoApplication* app, QWidget* parent)
             loadWorkspaceBtn_ = createButton("Load", ":/svgicons/open.svg",
                                              "Open selected workspace", "LoadWorkspaceToolButton");
             loadWorkspaceBtn_->setEnabled(false);
+            appendWorkspaceBtn_ = createButton("Append", ":/svgicons/open-append.svg",
+                                               "Append selected workspace to current one",
+                                               "AppendWorkspaceToolButton");
+            appendWorkspaceBtn_->setEnabled(false);
             auto horizontalSpacer =
                 new QSpacerItem(utilqt::emToPx(this, 2.0), utilqt::emToPx(this, 2.0),
                                 QSizePolicy::Expanding, QSizePolicy::Minimum);
@@ -473,7 +471,8 @@ WelcomeWidget::WelcomeWidget(InviwoApplication* app, QWidget* parent)
                              [this]() { emit restoreWorkspace(); });
             centerLayout->addLayout(buttonLayout);
 
-            setTabOrder(loadWorkspaceBtn_, newButton);
+            setTabOrder(loadWorkspaceBtn_, appendWorkspaceBtn_);
+            setTabOrder(appendWorkspaceBtn_, newButton);
             setTabOrder(newButton, openFileButton);
             setTabOrder(openFileButton, restoreButton_);
             setTabOrder(restoreButton_, details_);
@@ -579,22 +578,6 @@ void WelcomeWidget::enableRestoreButton(bool hasRestoreWorkspace) {
     restoreButton_->setEnabled(hasRestoreWorkspace);
 }
 
-void WelcomeWidget::updateLoadIcon(bool append, bool openWithPath) {
-    if (append) {
-        loadWorkspaceBtn_->setText("Append");
-        loadWorkspaceBtn_->setIcon(QIcon(":/svgicons/open-append.svg"));
-        loadWorkspaceBtn_->setToolTip("Append selected workspace to current one");
-    } else {
-        loadWorkspaceBtn_->setText("Load");
-        loadWorkspaceBtn_->setIcon(QIcon(":/svgicons/open.svg"));
-        if (openWithPath) {
-            loadWorkspaceBtn_->setToolTip("Open selected workspace with full path");
-        } else {
-            loadWorkspaceBtn_->setToolTip("Open selected workspace");
-        }
-    }
-}
-
 void WelcomeWidget::selectFirstLeaf() {
     // select first leaf node
     QTreeView* view = workspaceGridView_->isVisible() ? static_cast<QTreeView*>(workspaceGridView_)
@@ -636,18 +619,11 @@ void WelcomeWidget::showEvent(QShowEvent* event) {
         expandTreeView();
     }
 
-    QApplication::instance()->installEventFilter(keyboardEventFilter_);
-    keyboardEventFilter_->update();
-
     QSplitter::showEvent(event);
     filterLineEdit_->setFocus(Qt::OtherFocusReason);
 }
 
-void WelcomeWidget::hideEvent(QHideEvent* event) {
-    QApplication::instance()->removeEventFilter(keyboardEventFilter_);
-
-    QSplitter::hideEvent(event);
-}
+void WelcomeWidget::hideEvent(QHideEvent* event) { QSplitter::hideEvent(event); }
 
 void WelcomeWidget::keyPressEvent(QKeyEvent* event) {
     if ((event->key() >= Qt::Key_0) && (event->key() <= Qt::Key_9) &&
@@ -666,7 +642,12 @@ void WelcomeWidget::keyPressEvent(QKeyEvent* event) {
             event->accept();
         }
     } else if ((event->key() == Qt::Key_Return) || (event->key() == Qt::Key_Enter)) {
-        loadWorkspaceBtn_->animateClick();
+        auto action = util::getModifierAction(QApplication::queryKeyboardModifiers());
+        if (action == ModifierAction::AppendWorkspace) {
+            appendWorkspaceBtn_->animateClick();
+        } else {
+            loadWorkspaceBtn_->animateClick();
+        }
         event->accept();
     }
     QWidget::keyPressEvent(event);
@@ -689,6 +670,7 @@ std::string formatDescription(std::string_view str) {
 
 void WelcomeWidget::updateDetails(const QModelIndex& index) {
     loadWorkspaceBtn_->setEnabled(index.isValid());
+    appendWorkspaceBtn_->setEnabled(index.isValid());
     if (!index.isValid()) {
         dragAndDrop_->show();
         details_->hide();

--- a/src/qt/editor/workspacegridview.cpp
+++ b/src/qt/editor/workspacegridview.cpp
@@ -348,7 +348,11 @@ WorkspaceGridView::WorkspaceGridView(QAbstractItemModel* theModel, QWidget* pare
     setItemDelegate(new SectionDelegate(itemSize_, this));
     setIndentation(0);
 
-    // use custom selection model to prevent unselecting an already selected item
+    // use custom selection model to prevent unselecting an already selected item matching the
+    // behavior of the WorktreeTreeView widget. This also matches single file selection in
+    // Windows Explorer. Drag & drop of workspace files onto the Welcome widget is unaffected since
+    // the entire widget is a drop target.
+    //
     // see https://doc.qt.io/qt-6/qabstractitemview.html#SelectionMode-enum
     setSelectionModel(new SelectionModel(proxy_, this));
 


### PR DESCRIPTION
Fixes
* issue when aborting saving the old workspace, it just gets replaced and all changes are lost. Now opening the new workspace is aborted
* items in the gridview in the WelcomeWidget can be deselected

Changes proposed in this PR:
* "append workspace" from File menu is now integrated in WelcomeWidget
* added utility function to query modifiers (append, open with path)
* current workspace is not automatically closed when showing the welcome widget, this enables appending a workspace
* the state of processor and dock widgets is saved before showing the WelcomeWidget and restored when hiding it
* <kbd>Shift</kbd> is now used for opening example and test workspaces with full path since <kbd>Alt/Modifier</kbd> did not work well with the menu on Windows

![image](https://user-images.githubusercontent.com/9251300/188194415-22e8fe74-6c6b-4308-8ddc-5494df694396.png)


This has been tested on: Windows, MSVS 2022 17.3.2