### PR TITLE
Feature/python bindings split-up

### DIFF
--- a/modules/base/src/io/binarystlwriter.cpp
+++ b/modules/base/src/io/binarystlwriter.cpp
@@ -84,7 +84,7 @@ std::unique_ptr<std::vector<unsigned char>> BinarySTLWriter::writeDataToBuffer(
     const Mesh* data, std::string_view /*fileExtension*/) const {
     std::stringstream ss(std::ios_base::binary);
     writeData(data, ss);
-    auto stringdata = move(ss).str();
+    auto stringdata = std::move(ss).str();
     return std::make_unique<std::vector<unsigned char>>(stringdata.begin(), stringdata.end());
 }
 

--- a/modules/dataframe/src/io/csvwriter.cpp
+++ b/modules/dataframe/src/io/csvwriter.cpp
@@ -70,7 +70,7 @@ std::unique_ptr<std::vector<unsigned char>> CSVWriter::writeDataToBuffer(
     const DataFrame* data, std::string_view /*fileExtension*/) const {
     std::stringstream ss;
     writeData(data, ss);
-    auto stringData = move(ss).str();
+    auto stringData = std::move(ss).str();
     return std::make_unique<std::vector<unsigned char>>(stringData.begin(), stringData.end());
 }
 

--- a/modules/glfw/CMakeLists.txt
+++ b/modules/glfw/CMakeLists.txt
@@ -27,6 +27,11 @@ ivw_group("Source Files" ${SOURCE_FILES})
 # Create module
 ivw_create_module(${SOURCE_FILES} ${HEADER_FILES})
 
+find_package(utf8cpp CONFIG REQUIRED)
+target_link_libraries(inviwo-module-glfw PRIVATE
+    utf8cpp
+)
+
 option(IVW_USE_EXTERNAL_GLFW "GLFW is provided externaly" OFF)
 if(NOT IVW_USE_EXTERNAL_GLFW)
     add_subdirectory(ext/glfw)

--- a/modules/python3/bindings/CMakeLists.txt
+++ b/modules/python3/bindings/CMakeLists.txt
@@ -1,6 +1,10 @@
 # Create python module
 set(HEADER_FILES
     include/inviwopy/inviwopy.h
+    include/inviwopy/properties/pyminmaxproperties.h
+    include/inviwopy/properties/pyoptionproperties.h
+    include/inviwopy/properties/pyordinalproperties.h
+    include/inviwopy/properties/pyordinalrefproperties.h
     include/inviwopy/pybitset.h
     include/inviwopy/pybuffer.h
     include/inviwopy/pycamera.h
@@ -39,12 +43,17 @@ set(HEADER_FILES
     include/inviwopy/pytfprimitiveset.h
     include/inviwopy/pyvolume.h
     include/inviwopy/util/pyglmhelper.h
+    include/inviwopy/util/pypropertyhelper.h
     include/inviwopy/vectoridentifierwrapper.h
 )
 ivw_group("Header Files" BASE ${CMAKE_CURRENT_SOURCE_DIR}/include/inviwopy ${HEADER_FILES})
 
 set(SOURCE_FILES
     src/inviwopy.cpp
+    src/properties/pyminmaxproperties.cpp
+    src/properties/pyoptionproperties.cpp
+    src/properties/pyordinalproperties.cpp
+    src/properties/pyordinalrefproperties.cpp
     src/pybitset.cpp
     src/pybuffer.cpp
     src/pycamera.cpp
@@ -83,6 +92,7 @@ set(SOURCE_FILES
     src/pytfprimitiveset.cpp
     src/pyvolume.cpp
     src/util/pyglmhelper.cpp
+    src/util/pypropertyhelper.cpp
     src/vectoridentifierwrapper.cpp
 )
 ivw_group("Source Files" ${SOURCE_FILES})

--- a/modules/python3/bindings/CMakeLists.txt
+++ b/modules/python3/bindings/CMakeLists.txt
@@ -1,8 +1,8 @@
 # Create python module
 set(HEADER_FILES
     include/inviwopy/inviwopy.h
-    include/inviwopy/pybuffer.h
     include/inviwopy/pybitset.h
+    include/inviwopy/pybuffer.h
     include/inviwopy/pycamera.h
     include/inviwopy/pycameraproperty.h
     include/inviwopy/pycompositeproperties.h
@@ -14,7 +14,15 @@ set(HEADER_FILES
     include/inviwopy/pyevent.h
     include/inviwopy/pyflags.h
     include/inviwopy/pyglmmattypes.h
+    include/inviwopy/pyglmmattypesdouble.h
+    include/inviwopy/pyglmmattypesfloat.h
+    include/inviwopy/pyglmmattypesint.h
+    include/inviwopy/pyglmmattypesuint.h
     include/inviwopy/pyglmports.h
+    include/inviwopy/pyglmportsdouble.h
+    include/inviwopy/pyglmportsfloat.h
+    include/inviwopy/pyglmportsint.h
+    include/inviwopy/pyglmportsuint.h
     include/inviwopy/pyglmtypes.h
     include/inviwopy/pyimage.h
     include/inviwopy/pyinviwoapplication.h
@@ -30,26 +38,35 @@ set(HEADER_FILES
     include/inviwopy/pypropertytypehook.h
     include/inviwopy/pytfprimitiveset.h
     include/inviwopy/pyvolume.h
+    include/inviwopy/util/pyglmhelper.h
     include/inviwopy/vectoridentifierwrapper.h
 )
 ivw_group("Header Files" BASE ${CMAKE_CURRENT_SOURCE_DIR}/include/inviwopy ${HEADER_FILES})
 
 set(SOURCE_FILES
     src/inviwopy.cpp
-    src/pybuffer.cpp
     src/pybitset.cpp
+    src/pybuffer.cpp
     src/pycamera.cpp
     src/pycameraproperty.cpp
     src/pycompositeproperties.cpp
     src/pydataformat.cpp
     src/pydatamapper.cpp
-    src/pydocument.cpp
     src/pydatareaders.cpp
     src/pydatawriters.cpp
+    src/pydocument.cpp
     src/pyevent.cpp
     src/pyflags.cpp
     src/pyglmmattypes.cpp
+    src/pyglmmattypesdouble.cpp
+    src/pyglmmattypesfloat.cpp
+    src/pyglmmattypesint.cpp
+    src/pyglmmattypesuint.cpp
     src/pyglmports.cpp
+    src/pyglmportsdouble.cpp
+    src/pyglmportsfloat.cpp
+    src/pyglmportsint.cpp
+    src/pyglmportsuint.cpp
     src/pyglmtypes.cpp
     src/pyimage.cpp
     src/pyinviwoapplication.cpp
@@ -65,6 +82,7 @@ set(SOURCE_FILES
     src/pypropertytypehook.cpp
     src/pytfprimitiveset.cpp
     src/pyvolume.cpp
+    src/util/pyglmhelper.cpp
     src/vectoridentifierwrapper.cpp
 )
 ivw_group("Source Files" ${SOURCE_FILES})

--- a/modules/python3/bindings/include/inviwopy/properties/pyminmaxproperties.h
+++ b/modules/python3/bindings/include/inviwopy/properties/pyminmaxproperties.h
@@ -1,0 +1,41 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2023 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#pragma once
+
+#include <warn/push>
+#include <warn/ignore/shadow>
+#include <pybind11/pybind11.h>
+#include <warn/pop>
+
+namespace inviwo {
+
+void exposeMinMaxProperties(pybind11::module& m);
+
+}  // namespace inviwo

--- a/modules/python3/bindings/include/inviwopy/properties/pyoptionproperties.h
+++ b/modules/python3/bindings/include/inviwopy/properties/pyoptionproperties.h
@@ -1,0 +1,41 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2023 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#pragma once
+
+#include <warn/push>
+#include <warn/ignore/shadow>
+#include <pybind11/pybind11.h>
+#include <warn/pop>
+
+namespace inviwo {
+
+void exposeOptionProperties(pybind11::module& m);
+
+}  // namespace inviwo

--- a/modules/python3/bindings/include/inviwopy/properties/pyordinalproperties.h
+++ b/modules/python3/bindings/include/inviwopy/properties/pyordinalproperties.h
@@ -1,0 +1,41 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2023 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#pragma once
+
+#include <warn/push>
+#include <warn/ignore/shadow>
+#include <pybind11/pybind11.h>
+#include <warn/pop>
+
+namespace inviwo {
+
+void exposeOrdinalProperties(pybind11::module& m);
+
+}  // namespace inviwo

--- a/modules/python3/bindings/include/inviwopy/properties/pyordinalrefproperties.h
+++ b/modules/python3/bindings/include/inviwopy/properties/pyordinalrefproperties.h
@@ -1,0 +1,41 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2023 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#pragma once
+
+#include <warn/push>
+#include <warn/ignore/shadow>
+#include <pybind11/pybind11.h>
+#include <warn/pop>
+
+namespace inviwo {
+
+void exposeOrdinalRefProperties(pybind11::module& m);
+
+}  // namespace inviwo

--- a/modules/python3/bindings/include/inviwopy/pyglmmattypes.h
+++ b/modules/python3/bindings/include/inviwopy/pyglmmattypes.h
@@ -38,56 +38,6 @@
 
 #include <vector>
 
-// Need to declare vectors of glm types as opaque otherwise they will be copied back and
-// forth between c++ and python
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 2, float>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 3, float>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 4, float>>)
-
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 2, float>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 3, float>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 4, float>>)
-
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 2, float>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 3, float>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 4, float>>)
-
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 2, double>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 3, double>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 4, double>>)
-
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 2, double>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 3, double>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 4, double>>)
-
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 2, double>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 3, double>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 4, double>>)
-
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 2, int>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 3, int>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 4, int>>)
-
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 2, int>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 3, int>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 4, int>>)
-
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 2, int>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 3, int>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 4, int>>)
-
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 2, unsigned int>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 3, unsigned int>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 4, unsigned int>>)
-
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 2, unsigned int>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 3, unsigned int>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 4, unsigned int>>)
-
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 2, unsigned int>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 3, unsigned int>>)
-PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 4, unsigned int>>)
-
 namespace inviwo {
 
 void exposeGLMMatTypes(pybind11::module& m);

--- a/modules/python3/bindings/include/inviwopy/pyglmmattypesdouble.h
+++ b/modules/python3/bindings/include/inviwopy/pyglmmattypesdouble.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2014-2023 Inviwo Foundation
+ * Copyright (c) 2023 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,22 +27,33 @@
  *
  *********************************************************************************/
 
-#include <inviwopy/pyglmmattypes.h>
+#pragma once
 
-#include <inviwopy/pyglmmattypesfloat.h>
-#include <inviwopy/pyglmmattypesdouble.h>
-#include <inviwopy/pyglmmattypesint.h>
-#include <inviwopy/pyglmmattypesuint.h>
+#include <warn/push>
+#include <warn/ignore/shadow>
+#include <pybind11/pybind11.h>
+#include <warn/pop>
+
+#include <inviwo/core/util/glm.h>
+
+#include <vector>
+
+// Need to declare vectors of glm types as opaque otherwise they will be copied back and
+// forth between c++ and python
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 2, double>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 3, double>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 4, double>>)
+
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 2, double>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 3, double>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 4, double>>)
+
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 2, double>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 3, double>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 4, double>>)
 
 namespace inviwo {
 
-namespace py = pybind11;
+void exposeGLMMatTypesDouble(pybind11::module& m);
 
-void exposeGLMMatTypes(py::module& m) {
-    exposeGLMMatTypesFloat(m);
-    exposeGLMMatTypesDouble(m);
-    exposeGLMMatTypesInt(m);
-    exposeGLMMatTypesUint(m);
 }
-
-}  // namespace inviwo

