### PR TITLE
Doc: change placeholders<modulePath> to ~modulePath~

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,20 +62,20 @@ R"(
     in a set of properties.
     
     Example network:
-    [basegl/instance_renderer.inv](file:///<modulePath>/data/workspaces/instance_renderer.inv)
+    [basegl/instance_renderer.inv](file:~modulePath~/data/workspaces/instance_renderer.inv)
 )"_unindentHelp};
 ```
 The `_unindentHelp`  suffix will remove any leading indent and parse the string as a markdown document and then convert it to an inviwo document, which is what is expected by the `ProcessorInfo` struct.
 One can refer to images like so:
 ```c++
-"![](file:///<modulePath>/docs/images/heightfield-network.png)"
+"![](file:~modulePath~/docs/images/heightfield-network.png)"
 ```
 or networks
 ```c++
-"[basegl/instance_renderer.inv](file:///<modulePath>/data/workspaces/instance_renderer.inv)"
+"[basegl/instance_renderer.inv](file:~modulePath~/data/workspaces/instance_renderer.inv)"
 ```
 Images will be shown inline, and clicking on processor network will append them to the current network. 
-To be able to refer to files there are two placeholder `<basePath>` and `<modulePath>` the former will refer to the base path of the inviwo installation and the latter to the current module. Make sure that any resources linked are also included in the installer. By default the `data` directory and the `docs` folders are always included in the installer. 
+To be able to refer to files there are two placeholder `~basePath~` and `~modulePath~` the former will refer to the base path of the inviwo installation and the latter to the current module. Make sure that any resources linked are also included in the installer. By default the `data` directory and the `docs` folders are always included in the installer. 
 
 For Ports a second constructor argument has been added for a help Document like so
 ```cpp

