### PR TITLE
CMake: vcpkg script update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -36,7 +36,7 @@
     url = https://github.com/pantor/inja.git
 [submodule "modules/cimg/ext/openexr/openexr"]
     path = modules/cimg/ext/openexr/openexr
-    url = https://github.com/inviwo/openexr.git
+    url = https://github.com/AcademySoftwareFoundation/openexr.git
 [submodule "modules/assimp/ext/assimp/assimp"]
     path = modules/assimp/ext/assimp/assimp
     url = https://github.com/inviwo/assimp.git

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -28,13 +28,10 @@
     {
       "name": "vcpkg",
       "hidden": true,
-      "environment": {
-        "VCPKG_OVERLAY_PORTS" : "${sourceDir}/tools/vcpkg"
-      },
       "toolchainFile": "${sourceParentDir}/vcpkg/scripts/buildsystems/vcpkg.cmake",
       "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE" : "${sourceParentDir}/vcpkg/scripts/buildsystems/vcpkg.cmake",
-        "IVW_CFG_VCPKG_OVERLAYS": "${sourceDir}/tools/vcpkg",
+        "CMAKE_TOOLCHAIN_FILE":       "${sourceParentDir}/vcpkg/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_OVERLAY_PORTS":        "${sourceDir}/tools/vcpkg",
         "IVW_USE_EXTERNAL_ASSIMP":    { "type": "BOOL", "value": "ON"},
         "IVW_USE_EXTERNAL_BENCHMARK": { "type": "BOOL", "value": "ON"},
         "IVW_USE_EXTERNAL_EIGEN":     { "type": "BOOL", "value": "ON"},

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -149,8 +149,7 @@ if(NOT IVW_USE_EXTERNAL_TINYDIR)
         FILES ${IVW_EXTENSIONS_DIR}/tinydir/COPYING
     )
 else()
-    ivw_vcpkg_paths(INCLUDE vcpkgInclude) # get the vcpkg include path as a hint if available
-    find_path(TINYDIR_INCLUDE_DIR NAMES tinydir.h HINTS ${vcpkgInclude} REQUIRED)
+    find_path(TINYDIR_INCLUDE_DIR NAMES tinydir.h REQUIRED)
     add_library(tinydir INTERFACE)
     add_library(inviwo::tinydir ALIAS tinydir)
     target_include_directories(tinydir INTERFACE $<BUILD_INTERFACE:${TINYDIR_INCLUDE_DIR}>)