--- a/modules/python3/bindings/include/inviwopy/pyglmmattypesfloat.h
+++ b/modules/python3/bindings/include/inviwopy/pyglmmattypesfloat.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2014-2023 Inviwo Foundation
+ * Copyright (c) 2023 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,22 +27,33 @@
  *
  *********************************************************************************/
 
-#include <inviwopy/pyglmmattypes.h>
+#pragma once
 
-#include <inviwopy/pyglmmattypesfloat.h>
-#include <inviwopy/pyglmmattypesdouble.h>
-#include <inviwopy/pyglmmattypesint.h>
-#include <inviwopy/pyglmmattypesuint.h>
+#include <warn/push>
+#include <warn/ignore/shadow>
+#include <pybind11/pybind11.h>
+#include <warn/pop>
+
+#include <inviwo/core/util/glm.h>
+
+#include <vector>
+
+// Need to declare vectors of glm types as opaque otherwise they will be copied back and
+// forth between c++ and python
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 2, float>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 3, float>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 4, float>>)
+
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 2, float>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 3, float>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 4, float>>)
+
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 2, float>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 3, float>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 4, float>>)
 
 namespace inviwo {
 
-namespace py = pybind11;
+void exposeGLMMatTypesFloat(pybind11::module& m);
 
-void exposeGLMMatTypes(py::module& m) {
-    exposeGLMMatTypesFloat(m);
-    exposeGLMMatTypesDouble(m);
-    exposeGLMMatTypesInt(m);
-    exposeGLMMatTypesUint(m);
 }
-
-}  // namespace inviwo

--- a/modules/python3/bindings/include/inviwopy/pyglmmattypesint.h
+++ b/modules/python3/bindings/include/inviwopy/pyglmmattypesint.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2014-2023 Inviwo Foundation
+ * Copyright (c) 2023 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,22 +27,33 @@
  *
  *********************************************************************************/
 
-#include <inviwopy/pyglmmattypes.h>
+#pragma once
 
-#include <inviwopy/pyglmmattypesfloat.h>
-#include <inviwopy/pyglmmattypesdouble.h>
-#include <inviwopy/pyglmmattypesint.h>
-#include <inviwopy/pyglmmattypesuint.h>
+#include <warn/push>
+#include <warn/ignore/shadow>
+#include <pybind11/pybind11.h>
+#include <warn/pop>
+
+#include <inviwo/core/util/glm.h>
+
+#include <vector>
+
+// Need to declare vectors of glm types as opaque otherwise they will be copied back and
+// forth between c++ and python
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 2, int>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 3, int>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 4, int>>)
+
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 2, int>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 3, int>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 4, int>>)
+
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 2, int>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 3, int>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 4, int>>)
 
 namespace inviwo {
 
-namespace py = pybind11;
+void exposeGLMMatTypesInt(pybind11::module& m);
 
-void exposeGLMMatTypes(py::module& m) {
-    exposeGLMMatTypesFloat(m);
-    exposeGLMMatTypesDouble(m);
-    exposeGLMMatTypesInt(m);
-    exposeGLMMatTypesUint(m);
 }
-
-}  // namespace inviwo

--- a/modules/python3/bindings/include/inviwopy/pyglmmattypesuint.h
+++ b/modules/python3/bindings/include/inviwopy/pyglmmattypesuint.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2014-2023 Inviwo Foundation
+ * Copyright (c) 2023 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,22 +27,33 @@
  *
  *********************************************************************************/
 
-#include <inviwopy/pyglmmattypes.h>
+#pragma once
 
-#include <inviwopy/pyglmmattypesfloat.h>
-#include <inviwopy/pyglmmattypesdouble.h>
-#include <inviwopy/pyglmmattypesint.h>
-#include <inviwopy/pyglmmattypesuint.h>
+#include <warn/push>
+#include <warn/ignore/shadow>
+#include <pybind11/pybind11.h>
+#include <warn/pop>
+
+#include <inviwo/core/util/glm.h>
+
+#include <vector>
+
+// Need to declare vectors of glm types as opaque otherwise they will be copied back and
+// forth between c++ and python
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 2, unsigned int>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 3, unsigned int>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<2, 4, unsigned int>>)
+
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 2, unsigned int>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 3, unsigned int>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<3, 4, unsigned int>>)
+
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 2, unsigned int>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 3, unsigned int>>)
+PYBIND11_MAKE_OPAQUE(std::vector<glm::mat<4, 4, unsigned int>>)
 
 namespace inviwo {
 
-namespace py = pybind11;
+void exposeGLMMatTypesUint(pybind11::module& m);
 
-void exposeGLMMatTypes(py::module& m) {
-    exposeGLMMatTypesFloat(m);
-    exposeGLMMatTypesDouble(m);
-    exposeGLMMatTypesInt(m);
-    exposeGLMMatTypesUint(m);
 }
-
-}  // namespace inviwo

