### PR TITLE
Feature/misc fixes

### DIFF
--- a/apps/inviwo/inviwo.cpp
+++ b/apps/inviwo/inviwo.cpp
@@ -49,6 +49,7 @@
 
 #include <QMessageBox>
 #include <QApplication>
+#include <QGuiApplication>
 
 int main(int argc, char** argv) {
     inviwo::LogCentral logger;
@@ -78,6 +79,11 @@ int main(int argc, char** argv) {
     inviwo::utilqt::configurePostEnqueueFront(inviwoApp);
     inviwo::utilqt::setStyleSheetFile(":/stylesheets/inviwo.qss");
     inviwoApp.setUILocale(inviwo::utilqt::getCurrentStdLocale());
+
+    QPalette palette(QGuiApplication::palette());
+    palette.setColor(QPalette::Link, QColor("#268BD2"));
+    palette.setColor(QPalette::LinkVisited, QColor("#268BD2"));
+    QGuiApplication::setPalette(palette);
 
     auto& clp = inviwoApp.getCommandLineParser();
 

--- a/apps/inviwo/inviwo.cpp
+++ b/apps/inviwo/inviwo.cpp
@@ -49,7 +49,6 @@
 
 #include <QMessageBox>
 #include <QApplication>
-#include <QGuiApplication>
 
 int main(int argc, char** argv) {
     inviwo::LogCentral logger;
@@ -78,12 +77,8 @@ int main(int argc, char** argv) {
     inviwo::utilqt::configureFileSystemObserver(inviwoApp);
     inviwo::utilqt::configurePostEnqueueFront(inviwoApp);
     inviwo::utilqt::setStyleSheetFile(":/stylesheets/inviwo.qss");
+    inviwo::utilqt::configurePalette();
     inviwoApp.setUILocale(inviwo::utilqt::getCurrentStdLocale());
-
-    QPalette palette(QGuiApplication::palette());
-    palette.setColor(QPalette::Link, QColor("#268BD2"));
-    palette.setColor(QPalette::LinkVisited, QColor("#268BD2"));
-    QGuiApplication::setPalette(palette);
 
     auto& clp = inviwoApp.getCommandLineParser();
 

--- a/include/inviwo/qt/applicationbase/qtapptools.h
+++ b/include/inviwo/qt/applicationbase/qtapptools.h
@@ -87,6 +87,11 @@ IVW_QTAPPLICATIONBASE_API void configurePoolResizeWait(InviwoApplication& app, Q
  */
 IVW_QTAPPLICATIONBASE_API void setStyleSheetFile(std::string_view file);
 
+/**
+ * Configure the global palette to use the same link colors as in the help widget and stylesheet
+ */
+IVW_QTAPPLICATIONBASE_API void configurePalette();
+
 namespace detail {
 class IVW_QTAPPLICATIONBASE_API QtProcessFrontHelper : public QObject {
     Q_OBJECT

--- a/modules/animation/include/modules/animation/datastructures/valuekeyframesequence.h
+++ b/modules/animation/include/modules/animation/datastructures/valuekeyframesequence.h
@@ -49,6 +49,7 @@
 #include <type_traits>  // for is_base_of
 #include <utility>      // for move
 #include <vector>       // for vector
+#include <concepts>
 
 #include <glm/fwd.hpp>  // IWYU pragma: keep
 
@@ -66,6 +67,16 @@ template <typename Key>
 struct DefaultInterpolationCreator {
     static std::unique_ptr<InterpolationTyped<Key>> create() {
         return std::make_unique<ConstantInterpolation<Key>>();
+    }
+};
+
+template <typename T>
+concept Scalar = std::is_floating_point_v<T> || (std::is_integral_v<T> && !std::is_same_v<T, bool>);
+
+template <Scalar T>
+struct DefaultInterpolationCreator<ValueKeyframe<T>> {
+    static std::unique_ptr<InterpolationTyped<ValueKeyframe<T>>> create() {
+        return std::make_unique<LinearInterpolation<ValueKeyframe<T>>>();
     }
 };
 

--- a/modules/animationqt/include/modules/animationqt/animationeditordockwidgetqt.h
+++ b/modules/animationqt/include/modules/animationqt/animationeditordockwidgetqt.h
@@ -73,6 +73,8 @@ public:
      */
     void importAnimation();
 
+    virtual void closeEvent(QCloseEvent* event) override;
+
 protected:
     virtual void onStateChanged(AnimationController* controller, AnimationState prevState,
                                 AnimationState newState) override;

--- a/modules/animationqt/src/animationeditordockwidgetqt.cpp
+++ b/modules/animationqt/src/animationeditordockwidgetqt.cpp
@@ -379,6 +379,8 @@ void AnimationEditorDockWidgetQt::importAnimation() {
     }
 }
 
+void AnimationEditorDockWidgetQt::closeEvent(QCloseEvent*) { controller_.pause(); }
+
 void AnimationEditorDockWidgetQt::onStateChanged(AnimationController*, AnimationState,
                                                  AnimationState newState) {
     if (newState == AnimationState::Playing) {

--- a/modules/cimg/src/cimgutils.cpp
+++ b/modules/cimg/src/cimgutils.cpp
@@ -171,7 +171,7 @@ namespace cimgutil {
 
 namespace detail {
 
-cimgutil::InterpolationType convertInterpolationType(inviwo::InterpolationType type) {
+cimgutil::InterpolationType toCImgInterpolationType(inviwo::InterpolationType type) {
     switch (type) {
         case inviwo::InterpolationType::Linear:
             return cimgutil::InterpolationType::Linear;
@@ -578,7 +578,7 @@ struct CImgRescaleLayerRamToLayerRamDispatcher {
         auto srcData = static_cast<const P*>(source->getData());
         P* dstData = static_cast<P*>(target->getData());
 
-        auto interpolation = detail::convertInterpolationType(source->getInterpolation());
+        auto interpolation = detail::toCImgInterpolationType(source->getInterpolation());
 
         if (rank == 0) {
             cimg_library::CImg<P> src(srcData, sourceDim.x, sourceDim.y, 1, 1, true);

--- a/modules/cimg/src/cimgutils.cpp
+++ b/modules/cimg/src/cimgutils.cpp
@@ -169,6 +169,21 @@ namespace inviwo {
 
 namespace cimgutil {
 
+namespace detail {
+
+cimgutil::InterpolationType convertInterpolationType(inviwo::InterpolationType type) {
+    switch (type) {
+        case inviwo::InterpolationType::Linear:
+            return cimgutil::InterpolationType::Linear;
+        case inviwo::InterpolationType::Nearest:
+            return cimgutil::InterpolationType::Nearest;
+        default:
+            return cimgutil::InterpolationType::Linear;
+    }
+}
+
+}  // namespace detail
+
 std::unordered_map<std::string, DataFormatId> extToBaseTypeMap_ = {{"jpg", DataFormatId::UInt8},
                                                                    {"jpeg", DataFormatId::UInt8},
                                                                    {"bmp", DataFormatId::UInt8},
@@ -563,10 +578,12 @@ struct CImgRescaleLayerRamToLayerRamDispatcher {
         auto srcData = static_cast<const P*>(source->getData());
         P* dstData = static_cast<P*>(target->getData());
 
+        auto interpolation = detail::convertInterpolationType(source->getInterpolation());
+
         if (rank == 0) {
             cimg_library::CImg<P> src(srcData, sourceDim.x, sourceDim.y, 1, 1, true);
             auto resized = src.get_resize(resizeDim.x, resizeDim.y, -100, -100,
-                                          static_cast<int>(InterpolationType::Linear));
+                                          static_cast<int>(interpolation));
 
             cimg_library::CImg<P> dst(dstData, targetDim.x, targetDim.y, 1, 1, true);
             dst.fill(P{0});
@@ -583,8 +600,7 @@ struct CImgRescaleLayerRamToLayerRamDispatcher {
             cimg_library::CImg<P> src(srcData, comp, sourceDim.x, sourceDim.y, 1, true);
             auto temp = src.get_permute_axes("yzcx");  // put first index last
 
-            temp.resize(resizeDim.x, resizeDim.y, -100, -100,
-                        static_cast<int>(InterpolationType::Linear));
+            temp.resize(resizeDim.x, resizeDim.y, -100, -100, static_cast<int>(interpolation));
 
             cimg_library::CImg<P> dst(dstData, targetDim.x, targetDim.y, 1, comp, true);
             dst.fill(P{0});

--- a/modules/opengl/src/texture/texture.cpp
+++ b/modules/opengl/src/texture/texture.cpp
@@ -164,7 +164,7 @@ Texture::Texture(const Texture& other)
     glBindTexture(target_, id_);
     glTexParameteriv(target_, GL_TEXTURE_SWIZZLE_RGBA, swizzleMaskGL.data());
     glTexParameterIuiv(target_, GL_TEXTURE_MIN_FILTER, &minfiltering);
-    glTexParameterIuiv(target_, GL_TEXTURE_MAG_FILTER, &minfiltering);
+    glTexParameterIuiv(target_, GL_TEXTURE_MAG_FILTER, &magfiltering);
     for (size_t i = 0; i < dims; ++i) {
         glTexParameterIuiv(target_, wrapNames[i], &(wrapping[i]));
     }

--- a/modules/python3/bindings/src/pydataformat.cpp
+++ b/modules/python3/bindings/src/pydataformat.cpp
@@ -70,7 +70,7 @@ void exposeDataFormat(pybind11::module& m) {
         .def_property_readonly("max", &DataFormatBase::getMax)
         .def_property_readonly("min", &DataFormatBase::getMin)
         .def_property_readonly("lowest", &DataFormatBase::getLowest)
-        .def_property_readonly("__repr__", &DataFormatBase::getString);
+        .def("__repr__", &DataFormatBase::getString);
 
     util::for_each_type<DefaultDataFormats>{}(DataFormatHelper{}, m);
 }

--- a/modules/python3/bindings/src/pydataformat.cpp
+++ b/modules/python3/bindings/src/pydataformat.cpp
@@ -32,6 +32,8 @@
 #include <inviwo/core/util/formats.h>
 #include <inviwo/core/util/stdextensions.h>
 
+#include <fmt/core.h>
+
 namespace inviwo {
 
 struct DataFormatHelper {
@@ -70,7 +72,8 @@ void exposeDataFormat(pybind11::module& m) {
         .def_property_readonly("max", &DataFormatBase::getMax)
         .def_property_readonly("min", &DataFormatBase::getMin)
         .def_property_readonly("lowest", &DataFormatBase::getLowest)
-        .def("__repr__", &DataFormatBase::getString);
+        .def("__repr__",
+             [](DataFormatBase& d) { return fmt::format("DataFormat({})", d.getString()); });
 
     util::for_each_type<DefaultDataFormats>{}(DataFormatHelper{}, m);
 }

--- a/modules/python3/include/modules/python3/pythonprocessorfactoryobject.h
+++ b/modules/python3/include/modules/python3/pythonprocessorfactoryobject.h
@@ -69,7 +69,7 @@ public:
 
     virtual Document getMetaInformation() const override {
         Document doc;
-        doc.append("a", "", {{"href", "file://" + file_}}).append("b", file_);
+        doc.append("a", "", {{"href", "file:///" + file_}}).append("b", file_);
         return doc;
     }
 

--- a/modules/python3qt/src/pythoneditorwidget.cpp
+++ b/modules/python3qt/src/pythoneditorwidget.cpp
@@ -245,13 +245,16 @@ void PythonEditorWidget::closeEvent(QCloseEvent* event) {
     if (pythonCode_->document()->isModified()) {
         QMessageBox msgBox(QMessageBox::Question, "Python Editor",
                            "Do you want to save unsaved changes?",
-                           QMessageBox::Save | QMessageBox::Discard, this);
+                           QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel, this);
 
         int retval = msgBox.exec();
         if (retval == static_cast<int>(QMessageBox::Save)) {
             save();
         } else if (retval == static_cast<int>(QMessageBox::Cancel)) {
+            event->ignore();
             return;
+        } else {
+            pythonCode_->document()->setModified(false);
         }
     }
     InviwoDockWidget::closeEvent(event);

--- a/src/qt/applicationbase/qtapptools.cpp
+++ b/src/qt/applicationbase/qtapptools.cpp
@@ -36,6 +36,7 @@
 #include <inviwo/core/util/zip.h>
 
 #include <QApplication>
+#include <QGuiApplication>
 #include <QFileSystemWatcher>
 #include <QFile>
 #include <QIcon>
@@ -218,6 +219,13 @@ void utilqt::setStyleSheetFile(std::string_view file) {
     QString styleSheet = QString::fromUtf8(styleSheetFile.readAll());
     qApp->setStyleSheet(styleSheet);
     styleSheetFile.close();
+}
+
+void utilqt::configurePalette() {
+    QPalette palette(QGuiApplication::palette());
+    palette.setColor(QPalette::Link, QColor("#268BD2"));
+    palette.setColor(QPalette::LinkVisited, QColor("#268BD2"));
+    QGuiApplication::setPalette(palette);
 }
 
 void utilqt::configurePostEnqueueFront(InviwoApplication& app) {

--- a/src/qt/editor/fileassociations.cpp
+++ b/src/qt/editor/fileassociations.cpp
@@ -198,7 +198,7 @@ public:
         LONG lResult =
             ::RegQueryValue(HKEY_CLASSES_ROOT, (const wchar_t*)ext.utf16(), szTempBuffer, &lSize);
 
-        QString temp = QString::fromUtf16((unsigned short*)szTempBuffer);
+        QString temp = QString::fromUtf16((const char16_t*)szTempBuffer);
 
         if (lResult != ERROR_SUCCESS || temp.isEmpty() || temp == dId) {
             // no association for that suffix
@@ -293,7 +293,7 @@ private:
         } else {
             wchar_t buffer[4096];
             ::FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM, 0, lRetVal, 0, buffer, 4096, 0);
-            QString szText = QString::fromUtf16((const ushort*)buffer);
+            QString szText = QString::fromUtf16((const char16_t*)buffer);
             LogError("Error in setting Registry value: " << utilqt::fromQString(szText));
         }
         return false;

--- a/src/qt/editor/helpwidget.cpp
+++ b/src/qt/editor/helpwidget.cpp
@@ -79,7 +79,7 @@ public:
     void setCurrent(std::string_view processorClassIdentifier);
 
 protected:
-    QVariant loadResource(int type, const QUrl& name);
+    virtual QVariant loadResource(int type, const QUrl& name) override;
 
 private:
     InviwoApplication* app_;
@@ -369,10 +369,10 @@ std::tuple<std::string, std::string> loadIdUrl(const QUrl& url, InviwoApplicatio
                 return {helpText, module.getPath()};
             }
         } else {
-            return {fmt::format("Could not crate help for: {}", processorClassIdentifier), ""};
+            return {fmt::format("Could not create help for: {}", processorClassIdentifier), ""};
         }
     } catch (const Exception& e) {
-        return {fmt::format("Could not crate help for: {}, {}", processorClassIdentifier,
+        return {fmt::format("Could not create help for: {}, {}", processorClassIdentifier,
                             e.getMessage()),
                 ""};
     }
@@ -407,7 +407,7 @@ QVariant HelpBrowser::loadResource(int type, const QUrl& url) {
     const QUrlQuery query(url);
 
     auto toFilePath = [&](const QUrl& url) {
-        auto filePath = utilqt::fromQString(url.path());
+        auto filePath = utilqt::fromQString(url.toLocalFile());
         replaceInString(filePath, "~modulePath~", currentModulePath_);
         replaceInString(filePath, "~basePath~", app_->getBasePath());
         return filePath;
@@ -456,6 +456,8 @@ QVariant HelpBrowser::loadResource(int type, const QUrl& url) {
             return {"Workspace loaded"};
         } else {
             QDesktopServices::openUrl(url);
+            QTimer::singleShot(0, this, [this]() { backward(); });
+            return {"File opened"};
         }
     }
 

--- a/src/qt/editor/inviwoaboutwindow.cpp
+++ b/src/qt/editor/inviwoaboutwindow.cpp
@@ -122,7 +122,7 @@ InviwoAboutWindow::InviwoAboutWindow(InviwoMainWindow* mainwindow)
         auto html = doc.append("html");
         html.append("head").append(
             "style",
-            "a { color: #c8ccd0; font-weight: normal; text-decoration:none;}\n"
+            "a { color: #268BD2; font-weight: normal; text-decoration:none;}\n"
             "body, table, div, p, dl "
             "{color: #9d9995; background-color: #323235; font: 400 14px/18px"
             "Calibra, sans-serif;}\n "

--- a/src/qt/editor/inviwomainwindow.cpp
+++ b/src/qt/editor/inviwomainwindow.cpp
@@ -1517,10 +1517,15 @@ void InviwoMainWindow::closeEvent(QCloseEvent* event) {
     }
     settings.endGroup();
 
-    // pass a close event to all children to let the same state etc.
+    // loop over all children and trigger close events _before_ the main window is closed and
+    // destroyed. This way, the main window can stay open if a child widget does not close, i.e.
+    // calls event->ignore().
+    // @see QWidget::closeEvent()
     for (auto& child : children()) {
-        QCloseEvent closeEvent;
-        QApplication::sendEvent(child, &closeEvent);
+        QApplication::sendEvent(child, event);
+        if (!event->isAccepted()) {
+            return;
+        }
     }
 
     QMainWindow::closeEvent(event);


### PR DESCRIPTION
Fixes #1394 
* MainWindow / Qt
    + fixed closeEvent handling
    + prevent PythonEditor asking twice to save changes
* Python
    + `__repr__` for `DataFormatBase` was not defined properly, which broke `str(inviwopy.data.formats)`
* Animation Editor
    + playback stops when closing the editor
    + default interpolation for scalars changed to `linear` (was `constant`)