--- a/include/inviwo/core/network/lambdanetworkvisitor.h
+++ b/include/inviwo/core/network/lambdanetworkvisitor.h
@@ -94,8 +94,8 @@ struct LambdaNetworkVisitor : NetworkVisitor, Funcs... {
     using ProcessorOverload = decltype(std::declval<T>()(std::declval<Processor&>()));
 
     template <typename T>
-    using ProcessorEnter = decltype(std::declval<T>()(std::declval<Processor&>(),
-                                                      std::declval<NetworkVisitorEnter>()));
+    using ProcessorEnter = decltype(
+        std::declval<T>()(std::declval<Processor&>(), std::declval<NetworkVisitorEnter>()));
     template <typename T>
     using ProcessorExit =
         decltype(std::declval<T>()(std::declval<Processor&>(), std::declval<NetworkVisitorExit>()));
@@ -104,11 +104,11 @@ struct LambdaNetworkVisitor : NetworkVisitor, Funcs... {
     using CompositeOverload = decltype(std::declval<T>()(std::declval<CompositeProperty&>()));
 
     template <typename T>
-    using CompositeEnter = decltype(std::declval<T>()(std::declval<CompositeProperty&>(),
-                                                      std::declval<NetworkVisitorEnter>()));
+    using CompositeEnter = decltype(
+        std::declval<T>()(std::declval<CompositeProperty&>(), std::declval<NetworkVisitorEnter>()));
     template <typename T>
-    using CompositeExit = decltype(std::declval<T>()(std::declval<CompositeProperty&>(),
-                                                     std::declval<NetworkVisitorExit>()));
+    using CompositeExit = decltype(
+        std::declval<T>()(std::declval<CompositeProperty&>(), std::declval<NetworkVisitorExit>()));
 
     template <typename T>
     using PropertyOverload = decltype(std::declval<T>()(std::declval<Property&>()));

--- a/include/inviwo/core/network/lambdanetworkvisitor.h
+++ b/include/inviwo/core/network/lambdanetworkvisitor.h
@@ -94,8 +94,8 @@ struct LambdaNetworkVisitor : NetworkVisitor, Funcs... {
     using ProcessorOverload = decltype(std::declval<T>()(std::declval<Processor&>()));
 
     template <typename T>
-    using ProcessorEnter = decltype(
-        std::declval<T>()(std::declval<Processor&>(), std::declval<NetworkVisitorEnter>()));
+    using ProcessorEnter = decltype(std::declval<T>()(std::declval<Processor&>(),
+                                                      std::declval<NetworkVisitorEnter>()));
     template <typename T>
     using ProcessorExit =
         decltype(std::declval<T>()(std::declval<Processor&>(), std::declval<NetworkVisitorExit>()));
@@ -104,14 +104,23 @@ struct LambdaNetworkVisitor : NetworkVisitor, Funcs... {
     using CompositeOverload = decltype(std::declval<T>()(std::declval<CompositeProperty&>()));
 
     template <typename T>
-    using CompositeEnter = decltype(
-        std::declval<T>()(std::declval<CompositeProperty&>(), std::declval<NetworkVisitorEnter>()));
+    using CompositeEnter = decltype(std::declval<T>()(std::declval<CompositeProperty&>(),
+                                                      std::declval<NetworkVisitorEnter>()));
     template <typename T>
-    using CompositeExit = decltype(
-        std::declval<T>()(std::declval<CompositeProperty&>(), std::declval<NetworkVisitorExit>()));
+    using CompositeExit = decltype(std::declval<T>()(std::declval<CompositeProperty&>(),
+                                                     std::declval<NetworkVisitorExit>()));
 
     template <typename T>
     using PropertyOverload = decltype(std::declval<T>()(std::declval<Property&>()));
+
+    template <typename T>
+    static constexpr auto isOverloadCalled =
+        util::is_detected_v<ProcessorOverload, T> || util::is_detected_v<ProcessorEnter, T> ||
+        util::is_detected_v<ProcessorExit, T> || util::is_detected_v<CompositeOverload, T> ||
+        util::is_detected_v<CompositeEnter, T> || util::is_detected_v<CompositeExit, T> ||
+        util::is_detected_v<PropertyOverload, T>;
+
+    static_assert((isOverloadCalled<Funcs> && ...), "Some overloads will never be called");
 
     virtual bool enter([[maybe_unused]] Processor& processor) override {
         if constexpr (util::is_detected_exact_v<bool, ProcessorEnter, decltype(*this)>) {

--- a/modules/cimg/CMakeLists.txt
+++ b/modules/cimg/CMakeLists.txt
@@ -75,51 +75,17 @@ option(IVW_USE_EXTERNAL_OPENEXR  "OpenEXR is provided externaly" OFF)
 if(IVW_USE_OPENEXR)
     target_compile_definitions(inviwo-module-cimg PRIVATE cimg_use_openexr)
     if(IVW_USE_EXTERNAL_OPENEXR)
-        find_package(IlmBase CONFIG REQUIRED)
         find_package(OpenEXR CONFIG REQUIRED)
-        target_link_libraries(inviwo-module-cimg PRIVATE 
-            IlmBase::Iex IlmBase::Half IlmBase::Imath IlmBase::IexMath
-            OpenEXR::IlmImf OpenEXR::IlmImfUtil OpenEXR::IlmImfConfig
-        )
-
+        target_link_libraries(inviwo-module-cimg PRIVATE OpenEXR::OpenEXR)
         ivw_vcpkg_install(openexr MODULE CImg)
     else()
         add_subdirectory(ext/openexr)
-        ivw_register_license_file(NAME "OpenEXR" TARGET OpenEXR::IlmImf MODULE CImg
+        ivw_register_license_file(NAME "OpenEXR" TARGET OpenEXR::OpenEXR MODULE CImg
             URL "http://www.openexr.com"
             TYPE "Modified BSD License"
             FILES ext/openexr/openexr/LICENSE.md
         )
-        ivw_default_install_targets(
-            Half
-            Iex
-            IexMath
-            Imath
-            IlmThread
-            IlmImf
-            IlmImfUtil
-        )
-        target_link_libraries(inviwo-module-cimg
-            PRIVATE
-                IlmBase::Half
-                IlmBase::Iex
-                IlmBase::IexMath
-                IlmBase::Imath
-                IlmBase::IlmThread
-                OpenEXR::IlmImf
-                OpenEXR::IlmImfUtil
-        )
-        target_include_directories(inviwo-module-cimg PRIVATE 
-            ${CMAKE_CURRENT_BINARY_DIR}/ext/openexr/openexr/IlmBase/config
-            ${CMAKE_CURRENT_SOURCE_DIR}/ext/openexr/openexr/IlmBase/Half
-            ${CMAKE_CURRENT_SOURCE_DIR}/ext/openexr/openexr/IlmBase/Iex
-            ${CMAKE_CURRENT_SOURCE_DIR}/ext/openexr/openexr/IlmBase/IexMath
-            ${CMAKE_CURRENT_SOURCE_DIR}/ext/openexr/openexr/IlmBase/Imath
-            ${CMAKE_CURRENT_SOURCE_DIR}/ext/openexr/openexr/IlmBase/IlmThread
-            ${CMAKE_CURRENT_BINARY_DIR}/ext/openexr/openexr/OpenEXR/config
-            ${CMAKE_CURRENT_SOURCE_DIR}/ext/openexr/openexr/OpenEXR/IlmImf
-            ${CMAKE_CURRENT_SOURCE_DIR}/ext/openexr/openexr/OpenEXR/IlmImfUtil
-        )
+        target_link_libraries(inviwo-module-cimg PRIVATE  OpenEXR::OpenEXR)
     endif()
 endif()
 

--- a/modules/cimg/ext/openexr/CMakeLists.txt
+++ b/modules/cimg/ext/openexr/CMakeLists.txt
@@ -1,11 +1,13 @@
 # Adapted settings from openexr/CMakeLists.txt and others, such as /openexr/OpenEXR/config/OpenEXRSetup.cmake
 
-set(PYILMBASE_ENABLE             OFF CACHE INTERNAL "Enables configuration of the PyIlmBase module" FORCE)
-set(OPENEXR_VIEWERS_ENABLE       OFF CACHE INTERNAL "Enables configuration of the viewers module" FORCE)
-set(BUILD_TESTING          	     OFF CACHE INTERNAL "Enable the tests" FORCE)
-set(OPENEXR_BUILD_UTILS          OFF CACHE INTERNAL "Enables building of utility programs" FORCE)
-set(INSTALL_OPENEXR_EXAMPLES     OFF CACHE INTERNAL "Install OpenEXR examples" FORCE)
-set(INSTALL_OPENEXR_DOCS         OFF CACHE INTERNAL "Install OpenEXR documentation" FORCE)
+set(OPENEXR_BUILD_UTILS OFF)
+set(INSTALL_DOCS OFF)
+set(BUILD_TESTING OFF)
+set(OPENEXR_INSTALL ON)
+set(OPENEXR_BUILD_TOOLS OFF)
+set(OPENEXR_INSTALL_TOOLS OFF)
+set(OPENEXR_INSTALL_EXAMPLES OFF)
+set(OPENEXR_FORCE_INTERNAL_IMATH ON)
 
 add_subdirectory(openexr)
 

--- a/src/qt/editor/subpropertyselectiondialog.cpp
+++ b/src/qt/editor/subpropertyselectiondialog.cpp
@@ -541,8 +541,8 @@ public:
         return true;
     }
 
-    bool dropMimeData(const QMimeData* data,[[maybe_unused]] Qt::DropAction action, [[maybe_unused]] int row,
-                      [[maybe_unused]] int column,
+    bool dropMimeData(const QMimeData* data, [[maybe_unused]] Qt::DropAction action,
+                      [[maybe_unused]] int row, [[maybe_unused]] int column,
                       [[maybe_unused]] const QModelIndex& parent) override {
         try {
             if (auto* propData = SuperPropertyMimeData::toSuperPropertyMimeData(data)) {


### PR DESCRIPTION
Changes proposed in this PR:
 * Modernized some vcpkg helper scripts
 * lambdanetworkvisitor only accepts lambdas that are used.
 * update OpenEXR to version 3.1.5.
 
 If you use vcpkg you need to update to latest version.