--- a/modules/python3/bindings/include/inviwopy/pyglmportsdouble.h
+++ b/modules/python3/bindings/include/inviwopy/pyglmportsdouble.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2014-2023 Inviwo Foundation
+ * Copyright (c) 2023 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,22 +27,15 @@
  *
  *********************************************************************************/
 
-#include <inviwopy/pyglmmattypes.h>
+#pragma once
 
-#include <inviwopy/pyglmmattypesfloat.h>
-#include <inviwopy/pyglmmattypesdouble.h>
-#include <inviwopy/pyglmmattypesint.h>
-#include <inviwopy/pyglmmattypesuint.h>
+#include <warn/push>
+#include <warn/ignore/shadow>
+#include <pybind11/pybind11.h>
+#include <warn/pop>
 
 namespace inviwo {
 
-namespace py = pybind11;
-
-void exposeGLMMatTypes(py::module& m) {
-    exposeGLMMatTypesFloat(m);
-    exposeGLMMatTypesDouble(m);
-    exposeGLMMatTypesInt(m);
-    exposeGLMMatTypesUint(m);
-}
+void exposeGLMPortsDouble(pybind11::module& m);
 
 }  // namespace inviwo

--- a/modules/python3/bindings/include/inviwopy/pyglmportsfloat.h
+++ b/modules/python3/bindings/include/inviwopy/pyglmportsfloat.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2014-2023 Inviwo Foundation
+ * Copyright (c) 2023 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,22 +27,15 @@
  *
  *********************************************************************************/
 
-#include <inviwopy/pyglmmattypes.h>
+#pragma once
 
-#include <inviwopy/pyglmmattypesfloat.h>
-#include <inviwopy/pyglmmattypesdouble.h>
-#include <inviwopy/pyglmmattypesint.h>
-#include <inviwopy/pyglmmattypesuint.h>
+#include <warn/push>
+#include <warn/ignore/shadow>
+#include <pybind11/pybind11.h>
+#include <warn/pop>
 
 namespace inviwo {
 
-namespace py = pybind11;
-
-void exposeGLMMatTypes(py::module& m) {
-    exposeGLMMatTypesFloat(m);
-    exposeGLMMatTypesDouble(m);
-    exposeGLMMatTypesInt(m);
-    exposeGLMMatTypesUint(m);
-}
+void exposeGLMPortsFloat(pybind11::module& m);
 
 }  // namespace inviwo

--- a/modules/python3/bindings/include/inviwopy/pyglmportsint.h
+++ b/modules/python3/bindings/include/inviwopy/pyglmportsint.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2014-2023 Inviwo Foundation
+ * Copyright (c) 2023 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,22 +27,15 @@
  *
  *********************************************************************************/
 
-#include <inviwopy/pyglmmattypes.h>
+#pragma once
 
-#include <inviwopy/pyglmmattypesfloat.h>
-#include <inviwopy/pyglmmattypesdouble.h>
-#include <inviwopy/pyglmmattypesint.h>
-#include <inviwopy/pyglmmattypesuint.h>
+#include <warn/push>
+#include <warn/ignore/shadow>
+#include <pybind11/pybind11.h>
+#include <warn/pop>
 
 namespace inviwo {
 
-namespace py = pybind11;
-
-void exposeGLMMatTypes(py::module& m) {
-    exposeGLMMatTypesFloat(m);
-    exposeGLMMatTypesDouble(m);
-    exposeGLMMatTypesInt(m);
-    exposeGLMMatTypesUint(m);
-}
+void exposeGLMPortsInt(pybind11::module& m);
 
 }  // namespace inviwo

--- a/modules/python3/bindings/include/inviwopy/pyglmportsuint.h
+++ b/modules/python3/bindings/include/inviwopy/pyglmportsuint.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2014-2023 Inviwo Foundation
+ * Copyright (c) 2023 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,22 +27,15 @@
  *
  *********************************************************************************/
 
-#include <inviwopy/pyglmmattypes.h>
+#pragma once
 
-#include <inviwopy/pyglmmattypesfloat.h>
-#include <inviwopy/pyglmmattypesdouble.h>
-#include <inviwopy/pyglmmattypesint.h>
-#include <inviwopy/pyglmmattypesuint.h>
+#include <warn/push>
+#include <warn/ignore/shadow>
+#include <pybind11/pybind11.h>
+#include <warn/pop>
 
 namespace inviwo {
 
-namespace py = pybind11;
-
-void exposeGLMMatTypes(py::module& m) {
-    exposeGLMMatTypesFloat(m);
-    exposeGLMMatTypesDouble(m);
-    exposeGLMMatTypesInt(m);
-    exposeGLMMatTypesUint(m);
-}
+void exposeGLMPortsUint(pybind11::module& m);
 
 }  // namespace inviwo

