### PR TITLE
OrdinalRefProperty fallback value

### DIFF
--- a/include/inviwo/core/properties/ordinalproperty.h
+++ b/include/inviwo/core/properties/ordinalproperty.h
@@ -34,6 +34,8 @@
 #include <inviwo/core/properties/constraintbehavior.h>
 #include <inviwo/core/util/glmvec.h>
 #include <inviwo/core/util/glmmat.h>
+#include <inviwo/core/util/glmmatext.h>
+#include <inviwo/core/util/glmfmt.h>
 
 #include <string>
 #include <type_traits>

--- a/include/inviwo/core/properties/ordinalproperty.h
+++ b/include/inviwo/core/properties/ordinalproperty.h
@@ -152,7 +152,7 @@ public:
     virtual OrdinalProperty<T>* clone() const override;
     virtual ~OrdinalProperty();
 
-    operator const T &() const;
+    operator const T&() const;
     const T& operator*() const;
     const T* operator->() const;
 
@@ -519,7 +519,7 @@ std::string OrdinalProperty<T>::getClassIdentifier() const {
 }
 
 template <typename T>
-OrdinalProperty<T>::operator const T &() const {
+OrdinalProperty<T>::operator const T&() const {
     return value_.value;
 }
 

--- a/include/inviwo/core/properties/ordinalproperty.h
+++ b/include/inviwo/core/properties/ordinalproperty.h
@@ -32,13 +32,14 @@
 #include <inviwo/core/common/inviwocoredefine.h>
 #include <inviwo/core/properties/property.h>
 #include <inviwo/core/properties/constraintbehavior.h>
-#include <inviwo/core/util/glm.h>
+#include <inviwo/core/util/glmvec.h>
+#include <inviwo/core/util/glmmat.h>
 
 #include <string>
 #include <type_traits>
 
-#include <fmt/format.h>
-#include <fmt/ostream.h>
+#include <fmt/core.h>
+#include <ostream>
 
 namespace inviwo {
 
@@ -149,7 +150,7 @@ public:
     virtual OrdinalProperty<T>* clone() const override;
     virtual ~OrdinalProperty();
 
-    operator const T&() const;
+    operator const T &() const;
     const T& operator*() const;
     const T* operator->() const;
 
@@ -423,9 +424,8 @@ struct PropertyTraits<OrdinalProperty<T>> {
     }
 };
 
-template <typename CTy, typename CTr, typename T>
-std::basic_ostream<CTy, CTr>& operator<<(std::basic_ostream<CTy, CTr>& os,
-                                         const OrdinalProperty<T>& prop) {
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const OrdinalProperty<T>& prop) {
     return os << prop.get();
 }
 
@@ -517,7 +517,7 @@ std::string OrdinalProperty<T>::getClassIdentifier() const {
 }
 
 template <typename T>
-OrdinalProperty<T>::operator const T&() const {
+OrdinalProperty<T>::operator const T &() const {
     return value_.value;
 }
 
@@ -811,3 +811,13 @@ extern template class IVW_CORE_TMPL_EXP OrdinalProperty<glm::fquat>;
 /// @endcond
 
 }  // namespace inviwo
+
+template <typename T>
+struct fmt::formatter<inviwo::OrdinalProperty<T>> : fmt::formatter<fmt::string_view> {
+    template <typename FormatContext>
+    auto format(const inviwo::OrdinalProperty<T>& prop, FormatContext& ctx) const {
+        fmt::memory_buffer buff;
+        fmt::format_to(std::back_inserter(buff), "{}", prop.get());
+        return formatter<fmt::string_view>::format(fmt::string_view(buff.data(), buff.size()), ctx);
+    }
+};

--- a/include/inviwo/core/properties/ordinalrefproperty.h
+++ b/include/inviwo/core/properties/ordinalrefproperty.h
@@ -540,7 +540,7 @@ void OrdinalRefProperty<T>::setMinValue(const T& newMinValue) {
     // Make sure min < max
     modified |= maxValue_.update(glm::max(maxValue_.value, minValue_.value));
 
-    auto val = clamp(get_());  // make sure we clamp after we update min/max    
+    auto val = clamp(get_());  // make sure we clamp after we update min/max
     if (val != get_()) {
         set_(val);
         modified = true;

--- a/include/inviwo/core/properties/ordinalrefproperty.h
+++ b/include/inviwo/core/properties/ordinalrefproperty.h
@@ -34,6 +34,8 @@
 #include <inviwo/core/properties/constraintbehavior.h>
 #include <inviwo/core/util/glmvec.h>
 #include <inviwo/core/util/glmmat.h>
+#include <inviwo/core/util/glmmatext.h>
+#include <inviwo/core/util/glmfmt.h>
 #include <inviwo/core/util/assertion.h>
 
 #include <string>
@@ -538,7 +540,7 @@ void OrdinalRefProperty<T>::setMinValue(const T& newMinValue) {
     // Make sure min < max
     modified |= maxValue_.update(glm::max(maxValue_.value, minValue_.value));
 
-    auto val = clamp(get_());  // make sure we clamp after we update min/max
+    auto val = clamp(get_());  // make sure we clamp after we update min/max    
     if (val != get_()) {
         set_(val);
         modified = true;

--- a/include/inviwo/core/properties/ordinalrefproperty.h
+++ b/include/inviwo/core/properties/ordinalrefproperty.h
@@ -32,14 +32,15 @@
 #include <inviwo/core/common/inviwocoredefine.h>
 #include <inviwo/core/properties/property.h>
 #include <inviwo/core/properties/constraintbehavior.h>
-#include <inviwo/core/util/glm.h>
+#include <inviwo/core/util/glmvec.h>
+#include <inviwo/core/util/glmmat.h>
 #include <inviwo/core/util/assertion.h>
 
 #include <string>
 #include <functional>
 
-#include <fmt/format.h>
-#include <fmt/ostream.h>
+#include <fmt/core.h>
+#include <ostream>
 
 namespace inviwo {
 
@@ -113,8 +114,7 @@ public:
 
     OrdinalRefProperty(
         std::string_view identifier, std::string_view displayName, Document help = {},
-        std::function<T()> get = []() { return T{}; },
-        std::function<void(const T&)> set = [](const T&) {},
+        std::function<T()> get = nullptr, std::function<void(const T&)> set = nullptr,
         const std::pair<T, ConstraintBehavior>& minValue = std::pair{Defaultvalues<T>::getMin(),
                                                                      ConstraintBehavior::Editable},
         const std::pair<T, ConstraintBehavior>& maxValue = std::pair{Defaultvalues<T>::getMax(),
@@ -244,6 +244,7 @@ public:
 private:
     std::function<T()> get_;
     std::function<void(const T&)> set_;
+    std::weak_ptr<ValueWrapper<T>> fallbackValue_;
     ValueWrapper<T> minValue_;
     ValueWrapper<T> maxValue_;
     ValueWrapper<T> increment_;
@@ -301,9 +302,8 @@ struct PropertyTraits<OrdinalRefProperty<T>> {
     }
 };
 
-template <typename CTy, typename CTr, typename T>
-std::basic_ostream<CTy, CTr>& operator<<(std::basic_ostream<CTy, CTr>& os,
-                                         const OrdinalRefProperty<T>& prop) {
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const OrdinalRefProperty<T>& prop) {
     return os << prop.get();
 }
 
@@ -318,14 +318,26 @@ OrdinalRefProperty<T>::OrdinalRefProperty(std::string_view identifier, std::stri
     : Property(identifier, displayName, std::move(help), invalidationLevel, semantics)
     , get_{std::move(get)}
     , set_{std::move(set)}
-    , minValue_("minvalue", minValue.first)
-    , maxValue_("maxvalue", maxValue.first)
-    , increment_("increment", increment)
+    , fallbackValue_{}
+    , minValue_{"minvalue", minValue.first}
+    , maxValue_{"maxvalue", maxValue.first}
+    , increment_{"increment", increment}
     , minConstraint_{"minConstraint", minValue.second}
     , maxConstraint_{"maxConstraint", maxValue.second} {
 
-    IVW_ASSERT(get_, "The getter has to be valid");
-    IVW_ASSERT(set_, "The setter has to be valid");
+    if (get_ && set_) {
+        // Valid case
+    } else if (!get_ && !set_) {
+        // Both default we assign a dummy
+        auto val = std::make_shared<ValueWrapper<T>>("fallbackValue", Defaultvalues<T>::getVal());
+        get_ = [val]() { return *val; };
+        set_ = [val](const T& newVal) { *val = newVal; };
+        fallbackValue_ = val;
+    } else {
+        // One valid and one not. One has to set both or none.
+        IVW_ASSERT(get_, "The getter has to be valid");
+        IVW_ASSERT(set_, "The setter has to be valid");
+    }
 
     if (!validRange(minValue_, maxValue_) || get_() != clamp(get_())) {
         throw Exception{
@@ -363,7 +375,22 @@ OrdinalRefProperty<T>::OrdinalRefProperty(std::string_view identifier, std::stri
                          state.semantics} {}
 
 template <typename T>
-OrdinalRefProperty<T>::OrdinalRefProperty(const OrdinalRefProperty<T>& rhs) = default;
+OrdinalRefProperty<T>::OrdinalRefProperty(const OrdinalRefProperty<T>& rhs)
+    : Property{rhs}
+    , get_{nullptr}
+    , set_{nullptr}
+    , fallbackValue_{}
+    , minValue_{rhs.minValue_}
+    , maxValue_{rhs.maxValue_}
+    , increment_{rhs.increment_}
+    , minConstraint_{rhs.minConstraint_}
+    , maxConstraint_{rhs.maxConstraint_} {
+
+    auto val = std::make_shared<ValueWrapper<T>>("fallbackValue", rhs.get());
+    get_ = [val]() { return *val; };
+    set_ = [val](const T& newVal) { *val = newVal; };
+    fallbackValue_ = val;
+}
 
 template <typename T>
 OrdinalRefProperty<T>& OrdinalRefProperty<T>::operator=(const T& value) {
@@ -565,6 +592,9 @@ void OrdinalRefProperty<T>::setIncrement(const T& newInc) {
 template <typename T>
 OrdinalRefProperty<T>& OrdinalRefProperty<T>::resetToDefaultState() {
     bool modified = false;
+    if (auto value = fallbackValue_.lock()) {
+        modified |= value->reset();
+    }
     modified |= minValue_.reset();
     modified |= maxValue_.reset();
     modified |= increment_.reset();
@@ -574,12 +604,20 @@ OrdinalRefProperty<T>& OrdinalRefProperty<T>::resetToDefaultState() {
 
 template <typename T>
 bool OrdinalRefProperty<T>::isDefaultState() const {
-    return increment_.isDefault() && minValue_.isDefault() && maxValue_.isDefault();
+    if (auto value = fallbackValue_.lock()) {
+        return value->isDefault() && increment_.isDefault() && minValue_.isDefault() &&
+               maxValue_.isDefault();
+    } else {
+        return increment_.isDefault() && minValue_.isDefault() && maxValue_.isDefault();
+    }
 }
 
 template <typename T>
 OrdinalRefProperty<T>& OrdinalRefProperty<T>::setCurrentStateAsDefault() {
     Property::setCurrentStateAsDefault();
+    if (auto value = fallbackValue_.lock()) {
+        value->setAsDefault();
+    }
     minValue_.setAsDefault();
     maxValue_.setAsDefault();
     increment_.setAsDefault();
@@ -599,6 +637,13 @@ template <typename T>
 void OrdinalRefProperty<T>::serialize(Serializer& s) const {
     Property::serialize(s);
 
+    if (auto value = fallbackValue_.lock()) {
+        value->serialize(s, this->serializationMode_);
+    } else {
+        ValueWrapper<T> val{"fallbackValue", get()};
+        val.serialize(s, this->serializationMode_);
+    }
+
     minConstraint_.serialize(s, this->serializationMode_);
     maxConstraint_.serialize(s, this->serializationMode_);
     minValue_.serialize(s, this->serializationMode_);
@@ -611,6 +656,9 @@ void OrdinalRefProperty<T>::deserialize(Deserializer& d) {
     Property::deserialize(d);
 
     bool modified = false;
+    if (auto value = fallbackValue_.lock()) {
+        modified |= value->deserialize(d, this->serializationMode_);
+    }
     modified |= minConstraint_.deserialize(d, this->serializationMode_);
     modified |= maxConstraint_.deserialize(d, this->serializationMode_);
     modified |= minValue_.deserialize(d, this->serializationMode_);
@@ -716,3 +764,13 @@ extern template class IVW_CORE_TMPL_EXP OrdinalRefProperty<glm::fquat>;
 /// @endcond
 
 }  // namespace inviwo
+
+template <typename T>
+struct fmt::formatter<inviwo::OrdinalRefProperty<T>> : fmt::formatter<fmt::string_view> {
+    template <typename FormatContext>
+    auto format(const inviwo::OrdinalRefProperty<T>& prop, FormatContext& ctx) const {
+        fmt::memory_buffer buff;
+        fmt::format_to(std::back_inserter(buff), "{}", prop.get());
+        return formatter<fmt::string_view>::format(fmt::string_view(buff.data(), buff.size()), ctx);
+    }
+};

--- a/include/inviwo/core/util/glm.h
+++ b/include/inviwo/core/util/glm.h
@@ -34,6 +34,8 @@
 #include <inviwo/core/util/glmmat.h>
 #include <inviwo/core/util/glmutils.h>
 #include <inviwo/core/util/glmconvert.h>
+#include <inviwo/core/util/glmmatext.h>
+#include <inviwo/core/util/glmfmt.h>
 
 #include <warn/push>
 #include <warn/ignore/all>
@@ -66,9 +68,6 @@
 #include <limits>
 #include <type_traits>
 #include <utility>
-
-#include <fmt/format.h>
-#include <fmt/ostream.h>
 
 namespace inviwo {
 
@@ -291,200 +290,6 @@ bool almostEqual(const T& x, const T& y, int ulp = 2) {
 }  // namespace inviwo
 
 namespace glm {
-
-namespace detail {
-
-// Vectorize mat
-template <typename F, length_t C, length_t R, typename T, qualifier Q, size_t... Is>
-constexpr auto vectorize_mat_helper(F&& f, const mat<C, R, T, Q>& a, std::index_sequence<Is...>) {
-    using U = decltype(std::forward<F>(f)(value_ptr(a)[0]));
-    return mat<C, R, U, Q>{std::forward<F>(f)(value_ptr(a)[Is])...};
-}
-template <typename F, length_t C, length_t R, typename T, qualifier Q>
-constexpr auto vectorize_mat(F&& f, const mat<C, R, T, Q>& a) {
-    return vectorize_mat_helper(std::forward<F>(f), a, std::make_index_sequence<C * R>{});
-}
-
-// Vectorize mat scalar
-template <typename F, length_t C, length_t R, typename T, qualifier Q, typename Scalar,
-          size_t... Is>
-constexpr auto vectorize_mat_scalar_helper(F&& f, const mat<C, R, T, Q>& a, Scalar s,
-                                           std::index_sequence<Is...>) {
-    using U = decltype(std::forward<F>(f)(value_ptr(a)[0], s));
-    return mat<C, R, U, Q>{std::forward<F>(f)(value_ptr(a)[Is], s)...};
-}
-template <typename F, length_t C, length_t R, typename T, qualifier Q, typename Scalar>
-constexpr auto vectorize_mat_scalar(F&& f, const mat<C, R, T, Q>& a, Scalar s) {
-    return vectorize_mat_scalar_helper(std::forward<F>(f), a, s, std::make_index_sequence<C * R>{});
-}
-
-// Vectorize mat scalar scalar
-template <typename F, length_t C, length_t R, typename T, qualifier Q, typename Scalar,
-          size_t... Is>
-constexpr auto vectorize_mat_scalar_scalar_helper(F&& f, const mat<C, R, T, Q>& a, Scalar s1,
-                                                  Scalar s2, std::index_sequence<Is...>) {
-    using U = decltype(std::forward<F>(f)(value_ptr(a)[0], s1, s2));
-    return mat<C, R, U, Q>{std::forward<F>(f)(value_ptr(a)[Is], s1, s2)...};
-}
-template <typename F, length_t C, length_t R, typename T, qualifier Q, typename Scalar>
-constexpr auto vectorize_mat_scalar_scalar(F&& f, const mat<C, R, T, Q>& a, Scalar s1, Scalar s2) {
-    return vectorize_mat_scalar_scalar_helper(std::forward<F>(f), a, s1, s2,
-                                              std::make_index_sequence<C * R>{});
-}
-
-// Vectorize mat mat
-template <typename F, length_t C, length_t R, typename T, typename V, qualifier Q, size_t... Is>
-constexpr auto vectorize_mat_mat_helper(F&& f, const mat<C, R, T, Q>& a, const mat<C, R, V, Q>& b,
-                                        std::index_sequence<Is...>) {
-    using U = decltype(std::forward<F>(f)(value_ptr(a)[0], value_ptr(b)[0]));
-    return mat<C, R, U, Q>{std::forward<F>(f)(value_ptr(a)[Is], value_ptr(b)[Is])...};
-}
-template <typename F, length_t C, length_t R, typename T, typename V, qualifier Q>
-constexpr auto vectorize_mat_mat(F&& f, const mat<C, R, T, Q>& a, const mat<C, R, V, Q>& b) {
-    return vectorize_mat_mat_helper(std::forward<F>(f), a, b, std::make_index_sequence<C * R>{});
-}
-
-// Vectorize mat mat scalar
-template <typename F, length_t C, length_t R, typename T, typename V, qualifier Q, typename Scalar,
-          size_t... Is>
-constexpr auto vectorize_mat_mat_scalar_helper(F&& f, const mat<C, R, T, Q>& a,
-                                               const mat<C, R, V, Q>& b, Scalar s,
-                                               std::index_sequence<Is...>) {
-    using U = decltype(std::forward<F>(f)(value_ptr(a)[0], value_ptr(b)[0], s));
-    return mat<C, R, U, Q>{std::forward<F>(f)(value_ptr(a)[Is], value_ptr(b)[Is], s)...};
-}
-template <typename F, length_t C, length_t R, typename T, typename V, qualifier Q, typename Scalar>
-constexpr auto vectorize_mat_mat_scalar(F&& f, const mat<C, R, T, Q>& a, const mat<C, R, V, Q>& b,
-                                        Scalar s) {
-    return vectorize_mat_mat_scalar_helper(std::forward<F>(f), a, b, s,
-                                           std::make_index_sequence<C * R>{});
-}
-
-// Vectorize mat mat mat
-template <typename F, length_t C, length_t R, typename T, typename V, typename W, qualifier Q,
-          size_t... Is>
-constexpr auto vectorize_mat_mat_mat_helper(F&& f, const mat<C, R, T, Q>& a,
-                                            const mat<C, R, V, Q>& b, const mat<C, R, W, Q>& c,
-                                            std::index_sequence<Is...>) {
-    using U = decltype(std::forward<F>(f)(value_ptr(a)[0], value_ptr(b)[0], value_ptr(c)[0]));
-    return mat<C, R, U, Q>{
-        std::forward<F>(f)(value_ptr(a)[Is], value_ptr(b)[Is], value_ptr(c)[Is])...};
-}
-template <typename F, length_t C, length_t R, typename T, typename V, typename W, qualifier Q>
-constexpr auto vectorize_mat_mat_mat(F&& f, const mat<C, R, T, Q>& a, const mat<C, R, V, Q>& b,
-                                     const mat<C, R, W, Q>& c) {
-    return vectorize_mat_mat_mat_helper(std::forward<F>(f), a, b, c,
-                                        std::make_index_sequence<C * R>{});
-}
-
-}  // namespace detail
-
-template <length_t C, length_t R, typename T, qualifier Q>
-GLM_FUNC_QUALIFIER mat<C, R, T, Q> abs(const mat<C, R, T, Q>& a) {
-    return detail::vectorize_mat(static_cast<T (*)(T)>(abs), a);
-}
-template <length_t C, length_t R, typename T, qualifier Q>
-GLM_FUNC_QUALIFIER mat<C, R, T, Q> sign(const mat<C, R, T, Q>& a) {
-    return detail::vectorize_mat(static_cast<T (*)(T)>(sign), a);
-}
-template <length_t C, length_t R, typename T, qualifier Q>
-GLM_FUNC_QUALIFIER mat<C, R, T, Q> floor(const mat<C, R, T, Q>& a) {
-    return detail::vectorize_mat(static_cast<T (*)(T)>(floor), a);
-}
-template <length_t C, length_t R, typename T, qualifier Q>
-GLM_FUNC_QUALIFIER mat<C, R, T, Q> trunc(const mat<C, R, T, Q>& a) {
-    return detail::vectorize_mat(static_cast<T (*)(T)>(trunc), a);
-}
-template <length_t C, length_t R, typename T, qualifier Q>
-GLM_FUNC_QUALIFIER mat<C, R, T, Q> round(const mat<C, R, T, Q>& a) {
-    return detail::vectorize_mat(static_cast<T (*)(T)>(round), a);
-}
-template <length_t C, length_t R, typename T, qualifier Q>
-GLM_FUNC_QUALIFIER mat<C, R, T, Q> roundEven(const mat<C, R, T, Q>& a) {
-    return detail::vectorize_mat(static_cast<T (*)(T)>(roundEven), a);
-}
-template <length_t C, length_t R, typename T, qualifier Q>
-GLM_FUNC_QUALIFIER mat<C, R, T, Q> ceil(const mat<C, R, T, Q>& a) {
-    return detail::vectorize_mat(static_cast<T (*)(T)>(ceil), a);
-}
-template <length_t C, length_t R, typename T, qualifier Q>
-GLM_FUNC_QUALIFIER mat<C, R, T, Q> fract(const mat<C, R, T, Q>& a) {
-    return detail::vectorize_mat(static_cast<T (*)(T)>(fract), a);
-}
-
-template <length_t C, length_t R, typename T, qualifier Q, typename Scalar>
-GLM_FUNC_QUALIFIER mat<C, R, T, Q> mod(const mat<C, R, T, Q>& a, Scalar s) {
-    return detail::vectorize_mat_scalar(static_cast<T (*)(T, T)>(mod), a, s);
-}
-
-template <length_t C, length_t R, typename T, qualifier Q>
-GLM_FUNC_QUALIFIER mat<C, R, T, Q> min(const mat<C, R, T, Q>& a, T s) {
-    return detail::vectorize_mat_scalar(static_cast<T (*)(T, T)>(min), a, s);
-}
-template <length_t C, length_t R, typename T, qualifier Q>
-GLM_FUNC_QUALIFIER mat<C, R, T, Q> min(T s, const mat<C, R, T, Q>& a) {
-    return detail::vectorize_mat_scalar(static_cast<T (*)(T, T)>(min), a, s);
-}
-
-template <length_t C, length_t R, typename T, qualifier Q>
-GLM_FUNC_QUALIFIER mat<C, R, T, Q> max(const mat<C, R, T, Q>& a, T s) {
-    return detail::vectorize_mat_scalar(static_cast<T (*)(T, T)>(max), a, s);
-}
-template <length_t C, length_t R, typename T, qualifier Q>
-GLM_FUNC_QUALIFIER mat<C, R, T, Q> max(T s, const mat<C, R, T, Q>& a) {
-    return detail::vectorize_mat_scalar(static_cast<T (*)(T, T)>(max), a, s);
-}
-
-template <length_t C, length_t R, typename T, qualifier Q>
-GLM_FUNC_QUALIFIER mat<C, R, T, Q> min(const mat<C, R, T, Q>& a, const mat<C, R, T, Q>& b) {
-    return detail::vectorize_mat_mat(static_cast<T (*)(T, T)>(min), a, b);
-}
-template <length_t C, length_t R, typename T, qualifier Q>
-GLM_FUNC_QUALIFIER mat<C, R, T, Q> max(const mat<C, R, T, Q>& a, const mat<C, R, T, Q>& b) {
-    return detail::vectorize_mat_mat(static_cast<T (*)(T, T)>(max), a, b);
-}
-
-template <length_t C, length_t R, typename T, qualifier Q, typename Scalar>
-GLM_FUNC_QUALIFIER mat<C, R, T, Q> mix(const mat<C, R, T, Q>& a, const mat<C, R, T, Q>& b,
-                                       Scalar s) {
-    return detail::vectorize_mat_mat_scalar(static_cast<T (*)(T, T, Scalar)>(mix), a, b, s);
-}
-
-template <length_t C, length_t R, typename T, qualifier Q, typename Scalar>
-GLM_FUNC_QUALIFIER mat<C, R, T, Q> clamp(const mat<C, R, T, Q>& a, Scalar s1, Scalar s2) {
-    return detail::vectorize_mat_scalar_scalar(static_cast<T (*)(T, Scalar, Scalar)>(clamp), a, s1,
-                                               s2);
-}
-
-template <length_t C, length_t R, typename T, qualifier Q>
-GLM_FUNC_QUALIFIER mat<C, R, T, Q> clamp(const mat<C, R, T, Q>& a, const mat<C, R, T, Q>& b,
-                                         const mat<C, R, T, Q>& c) {
-    return detail::vectorize_mat_mat_mat(static_cast<T (*)(T, T, T)>(clamp), a, b, c);
-}
-
-// Quats
-template <typename T, precision P>
-GLM_FUNC_QUALIFIER tquat<T, P> clamp(tquat<T, P> const& q, T a, T b) {
-    return {clamp(q[0], a, b), clamp(q[1], a, b), clamp(q[2], a, b), clamp(q[3], a, b)};
-}
-
-template <typename T, precision P>
-GLM_FUNC_QUALIFIER tquat<T, P> clamp(tquat<T, P> const& q, const tquat<T, P>& a,
-                                     const tquat<T, P>& b) {
-    return {clamp(q[0], a[0], b[0]), clamp(q[1], a[1], b[1]), clamp(q[2], a[2], b[2]),
-            clamp(q[3], a[3], b[3])};
-}
-
-template <typename T, precision P>
-GLM_FUNC_QUALIFIER tquat<T, P> min(const tquat<T, P>& a, const tquat<T, P>& b) {
-    return {min(a[0], b[0]), min(a[1], b[1]), min(a[2], b[2]), min(a[3], b[3])};
-}
-
-template <typename T, precision P>
-GLM_FUNC_QUALIFIER tquat<T, P> max(const tquat<T, P>& a, const tquat<T, P>& b) {
-    return {max(a[0], b[0]), max(a[1], b[1]), max(a[2], b[2]), max(a[3], b[3])};
-}
-
 namespace detail {
 #ifdef DARWIN
 // Adding missing template specialization for size_t
@@ -507,7 +312,6 @@ template <std::size_t N, glm::length_t L, typename T, glm::qualifier Q>
 decltype(auto) get(glm::vec<L, T, Q>& vec) {
     return vec[N];
 }
-
 }  // namespace glm
 
 // Needed to get structured bindings to work for glm vecs
@@ -518,12 +322,3 @@ template <std::size_t N, glm::length_t L, typename T, glm::qualifier Q>
 struct std::tuple_element<N, glm::vec<L, T, Q>> {
     using type = T;
 };
-
-template <glm::length_t L, typename T, glm::qualifier Q>
-struct fmt::formatter<glm::vec<L, T, Q>> : fmt::ostream_formatter {};
-
-template <glm::length_t C, glm::length_t R, typename T, glm::qualifier Q>
-struct fmt::formatter<glm::mat<C, R, T, Q>> : fmt::ostream_formatter {};
-
-template <typename T, glm::qualifier Q>
-struct fmt::formatter<glm::qua<T, Q>> : fmt::ostream_formatter {};

--- a/include/inviwo/core/util/glmfmt.h
+++ b/include/inviwo/core/util/glmfmt.h
@@ -1,0 +1,46 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2022 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <inviwo/core/util/glmvec.h>
+#include <inviwo/core/util/glmmat.h>
+#include <glm/detail/type_quat.hpp>
+#include <glm/gtx/io.hpp>
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
+template <glm::length_t L, typename T, glm::qualifier Q>
+struct fmt::formatter<glm::vec<L, T, Q>> : fmt::ostream_formatter {};
+
+template <glm::length_t C, glm::length_t R, typename T, glm::qualifier Q>
+struct fmt::formatter<glm::mat<C, R, T, Q>> : fmt::ostream_formatter {};
+
+template <typename T, glm::qualifier Q>
+struct fmt::formatter<glm::qua<T, Q>> : fmt::ostream_formatter {};

--- a/include/inviwo/core/util/glmmatext.h
+++ b/include/inviwo/core/util/glmmatext.h
@@ -1,0 +1,231 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2022 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <inviwo/core/util/glmmat.h>
+#include <glm/gtc/type_ptr.hpp>
+#include <utility>
+
+// Add a bunch of element wise functions to glm which are not defined
+namespace glm {
+
+namespace detail {
+
+// Vectorize mat
+template <typename F, length_t C, length_t R, typename T, qualifier Q, size_t... Is>
+constexpr auto vectorize_mat_helper(F&& f, const mat<C, R, T, Q>& a, std::index_sequence<Is...>) {
+    using U = decltype(std::forward<F>(f)(value_ptr(a)[0]));
+    return mat<C, R, U, Q>{std::forward<F>(f)(value_ptr(a)[Is])...};
+}
+template <typename F, length_t C, length_t R, typename T, qualifier Q>
+constexpr auto vectorize_mat(F&& f, const mat<C, R, T, Q>& a) {
+    return vectorize_mat_helper(std::forward<F>(f), a, std::make_index_sequence<C * R>{});
+}
+
+// Vectorize mat scalar
+template <typename F, length_t C, length_t R, typename T, qualifier Q, typename Scalar,
+          size_t... Is>
+constexpr auto vectorize_mat_scalar_helper(F&& f, const mat<C, R, T, Q>& a, Scalar s,
+                                           std::index_sequence<Is...>) {
+    using U = decltype(std::forward<F>(f)(value_ptr(a)[0], s));
+    return mat<C, R, U, Q>{std::forward<F>(f)(value_ptr(a)[Is], s)...};
+}
+template <typename F, length_t C, length_t R, typename T, qualifier Q, typename Scalar>
+constexpr auto vectorize_mat_scalar(F&& f, const mat<C, R, T, Q>& a, Scalar s) {
+    return vectorize_mat_scalar_helper(std::forward<F>(f), a, s, std::make_index_sequence<C * R>{});
+}
+
+// Vectorize mat scalar scalar
+template <typename F, length_t C, length_t R, typename T, qualifier Q, typename Scalar,
+          size_t... Is>
+constexpr auto vectorize_mat_scalar_scalar_helper(F&& f, const mat<C, R, T, Q>& a, Scalar s1,
+                                                  Scalar s2, std::index_sequence<Is...>) {
+    using U = decltype(std::forward<F>(f)(value_ptr(a)[0], s1, s2));
+    return mat<C, R, U, Q>{std::forward<F>(f)(value_ptr(a)[Is], s1, s2)...};
+}
+template <typename F, length_t C, length_t R, typename T, qualifier Q, typename Scalar>
+constexpr auto vectorize_mat_scalar_scalar(F&& f, const mat<C, R, T, Q>& a, Scalar s1, Scalar s2) {
+    return vectorize_mat_scalar_scalar_helper(std::forward<F>(f), a, s1, s2,
+                                              std::make_index_sequence<C * R>{});
+}
+
+// Vectorize mat mat
+template <typename F, length_t C, length_t R, typename T, typename V, qualifier Q, size_t... Is>
+constexpr auto vectorize_mat_mat_helper(F&& f, const mat<C, R, T, Q>& a, const mat<C, R, V, Q>& b,
+                                        std::index_sequence<Is...>) {
+    using U = decltype(std::forward<F>(f)(value_ptr(a)[0], value_ptr(b)[0]));
+    return mat<C, R, U, Q>{std::forward<F>(f)(value_ptr(a)[Is], value_ptr(b)[Is])...};
+}
+template <typename F, length_t C, length_t R, typename T, typename V, qualifier Q>
+constexpr auto vectorize_mat_mat(F&& f, const mat<C, R, T, Q>& a, const mat<C, R, V, Q>& b) {
+    return vectorize_mat_mat_helper(std::forward<F>(f), a, b, std::make_index_sequence<C * R>{});
+}
+
+// Vectorize mat mat scalar
+template <typename F, length_t C, length_t R, typename T, typename V, qualifier Q, typename Scalar,
+          size_t... Is>
+constexpr auto vectorize_mat_mat_scalar_helper(F&& f, const mat<C, R, T, Q>& a,
+                                               const mat<C, R, V, Q>& b, Scalar s,
+                                               std::index_sequence<Is...>) {
+    using U = decltype(std::forward<F>(f)(value_ptr(a)[0], value_ptr(b)[0], s));
+    return mat<C, R, U, Q>{std::forward<F>(f)(value_ptr(a)[Is], value_ptr(b)[Is], s)...};
+}
+template <typename F, length_t C, length_t R, typename T, typename V, qualifier Q, typename Scalar>
+constexpr auto vectorize_mat_mat_scalar(F&& f, const mat<C, R, T, Q>& a, const mat<C, R, V, Q>& b,
+                                        Scalar s) {
+    return vectorize_mat_mat_scalar_helper(std::forward<F>(f), a, b, s,
+                                           std::make_index_sequence<C * R>{});
+}
+
+// Vectorize mat mat mat
+template <typename F, length_t C, length_t R, typename T, typename V, typename W, qualifier Q,
+          size_t... Is>
+constexpr auto vectorize_mat_mat_mat_helper(F&& f, const mat<C, R, T, Q>& a,
+                                            const mat<C, R, V, Q>& b, const mat<C, R, W, Q>& c,
+                                            std::index_sequence<Is...>) {
+    using U = decltype(std::forward<F>(f)(value_ptr(a)[0], value_ptr(b)[0], value_ptr(c)[0]));
+    return mat<C, R, U, Q>{
+        std::forward<F>(f)(value_ptr(a)[Is], value_ptr(b)[Is], value_ptr(c)[Is])...};
+}
+template <typename F, length_t C, length_t R, typename T, typename V, typename W, qualifier Q>
+constexpr auto vectorize_mat_mat_mat(F&& f, const mat<C, R, T, Q>& a, const mat<C, R, V, Q>& b,
+                                     const mat<C, R, W, Q>& c) {
+    return vectorize_mat_mat_mat_helper(std::forward<F>(f), a, b, c,
+                                        std::make_index_sequence<C * R>{});
+}
+
+}  // namespace detail
+
+template <length_t C, length_t R, typename T, qualifier Q>
+GLM_FUNC_QUALIFIER mat<C, R, T, Q> abs(const mat<C, R, T, Q>& a) {
+    return detail::vectorize_mat(static_cast<T (*)(T)>(abs), a);
+}
+template <length_t C, length_t R, typename T, qualifier Q>
+GLM_FUNC_QUALIFIER mat<C, R, T, Q> sign(const mat<C, R, T, Q>& a) {
+    return detail::vectorize_mat(static_cast<T (*)(T)>(sign), a);
+}
+template <length_t C, length_t R, typename T, qualifier Q>
+GLM_FUNC_QUALIFIER mat<C, R, T, Q> floor(const mat<C, R, T, Q>& a) {
+    return detail::vectorize_mat(static_cast<T (*)(T)>(floor), a);
+}
+template <length_t C, length_t R, typename T, qualifier Q>
+GLM_FUNC_QUALIFIER mat<C, R, T, Q> trunc(const mat<C, R, T, Q>& a) {
+    return detail::vectorize_mat(static_cast<T (*)(T)>(trunc), a);
+}
+template <length_t C, length_t R, typename T, qualifier Q>
+GLM_FUNC_QUALIFIER mat<C, R, T, Q> round(const mat<C, R, T, Q>& a) {
+    return detail::vectorize_mat(static_cast<T (*)(T)>(round), a);
+}
+template <length_t C, length_t R, typename T, qualifier Q>
+GLM_FUNC_QUALIFIER mat<C, R, T, Q> roundEven(const mat<C, R, T, Q>& a) {
+    return detail::vectorize_mat(static_cast<T (*)(T)>(roundEven), a);
+}
+template <length_t C, length_t R, typename T, qualifier Q>
+GLM_FUNC_QUALIFIER mat<C, R, T, Q> ceil(const mat<C, R, T, Q>& a) {
+    return detail::vectorize_mat(static_cast<T (*)(T)>(ceil), a);
+}
+template <length_t C, length_t R, typename T, qualifier Q>
+GLM_FUNC_QUALIFIER mat<C, R, T, Q> fract(const mat<C, R, T, Q>& a) {
+    return detail::vectorize_mat(static_cast<T (*)(T)>(fract), a);
+}
+
+template <length_t C, length_t R, typename T, qualifier Q, typename Scalar>
+GLM_FUNC_QUALIFIER mat<C, R, T, Q> mod(const mat<C, R, T, Q>& a, Scalar s) {
+    return detail::vectorize_mat_scalar(static_cast<T (*)(T, T)>(mod), a, s);
+}
+
+template <length_t C, length_t R, typename T, qualifier Q>
+GLM_FUNC_QUALIFIER mat<C, R, T, Q> min(const mat<C, R, T, Q>& a, T s) {
+    return detail::vectorize_mat_scalar(static_cast<T (*)(T, T)>(min), a, s);
+}
+template <length_t C, length_t R, typename T, qualifier Q>
+GLM_FUNC_QUALIFIER mat<C, R, T, Q> min(T s, const mat<C, R, T, Q>& a) {
+    return detail::vectorize_mat_scalar(static_cast<T (*)(T, T)>(min), a, s);
+}
+
+template <length_t C, length_t R, typename T, qualifier Q>
+GLM_FUNC_QUALIFIER mat<C, R, T, Q> max(const mat<C, R, T, Q>& a, T s) {
+    return detail::vectorize_mat_scalar(static_cast<T (*)(T, T)>(max), a, s);
+}
+template <length_t C, length_t R, typename T, qualifier Q>
+GLM_FUNC_QUALIFIER mat<C, R, T, Q> max(T s, const mat<C, R, T, Q>& a) {
+    return detail::vectorize_mat_scalar(static_cast<T (*)(T, T)>(max), a, s);
+}
+
+template <length_t C, length_t R, typename T, qualifier Q>
+GLM_FUNC_QUALIFIER mat<C, R, T, Q> min(const mat<C, R, T, Q>& a, const mat<C, R, T, Q>& b) {
+    return detail::vectorize_mat_mat(static_cast<T (*)(T, T)>(min), a, b);
+}
+template <length_t C, length_t R, typename T, qualifier Q>
+GLM_FUNC_QUALIFIER mat<C, R, T, Q> max(const mat<C, R, T, Q>& a, const mat<C, R, T, Q>& b) {
+    return detail::vectorize_mat_mat(static_cast<T (*)(T, T)>(max), a, b);
+}
+
+template <length_t C, length_t R, typename T, qualifier Q, typename Scalar>
+GLM_FUNC_QUALIFIER mat<C, R, T, Q> mix(const mat<C, R, T, Q>& a, const mat<C, R, T, Q>& b,
+                                       Scalar s) {
+    return detail::vectorize_mat_mat_scalar(static_cast<T (*)(T, T, Scalar)>(mix), a, b, s);
+}
+
+template <length_t C, length_t R, typename T, qualifier Q, typename Scalar>
+GLM_FUNC_QUALIFIER mat<C, R, T, Q> clamp(const mat<C, R, T, Q>& a, Scalar s1, Scalar s2) {
+    return detail::vectorize_mat_scalar_scalar(static_cast<T (*)(T, Scalar, Scalar)>(clamp), a, s1,
+                                               s2);
+}
+
+template <length_t C, length_t R, typename T, qualifier Q>
+GLM_FUNC_QUALIFIER mat<C, R, T, Q> clamp(const mat<C, R, T, Q>& a, const mat<C, R, T, Q>& b,
+                                         const mat<C, R, T, Q>& c) {
+    return detail::vectorize_mat_mat_mat(static_cast<T (*)(T, T, T)>(clamp), a, b, c);
+}
+
+// Quats
+template <typename T, precision P>
+GLM_FUNC_QUALIFIER tquat<T, P> clamp(tquat<T, P> const& q, T a, T b) {
+    return {clamp(q[0], a, b), clamp(q[1], a, b), clamp(q[2], a, b), clamp(q[3], a, b)};
+}
+
+template <typename T, precision P>
+GLM_FUNC_QUALIFIER tquat<T, P> clamp(tquat<T, P> const& q, const tquat<T, P>& a,
+                                     const tquat<T, P>& b) {
+    return {clamp(q[0], a[0], b[0]), clamp(q[1], a[1], b[1]), clamp(q[2], a[2], b[2]),
+            clamp(q[3], a[3], b[3])};
+}
+
+template <typename T, precision P>
+GLM_FUNC_QUALIFIER tquat<T, P> min(const tquat<T, P>& a, const tquat<T, P>& b) {
+    return {min(a[0], b[0]), min(a[1], b[1]), min(a[2], b[2]), min(a[3], b[3])};
+}
+
+template <typename T, precision P>
+GLM_FUNC_QUALIFIER tquat<T, P> max(const tquat<T, P>& a, const tquat<T, P>& b) {
+    return {max(a[0], b[0]), max(a[1], b[1]), max(a[2], b[2]), max(a[3], b[3])};
+}
+
+}  // namespace glm

--- a/modules/base/include/modules/base/properties/transformlistproperty.h
+++ b/modules/base/include/modules/base/properties/transformlistproperty.h
@@ -34,6 +34,7 @@
 #include <inviwo/core/properties/listproperty.h>
 #include <inviwo/core/properties/ordinalproperty.h>
 #include <inviwo/core/properties/optionproperty.h>
+#include <inviwo/core/util/glm.h>
 
 namespace inviwo {
 

--- a/modules/qtwidgets/include/modules/qtwidgets/properties/ordinalminmaxtextpropertywidgetqt.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/properties/ordinalminmaxtextpropertywidgetqt.h
@@ -38,6 +38,7 @@
 #include <inviwo/core/properties/minmaxproperty.h>
 #include <inviwo/core/properties/propertyowner.h>
 #include <inviwo/core/util/stringconversion.h>
+#include <inviwo/core/util/glm.h>
 #include <inviwo/core/metadata/metadata.h>
 
 #include <warn/push>

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -324,7 +324,9 @@ set(HEADER_FILES
     ${IVW_INCLUDE_DIR}/inviwo/core/util/formatsdefinefunc.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/glm.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/glmconvert.h
+    ${IVW_INCLUDE_DIR}/inviwo/core/util/glmfmt.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/glmmat.h
+    ${IVW_INCLUDE_DIR}/inviwo/core/util/glmmatext.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/glmutils.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/glmvec.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/hashcombine.h
@@ -666,7 +668,9 @@ set(SOURCE_FILES
     util/formats.cpp
     util/glm.cpp
     util/glmconvert.cpp
+    util/glmfmt.cpp
     util/glmmat.cpp
+    util/glmmatext.cpp
     util/glmutils.cpp
     util/glmvec.cpp
     util/hashcombine.cpp

--- a/src/core/util/glmfmt.cpp
+++ b/src/core/util/glmfmt.cpp
@@ -1,0 +1,30 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2022 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/core/util/glmfmt.h>

--- a/src/core/util/glmmatext.cpp
+++ b/src/core/util/glmmatext.cpp
@@ -1,0 +1,34 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2022 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/core/util/glmmatext.h>
+
+namespace inviwo {
+
+}  // namespace inviwo

--- a/src/core/util/glmmatext.cpp
+++ b/src/core/util/glmmatext.cpp
@@ -29,6 +29,4 @@
 
 #include <inviwo/core/util/glmmatext.h>
 
-namespace inviwo {
-
-}  // namespace inviwo
+namespace inviwo {}  // namespace inviwo


### PR DESCRIPTION


Maybe fixes #1330? 

Changes proposed in this PR:
 * Adds a fallback value to the ordinalrefproperty for use when the setter and getter is not set... this can be when you clone it  for example or when we use copy paste. A
 * Sets the default value to set and get to nullptr and then so a lambda in the constructor to work around some MSVC compiler bugs. 