### PR TITLE
Use standard FindHDF5 cmake module for system-provided HDF5 build

### DIFF
--- a/modules/fontrendering/CMakeLists.txt
+++ b/modules/fontrendering/CMakeLists.txt
@@ -50,6 +50,8 @@ ivw_handle_shader_resources(${CMAKE_CURRENT_SOURCE_DIR}/glsl ${SHADER_FILES})
 # Add font directory to pack
 ivw_add_to_module_pack(${CMAKE_CURRENT_SOURCE_DIR}/fonts)
 
+find_package(utf8cpp CONFIG REQUIRED)
+
 option(IVW_USE_EXTERNAL_FREETYPE "Freetype is provided externaly" OFF)
 if(NOT IVW_USE_EXTERNAL_FREETYPE)
     add_subdirectory(ext/freetype)
@@ -60,17 +62,33 @@ if(NOT IVW_USE_EXTERNAL_FREETYPE)
     )
     ivw_default_install_targets(freetype)
     ivw_make_package(freetype freetype)
-else()
-    find_package(freetype CONFIG REQUIRED)
-    ivw_vcpkg_install(freetype MODULE FontRendering)
-endif()
 
-find_package(utf8cpp CONFIG REQUIRED)
-target_link_libraries(inviwo-module-fontrendering 
-    PUBLIC 
-        freetype
-    PRIVATE
-        utf8cpp
-)
+    target_link_libraries(inviwo-module-fontrendering
+        PUBLIC
+            freetype
+        PRIVATE
+            utf8cpp
+    )
+
+else()
+    find_package(freetype CONFIG)
+    if(FREETYPE_FOUND)
+        ivw_vcpkg_install(freetype MODULE FontRendering)
+        target_link_libraries(inviwo-module-fontrendering
+            PUBLIC
+            freetype
+            PRIVATE
+            utf8cpp
+        )
+    else()
+      find_package(Freetype REQUIRED)
+      target_link_libraries(inviwo-module-fontrendering
+        PUBLIC
+            Freetype::Freetype
+        PRIVATE
+            utf8cpp
+        )
+    endif()
+endif()
 
 ivw_make_package(InviwoFontRenderingModule inviwo-module-fontrendering)

--- a/modules/hdf5/CMakeLists.txt
+++ b/modules/hdf5/CMakeLists.txt
@@ -109,7 +109,8 @@ if (NOT IVW_USE_EXTERNAL_HDF5)
     ivw_default_install_targets(${h5-targets})
 
 else()
-    find_package(hdf5 REQUIRED)
+    # Try vcpkg-provided Findhdf5
+    find_package(hdf5 QUIET)
     if(HDF5_FOUND)
         if(BUILD_SHARED_LIBS)
             target_link_libraries(inviwo-module-hdf5
@@ -131,6 +132,7 @@ else()
         ivw_vcpkg_install(hdf5 MODULE HDF5)
         set(version ${HDF5_VERSION_STRING})
     else()
+        # Try cmake standard FindHDF5
         if(NOT BUILD_SHARED_LIBS)
            set(HDF5_USE_STATIC_LIBRARIES ON)
         endif()

--- a/modules/hdf5/CMakeLists.txt
+++ b/modules/hdf5/CMakeLists.txt
@@ -109,24 +109,17 @@ if (NOT IVW_USE_EXTERNAL_HDF5)
     ivw_default_install_targets(${h5-targets})
 
 else()
-    find_package(hdf5 REQUIRED)
-    if(BUILD_SHARED_LIBS)
-        target_link_libraries(inviwo-module-hdf5 
-            PUBLIC 
-                hdf5::hdf5-shared 
-                hdf5::hdf5_hl-shared 
-                hdf5::hdf5_cpp-shared 
-                hdf5::hdf5_hl_cpp-shared
-        )
-    else()
-        target_link_libraries(inviwo-module-hdf5 
-            PUBLIC 
-                hdf5::hdf5-static 
-                hdf5::hdf5_hl-static 
-                hdf5::hdf5_cpp-static 
-                hdf5::hdf5_hl_cpp-static
-        )
+    if(NOT BUILD_SHARED_LIBS)
+        set(HDF5_USE_STATIC_LIBRARIES ON)
     endif()
+    find_package(HDF5 REQUIRED)
+    target_link_libraries(inviwo-module-hdf5
+        PUBLIC
+        ${HDF5_LIBRARIES}
+        ${HDF5_HL_LIBRARIES}
+        ${HDF5_CXX_LIBRARIES}
+        ${HDF5_HL_CXX_LIBRARIES}
+    )
     ivw_vcpkg_install(hdf5 MODULE HDF5)
     set(version ${HDF5_VERSION_STRING})
 endif()

--- a/modules/hdf5/CMakeLists.txt
+++ b/modules/hdf5/CMakeLists.txt
@@ -112,14 +112,15 @@ else()
     if(NOT BUILD_SHARED_LIBS)
         set(HDF5_USE_STATIC_LIBRARIES ON)
     endif()
-    find_package(HDF5 REQUIRED)
+    find_package(HDF5 REQUIRED COMPONENTS C CXX)
     target_link_libraries(inviwo-module-hdf5
         PUBLIC
         ${HDF5_LIBRARIES}
-        ${HDF5_HL_LIBRARIES}
         ${HDF5_CXX_LIBRARIES}
-        ${HDF5_HL_CXX_LIBRARIES}
-    )
+        )
+    target_include_directories(inviwo-module-hdf5
+        PUBLIC
+        ${HDF5_INCLUDE_DIRS})
     ivw_vcpkg_install(hdf5 MODULE HDF5)
     set(version ${HDF5_VERSION_STRING})
 endif()