--- a/modules/python3/bindings/include/inviwopy/util/pyglmhelper.h
+++ b/modules/python3/bindings/include/inviwopy/util/pyglmhelper.h
@@ -1,0 +1,243 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2023 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#pragma once
+
+#include <inviwo/core/util/glm.h>
+#include <inviwopy/pyglmtypes.h>
+
+#include <inviwo/core/util/ostreamjoiner.h>
+#include <inviwo/core/util/assertion.h>
+#include <modules/python3/pyportutils.h>
+
+#include <warn/push>
+#include <warn/ignore/shadow>
+// #include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl_bind.h>
+#include <pybind11/numpy.h>
+#include <warn/pop>
+
+#include <map>
+#include <string>
+#include <algorithm>
+#include <vector>
+
+#include <warn/push>
+#include <warn/ignore/self-assign-overloaded>
+
+namespace inviwo {
+
+namespace {
+
+template <typename T, size_t N>
+using ith_T = T;
+
+template <typename V, typename T, std::size_t... I>
+void addInitImpl(pybind11::class_<V>& pyv, std::index_sequence<I...>) {
+    pyv.def(pybind11::init<ith_T<T, I>...>());
+}
+
+template <typename T, typename V, unsigned C, typename Indices = std::make_index_sequence<C>>
+void addInit(pybind11::class_<V>& pyv) {
+    addInitImpl<V, T>(pyv, Indices{});
+}
+
+}  // namespace
+
+template <typename T, int Cols, int Rows>
+void matxx(pybind11::module& m, const std::string& prefix, const std::string& name,
+           const std::string& postfix) {
+
+    using Mat = typename util::glmtype<T, Cols, Rows>::type;
+
+    static_assert(std::is_standard_layout<Mat>::value, "has to be standard_layout");
+    static_assert(std::is_trivially_copyable<Mat>::value, "has to be trivially_copyable");
+    static_assert(pybind11::detail::is_pod_struct<Mat>::value, "has to be pod");
+
+    using ColumnVector = typename Mat::col_type;
+    using RowVector = typename Mat::row_type;
+
+    using Mat2 = typename util::glmtype<T, 2, Cols>::type;
+    using Mat3 = typename util::glmtype<T, 3, Cols>::type;
+    using Mat4 = typename util::glmtype<T, 4, Cols>::type;
+
+    const auto classname = [&]() {
+        std::stringstream ss;
+        ss << prefix << name << Cols;
+        if (Cols != Rows) {
+            ss << "x" << Rows;
+        }
+        ss << postfix;
+        return ss.str();
+    }();
+
+    pybind11::class_<Mat> pym(m, classname.c_str(), pybind11::buffer_protocol{});
+    addInit<T, Mat, Cols * Rows>(pym);
+    addInit<ColumnVector, Mat, Cols>(pym);
+    pym.def(pybind11::init<T>())
+        .def(pybind11::init<>())
+        .def(pybind11::init([](pybind11::array_t<T> arr) {
+            if (arr.ndim() != 2) throw std::invalid_argument{"Invalid dimensions"};
+            if (arr.shape(0) != Cols) throw std::invalid_argument{"Invalid dimensions"};
+            if (arr.shape(1) != Rows) throw std::invalid_argument{"Invalid dimensions"};
+
+            Mat res;
+            std::copy(arr.data(0), arr.data(0) + Cols * Rows, glm::value_ptr(res));
+            return res;
+        }))
+        .def(pybind11::self + pybind11::self)
+        .def(pybind11::self - pybind11::self)
+        .def(pybind11::self += pybind11::self)
+        .def(pybind11::self -= pybind11::self)
+        .def(pybind11::self == pybind11::self)
+        .def(pybind11::self != pybind11::self)
+
+        .def(pybind11::self + T())
+        .def(pybind11::self - T())
+        .def(pybind11::self * T())
+        .def(pybind11::self / T())
+        .def(pybind11::self += T())
+        .def(pybind11::self -= T())
+        .def(pybind11::self *= T())
+        .def(pybind11::self /= T())
+
+        .def(
+            "__getitem__", [](Mat& v, int idx) { return &v[idx]; },
+            pybind11::return_value_policy::reference_internal)
+        .def("__getitem__", [](Mat& m, int idx, int idy) { return m[idx][idy]; })
+        .def("__setitem__", [](Mat& m, int idx, ColumnVector& t) { return m[idx] = t; })
+        .def("__setitem__", [](Mat& m, int idx, int idy, T& t) { return m[idx][idy] = t; })
+
+        .def(pybind11::self * RowVector())
+        .def(ColumnVector() * pybind11::self)
+        .def(pybind11::self * Mat2())
+        .def(pybind11::self * Mat3())
+        .def(pybind11::self * Mat4())
+
+        .def_property_readonly(
+            "array",
+            [](Mat& self) {
+                return pybind11::array_t<T>(std::vector<size_t>{Rows, Cols}, glm::value_ptr(self));
+            })
+
+        .def("__repr__",
+             [](Mat& m) {
+                 std::ostringstream oss;
+                 // oss << m; This fails for some reason on GCC 5.4
+
+                 oss << "[";
+                 for (int col = 0; col < Cols; col++) {
+                     oss << "[";
+                     for (int row = 0; row < Rows; row++) {
+                         if (row != 0) oss << " ";
+                         oss << m[col][row];
+                     }
+                     oss << "]";
+                 }
+                 oss << "]";
+
+                 return oss.str();
+             })
+        .def_buffer([](Mat& mat) -> pybind11::buffer_info {
+            return pybind11::buffer_info(
+                glm::value_ptr(mat),                      /* Pointer to buffer */
+                sizeof(T),                                /* Size of one scalar */
+                pybind11::format_descriptor<T>::format(), /* Python struct-style format descriptor
+                                                           */
+                2,                                        /* Number of dimensions */
+                {Rows, Cols},                             /* Buffer dimensions */
+                {sizeof(T), sizeof(T) * Rows}             /* Strides (in bytes) for each index */
+            );
+        });
+
+    pybind11::bind_vector<std::vector<Mat>>(m, classname + "Vector", "Vectors of glm matrices");
+}
+
+template <typename T, int Cols>
+void matx(pybind11::module& m, const std::string& prefix, const std::string& name,
+          const std::string& postfix) {
+    matxx<T, Cols, 2>(m, prefix, name, postfix);
+    matxx<T, Cols, 3>(m, prefix, name, postfix);
+    matxx<T, Cols, 4>(m, prefix, name, postfix);
+}
+
+template <typename T>
+void mat(pybind11::module& m, const std::string& prefix, const std::string& name = "mat",
+         const std::string& postfix = "") {
+    matx<T, 2>(m, prefix, name, postfix);
+    matx<T, 3>(m, prefix, name, postfix);
+    matx<T, 4>(m, prefix, name, postfix);
+}
+
+namespace {
+
+template <typename T>
+constexpr bool alwaysFalse() {
+    return false;
+}
+
+}  // namespace
+
+struct ExposePortsFunctor {
+    template <typename T>
+    void operator()(pybind11::module& m) {
+        using V = typename util::value_type<T>::type;
+        constexpr auto N = util::extent<T>::value;
+
+        if constexpr (N == 1) {
+            constexpr auto name = []() {
+                if constexpr (std::is_same_v<T, float>) {
+                    return "float";
+                } else if constexpr (std::is_same_v<T, double>) {
+                    return "double";
+                } else if constexpr (std::is_same_v<T, int>) {
+                    return "int";
+                } else if constexpr (std::is_same_v<T, unsigned int>) {
+                    return "uint";
+                } else {
+                    static_assert(alwaysFalse<T>(), "Missing name for T");
+                }
+            }();
+            const auto vectorName = fmt::format("{}Vector", name);
+            pybind11::bind_vector<std::vector<T>>(m, vectorName);
+            exposeStandardDataPorts<std::vector<T>>(m, vectorName);
+
+        } else {
+            const auto prefix = glm::detail::prefix<V>::value();
+            const auto vectorName = fmt::format("{}vec{}Vector", prefix, N);
+            pybind11::bind_vector<std::vector<T>>(m, vectorName, pybind11::buffer_protocol{});
+            exposeStandardDataPorts<std::vector<T>>(m, vectorName);
+        }
+    }
+};
+
+}  // namespace inviwo
+
+#include <warn/pop>

--- a/modules/python3/bindings/include/inviwopy/util/pyglmhelper.h
+++ b/modules/python3/bindings/include/inviwopy/util/pyglmhelper.h
@@ -38,7 +38,6 @@
 
 #include <warn/push>
 #include <warn/ignore/shadow>
-// #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/numpy.h>

--- a/modules/python3/bindings/include/inviwopy/util/pypropertyhelper.h
+++ b/modules/python3/bindings/include/inviwopy/util/pypropertyhelper.h
@@ -1,0 +1,43 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2023 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#pragma once
+
+#include <inviwo/core/util/stringconversion.h>
+
+namespace inviwo {
+
+template <typename T, typename P, typename C>
+void pyTemplateProperty(C& prop) {
+    prop.def_property(
+            "value", [](P& p) { return p.get(); }, [](P& p, T t) { p.set(t); })
+        .def("__repr__", [](P& v) { return inviwo::toString(v.get()); });
+}
+
+}  // namespace inviwo

--- a/modules/python3/bindings/src/properties/pyminmaxproperties.cpp
+++ b/modules/python3/bindings/src/properties/pyminmaxproperties.cpp
@@ -1,0 +1,105 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2017-2023 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwopy/properties/pyminmaxproperties.h>
+#include <inviwopy/util/pypropertyhelper.h>
+
+#include <inviwo/core/properties/minmaxproperty.h>
+#include <inviwo/core/util/defaultvalues.h>
+#include <inviwo/core/util/stdextensions.h>
+#include <inviwo/core/util/foreacharg.h>
+#include <inviwo/core/util/stringconversion.h>
+
+#include <pybind11/stl.h>
+#include <pybind11/functional.h>
+#include <fmt/format.h>
+#include <glm/gtx/io.hpp>
+
+namespace py = pybind11;
+
+namespace inviwo {
+
+struct MinMaxHelper {
+    template <typename T>
+    auto operator()(pybind11::module& m) {
+        using P = MinMaxProperty<T>;
+        using range_type = glm::tvec2<T, glm::defaultp>;
+
+        auto classname = Defaultvalues<T>::getName() + "MinMaxProperty";
+
+        py::class_<P, Property> prop(m, classname.c_str());
+        prop.def(py::init([](std::string_view identifier, std::string_view name, Document help,
+                             const T& valueMin, const T& valueMax, const T& rangeMin,
+                             const T& rangeMax, const T& increment, const T& minSeparation,
+                             InvalidationLevel invalidationLevel, PropertySemantics semantics) {
+                     return new P(identifier, name, std::move(help), valueMin, valueMax, rangeMin,
+                                  rangeMax, increment, minSeparation, invalidationLevel, semantics);
+                 }),
+                 py::arg("identifier"), py::arg("name"), py::arg("help"),
+                 py::arg("valueMin") = Defaultvalues<T>::getMin(),
+                 py::arg("valueMax") = Defaultvalues<T>::getMax(),
+                 py::arg("rangeMin") = Defaultvalues<T>::getMin(),
+                 py::arg("rangeMax") = Defaultvalues<T>::getMax(),
+                 py::arg("increment") = Defaultvalues<T>::getInc(), py::arg("minSeparation") = 0,
+                 py::arg("invalidationLevel") = InvalidationLevel::InvalidOutput,
+                 py::arg("semantics") = PropertySemantics::Default)
+            .def(py::init([](std::string_view identifier, std::string_view name, const T& valueMin,
+                             const T& valueMax, const T& rangeMin, const T& rangeMax,
+                             const T& increment, const T& minSeparation,
+                             InvalidationLevel invalidationLevel, PropertySemantics semantics) {
+                     return new P(identifier, name, valueMin, valueMax, rangeMin, rangeMax,
+                                  increment, minSeparation, invalidationLevel, semantics);
+                 }),
+                 py::arg("identifier"), py::arg("name"),
+                 py::arg("valueMin") = Defaultvalues<T>::getMin(),
+                 py::arg("valueMax") = Defaultvalues<T>::getMax(),
+                 py::arg("rangeMin") = Defaultvalues<T>::getMin(),
+                 py::arg("rangeMax") = Defaultvalues<T>::getMax(),
+                 py::arg("increment") = Defaultvalues<T>::getInc(), py::arg("minSeparation") = 0,
+                 py::arg("invalidationLevel") = InvalidationLevel::InvalidOutput,
+                 py::arg("semantics") = PropertySemantics::Default)
+            .def_property("rangeMin", &P::getRangeMin, &P::setRangeMin)
+            .def_property("rangeMax", &P::getRangeMax, &P::setRangeMax)
+            .def_property("increment", &P::getIncrement, &P::setIncrement)
+            .def_property("minSeparation", &P::getMinSeparation, &P::setMinSeparation)
+            .def_property("range", &P::getRange, &P::setRange)
+            .def("__repr__", [](P& v) { return inviwo::toString(v.get()); });
+
+        pyTemplateProperty<range_type, P>(prop);
+
+        return prop;
+    }
+};
+
+void exposeMinMaxProperties(py::module& m) {
+    using MinMaxPropertyTypes = std::tuple<float, double, size_t, glm::i64, int>;
+    util::for_each_type<MinMaxPropertyTypes>{}(MinMaxHelper{}, m);
+}
+
+}  // namespace inviwo

