### PR TITLE
QtWidgets: title bar elide fix

### DIFF
--- a/modules/qtwidgets/include/modules/qtwidgets/inviwodockwidgettitlebar.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/inviwodockwidgettitlebar.h
@@ -82,8 +82,10 @@ protected slots:
 
 protected:
     virtual bool eventFilter(QObject* obj, QEvent* event) override;
+    virtual void resizeEvent(QResizeEvent* event) override;
 
 private:
+    void updateTitle();
     void stickyBtnToggled(bool toggle);
 
     QDockWidget* parent_;


### PR DESCRIPTION
Fixes window titles being elided all the time
