### PR TITLE
Python3: VolumePy array check

### DIFF
--- a/modules/python3/src/volumepy.cpp
+++ b/modules/python3/src/volumepy.cpp
@@ -56,6 +56,10 @@ const DataFormatBase* format(pybind11::array data) {
         throw Exception("Ndims must be either 3 or 4, with 1 <= size[3] <= 4",
                         IVW_CONTEXT_CUSTOM("VolumePy"));
     }
+    if ((data.flags() & pybind11::array::c_style) == 0) {
+        throw Exception("Numpy array must be C-contiguous.", IVW_CONTEXT_CUSTOM("VolumePy"));
+    }
+
     return pyutil::getDataFormat(ndim == 3 ? 1 : data.shape(3), data);
 }
 }  // namespace


### PR DESCRIPTION
Changes proposed in this PR:
 * additional check in `VolumePy` constructor for ensuring that the numpy array is c-contiguous