--- a/modules/python3/bindings/src/properties/pyoptionproperties.cpp
+++ b/modules/python3/bindings/src/properties/pyoptionproperties.cpp
@@ -1,0 +1,146 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2017-2023 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwopy/properties/pyoptionproperties.h>
+
+#include <inviwo/core/properties/optionproperty.h>
+#include <inviwo/core/util/defaultvalues.h>
+#include <inviwo/core/util/stdextensions.h>
+#include <inviwo/core/util/foreacharg.h>
+#include <inviwo/core/util/stringconversion.h>
+
+#include <pybind11/stl.h>
+#include <pybind11/functional.h>
+#include <fmt/format.h>
+
+#include <string>
+
+namespace py = pybind11;
+
+namespace inviwo {
+
+struct OptionPropertyHelper {
+    template <typename T>
+    auto operator()(pybind11::module& m) {
+        namespace py = pybind11;
+        using P = OptionProperty<T>;
+        using O = OptionPropertyOption<T>;
+
+        auto classname = "OptionProperty" + Defaultvalues<T>::getName();
+        auto optionclassname = Defaultvalues<T>::getName() + "Option";
+
+        py::class_<O>(m, optionclassname.c_str())
+            .def(py::init<>())
+            .def(py::init<std::string_view, std::string_view, const T&>())
+            .def_readwrite("id", &O::id_)
+            .def_readwrite("name", &O::name_)
+            .def_readwrite("value", &O::value_);
+
+        py::class_<P, BaseOptionProperty> prop(m, classname.c_str());
+        prop.def(py::init([](std::string_view identifier, std::string_view name, Document help,
+                             std::vector<OptionPropertyOption<T>> options, size_t selectedIndex,
+                             InvalidationLevel invalidationLevel, PropertySemantics semantics) {
+                     return new P(identifier, name, std::move(help), options, selectedIndex,
+                                  invalidationLevel, semantics);
+                 }),
+                 py::arg("identifier"), py::arg("name"), py::arg("help") = Document{},
+                 py::arg("options") = std::vector<OptionPropertyOption<T>>{},
+                 py::arg("selectedIndex") = 0,
+                 py::arg("invalidationLevel") = InvalidationLevel::InvalidOutput,
+                 py::arg("semantics") = PropertySemantics::Default)
+
+            .def(py::init([](std::string_view identifier, std::string_view name,
+                             std::vector<OptionPropertyOption<T>> options, size_t selectedIndex,
+                             InvalidationLevel invalidationLevel, PropertySemantics semantics) {
+                     return new P(identifier, name, options, selectedIndex, invalidationLevel,
+                                  semantics);
+                 }),
+                 py::arg("identifier"), py::arg("name"),
+                 py::arg("options") = std::vector<OptionPropertyOption<T>>{},
+                 py::arg("selectedIndex") = 0,
+                 py::arg("invalidationLevel") = InvalidationLevel::InvalidOutput,
+                 py::arg("semantics") = PropertySemantics::Default)
+
+            .def("addOption", [](P* p, std::string_view id, std::string_view displayName,
+                                 const T& t) { p->addOption(id, displayName, t); })
+
+            .def_property_readonly("values", &P::getValues)
+            .def("removeOption", py::overload_cast<size_t>(&P::removeOption))
+            .def("removeOption", py::overload_cast<std::string_view>(&P::removeOption))
+
+            .def_property(
+                "value", [](P* p) { return p->get(); }, [](P* p, T& t) { p->set(t); })
+            .def_property("selectedValue", &P::getSelectedValue,
+                          [](P* p, const T& val) { p->setSelectedValue(val); })
+            .def_property("selectedIdentifier", &P::getSelectedIdentifier,
+                          &P::setSelectedIdentifier)
+            .def_property("selectedDisplayName", &P::getSelectedDisplayName,
+                          &P::setSelectedDisplayName)
+
+            .def("replaceOptions",
+                 [](P* p, const std::vector<std::string>& ids,
+                    const std::vector<std::string>& displayNames,
+                    const std::vector<T>& values) { p->replaceOptions(ids, displayNames, values); })
+
+            .def("replaceOptions",
+                 [](P* p, std::vector<OptionPropertyOption<T>> options) {
+                     p->replaceOptions(options);
+                 })
+            .def("__repr__", [](P& v) { return inviwo::toString(v.get()); });
+
+        return prop;
+    }
+};
+
+void exposeOptionProperties(py::module& m) {
+
+    py::class_<BaseOptionProperty, Property>(m, "BaseOptionProperty")
+        .def_property_readonly("clearOptions", &BaseOptionProperty::clearOptions)
+        .def_property_readonly("size", &BaseOptionProperty::size)
+
+        .def_property("selectedIndex", &BaseOptionProperty::getSelectedIndex,
+                      &BaseOptionProperty::setSelectedIndex)
+        .def_property("selectedIdentifier", &BaseOptionProperty::getSelectedIdentifier,
+                      &BaseOptionProperty::setSelectedIdentifier)
+        .def_property("selectedDisplayName", &BaseOptionProperty::getSelectedDisplayName,
+                      &BaseOptionProperty::setSelectedDisplayName)
+
+        .def("isSelectedIndex", &BaseOptionProperty::isSelectedIndex)
+        .def("isSelectedIdentifier", &BaseOptionProperty::isSelectedIdentifier)
+        .def("isSelectedDisplayName", &BaseOptionProperty::isSelectedDisplayName)
+
+        .def_property_readonly("identifiers", &BaseOptionProperty::getIdentifiers)
+        .def_property_readonly("displayNames", &BaseOptionProperty::getDisplayNames);
+
+    using OptionPropertyTypes = std::tuple<double, float, int, std::string>;
+
+    util::for_each_type<OptionPropertyTypes>{}(OptionPropertyHelper{}, m);
+}
+
+}  // namespace inviwo