--- a/modules/hdf5/CMakeLists.txt
+++ b/modules/hdf5/CMakeLists.txt
@@ -109,20 +109,39 @@ if (NOT IVW_USE_EXTERNAL_HDF5)
     ivw_default_install_targets(${h5-targets})
 
 else()
-    if(NOT BUILD_SHARED_LIBS)
-        set(HDF5_USE_STATIC_LIBRARIES ON)
+    find_package(hdf5 REQUIRED)
+    if(HDF5_FOUND)
+        if(BUILD_SHARED_LIBS)
+            target_link_libraries(inviwo-module-hdf5
+                PUBLIC
+                    hdf5::hdf5-shared
+                    hdf5::hdf5_hl-shared
+                    hdf5::hdf5_cpp-shared
+                    hdf5::hdf5_hl_cpp-shared
+            )
+        else()
+            target_link_libraries(inviwo-module-hdf5
+                PUBLIC
+                    hdf5::hdf5-static
+                    hdf5::hdf5_hl-static
+                    hdf5::hdf5_cpp-static
+                    hdf5::hdf5_hl_cpp-static
+            )
+        endif()
+        ivw_vcpkg_install(hdf5 MODULE HDF5)
+        set(version ${HDF5_VERSION_STRING})
+    else()
+        if(NOT BUILD_SHARED_LIBS)
+           set(HDF5_USE_STATIC_LIBRARIES ON)
+        endif()
+        find_package(HDF5 REQUIRED COMPONENTS C CXX)
+        target_link_libraries(inviwo-module-hdf5
+            PUBLIC
+            hdf5::hdf5
+            hdf5::hdf5_cpp
+            )
+          set(version ${HDF5_VERSION})
     endif()
-    find_package(HDF5 REQUIRED COMPONENTS C CXX)
-    target_link_libraries(inviwo-module-hdf5
-        PUBLIC
-        ${HDF5_LIBRARIES}
-        ${HDF5_CXX_LIBRARIES}
-        )
-    target_include_directories(inviwo-module-hdf5
-        PUBLIC
-        ${HDF5_INCLUDE_DIRS})
-    ivw_vcpkg_install(hdf5 MODULE HDF5)
-    set(version ${HDF5_VERSION_STRING})
 endif()
 
 


### PR DESCRIPTION
This adjusts the modules/hdf5/CMakeLists.txt when using system libraries. This makes it possible to build Inviwo on Ubuntu 22.04 against its apt-provided hdf5 packages.

I'm not sure what "hdf5"-finding module the present cmake setup is supposed to be using (?), but the [FindHDF5](https://cmake.org/cmake/help/latest/module/FindHDF5.html) this PR changes it into seems to have been standard in cmake for quite a while.