--- a/modules/base/src/processors/camerafrustum.cpp
+++ b/modules/base/src/processors/camerafrustum.cpp
@@ -56,7 +56,7 @@ const ProcessorInfo CameraFrustum::processorInfo_{
     R"(Creates a line mesh of a frustum for a given camera.
     
     Example Workspace:
-    [base/camera_frustum.inv](file:///<modulePath>/data/workspaces/camera_frustum.inv)
+    [base/camera_frustum.inv](file:~modulePath~/data/workspaces/camera_frustum.inv)
     )"_unindentHelp};
 
 const ProcessorInfo CameraFrustum::getProcessorInfo() const { return processorInfo_; }

--- a/modules/base/src/processors/convexhull2dprocessor.cpp
+++ b/modules/base/src/processors/convexhull2dprocessor.cpp
@@ -77,7 +77,7 @@ const ProcessorInfo ConvexHull2DProcessor::processorInfo_{
     Tags::CPU,                           // Tags
     R"(Computes the convex hull of a 2D mesh.
     
-    Example Workspace: [core/convexhull.inv](file:///<basePath>/data/workspaces/convexhull.inv)
+    Example Workspace: [core/convexhull.inv](file:~basePath~/data/workspaces/convexhull.inv)
     )"_unindentHelp};
 
 const ProcessorInfo ConvexHull2DProcessor::getProcessorInfo() const { return processorInfo_; }

--- a/modules/base/src/processors/distancetransformram.cpp
+++ b/modules/base/src/processors/distancetransformram.cpp
@@ -82,7 +82,7 @@ const ProcessorInfo DistanceTransformRAM::processorInfo_{
     distance.
     
     Example Network:
-    [basegl/distance_transform.inv](file:///<modulePath>/tests/regression/distance_transform.inv)
+    [basegl/distance_transform.inv](file:~modulePath~/tests/regression/distance_transform.inv)
     )"_unindentHelp};
 const ProcessorInfo DistanceTransformRAM::getProcessorInfo() const { return processorInfo_; }
 

--- a/modules/base/src/processors/noiseprocessor.cpp
+++ b/modules/base/src/processors/noiseprocessor.cpp
@@ -71,7 +71,7 @@ const ProcessorInfo NoiseProcessor::processorInfo_{"org.inviwo.NoiseProcessor", 
     A processor to generate noise images.
     Using the Mersenne Twister 19937 generator to generate random numbers.
         
-    ![Image Of Noise Types](file:///<modulePath>/docs/images/noise_types.png)
+    ![Image Of Noise Types](file:~modulePath~/docs/images/noise_types.png)
     
     ### Available Methods
     * __Random__ Generates a uniform, random value in the range [min,max] for each pixel

--- a/modules/base/src/processors/noisevolumeprocessor.cpp
+++ b/modules/base/src/processors/noisevolumeprocessor.cpp
@@ -65,7 +65,7 @@ const ProcessorInfo NoiseVolumeProcessor::processorInfo_{
     A processor to generate noise volumes.
     Using the Mersenne Twister 19937 generator to generate random numbers.
     
-    ![Image Of Noise Types](file:///<modulePath>/docs/images/noise_types.png)
+    ![Image Of Noise Types](file:~modulePath~/docs/images/noise_types.png)
     
     #### Available Methods
     * __Random__ Generates a uniform, random value in the range [min,max] for each voxel
@@ -74,7 +74,7 @@ const ProcessorInfo NoiseVolumeProcessor::processorInfo_{
       of different bases (base 2 and base 3 gives good results)
       
     Example workspace:
-    [base/noise_volume_generation.inv](file:///<modulePath>/data/workspaces/noise_volume_generation.inv)
+    [base/noise_volume_generation.inv](file:~modulePath~/data/workspaces/noise_volume_generation.inv)
     )"_unindentHelp};
 
 const ProcessorInfo NoiseVolumeProcessor::getProcessorInfo() const { return processorInfo_; }

--- a/modules/basegl/src/processors/heightfieldprocessor.cpp
+++ b/modules/basegl/src/processors/heightfieldprocessor.cpp
@@ -67,9 +67,10 @@ const ProcessorInfo HeightFieldProcessor::processorInfo_{
     R"(
         Maps a height field onto a geometry and renders it to an image.
         
-        ![](file:///<modulePath>/docs/images/heightfield-network.png)
+        ![](file:~modulePath~/docs/images/heightfield-network.png)
         
-        Example Network: [core/heightfield.inv](file:///<basePath>/data/workspaces/heightfield.inv)
+        Example Network:
+        [core/heightfield.inv](file:~basePath~/data/workspaces/heightfield.inv)
     )"_unindentHelp};
 
 const ProcessorInfo HeightFieldProcessor::getProcessorInfo() const { return processorInfo_; }

--- a/modules/basegl/src/processors/instancerenderer.cpp
+++ b/modules/basegl/src/processors/instancerenderer.cpp
@@ -101,7 +101,7 @@ const ProcessorInfo InstanceRenderer::processorInfo_{
         How the uniforms are applied in the shader can be specified in a set of properties.
         
         Example network:
-        [basegl/instance_renderer.inv](file:///<modulePath>/data/workspaces/instance_renderer.inv)
+        [basegl/instance_renderer.inv](file:~modulePath~/data/workspaces/instance_renderer.inv)
     )"_unindentHelp};
 
 const ProcessorInfo InstanceRenderer::getProcessorInfo() const { return processorInfo_; }

--- a/src/qt/editor/helpwidget.cpp
+++ b/src/qt/editor/helpwidget.cpp
@@ -408,8 +408,8 @@ QVariant HelpBrowser::loadResource(int type, const QUrl& url) {
 
     auto toFilePath = [&](const QUrl& url) {
         auto filePath = utilqt::fromQString(url.path());
-        replaceInString(filePath, "<modulePath>", currentModulePath_);
-        replaceInString(filePath, "<basePath>", app_->getBasePath());
+        replaceInString(filePath, "~modulePath~", currentModulePath_);
+        replaceInString(filePath, "~basePath~", app_->getBasePath());
         return filePath;
     };
 


### PR DESCRIPTION
Fixes help links on windows