--- a/modules/python3/bindings/src/properties/pyordinalproperties.cpp
+++ b/modules/python3/bindings/src/properties/pyordinalproperties.cpp
@@ -1,0 +1,118 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2017-2023 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwopy/properties/pyordinalproperties.h>
+
+#include <inviwo/core/properties/ordinalproperty.h>
+#include <inviwo/core/util/defaultvalues.h>
+#include <inviwo/core/util/stdextensions.h>
+#include <inviwo/core/util/foreacharg.h>
+#include <inviwo/core/util/stringconversion.h>
+
+#include <pybind11/stl.h>
+#include <pybind11/functional.h>
+#include <fmt/format.h>
+
+namespace py = pybind11;
+
+namespace inviwo {
+
+struct OrdinalPropertyHelper {
+    template <typename T>
+    auto operator()(pybind11::module& m) {
+        namespace py = pybind11;
+        using P = OrdinalProperty<T>;
+
+        auto classname = Defaultvalues<T>::getName() + "Property";
+
+        py::class_<P, Property> prop(m, classname.c_str());
+        prop.def(py::init([](std::string_view identifier, std::string_view name, const T& value,
+                             const T& min, const T& max, const T& increment,
+                             InvalidationLevel invalidationLevel, PropertySemantics semantics) {
+                     return new P(identifier, name, value, min, max, increment, invalidationLevel,
+                                  semantics);
+                 }),
+                 py::arg("identifier"), py::arg("name"),
+                 py::arg("value") = Defaultvalues<T>::getVal(),
+                 py::arg("min") = Defaultvalues<T>::getMin(),
+                 py::arg("max") = Defaultvalues<T>::getMax(),
+                 py::arg("increment") = Defaultvalues<T>::getInc(),
+                 py::arg("invalidationLevel") = InvalidationLevel::InvalidOutput,
+                 py::arg("semantics") = PropertySemantics::Default)
+            .def(py::init([](std::string_view identifier, std::string_view name, Document help,
+                             const T& value, const std::pair<T, ConstraintBehavior>& min,
+                             const std::pair<T, ConstraintBehavior>& max, const T& increment,
+                             InvalidationLevel invalidationLevel, PropertySemantics semantics) {
+                     return new P(identifier, name, std::move(help), value, min, max, increment,
+                                  invalidationLevel, semantics);
+                 }),
+                 py::arg("identifier"), py::arg("name"), py::arg("help") = Document{},
+                 py::arg("value") = Defaultvalues<T>::getVal(),
+                 py::arg("min") =
+                     std::pair{Defaultvalues<T>::getMin(), ConstraintBehavior::Editable},
+                 py::arg("max") =
+                     std::pair{Defaultvalues<T>::getMax(), ConstraintBehavior::Editable},
+                 py::arg("increment") = Defaultvalues<T>::getInc(),
+                 py::arg("invalidationLevel") = InvalidationLevel::InvalidOutput,
+                 py::arg("semantics") = PropertySemantics::Default)
+            .def(py::init([](std::string_view identifier, std::string_view name, const T& value,
+                             const std::pair<T, ConstraintBehavior>& min,
+                             const std::pair<T, ConstraintBehavior>& max, const T& increment,
+                             InvalidationLevel invalidationLevel, PropertySemantics semantics) {
+                     return new P(identifier, name, value, min, max, increment, invalidationLevel,
+                                  semantics);
+                 }),
+                 py::arg("identifier"), py::arg("name"),
+                 py::arg("value") = Defaultvalues<T>::getVal(),
+                 py::arg("min") =
+                     std::pair{Defaultvalues<T>::getMin(), ConstraintBehavior::Editable},
+                 py::arg("max") =
+                     std::pair{Defaultvalues<T>::getMax(), ConstraintBehavior::Editable},
+                 py::arg("increment") = Defaultvalues<T>::getInc(),
+                 py::arg("invalidationLevel") = InvalidationLevel::InvalidOutput,
+                 py::arg("semantics") = PropertySemantics::Default)
+            .def_property(
+                "value", [](P& p) { return p.get(); }, [](P& p, T t) { p.set(t); })
+            .def_property("minValue", &P::getMinValue, &P::setMinValue)
+            .def_property("maxValue", &P::getMaxValue, &P::setMaxValue)
+            .def_property("increment", &P::getIncrement, &P::setIncrement)
+            .def("__repr__", [](P& v) { return inviwo::toString(v.get()); });
+
+        return prop;
+    }
+};
+
+void exposeOrdinalProperties(py::module& m) {
+    using OrdinalPropetyTypes = std::tuple<float, int, size_t, glm::i64, double, vec2, vec3, vec4,
+                                           dvec2, dvec3, dvec4, ivec2, ivec3, ivec4, size2_t,
+                                           size3_t, size4_t, mat2, mat3, mat4, dmat2, dmat3, dmat4>;
+    util::for_each_type<OrdinalPropetyTypes>{}(OrdinalPropertyHelper{}, m);
+}
+
+}  // namespace inviwo

--- a/modules/python3/bindings/src/properties/pyordinalrefproperties.cpp
+++ b/modules/python3/bindings/src/properties/pyordinalrefproperties.cpp
@@ -1,0 +1,108 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2023 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwopy/properties/pyordinalrefproperties.h>
+
+#include <inviwo/core/properties/ordinalrefproperty.h>
+#include <inviwo/core/util/defaultvalues.h>
+#include <inviwo/core/util/stdextensions.h>
+#include <inviwo/core/util/foreacharg.h>
+#include <inviwo/core/util/stringconversion.h>
+
+#include <pybind11/stl.h>
+#include <pybind11/functional.h>
+#include <fmt/format.h>
+
+namespace py = pybind11;
+
+namespace inviwo {
+
+struct OrdinalRefPropertyHelper {
+    template <typename T>
+    auto operator()(pybind11::module& m) {
+        namespace py = pybind11;
+        using P = OrdinalRefProperty<T>;
+
+        auto classname = Defaultvalues<T>::getName() + "RefProperty";
+
+        py::class_<P, Property> prop(m, classname.c_str());
+        prop.def(py::init([](std::string_view identifier, std::string_view name,
+                             std::function<T()> get, std::function<void(const T&)> set,
+                             const std::pair<T, ConstraintBehavior>& min,
+                             const std::pair<T, ConstraintBehavior>& max, const T& increment,
+                             InvalidationLevel invalidationLevel, PropertySemantics semantics) {
+                     return new P(identifier, name, std::move(get), std::move(set), min, max,
+                                  increment, invalidationLevel, semantics);
+                 }),
+                 py::arg("identifier"), py::arg("name"), py::arg("get"), py::arg("set"),
+                 py::arg("min") =
+                     std::pair{Defaultvalues<T>::getMin(), ConstraintBehavior::Editable},
+                 py::arg("max") =
+                     std::pair{Defaultvalues<T>::getMax(), ConstraintBehavior::Editable},
+                 py::arg("increment") = Defaultvalues<T>::getInc(),
+                 py::arg("invalidationLevel") = InvalidationLevel::InvalidOutput,
+                 py::arg("semantics") = PropertySemantics::Default)
+            .def(py::init([](std::string_view identifier, std::string_view name, Document help,
+                             std::function<T()> get, std::function<void(const T&)> set,
+                             const std::pair<T, ConstraintBehavior>& min,
+                             const std::pair<T, ConstraintBehavior>& max, const T& increment,
+                             InvalidationLevel invalidationLevel, PropertySemantics semantics) {
+                     return new P(identifier, name, std::move(help), std::move(get), std::move(set),
+                                  min, max, increment, invalidationLevel, semantics);
+                 }),
+                 py::arg("identifier"), py::arg("name"), py::arg("help"), py::arg("get"),
+                 py::arg("set"),
+                 py::arg("min") =
+                     std::pair{Defaultvalues<T>::getMin(), ConstraintBehavior::Editable},
+                 py::arg("max") =
+                     std::pair{Defaultvalues<T>::getMax(), ConstraintBehavior::Editable},
+                 py::arg("increment") = Defaultvalues<T>::getInc(),
+                 py::arg("invalidationLevel") = InvalidationLevel::InvalidOutput,
+                 py::arg("semantics") = PropertySemantics::Default)
+
+            .def_property(
+                "value", [](P& p) { return p.get(); }, [](P& p, T t) { p.set(t); })
+            .def_property("minValue", &P::getMinValue, &P::setMinValue)
+            .def_property("maxValue", &P::getMaxValue, &P::setMaxValue)
+            .def_property("increment", &P::getIncrement, &P::setIncrement)
+            .def("setGetAndSet", &P::setGetAndSet)
+            .def("__repr__", [](P& v) { return inviwo::toString(v.get()); });
+
+        return prop;
+    }
+};
+
+void exposeOrdinalRefProperties(py::module& m) {
+    using OrdinalPropetyTypes = std::tuple<float, int, size_t, glm::i64, double, vec2, vec3, vec4,
+                                           dvec2, dvec3, dvec4, ivec2, ivec3, ivec4, size2_t,
+                                           size3_t, size4_t, mat2, mat3, mat4, dmat2, dmat3, dmat4>;
+    util::for_each_type<OrdinalPropetyTypes>{}(OrdinalRefPropertyHelper{}, m);
+}
+
+}  // namespace inviwo

--- a/modules/python3/bindings/src/pyglmmattypesdouble.cpp
+++ b/modules/python3/bindings/src/pyglmmattypesdouble.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2014-2023 Inviwo Foundation
+ * Copyright (c) 2023 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,22 +27,11 @@
  *
  *********************************************************************************/
 
-#include <inviwopy/pyglmmattypes.h>
-
-#include <inviwopy/pyglmmattypesfloat.h>
 #include <inviwopy/pyglmmattypesdouble.h>
-#include <inviwopy/pyglmmattypesint.h>
-#include <inviwopy/pyglmmattypesuint.h>
+#include <inviwopy/util/pyglmhelper.h>
 
 namespace inviwo {
 
-namespace py = pybind11;
-
-void exposeGLMMatTypes(py::module& m) {
-    exposeGLMMatTypesFloat(m);
-    exposeGLMMatTypesDouble(m);
-    exposeGLMMatTypesInt(m);
-    exposeGLMMatTypesUint(m);
-}
+void exposeGLMMatTypesDouble(pybind11::module& m) { mat<double>(m, "d"); }
 
 }  // namespace inviwo

--- a/modules/python3/bindings/src/pyglmmattypesfloat.cpp
+++ b/modules/python3/bindings/src/pyglmmattypesfloat.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2014-2023 Inviwo Foundation
+ * Copyright (c) 2023 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,22 +27,11 @@
  *
  *********************************************************************************/
 
-#include <inviwopy/pyglmmattypes.h>
-
 #include <inviwopy/pyglmmattypesfloat.h>
-#include <inviwopy/pyglmmattypesdouble.h>
-#include <inviwopy/pyglmmattypesint.h>
-#include <inviwopy/pyglmmattypesuint.h>
+#include <inviwopy/util/pyglmhelper.h>
 
 namespace inviwo {
 
-namespace py = pybind11;
-
-void exposeGLMMatTypes(py::module& m) {
-    exposeGLMMatTypesFloat(m);
-    exposeGLMMatTypesDouble(m);
-    exposeGLMMatTypesInt(m);
-    exposeGLMMatTypesUint(m);
-}
+void exposeGLMMatTypesFloat(pybind11::module& m) { mat<float>(m, ""); }
 
 }  // namespace inviwo

--- a/modules/python3/bindings/src/pyglmmattypesint.cpp
+++ b/modules/python3/bindings/src/pyglmmattypesint.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2014-2023 Inviwo Foundation
+ * Copyright (c) 2023 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,22 +27,11 @@
  *
  *********************************************************************************/
 
-#include <inviwopy/pyglmmattypes.h>
-
-#include <inviwopy/pyglmmattypesfloat.h>
-#include <inviwopy/pyglmmattypesdouble.h>
 #include <inviwopy/pyglmmattypesint.h>
-#include <inviwopy/pyglmmattypesuint.h>
+#include <inviwopy/util/pyglmhelper.h>
 
 namespace inviwo {
 
-namespace py = pybind11;
-
-void exposeGLMMatTypes(py::module& m) {
-    exposeGLMMatTypesFloat(m);
-    exposeGLMMatTypesDouble(m);
-    exposeGLMMatTypesInt(m);
-    exposeGLMMatTypesUint(m);
-}
+void exposeGLMMatTypesInt(pybind11::module& m) { mat<int>(m, "i"); }
 
 }  // namespace inviwo

--- a/modules/python3/bindings/src/pyglmmattypesuint.cpp
+++ b/modules/python3/bindings/src/pyglmmattypesuint.cpp
@@ -27,22 +27,11 @@
  *
  *********************************************************************************/
 
-#include <inviwopy/pyglmmattypes.h>
-
-#include <inviwopy/pyglmmattypesfloat.h>
-#include <inviwopy/pyglmmattypesdouble.h>
-#include <inviwopy/pyglmmattypesint.h>
 #include <inviwopy/pyglmmattypesuint.h>
+#include <inviwopy/util/pyglmhelper.h>
 
 namespace inviwo {
 
-namespace py = pybind11;
-
-void exposeGLMMatTypes(py::module& m) {
-    exposeGLMMatTypesFloat(m);
-    exposeGLMMatTypesDouble(m);
-    exposeGLMMatTypesInt(m);
-    exposeGLMMatTypesUint(m);
-}
+void exposeGLMMatTypesUint(pybind11::module& m) { mat<unsigned int>(m, "u"); }
 
 }  // namespace inviwo

--- a/modules/python3/bindings/src/pyglmports.cpp
+++ b/modules/python3/bindings/src/pyglmports.cpp
@@ -27,78 +27,19 @@
  *
  *********************************************************************************/
 
-#include <inviwopy/pyglmtypes.h>
-#include <inviwo/core/util/assertion.h>
-
-#include <inviwo/core/util/glm.h>
-
-#include <modules/python3/pyportutils.h>
-
-#include <warn/push>
-#include <warn/ignore/shadow>
-#include <pybind11/stl_bind.h>
-#include <pybind11/numpy.h>
-#include <warn/pop>
-
-#include <vector>
-
-namespace py = pybind11;
+#include <inviwopy/pyglmports.h>
+#include <inviwopy/pyglmportsdouble.h>
+#include <inviwopy/pyglmportsfloat.h>
+#include <inviwopy/pyglmportsint.h>
+#include <inviwopy/pyglmportsuint.h>
 
 namespace inviwo {
 
-namespace {
-
-template <typename T>
-constexpr bool alwaysFalse() {
-    return false;
-}
-
-struct ExposePortsFunctor {
-    template <typename T>
-    void operator()(pybind11::module& m) {
-        using V = typename util::value_type<T>::type;
-        constexpr auto N = util::extent<T>::value;
-
-        if constexpr (N == 1) {
-            constexpr auto name = []() {
-                if constexpr (std::is_same_v<T, float>) {
-                    return "float";
-                } else if constexpr (std::is_same_v<T, double>) {
-                    return "double";
-                } else if constexpr (std::is_same_v<T, int>) {
-                    return "int";
-                } else if constexpr (std::is_same_v<T, unsigned int>) {
-                    return "uint";
-                } else {
-                    static_assert(alwaysFalse<T>(), "Missing name for T");
-                }
-            }();
-            const auto vectorName = fmt::format("{}Vector", name);
-            py::bind_vector<std::vector<T>>(m, vectorName);
-            exposeStandardDataPorts<std::vector<T>>(m, vectorName);
-
-        } else {
-            const auto prefix = glm::detail::prefix<V>::value();
-            const auto vectorName = fmt::format("{}vec{}Vector", prefix, N);
-            py::bind_vector<std::vector<T>>(m, vectorName, py::buffer_protocol{});
-            exposeStandardDataPorts<std::vector<T>>(m, vectorName);
-        }
-    }
-};
-
-}  // namespace
-
 void exposeGLMPorts(pybind11::module& m) {
-
-    // clang-format off
-    using types = std::tuple<
-        float, vec2, vec3, vec4,
-        double, dvec2, dvec3, dvec4,
-        int, ivec2, ivec3, ivec4,
-        unsigned int, uvec2, uvec3, uvec4
-    >;
-    // clang-format on
-    util::for_each_type<types>{}(ExposePortsFunctor{}, m);
+    exposeGLMPortsDouble(m);
+    exposeGLMPortsFloat(m);
+    exposeGLMPortsInt(m);
+    exposeGLMPortsUint(m);
 }
 
 }  // namespace inviwo

--- a/modules/python3/bindings/src/pyglmportsdouble.cpp
+++ b/modules/python3/bindings/src/pyglmportsdouble.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2014-2023 Inviwo Foundation
+ * Copyright (c) 2023 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,22 +27,16 @@
  *
  *********************************************************************************/
 
-#include <inviwopy/pyglmmattypes.h>
+#include <inviwopy/pyglmportsdouble.h>
+#include <inviwopy/util/pyglmhelper.h>
 
-#include <inviwopy/pyglmmattypesfloat.h>
-#include <inviwopy/pyglmmattypesdouble.h>
-#include <inviwopy/pyglmmattypesint.h>
-#include <inviwopy/pyglmmattypesuint.h>
+#include <inviwo/core/util/foreacharg.h>
 
 namespace inviwo {
 
-namespace py = pybind11;
-
-void exposeGLMMatTypes(py::module& m) {
-    exposeGLMMatTypesFloat(m);
-    exposeGLMMatTypesDouble(m);
-    exposeGLMMatTypesInt(m);
-    exposeGLMMatTypesUint(m);
+void exposeGLMPortsDouble(pybind11::module& m) {
+    using types = std::tuple<double, dvec2, dvec3, dvec4>;
+    util::for_each_type<types>{}(ExposePortsFunctor{}, m);
 }
 
 }  // namespace inviwo

--- a/modules/python3/bindings/src/pyglmportsfloat.cpp
+++ b/modules/python3/bindings/src/pyglmportsfloat.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2014-2023 Inviwo Foundation
+ * Copyright (c) 2023 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,22 +27,16 @@
  *
  *********************************************************************************/
 
-#include <inviwopy/pyglmmattypes.h>
+#include <inviwopy/pyglmportsfloat.h>
+#include <inviwopy/util/pyglmhelper.h>
 
-#include <inviwopy/pyglmmattypesfloat.h>
-#include <inviwopy/pyglmmattypesdouble.h>
-#include <inviwopy/pyglmmattypesint.h>
-#include <inviwopy/pyglmmattypesuint.h>
+#include <inviwo/core/util/foreacharg.h>
 
 namespace inviwo {
 
-namespace py = pybind11;
-
-void exposeGLMMatTypes(py::module& m) {
-    exposeGLMMatTypesFloat(m);
-    exposeGLMMatTypesDouble(m);
-    exposeGLMMatTypesInt(m);
-    exposeGLMMatTypesUint(m);
+void exposeGLMPortsFloat(pybind11::module& m) {
+    using types = std::tuple<float, vec2, vec3, vec4>;
+    util::for_each_type<types>{}(ExposePortsFunctor{}, m);
 }
 
 }  // namespace inviwo

--- a/modules/python3/bindings/src/pyglmportsint.cpp
+++ b/modules/python3/bindings/src/pyglmportsint.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2014-2023 Inviwo Foundation
+ * Copyright (c) 2023 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,22 +27,16 @@
  *
  *********************************************************************************/
 
-#include <inviwopy/pyglmmattypes.h>
+#include <inviwopy/pyglmportsint.h>
+#include <inviwopy/util/pyglmhelper.h>
 
-#include <inviwopy/pyglmmattypesfloat.h>
-#include <inviwopy/pyglmmattypesdouble.h>
-#include <inviwopy/pyglmmattypesint.h>
-#include <inviwopy/pyglmmattypesuint.h>
+#include <inviwo/core/util/foreacharg.h>
 
 namespace inviwo {
 
-namespace py = pybind11;
-
-void exposeGLMMatTypes(py::module& m) {
-    exposeGLMMatTypesFloat(m);
-    exposeGLMMatTypesDouble(m);
-    exposeGLMMatTypesInt(m);
-    exposeGLMMatTypesUint(m);
+void exposeGLMPortsInt(pybind11::module& m) {
+    using types = std::tuple<int, ivec2, ivec3, ivec4>;
+    util::for_each_type<types>{}(ExposePortsFunctor{}, m);
 }
 
 }  // namespace inviwo

--- a/modules/python3/bindings/src/pyglmportsuint.cpp
+++ b/modules/python3/bindings/src/pyglmportsuint.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2014-2023 Inviwo Foundation
+ * Copyright (c) 2023 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,22 +27,16 @@
  *
  *********************************************************************************/
 
-#include <inviwopy/pyglmmattypes.h>
+#include <inviwopy/pyglmportsuint.h>
+#include <inviwopy/util/pyglmhelper.h>
 
-#include <inviwopy/pyglmmattypesfloat.h>
-#include <inviwopy/pyglmmattypesdouble.h>
-#include <inviwopy/pyglmmattypesint.h>
-#include <inviwopy/pyglmmattypesuint.h>
+#include <inviwo/core/util/foreacharg.h>
 
 namespace inviwo {
 
-namespace py = pybind11;
-
-void exposeGLMMatTypes(py::module& m) {
-    exposeGLMMatTypesFloat(m);
-    exposeGLMMatTypesDouble(m);
-    exposeGLMMatTypesInt(m);
-    exposeGLMMatTypesUint(m);
+void exposeGLMPortsUint(pybind11::module& m) {
+    using types = std::tuple<unsigned int, uvec2, uvec3, uvec4>;
+    util::for_each_type<types>{}(ExposePortsFunctor{}, m);
 }
 
 }  // namespace inviwo

--- a/modules/python3/bindings/src/pyproperties.cpp
+++ b/modules/python3/bindings/src/pyproperties.cpp
@@ -203,7 +203,7 @@ struct MinMaxHelper {
                      return new P(identifier, name, std::move(help), valueMin, valueMax, rangeMin,
                                   rangeMax, increment, minSeparation, invalidationLevel, semantics);
                  }),
-                 py::arg("identifier"), py::arg("name"), py::arg("help") = Document{},
+                 py::arg("identifier"), py::arg("name"), py::arg("help"),
                  py::arg("valueMin") = Defaultvalues<T>::getMin(),
                  py::arg("valueMax") = Defaultvalues<T>::getMax(),
                  py::arg("rangeMin") = Defaultvalues<T>::getMin(),

--- a/modules/python3/bindings/src/util/pyglmhelper.cpp
+++ b/modules/python3/bindings/src/util/pyglmhelper.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2014-2023 Inviwo Foundation
+ * Copyright (c) 2023 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,22 +27,6 @@
  *
  *********************************************************************************/
 
-#include <inviwopy/pyglmmattypes.h>
+#include <inviwopy/util/pyglmhelper.h>
 
-#include <inviwopy/pyglmmattypesfloat.h>
-#include <inviwopy/pyglmmattypesdouble.h>
-#include <inviwopy/pyglmmattypesint.h>
-#include <inviwopy/pyglmmattypesuint.h>
-
-namespace inviwo {
-
-namespace py = pybind11;
-
-void exposeGLMMatTypes(py::module& m) {
-    exposeGLMMatTypesFloat(m);
-    exposeGLMMatTypesDouble(m);
-    exposeGLMMatTypesInt(m);
-    exposeGLMMatTypesUint(m);
-}
-
-}  // namespace inviwo
+namespace inviwo {}

--- a/modules/python3/bindings/src/util/pypropertyhelper.cpp
+++ b/modules/python3/bindings/src/util/pypropertyhelper.cpp
@@ -1,0 +1,32 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2023 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwopy/util/pypropertyhelper.h>
+
+namespace inviwo {}

--- a/modules/webbrowser/CMakeLists.txt
+++ b/modules/webbrowser/CMakeLists.txt
@@ -172,6 +172,11 @@ ivw_handle_shader_resources(${CMAKE_CURRENT_SOURCE_DIR}/glsl ${SHADER_FILES})
 
 ivw_add_to_module_pack(${CMAKE_CURRENT_SOURCE_DIR}/data/js)
 
+find_package(utf8cpp CONFIG REQUIRED)
+target_link_libraries(inviwo-module-webbrowser PRIVATE
+    utf8cpp
+)
+
 # Inviwo: CEF only provides release/debug configurations. Set RelWithDebInfo and MinSizeRel to use release 
 set(CEF_BINARY_DIR "${_CEF_ROOT}/$<$<CONFIG:RelWithDebInfo>:Release>$<$<CONFIG:MinSizeRel>:Release>$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>")
 


### PR DESCRIPTION
Fixes github action build running out of memory
> D:\a\inviwo\inviwo\inviwo\modules\python3\bindings\src\pyglmmattypes.cpp(200,1): fatal  error C1060: compiler is out of heap space 

Changes proposed in this PR:
 * Python bindings are distributed over more files
 * split up exposing glm matrix types and glm ports
 * split up exposing properties (ordinal, ordinal ref, option, minmax)

This has been tested on: Windows, MSVC 17.5.4

---

*Memory consumed during compilation of single source file*
Source | Before | After
---|---|---
`pyproperties` | 4.3GB | 1.4GB
`ordinalref` | | 2GB
`ordinal` | | 1.9GB
`option` | | 1.1GB
`minmax` | |  0.7GB
`pyglmmattypes` | 5.3GB | ~2GB each (float, double, int, uint)
`pyglmports` | 3.8GB | 1.4-1.8GB (float, double, int, uint)

