### PR TITLE
FileProperty enhancements and welcome widget updates

### DIFF
--- a/include/inviwo/core/network/processornetworkconverter.h
+++ b/include/inviwo/core/network/processornetworkconverter.h
@@ -67,6 +67,7 @@ private:
     void updatePropertyEditorMetadata(TxElement* node);
     void updateCameraPropertyToRefs(TxElement* node);
     void updateLinkAndConnections(TxElement* node);
+    void updateFileMode(TxElement* node);
 
     void traverseNodes(TxElement* node, updateType update);
 

--- a/include/inviwo/core/properties/fileproperty.h
+++ b/include/inviwo/core/properties/fileproperty.h
@@ -59,6 +59,7 @@ public:
     virtual std::string getClassIdentifier() const override;
     static const std::string classIdentifier;
     static constexpr std::string_view defaultContentType = "default";
+    using value_type = std::filesystem::path;
 
     /**
      * \brief Constructor for the FileProperty
@@ -77,7 +78,7 @@ public:
      * @param semantics Can be set to Editor
      */
     FileProperty(std::string_view identifier, std::string_view displayName, Document help,
-                 const std::filesystem::path& value = {}, AcceptMode acceptMode = AcceptMode::Open,
+                 const std::filesystem::path& value, AcceptMode acceptMode = AcceptMode::Open,
                  FileMode fileMode = FileMode::AnyFile,
                  std::string_view contentType = defaultContentType,
                  InvalidationLevel invalidationLevel = InvalidationLevel::InvalidOutput,
@@ -136,7 +137,7 @@ public:
      * Set the file name and the selected extension.
      */
     virtual void set(const std::filesystem::path& file, const FileExtension& selectedExtension);
-    
+
     virtual void set(const Property* property) override;
     virtual void set(const FileProperty* property);
 
@@ -172,11 +173,15 @@ public:
     virtual void requestFile();
 
     virtual Document getDescription() const override;
-    
+
     virtual FileProperty& setCurrentStateAsDefault() override;
     FileProperty& setDefault(const std::filesystem::path& value);
     virtual FileProperty& resetToDefaultState() override;
     virtual bool isDefaultState() const override;
+
+    friend std::ostream& operator<<(std::ostream& os, const FileProperty& prop) {
+        return os << prop.file_.value;
+    }
 
 private:
     ValueWrapper<std::filesystem::path> file_;

--- a/include/inviwo/core/properties/fileproperty.h
+++ b/include/inviwo/core/properties/fileproperty.h
@@ -54,11 +54,34 @@ public:
  *
  * @see TemplateProperty
  */
-class IVW_CORE_API FileProperty : public TemplateProperty<std::filesystem::path> {
+class IVW_CORE_API FileProperty : public Property {
 public:
     virtual std::string getClassIdentifier() const override;
     static const std::string classIdentifier;
     static constexpr std::string_view defaultContentType = "default";
+
+    /**
+     * \brief Constructor for the FileProperty
+     *
+     * The PropertySemantics can be set to TextEditor. Then a TextEditorWidget will be used instead
+     * of a FilePropertyWidget
+     *
+     * @param identifier identifier for the property
+     * @param displayName displayName for the property
+     * @param help descriptive text
+     * @param value the path to the file
+     * @param acceptMode
+     * @param fileMode
+     * @param contentType
+     * @param invalidationLevel
+     * @param semantics Can be set to Editor
+     */
+    FileProperty(std::string_view identifier, std::string_view displayName, Document help,
+                 const std::filesystem::path& value = {}, AcceptMode acceptMode = AcceptMode::Open,
+                 FileMode fileMode = FileMode::AnyFile,
+                 std::string_view contentType = defaultContentType,
+                 InvalidationLevel invalidationLevel = InvalidationLevel::InvalidOutput,
+                 PropertySemantics semantics = PropertySemantics::Default);
 
     /**
      * \brief Constructor for the FileProperty
@@ -108,14 +131,19 @@ public:
     /**
      * Set the file name and also update the selected extension to the first one matching file.
      */
-    virtual void set(const std::filesystem::path& file) override;
+    virtual void set(const std::filesystem::path& file);
     /**
      * Set the file name and the selected extension.
      */
     virtual void set(const std::filesystem::path& file, const FileExtension& selectedExtension);
+    
     virtual void set(const Property* property) override;
+    virtual void set(const FileProperty* property);
 
-    operator const std::filesystem::path&() const;
+    operator const std::filesystem::path&() const { return file_; }
+    const std::filesystem::path& get() const { return file_; }
+    const std::filesystem::path& operator*() const { return file_; };
+    const std::filesystem::path* operator->() const { return &file_.value; }
 
     virtual void serialize(Serializer& s) const override;
     virtual void deserialize(Deserializer& d) override;
@@ -126,10 +154,10 @@ public:
     virtual void clearNameFilters();
     virtual const std::vector<FileExtension>& getNameFilters() const;
 
-    virtual void setAcceptMode(AcceptMode mode);
+    virtual void setAcceptMode(AcceptMode acceptMode);
     AcceptMode getAcceptMode() const;
 
-    virtual void setFileMode(FileMode mode);
+    virtual void setFileMode(FileMode fileMode);
     FileMode getFileMode() const;
 
     void setContentType(std::string_view contentType);
@@ -144,8 +172,14 @@ public:
     virtual void requestFile();
 
     virtual Document getDescription() const override;
+    
+    virtual FileProperty& setCurrentStateAsDefault() override;
+    FileProperty& setDefault(const std::filesystem::path& value);
+    virtual FileProperty& resetToDefaultState() override;
+    virtual bool isDefaultState() const override;
 
 private:
+    ValueWrapper<std::filesystem::path> file_;
     std::vector<FileExtension> nameFilters_;
     FileExtension selectedExtension_;
     AcceptMode acceptMode_;

--- a/include/inviwo/core/properties/templateproperty.h
+++ b/include/inviwo/core/properties/templateproperty.h
@@ -82,9 +82,8 @@ protected:
     ValueWrapper<T> value_;
 };
 
-template <typename CTy, typename CTr, typename T>
-std::basic_ostream<CTy, CTr>& operator<<(std::basic_ostream<CTy, CTr>& os,
-                                         const TemplateProperty<T>& prop) {
+template <typename T, typename = std::enable_if_t<util::is_stream_insertable<T>::value>>
+std::ostream& operator<<(std::ostream& os, const TemplateProperty<T>& prop) {
     return os << prop.get();
 }
 

--- a/include/inviwo/core/util/filedialogstate.h
+++ b/include/inviwo/core/util/filedialogstate.h
@@ -40,8 +40,8 @@ enum class FileMode { AnyFile, ExistingFile, Directory, ExistingFiles };
 
 IVW_CORE_API std::string_view enumToStr(AcceptMode mode);
 IVW_CORE_API std::string_view enumToStr(FileMode mode);
-IVW_CORE_API std::ostream& operator<<(std::ostream& ss, AcceptMode& mode);
-IVW_CORE_API std::ostream& operator<<(std::ostream& ss, FileMode& mode);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, AcceptMode mode);
+IVW_CORE_API std::ostream& operator<<(std::ostream& ss, FileMode mode);
 
 }  // namespace inviwo
 

--- a/include/inviwo/core/util/filedialogstate.h
+++ b/include/inviwo/core/util/filedialogstate.h
@@ -36,7 +36,7 @@
 namespace inviwo {
 
 enum class AcceptMode { Open, Save };
-enum class FileMode { AnyFile, ExistingFile, Directory, ExistingFiles, DirectoryOnly };
+enum class FileMode { AnyFile, ExistingFile, Directory, ExistingFiles };
 
 IVW_CORE_API std::string_view enumToStr(AcceptMode mode);
 IVW_CORE_API std::string_view enumToStr(FileMode mode);

--- a/include/inviwo/qt/editor/inviwomainwindow.h
+++ b/include/inviwo/qt/editor/inviwomainwindow.h
@@ -252,10 +252,6 @@ private:
     WelcomeWidget* welcomeWidget_ = nullptr;
     AnnotationsWidget* annotationsWidget_ = nullptr;
     InviwoAboutWindow* inviwoAboutWindow_ = nullptr;
-
-    std::vector<QAction*> workspaceActionRecent_;
-    QAction* clearRecentWorkspaces_;
-
     std::unique_ptr<FileAssociations> fileAssociations_;
 
     WorkspaceManager::SerializationHandle annotationSerializationHandle_;

--- a/include/inviwo/qt/editor/workspaceannotationsqt.h
+++ b/include/inviwo/qt/editor/workspaceannotationsqt.h
@@ -40,6 +40,7 @@
 
 #include <vector>
 #include <filesystem>
+#include <map>
 
 namespace inviwo {
 
@@ -68,6 +69,9 @@ public:
 
     static QStringList workspaceProcessors(const std::filesystem::path& path,
                                            InviwoApplication* app = util::getInviwoApplication());
+
+    static std::map<std::string, int> workspaceProcessorsCounts(
+        const std::filesystem::path& path, InviwoApplication* app = util::getInviwoApplication());
 
 private:
     Base64Image network_;

--- a/include/inviwo/qt/editor/workspacetreemodel.h
+++ b/include/inviwo/qt/editor/workspacetreemodel.h
@@ -107,11 +107,15 @@ public:
     virtual int columnCount(const QModelIndex& parent = QModelIndex()) const override;
 
     void updateRecentWorkspaces(const QStringList& recentFiles);
+    void updateRestoreEntries();
+    void updateCustomEntries();
     void updateExampleEntries();
     void updateRegressionTestEntries();
 
     QModelIndex getCategoryIndex(std::string_view category);
     static constexpr std::string_view recent = "Recent Workspaces";
+    static constexpr std::string_view restore = "Restore";
+    static constexpr std::string_view custom = "Custom";
     static constexpr std::string_view examples = "Examples";
     static constexpr std::string_view tests = "Regression Tests";
 

--- a/modules/animation/src/demo/democontroller.cpp
+++ b/modules/animation/src/demo/democontroller.cpp
@@ -55,7 +55,7 @@ namespace animation {
 DemoController::DemoController(InviwoApplication* app)
     : app_(app), demoFolder_("demoFolder", "Folder", ""), demoFile_("demoFile", "File") {
 
-    demoFolder_.setFileMode(FileMode::DirectoryOnly);
+    demoFolder_.setFileMode(FileMode::Directory);
     addProperty(demoFolder_);
     addProperty(demoFile_);
     demoFolder_.onChange([this]() { setFileOptions(); });

--- a/modules/dataframe/src/processors/dataframeexporter.cpp
+++ b/modules/dataframe/src/processors/dataframeexporter.cpp
@@ -129,8 +129,8 @@ void DataFrameExporter::exportData() {
         exportAsCSV();
     } else {
         // use CSV format as fallback
-        LogWarn("Could not determine export format from file '"
-                << exportFile_ << "', exporting as comma-separated values (csv).");
+        LogWarn("Could not determine export format from file "
+                << exportFile_ << ", exporting as comma-separated values (csv).");
         exportAsCSV();
     }
 

--- a/modules/python3/bindings/src/pyproperties.cpp
+++ b/modules/python3/bindings/src/pyproperties.cpp
@@ -307,8 +307,7 @@ void exposeProperties(py::module& m) {
         .value("AnyFile", FileMode::AnyFile)
         .value("ExistingFile", FileMode::ExistingFile)
         .value("Directory", FileMode::Directory)
-        .value("ExistingFiles", FileMode::ExistingFiles)
-        .value("DirectoryOnly", FileMode::DirectoryOnly);
+        .value("ExistingFiles", FileMode::ExistingFiles);
 
     py::class_<FileExtension>(m, "FileExtension")
         .def(py::init<>())

--- a/modules/qtwidgets/CMakeLists.txt
+++ b/modules/qtwidgets/CMakeLists.txt
@@ -39,6 +39,7 @@ set(HEADER_FILES
     ${MOC_FILES}
     include/modules/qtwidgets/codeedit.h
     include/modules/qtwidgets/editorfileobserver.h
+    include/modules/qtwidgets/editorsettings.h
     include/modules/qtwidgets/eventconverterqt.h
     include/modules/qtwidgets/inviwoqtutils.h
     include/modules/qtwidgets/keyboardutils.h
@@ -101,6 +102,7 @@ set(SOURCE_FILES
     src/customdoublespinboxqt.cpp
     src/editablelabelqt.cpp
     src/editorfileobserver.cpp
+    src/editorsettings.cpp
     src/eventconverterqt.cpp
     src/filepathlineeditqt.cpp
     src/inviwodockwidget.cpp

--- a/modules/qtwidgets/include/modules/qtwidgets/editorsettings.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/editorsettings.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2013-2023 Inviwo Foundation
+ * Copyright (c) 2023 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,49 +26,30 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  *********************************************************************************/
-
 #pragma once
 
+#include <modules/qtwidgets/qtwidgetsmoduledefine.h>
+
 #include <inviwo/core/util/settings/settings.h>
-#include <inviwo/core/properties/optionproperty.h>
-#include <inviwo/core/properties/boolproperty.h>
+
 #include <inviwo/core/properties/ordinalproperty.h>
 #include <inviwo/core/properties/stringproperty.h>
+#include <inviwo/core/properties/listproperty.h>
+#include <inviwo/core/properties/fileproperty.h>
 
 namespace inviwo {
 
-class InviwoApplication;
-class LogStream;
-
-/**
- * System settings, owned by the application, loaded before all the factories so we can't use any
- * dynamic properties here
- */
-class IVW_CORE_API SystemSettings : public Settings {
+class IVW_MODULE_QTWIDGETS_API EditorSettings : public Settings {
 public:
-    SystemSettings(InviwoApplication* app);
-    virtual ~SystemSettings();
-    IntSizeTProperty poolSize_;
-    BoolProperty enablePortInspectors_;
-    IntProperty portInspectorSize_;
-    BoolProperty enableTouchProperty_;
-    BoolProperty enableGesturesProperty_;
-    BoolProperty enablePickingProperty_;
-    BoolProperty enableSoundProperty_;
-    BoolProperty logStackTraceProperty_;
-    BoolProperty runtimeModuleReloading_;
-    BoolProperty enableResourceManager_;
-    OptionProperty<MessageBreakLevel> breakOnMessage_;
-    BoolProperty breakOnException_;
-    BoolProperty stackTraceInException_;
-
-    BoolProperty redirectCout_;
-    BoolProperty redirectCerr_;
-
-    static size_t defaultPoolSize();
-
-    std::unique_ptr<LogStream> cout_;
-    std::unique_ptr<LogStream> cerr_;
+    EditorSettings(InviwoApplication* app);
+    virtual ~EditorSettings() = default;
+    
+    StringProperty workspaceAuthor;
+    IntProperty numRecentFiles;
+    IntProperty numRestoreFiles;
+    IntProperty restoreFrequency;
+    ListProperty workspaceDirectories;
+     
 };
 
 }  // namespace inviwo

--- a/modules/qtwidgets/include/modules/qtwidgets/editorsettings.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/editorsettings.h
@@ -43,13 +43,12 @@ class IVW_MODULE_QTWIDGETS_API EditorSettings : public Settings {
 public:
     EditorSettings(InviwoApplication* app);
     virtual ~EditorSettings() = default;
-    
+
     StringProperty workspaceAuthor;
     IntProperty numRecentFiles;
     IntProperty numRestoreFiles;
     IntProperty restoreFrequency;
     ListProperty workspaceDirectories;
-     
 };
 
 }  // namespace inviwo

--- a/modules/qtwidgets/include/modules/qtwidgets/filepathlineeditqt.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/filepathlineeditqt.h
@@ -80,12 +80,11 @@ private:
     std::filesystem::path path_;  //!< full path including file name
     AcceptMode acceptMode_;
     FileMode fileMode_;
-    
+
     bool editingEnabled_;  //!< if this flag is set, the full path is shown. Otherwise only the file
                            //!< name is shown
     int cursorPos_;
     bool cursorPosDirty_;
-    
 };
 
 }  // namespace inviwo

--- a/modules/qtwidgets/include/modules/qtwidgets/filepathlineeditqt.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/filepathlineeditqt.h
@@ -32,6 +32,7 @@
 #include <modules/qtwidgets/qtwidgetsmoduledefine.h>  // for IVW_MODULE_QTWIDGETS_API
 
 #include <modules/qtwidgets/lineeditqt.h>  // for LineEditQt
+#include <inviwo/core/util/filedialogstate.h>
 
 #include <filesystem>
 
@@ -63,6 +64,9 @@ public:
     void setEditing(bool editing);
     bool isEditingEnabled() const;
 
+    void setAcceptMode(AcceptMode mode);
+    void setFileMode(FileMode mode);
+
 protected:
     virtual void resizeEvent(QResizeEvent* event) override;
     virtual void focusInEvent(QFocusEvent* event) override;
@@ -74,10 +78,14 @@ protected:
 private:
     QLabel* warningLabel_;        //!< warning icon which is visible if the path is invalid
     std::filesystem::path path_;  //!< full path including file name
+    AcceptMode acceptMode_;
+    FileMode fileMode_;
+    
     bool editingEnabled_;  //!< if this flag is set, the full path is shown. Otherwise only the file
                            //!< name is shown
     int cursorPos_;
     bool cursorPosDirty_;
+    
 };
 
 }  // namespace inviwo

--- a/modules/qtwidgets/include/modules/qtwidgets/inviwofiledialog.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/inviwofiledialog.h
@@ -104,8 +104,6 @@ public:
     void addSidebarPath(const std::filesystem::path& path);
     void addSidebarPath(const QString& path);
 
-    void useNativeDialog(const bool& use = true);
-
     static QString getPreviousPath(const QString& pathType);
     static void setPreviousPath(const QString& pathType, const QString& path);
 

--- a/modules/qtwidgets/src/editorsettings.cpp
+++ b/modules/qtwidgets/src/editorsettings.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2013-2023 Inviwo Foundation
+ * Copyright (c) 2023 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,48 +27,30 @@
  *
  *********************************************************************************/
 
-#pragma once
-
-#include <inviwo/core/util/settings/settings.h>
-#include <inviwo/core/properties/optionproperty.h>
-#include <inviwo/core/properties/boolproperty.h>
-#include <inviwo/core/properties/ordinalproperty.h>
-#include <inviwo/core/properties/stringproperty.h>
+#include <modules/qtwidgets/editorsettings.h>
 
 namespace inviwo {
 
-class InviwoApplication;
-class LogStream;
+EditorSettings::EditorSettings(InviwoApplication* app)
+    : Settings("Editor Settings", app)
+    , workspaceAuthor("workspaceAuthor", "Default Workspace Author", "")
+    , numRecentFiles("numRecentFiles", "Number of Recent Files", 12,
+                     {1, ConstraintBehavior::Immutable}, {100, ConstraintBehavior::Ignore})
+    , numRestoreFiles(
+          "numRestoreFiles", "Number of Restore Files",
+          "The maximum number of backup files to store, the oldest will be removed frist"_help, 24,
+          {1, ConstraintBehavior::Immutable}, {100, ConstraintBehavior::Ignore})
+    , restoreFrequency("restoreFrequency", "Restore Frequency",
+                       "Minutes between new backup files"_help, 10,
+                       {1, ConstraintBehavior::Immutable}, {100, ConstraintBehavior::Ignore})
 
-/**
- * System settings, owned by the application, loaded before all the factories so we can't use any
- * dynamic properties here
- */
-class IVW_CORE_API SystemSettings : public Settings {
-public:
-    SystemSettings(InviwoApplication* app);
-    virtual ~SystemSettings();
-    IntSizeTProperty poolSize_;
-    BoolProperty enablePortInspectors_;
-    IntProperty portInspectorSize_;
-    BoolProperty enableTouchProperty_;
-    BoolProperty enableGesturesProperty_;
-    BoolProperty enablePickingProperty_;
-    BoolProperty enableSoundProperty_;
-    BoolProperty logStackTraceProperty_;
-    BoolProperty runtimeModuleReloading_;
-    BoolProperty enableResourceManager_;
-    OptionProperty<MessageBreakLevel> breakOnMessage_;
-    BoolProperty breakOnException_;
-    BoolProperty stackTraceInException_;
+    , workspaceDirectories("workspaceDirectories", "Workspace Directories",
+                           std::make_unique<FileProperty>("directory", "Directory")) {
 
-    BoolProperty redirectCout_;
-    BoolProperty redirectCerr_;
+    addProperties(workspaceAuthor, numRecentFiles, numRestoreFiles, restoreFrequency,
+                  workspaceDirectories);
 
-    static size_t defaultPoolSize();
-
-    std::unique_ptr<LogStream> cout_;
-    std::unique_ptr<LogStream> cerr_;
-};
+    load();
+}
 
 }  // namespace inviwo

--- a/modules/qtwidgets/src/editorsettings.cpp
+++ b/modules/qtwidgets/src/editorsettings.cpp
@@ -38,7 +38,7 @@ EditorSettings::EditorSettings(InviwoApplication* app)
                      {1, ConstraintBehavior::Immutable}, {100, ConstraintBehavior::Ignore})
     , numRestoreFiles(
           "numRestoreFiles", "Number of Restore Files",
-          "The maximum number of backup files to store, the oldest will be removed frist"_help, 24,
+          "The maximum number of backup files to keep, the oldest will be removed first"_help, 24,
           {1, ConstraintBehavior::Immutable}, {100, ConstraintBehavior::Ignore})
     , restoreFrequency("restoreFrequency", "Restore Frequency",
                        "Minutes between new backup files"_help, 10,

--- a/modules/qtwidgets/src/filepathlineeditqt.cpp
+++ b/modules/qtwidgets/src/filepathlineeditqt.cpp
@@ -69,7 +69,7 @@ FilePathLineEditQt::FilePathLineEditQt(QWidget* parent)
     warningLabel_->setScaledContents(true);
     warningLabel_->setPixmap(QPixmap(":/svgicons/file-warning.svg"));
     warningLabel_->setFixedSize(labelSize);
-    warningLabel_->setToolTip("Could not locate file!");
+    warningLabel_->setToolTip("Could not locate file");
     warningLabel_->hide();
 
     auto fsModel = new QFileSystemModel(this);

--- a/modules/qtwidgets/src/filepathlineeditqt.cpp
+++ b/modules/qtwidgets/src/filepathlineeditqt.cpp
@@ -29,6 +29,7 @@
 
 #include <modules/qtwidgets/filepathlineeditqt.h>
 
+#include <inviwo/core/util/logcentral.h>
 #include <inviwo/core/util/filesystem.h>      // for fileExists, getFileNameWithExtension, getFi...
 #include <modules/qtwidgets/inviwoqtutils.h>  // for toQString, fromQString
 #include <modules/qtwidgets/lineeditqt.h>     // for LineEditQt
@@ -42,6 +43,9 @@
 #include <QString>      // for QString, operator!=
 #include <QStyle>       // for QStyle, QStyle::PM_DefaultFrameWidth
 #include <Qt>           // for MouseFocusReason
+#include <QCompleter>
+#include <QFileSystemModel>
+#include <QListView>
 
 class QFocusEvent;
 class QMouseEvent;
@@ -57,7 +61,7 @@ FilePathLineEditQt::FilePathLineEditQt(QWidget* parent)
     , acceptMode_{AcceptMode::Open}
     , fileMode_{FileMode::AnyFile}
     , editingEnabled_{false}
-    , cursorPos_{-1}
+    , cursorPos_{0}
     , cursorPosDirty_{false} {
 
     int width = this->sizeHint().height();
@@ -65,8 +69,20 @@ FilePathLineEditQt::FilePathLineEditQt(QWidget* parent)
     warningLabel_->setScaledContents(true);
     warningLabel_->setPixmap(QPixmap(":/svgicons/file-warning.svg"));
     warningLabel_->setFixedSize(labelSize);
-    warningLabel_->setToolTip("Invalid File: Could not locate file");
+    warningLabel_->setToolTip("Could not locate file!");
     warningLabel_->hide();
+
+    auto fsModel = new QFileSystemModel(this);
+    fsModel->setRootPath(QString());
+    // Need to access the model once to have it cache the current path
+    // Otherwise there will be no suggestions.
+    connect(this, &QLineEdit::textChanged,
+            [fsModel](const QString& path) { fsModel->index(path); });
+    QCompleter* completer = new QCompleter(fsModel, this);
+    completer->setCompletionMode(QCompleter::PopupCompletion);
+    completer->setCaseSensitivity(Qt::CaseInsensitive);
+    setCompleter(completer);
+    completer->popup()->setObjectName("Completer");
 
     auto trimFilename = [this]() {
         auto str = text().trimmed();
@@ -78,27 +94,25 @@ FilePathLineEditQt::FilePathLineEditQt(QWidget* parent)
         }
     };
 
-    QObject::connect(this, &QLineEdit::returnPressed, [this, trimFilename]() {
+    connect(this, &QLineEdit::returnPressed, [this, trimFilename]() {
         if (editingEnabled_) {
-            cursorPos_ = -1;
             trimFilename();
             path_ = utilqt::toPath(text().trimmed());
             setEditing(false);
         }
     });
-    QObject::connect(this, &QLineEdit::editingFinished, [this, trimFilename]() {
+    connect(this, &QLineEdit::editingFinished, [this, trimFilename]() {
         if (editingEnabled_) {
-            cursorPos_ = this->cursorPosition();
             trimFilename();
-            path_ = utilqt::fromQString(text());
+            path_ = utilqt::toPath(text());
             setEditing(false);
         }
     });
-    QObject::connect(this, &LineEditQt::editingCanceled, [this]() {
+
+    connect(this, &LineEditQt::editingCanceled, [this]() {
         // revert changes
         if (editingEnabled_) {
             setModified(false);
-            cursorPos_ = -1;
             updateContents();
             setEditing(false);
         }
@@ -121,7 +135,6 @@ void FilePathLineEditQt::setFileMode(FileMode fileMode) {
 void FilePathLineEditQt::setPath(const std::filesystem::path& path) {
     if (path_ != path) {
         path_ = path;
-        cursorPos_ = -1;
         setModified(false);
         updateContents();
     } else {
@@ -148,43 +161,50 @@ void FilePathLineEditQt::resizeEvent(QResizeEvent*) {
 }
 
 void FilePathLineEditQt::focusInEvent(QFocusEvent* event) {
+    cursorPosDirty_ = false;
     if (event->reason() == Qt::MouseFocusReason) {
         // user has used the mouse to click into this widget
         auto cursor = QCursor::pos();
         // get current cursor position in line edit
-        int pos = this->cursorPositionAt(this->mapFromGlobal(cursor));
-        // transform position into position within entire path
-        auto lenFilename = path_.stem().string().size();
-        cursorPos_ = static_cast<int>(path_.string().size() - lenFilename) + pos;
+        cursorPos_ = this->cursorPositionAt(this->mapFromGlobal(cursor));
         // the cursor position has to be set again after the mouse click has been processed in
         // mousePressEvent()
         cursorPosDirty_ = true;
     }
     setEditing(true);
+
     QLineEdit::focusInEvent(event);
-    if (cursorPos_ >= 0) {
-        // update cursor position
-        this->setCursorPosition(cursorPos_);
-    }
 }
 
 void FilePathLineEditQt::mousePressEvent(QMouseEvent* event) {
     LineEditQt::mousePressEvent(event);
+
     if (cursorPosDirty_) {
-        // adjust cursor position since the text has changed
-        this->setCursorPosition(cursorPos_);
+
+        const auto length = static_cast<int>(path_.string().size());
+        const auto lenFilename = static_cast<int>(path_.filename().string().size());
+        const auto lenDir = static_cast<int>(path_.parent_path().string().size());
+
+        if (cursorPos_ >= lenFilename) {
+            this->setSelection(lenDir, lenFilename);
+            this->setCursorPosition(length);
+        } else {
+            this->setCursorPosition(lenDir + cursorPos_);
+        }
+
         cursorPosDirty_ = false;
     }
 }
 
 void FilePathLineEditQt::updateContents() {
+
     const bool modified = isModified();
     if (editingEnabled_) {
         // show entire path
         this->setText(utilqt::toQString(path_));
     } else {
         // abbreviate file path and show only the file name
-        this->setText(utilqt::toQString(path_.stem()));
+        this->setText(utilqt::toQString(path_.filename()));
     }
     setModified(modified);
     updateIcon();
@@ -193,17 +213,71 @@ void FilePathLineEditQt::updateContents() {
 void FilePathLineEditQt::updateIcon() {
     // update visibility of warning icon
 
-    bool hasWildcard = (path_.string().find_first_of("*?#", 0) != std::string::npos);
     bool visible = false;
     QString tooltip;
-    if (hasWildcard) {
-        // check, if the parent directory is valid
-        visible = !std::filesystem::is_directory(path_.parent_path());
-        tooltip = "Invalid Path";
-    } else if (!path_.empty()) {
-        // no wildcards, check for file existence
-        visible = !std::filesystem::is_regular_file(path_);
-        tooltip = "Invalid File: Could not locate file";
+
+    bool hasWildcard = (path_.string().find_first_of("*?#", 0) != std::string::npos);
+
+    auto status = std::filesystem::status(path_);
+    const bool isFile = std::filesystem::is_regular_file(status);
+    const bool isDir = std::filesystem::is_directory(status);
+
+    const bool parentDir = std::filesystem::is_directory(path_.parent_path());
+
+    switch (acceptMode_) {
+        case AcceptMode::Open: {
+            switch (fileMode_) {
+                case FileMode::AnyFile: {
+                    break;
+                }
+                case FileMode::ExistingFile: {
+                    if (!hasWildcard) {
+                        visible = !isFile;
+                        tooltip = "Could not locate file!";
+                    } else {
+                        visible = !parentDir;
+                        tooltip = "Could not locate parent directory!";
+                    }
+                    break;
+                }
+                case FileMode::ExistingFiles: {
+                    if (!hasWildcard) {
+                        visible = !isFile;
+                        tooltip = "Could not locate file!";
+                    } else {
+                        visible = !parentDir;
+                        tooltip = "Could not locate parent directory!";
+                    }
+                    break;
+                }
+                case FileMode::Directory: {
+                    visible = !isDir;
+                    tooltip = "Could not locate directory!";
+                    break;
+                }
+            }
+            break;
+        }
+        case AcceptMode::Save: {
+            switch (fileMode_) {
+                case FileMode::AnyFile: {
+                    break;
+                }
+                case FileMode::ExistingFile: {
+                    break;
+                }
+                case FileMode::ExistingFiles: {
+                    break;
+                }
+                case FileMode::Directory: {
+                    visible = !isDir;
+                    tooltip = "Could not locate directory!";
+                    break;
+                }
+            }
+
+            break;
+        }
     }
 
     warningLabel_->setVisible(visible);

--- a/modules/qtwidgets/src/filepathlineeditqt.cpp
+++ b/modules/qtwidgets/src/filepathlineeditqt.cpp
@@ -51,9 +51,15 @@ class QWidget;
 namespace inviwo {
 
 FilePathLineEditQt::FilePathLineEditQt(QWidget* parent)
-    : LineEditQt(parent), editingEnabled_(false), cursorPos_(-1), cursorPosDirty_(false) {
-    // warning icon at the right side of the line edit for indication of "file not found"
-    warningLabel_ = new QLabel(this);
+    : LineEditQt{parent}
+    , warningLabel_{new QLabel(this)}
+    , path_{}
+    , acceptMode_{AcceptMode::Open}
+    , fileMode_{FileMode::AnyFile}
+    , editingEnabled_{false}
+    , cursorPos_{-1}
+    , cursorPosDirty_{false} {
+
     int width = this->sizeHint().height();
     QSize labelSize(width, width);
     warningLabel_->setScaledContents(true);
@@ -76,7 +82,7 @@ FilePathLineEditQt::FilePathLineEditQt(QWidget* parent)
         if (editingEnabled_) {
             cursorPos_ = -1;
             trimFilename();
-            path_ = utilqt::fromQString(text().trimmed());
+            path_ = utilqt::toPath(text().trimmed());
             setEditing(false);
         }
     });
@@ -97,6 +103,19 @@ FilePathLineEditQt::FilePathLineEditQt(QWidget* parent)
             setEditing(false);
         }
     });
+}
+
+void FilePathLineEditQt::setAcceptMode(AcceptMode acceptMode) {
+    if (acceptMode_ != acceptMode) {
+        acceptMode_ = acceptMode;
+        updateIcon();
+    }
+}
+void FilePathLineEditQt::setFileMode(FileMode fileMode) {
+    if (fileMode_ != fileMode) {
+        fileMode_ = fileMode;
+        updateIcon();
+    }
 }
 
 void FilePathLineEditQt::setPath(const std::filesystem::path& path) {

--- a/modules/qtwidgets/src/inviwofiledialog.cpp
+++ b/modules/qtwidgets/src/inviwofiledialog.cpp
@@ -145,10 +145,6 @@ void InviwoFileDialog::setFileMode(inviwo::FileMode mode) {
         case inviwo::FileMode::ExistingFiles:
             QFileDialog::setFileMode(QFileDialog::ExistingFiles);
             break;
-        case inviwo::FileMode::DirectoryOnly:
-            QFileDialog::setFileMode(QFileDialog::Directory);
-            QFileDialog::setOption(QFileDialog::ShowDirsOnly, true);
-            break;
         default:
             QFileDialog::setFileMode(QFileDialog::AnyFile);
             break;
@@ -161,13 +157,8 @@ FileMode InviwoFileDialog::getFileMode() const {
             return inviwo::FileMode::AnyFile;
         case FileMode::ExistingFile:
             return inviwo::FileMode::ExistingFile;
-        case FileMode::Directory: {
-            if (testOption(ShowDirsOnly)) {
-                return inviwo::FileMode::DirectoryOnly;
-            } else {
-                return inviwo::FileMode::Directory;
-            }
-        }
+        case FileMode::Directory:
+            return inviwo::FileMode::Directory;
         case FileMode::ExistingFiles:
             return inviwo::FileMode::ExistingFiles;
         default:

--- a/modules/qtwidgets/src/inviwofiledialog.cpp
+++ b/modules/qtwidgets/src/inviwofiledialog.cpp
@@ -61,8 +61,8 @@ InviwoFileDialog::InviwoFileDialog(QWidget* parent, const std::string& title,
     sidebarURLs_ << QUrl::fromLocalFile(
         QStandardPaths::writableLocation(QStandardPaths::HomeLocation));
 
-    useNativeDialog();
-    QFileDialog::setOption(QFileDialog::DontUseCustomDirectoryIcons);
+    QFileDialog::setOption(QFileDialog::DontUseNativeDialog, false);
+    QFileDialog::setOption(QFileDialog::DontResolveSymlinks, true);
     QObject::connect(this, SIGNAL(filterSelected(const QString&)), this,
                      SLOT(filterSelectionChanged(const QString&)));
 }
@@ -170,10 +170,6 @@ void InviwoFileDialog::setContentType(const std::string& contentType) {
 }
 
 std::string InviwoFileDialog::getContentType() const { return utilqt::fromQString(pathType_); }
-
-void InviwoFileDialog::useNativeDialog(const bool& use) {
-    QFileDialog::setOption(QFileDialog::DontUseNativeDialog, !use);
-}
 
 void InviwoFileDialog::setCurrentDirectory(const std::filesystem::path& path) {
     if (!path.empty()) {

--- a/modules/qtwidgets/src/inviwofiledialog.cpp
+++ b/modules/qtwidgets/src/inviwofiledialog.cpp
@@ -119,7 +119,7 @@ void InviwoFileDialog::setAcceptMode(inviwo::AcceptMode mode) {
     }
 }
 
-AcceptMode InviwoFileDialog::getAcceptMode() const {
+inviwo::AcceptMode InviwoFileDialog::getAcceptMode() const {
     switch (QFileDialog::acceptMode()) {
         case QFileDialog::AcceptSave:
             return inviwo::AcceptMode::Save;

--- a/modules/qtwidgets/src/inviwofiledialog.cpp
+++ b/modules/qtwidgets/src/inviwofiledialog.cpp
@@ -119,7 +119,7 @@ void InviwoFileDialog::setAcceptMode(inviwo::AcceptMode mode) {
     }
 }
 
-inviwo::AcceptMode InviwoFileDialog::getAcceptMode() const {
+AcceptMode InviwoFileDialog::getAcceptMode() const {
     switch (QFileDialog::acceptMode()) {
         case QFileDialog::AcceptSave:
             return inviwo::AcceptMode::Save;

--- a/modules/qtwidgets/src/properties/filepropertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/filepropertywidgetqt.cpp
@@ -203,8 +203,7 @@ void FilePropertyWidgetQt::dragEnterEvent(QDragEnterEvent* event) {
                                 break;
                             }
 
-                            case FileMode::Directory:
-                            case FileMode::DirectoryOnly: {
+                            case FileMode::Directory: {
                                 if (std::filesystem::is_directory(file)) {
                                     event->accept();
                                     return;

--- a/modules/qtwidgets/src/properties/multifilepropertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/multifilepropertywidgetqt.cpp
@@ -195,8 +195,7 @@ void MultiFilePropertyWidgetQt::dragEnterEvent(QDragEnterEvent* event) {
                                 break;
                             }
 
-                            case FileMode::Directory:
-                            case FileMode::DirectoryOnly: {
+                            case FileMode::Directory: {
                                 if (std::filesystem::is_directory(file)) {
                                     event->accept();
                                     return;

--- a/modules/qtwidgets/src/properties/propertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/propertywidgetqt.cpp
@@ -444,7 +444,11 @@ bool PropertyWidgetQt::event(QEvent* event) {
             }
         )"_unindent);
 
-        html.append("body").append(property_->getDescription());
+        try {
+            html.append("body").append(property_->getDescription());
+        } catch (const Exception& e) {
+            util::log(e.getContext(), e.getFullMessage());
+        }
 
         QToolTip::showText(helpEvent->globalPos(), utilqt::toQString(desc));
         return true;

--- a/modules/qtwidgets/src/qtwidgetsmodule.cpp
+++ b/modules/qtwidgets/src/qtwidgetsmodule.cpp
@@ -84,6 +84,7 @@
 #include <modules/qtwidgets/properties/tfpropertywidgetqt.h>                 // for TFPropertyWi...
 #include <modules/qtwidgets/rawdatareaderdialogqt.h>                         // for RawDataReade...
 #include <modules/qtwidgets/tfhelpwindow.h>                                  // for TFMenuHelper
+#include <modules/qtwidgets/editorsettings.h>
 
 #include <array>        // for array
 #include <cstddef>      // for size_t
@@ -278,6 +279,8 @@ QtWidgetsModule::QtWidgetsModule(InviwoApplication* app)
     // Register dialogs
     registerDialog<RawDataReaderDialogQt>("RawVolumeReader");
     registerDialog<InviwoFileDialog>("FileDialog");
+
+    registerSettings(std::make_unique<EditorSettings>(app));
 }
 
 QtWidgetsModule::~QtWidgetsModule() = default;

--- a/resources/stylesheets/inviwo.qss
+++ b/resources/stylesheets/inviwo.qss
@@ -442,7 +442,6 @@ QGroupBox::title {
 ************************/
 QListView {
     background: transparent;
-    background: #3a3a3d;
     /*using border here breaks the QCombobox */
 }
 

--- a/resources/stylesheets/inviwo.qss
+++ b/resources/stylesheets/inviwo.qss
@@ -442,7 +442,12 @@ QGroupBox::title {
 ************************/
 QListView {
     background: transparent;
+    background: #3a3a3d;
     /*using border here breaks the QCombobox */
+}
+
+QListVie#Completer {
+    background: #3a3a3d;
 }
 
 QDockWidget#AnimationEditorWidget QListView {

--- a/src/core/network/processornetwork.cpp
+++ b/src/core/network/processornetwork.cpp
@@ -419,7 +419,7 @@ void ProcessorNetwork::removePropertyOwnerObservation(PropertyOwner* po) {
 
 int ProcessorNetwork::getVersion() const { return processorNetworkVersion_; }
 
-const int ProcessorNetwork::processorNetworkVersion_ = 19;
+const int ProcessorNetwork::processorNetworkVersion_ = 20;
 
 void ProcessorNetwork::deserialize(Deserializer& d) {
     NetworkLock lock(this);

--- a/src/core/network/processornetworkconverter.cpp
+++ b/src/core/network/processornetworkconverter.cpp
@@ -99,6 +99,9 @@ bool ProcessorNetworkConverter::convert(TxElement* root) {
             [[fallthrough]];
         case 18:
             traverseNodes(root, &ProcessorNetworkConverter::updateShadingModeEnum);
+            [[fallthrough]];
+        case 19:
+            updateFileMode(root);
             return true;  // Changes has been made.
         default:
             return false;  // No changes
@@ -881,6 +884,12 @@ void ProcessorNetworkConverter::updateLinkAndConnections(TxElement* root) {
             child->SetAttribute("dst", properties[dst]);
         }
     }
+}
+
+void ProcessorNetworkConverter::updateFileMode(TxElement* node) {
+    xml::visitMatchingNodesRecursive(
+        node, {{"Property", {}}, {"fileMode", {{"content", "4"}}}},
+        [](TxElement* matchingNode) { matchingNode->SetAttribute("content", "2"); });
 }
 
 }  // namespace inviwo

--- a/src/core/properties/directoryproperty.cpp
+++ b/src/core/properties/directoryproperty.cpp
@@ -43,7 +43,7 @@ DirectoryProperty::DirectoryProperty(std::string_view identifier, std::string_vi
     : FileProperty(identifier, displayName, std::move(help), value, contentType, invalidationLevel,
                    semantics) {
     setAcceptMode(AcceptMode::Open);
-    setFileMode(FileMode::DirectoryOnly);
+    setFileMode(FileMode::Directory);
 }
 
 DirectoryProperty::DirectoryProperty(std::string_view identifier, std::string_view displayName,

--- a/src/core/properties/fileproperty.cpp
+++ b/src/core/properties/fileproperty.cpp
@@ -356,8 +356,7 @@ Document FileProperty::getDescription() const {
             break;
         }
 
-        case FileMode::Directory:
-        case FileMode::DirectoryOnly: {
+        case FileMode::Directory: {
             tb(H("Directory"), file_.value);
             break;
         }

--- a/src/core/properties/multifileproperty.cpp
+++ b/src/core/properties/multifileproperty.cpp
@@ -314,9 +314,7 @@ Document MultiFileProperty::getDescription() const {
             tb(H("Files"), buff.view());
             break;
         }
-
-        case FileMode::Directory:
-        case FileMode::DirectoryOnly: {
+        case FileMode::Directory: {
             tb(H("Directories"), buff.view());
             break;
         }

--- a/src/core/util/filedialogstate.cpp
+++ b/src/core/util/filedialogstate.cpp
@@ -59,7 +59,7 @@ std::string_view enumToStr(FileMode mode) {
                     static_cast<int>(mode));
 }
 
-std::ostream& operator<<(std::ostream& ss, AcceptMode& mode) { return ss << enumToStr(mode); }
-std::ostream& operator<<(std::ostream& ss, FileMode& mode) { return ss << enumToStr(mode); }
+std::ostream& operator<<(std::ostream& ss, AcceptMode mode) { return ss << enumToStr(mode); }
+std::ostream& operator<<(std::ostream& ss, FileMode mode) { return ss << enumToStr(mode); }
 
 }  // namespace inviwo

--- a/src/core/util/filedialogstate.cpp
+++ b/src/core/util/filedialogstate.cpp
@@ -54,8 +54,6 @@ std::string_view enumToStr(FileMode mode) {
             return "Directory";
         case FileMode::ExistingFiles:
             return "Existing Files";
-        case FileMode::DirectoryOnly:
-            return "Directory Only";
     }
     throw Exception(IVW_CONTEXT_CUSTOM("enumName"), "Found invalid FileMode enum value '{}'",
                     static_cast<int>(mode));

--- a/src/core/util/settings/systemsettings.cpp
+++ b/src/core/util/settings/systemsettings.cpp
@@ -60,11 +60,11 @@ SystemSettings::SystemSettings(InviwoApplication* app)
     , redirectCout_{"redirectCout", "Redirect cout to LogCentral", false}
     , redirectCerr_{"redirectCerr", "Redirect cerr to LogCentral", false} {
 
-    addProperties(poolSize_, enablePortInspectors_,
-                  portInspectorSize_, enableTouchProperty_, enableGesturesProperty_,
-                  enablePickingProperty_, enableSoundProperty_, logStackTraceProperty_,
-                  runtimeModuleReloading_, enableResourceManager_, breakOnMessage_,
-                  breakOnException_, stackTraceInException_, redirectCout_, redirectCerr_);
+    addProperties(poolSize_, enablePortInspectors_, portInspectorSize_, enableTouchProperty_,
+                  enableGesturesProperty_, enablePickingProperty_, enableSoundProperty_,
+                  logStackTraceProperty_, runtimeModuleReloading_, enableResourceManager_,
+                  breakOnMessage_, breakOnException_, stackTraceInException_, redirectCout_,
+                  redirectCerr_);
 
     logStackTraceProperty_.onChange(
         [this]() { LogCentral::getPtr()->setLogStacktrace(logStackTraceProperty_.get()); });

--- a/src/core/util/settings/systemsettings.cpp
+++ b/src/core/util/settings/systemsettings.cpp
@@ -36,9 +36,6 @@ namespace inviwo {
 
 SystemSettings::SystemSettings(InviwoApplication* app)
     : Settings("System Settings", app)
-    , workspaceAuthor_("workspaceAuthor", "Default Workspace Author", "")
-    , maxNumRecentFiles_("maxNumRecentFiles", "Max Number of Recent Files", 10,
-                         {1, ConstraintBehavior::Immutable}, {100, ConstraintBehavior::Ignore})
     , poolSize_("poolSize", "Pool Size", defaultPoolSize(), 0, 32)
     , enablePortInspectors_("enablePortInspectors", "Enable port inspectors", true)
     , portInspectorSize_("portInspectorSize", "Port inspector size", 128, 1, 1024)
@@ -63,7 +60,7 @@ SystemSettings::SystemSettings(InviwoApplication* app)
     , redirectCout_{"redirectCout", "Redirect cout to LogCentral", false}
     , redirectCerr_{"redirectCerr", "Redirect cerr to LogCentral", false} {
 
-    addProperties(workspaceAuthor_, maxNumRecentFiles_, poolSize_, enablePortInspectors_,
+    addProperties(poolSize_, enablePortInspectors_,
                   portInspectorSize_, enableTouchProperty_, enableGesturesProperty_,
                   enablePickingProperty_, enableSoundProperty_, logStackTraceProperty_,
                   runtimeModuleReloading_, enableResourceManager_, breakOnMessage_,

--- a/src/qt/editor/toolsmenu.cpp
+++ b/src/qt/editor/toolsmenu.cpp
@@ -268,7 +268,7 @@ ToolsMenu::ToolsMenu(InviwoMainWindow* win) : QMenu(tr("&Tools"), win) {
         "the workspaces. Loads all workspace found in the folder recursively.");
     connect(loadWorkspaces, &QAction::triggered, [win]() {
         InviwoFileDialog dialog(nullptr, "workspace", "Workspace Directory");
-        dialog.setFileMode(FileMode::DirectoryOnly);
+        dialog.setFileMode(FileMode::Directory);
         dialog.setAcceptMode(AcceptMode::Open);
 
         if (dialog.exec()) {
@@ -289,7 +289,7 @@ ToolsMenu::ToolsMenu(InviwoMainWindow* win) : QMenu(tr("&Tools"), win) {
 
     connect(updateWorkspaces, &QAction::triggered, [win]() {
         InviwoFileDialog dialog(nullptr, "workspace", "Workspace Directory");
-        dialog.setFileMode(FileMode::DirectoryOnly);
+        dialog.setFileMode(FileMode::Directory);
         dialog.setAcceptMode(AcceptMode::Open);
 
         if (dialog.exec()) {

--- a/src/qt/editor/undomanager.cpp
+++ b/src/qt/editor/undomanager.cpp
@@ -34,6 +34,7 @@
 #include <inviwo/core/util/raiiutils.h>
 #include <inviwo/core/util/filesystem.h>
 #include <inviwo/core/util/threadutil.h>
+#include <modules/qtwidgets/editorsettings.h>
 
 #include <warn/push>
 #include <warn/ignore/all>
@@ -51,15 +52,20 @@
 #include <atomic>
 #include <vector>
 #include <string>
-
 #include <filesystem>
+
+#include <fmt/format.h>
+#include <fmt/chrono.h>
 
 namespace inviwo {
 
 class AutoSaver {
 public:
-    AutoSaver()
+    using clock_t = std::chrono::system_clock;
+
+    AutoSaver(InviwoApplication* app)
         : path_{filesystem::getPath(PathType::Settings)}
+        , sessionStart_{clock_t::now()}
         , restored_{[this]() -> std::optional<std::string> {
             if (std::filesystem::is_regular_file(path_ / "autosave.inv")) {
                 auto ifstream = std::ifstream(path_ / "autosave.inv");
@@ -71,7 +77,7 @@ public:
             return std::nullopt;
         }()}
         , quit_{false}
-        , saver_{[this]() {
+        , saver_{[this, app]() {
             util::setThreadDescription("Inviwo AutoSave");
             for (;;) {
 
@@ -91,6 +97,14 @@ public:
                 }
 
                 if (str) {
+                    int numRestoreFiles = 100000;
+                    int restoreFrequency = 1440;
+                    if (auto* settings = app->getSettingsByType<EditorSettings>()) {
+                        numRestoreFiles = settings->numRestoreFiles.get();
+                        restoreFrequency = settings->restoreFrequency.get();
+                    }
+
+                    std::filesystem::create_directories(path_ / "autosaves");
                     {
                         // make sure we have closed the file _before_ we copy it.
                         auto ofstream = std::ofstream(path_ / "autosave.inv.tmp");
@@ -99,6 +113,15 @@ public:
 
                     std::filesystem::copy(path_ / "autosave.inv.tmp", path_ / "autosave.inv",
                                           std::filesystem::copy_options::overwrite_existing);
+
+                    if (clock_t::now() - sessionStart_ > std::chrono::minutes(restoreFrequency)) {
+                        sessionStart_ = clock_t::now();
+                    }
+                    std::filesystem::copy(path_ / "autosave.inv.tmp",
+                                          path_ / "autosaves" / sessionName(sessionStart_),
+                                          std::filesystem::copy_options::overwrite_existing);
+
+                    clearOldSaves(path_ / "autosaves", numRestoreFiles);
                 }
             }
         }} {}
@@ -120,7 +143,28 @@ public:
     }
 
 private:
+    static std::filesystem::path sessionName(clock_t::time_point now) {
+        return fmt::format("autosave-{}-{:%Y-%m-%d-%H-%M}.inv", util::getPid(), now);
+    }
+
+    static void clearOldSaves(const std::filesystem::path& path, size_t maxSaves) {
+        std::filesystem::directory_iterator it(path);
+
+        std::vector<std::filesystem::path> files{it, end(it)};
+
+        std::sort(files.begin(), files.end(),
+                  [](const std::filesystem::path& a, const std::filesystem::path& b) {
+                      return std::filesystem::last_write_time(a) >
+                             std::filesystem::last_write_time(b);
+                  });
+
+        std::for_each(files.begin() + std::min(files.size(), size_t{maxSaves}), files.end(),
+                      [](const std::filesystem::path& a) { std::filesystem::remove(a); });
+    }
+
     std::filesystem::path path_;
+    clock_t::time_point sessionStart_;
+
     std::optional<std::string> restored_;
     std::atomic<bool> quit_;
     std::condition_variable condition_;
@@ -134,7 +178,9 @@ UndoManager::UndoManager(InviwoMainWindow* mainWindow)
     : mainWindow_(mainWindow)
     , manager_{mainWindow_->getInviwoApplication()->getWorkspaceManager()}
     , refPath_{filesystem::findBasePath()}
-    , autoSaver_{std::make_unique<AutoSaver>()} {
+    , autoSaver_{std::make_unique<AutoSaver>(mainWindow_->getInviwoApplication())}
+
+{
 
     QApplication::instance()->installEventFilter(this);
 
@@ -190,7 +236,9 @@ void UndoManager::pushState() {
     undoBuffer_.erase(undoBuffer_.begin() + offset, undoBuffer_.end());
     undoBuffer_.push_back(str);
 
-    autoSaver_->save(str);
+    if (!mainWindow_->getInviwoApplication()->getProcessorNetwork()->empty()) {
+        autoSaver_->save(str);
+    }
 
     updateActions();
 }

--- a/src/qt/editor/workspaceannotationsqt.cpp
+++ b/src/qt/editor/workspaceannotationsqt.cpp
@@ -165,4 +165,27 @@ QStringList WorkspaceAnnotationsQt::workspaceProcessors(const std::filesystem::p
     }
 }
 
+std::map<std::string, int> WorkspaceAnnotationsQt::workspaceProcessorsCounts(
+    const std::filesystem::path& path, InviwoApplication* app) {
+    if (auto f = std::ifstream(path)) {
+        LogFilter logger{LogCentral::getPtr(), LogVerbosity::None};
+        auto d = app->getWorkspaceManager()->createWorkspaceDeserializer(f, path, &logger);
+
+        DummyNetwork dummy;
+        d.deserialize("ProcessorNetwork", dummy);
+
+        std::map<std::string, int> list;
+
+        for (const auto& p : dummy.processors) {
+            ++list[p.displayName];
+        }
+
+        return list;
+
+    } else {
+        throw Exception(IVW_CONTEXT_CUSTOM("WorkspaceAnnotationsQt"), "Unable to open file {}",
+                        path);
+    }
+}
+
 }  // namespace inviwo

--- a/src/qt/editor/workspacegridview.cpp
+++ b/src/qt/editor/workspacegridview.cpp
@@ -64,7 +64,7 @@ namespace {
 
 class SectionDelegate : public QStyledItemDelegate {
 public:
-    SectionDelegate(int itemSize, QWidget* parent = nullptr);
+    SectionDelegate(int itemSize, QTreeView* parent);
     virtual ~SectionDelegate() override = default;
 
     virtual void paint(QPainter* painter, const QStyleOptionViewItem& option,
@@ -72,16 +72,20 @@ public:
     QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const override;
 
 private:
+    QString elidedText(const QString& str, const QFontMetrics& metrics, int width) const;
+
     QImage rightArrow;
     QImage downArrow;
     int itemSize_;
+    QTreeView* view_;
 };
 
-SectionDelegate::SectionDelegate(int itemSize, QWidget* parent)
+SectionDelegate::SectionDelegate(int itemSize, QTreeView* parent)
     : QStyledItemDelegate(parent)
     , rightArrow{":/svgicons/arrow-right-enabled.svg"}
     , downArrow{":/svgicons/arrow-down-enabled.svg"}
-    , itemSize_(itemSize) {}
+    , itemSize_(itemSize)
+    , view_{parent} {}
 
 void SectionDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o,
                             const QModelIndex& index) const {
@@ -161,14 +165,66 @@ void SectionDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o,
         painter->drawImage(imgRect, img, img.rect());
 
         auto nameRect = option.rect;
+        
+        auto cols = view_->header()->count();
+        auto width = nameRect.width();
+        for (int i = 1; i < cols; ++i) {
+            width += view_->columnWidth(i);
+        }
+        nameRect.setWidth(width);
+        
         nameRect.adjust(level * indent + rect.height(), 0, 0, 0);
 
         painter->setFont(option.font);
         painter->drawText(nameRect,
                           Qt::AlignLeft | Qt::AlignVCenter | Qt::TextDontClip | Qt::TextSingleLine,
-                          name);
+                          elidedText(name, QFontMetrics(option.font), nameRect.width()));
     }
     painter->restore();
+}
+
+QString SectionDelegate::elidedText(const QString& str, const QFontMetrics& metrics,
+                                    int width) const {
+    if (str.isEmpty() || (metrics.boundingRect(str).width() <= width)) {
+        return str;
+    }
+
+    auto directories = str.split('/');
+
+    bool keepFirst = str[0] != '/';
+    const int widthFirst = (keepFirst ? metrics.boundingRect(directories.front()).width() : 0);
+    const QString strFirst = (keepFirst ? directories.front() : "");
+    if (keepFirst) {
+        directories.erase(directories.begin());
+    }
+
+    std::reverse(directories.begin(), directories.end());
+
+    std::vector<int> widthDirs;
+    std::transform(directories.begin(), directories.end(), std::back_inserter(widthDirs),
+                   [&](const auto& dir) { return metrics.boundingRect("/" + dir).width(); });
+
+    const int widthDots = metrics.boundingRect("/...").width();
+
+    if (widthFirst + widthDots + widthDirs.front() > width) {
+        // eliding path components is not sufficient, elide entire string
+        return metrics.elidedText(str, Qt::ElideRight, width);
+    }
+
+    int leftWidth = width - widthFirst - widthDots;
+    QString result =
+        std::accumulate(directories.begin(), directories.end(), QString(),
+                        [&, index = 0, leftWidth](QString str, const QString& dir) mutable {
+                            if (leftWidth >= widthDirs[index]) {
+                                str.prepend("/" + dir);
+                                leftWidth -= widthDirs[index];
+                            } else {
+                                leftWidth = 0;
+                            }
+                            ++index;
+                            return str;
+                        });
+    return strFirst + "/..." + result;
 }
 
 QSize SectionDelegate::sizeHint(const QStyleOptionViewItem& o, const QModelIndex& index) const {

--- a/src/qt/editor/workspacegridview.cpp
+++ b/src/qt/editor/workspacegridview.cpp
@@ -165,14 +165,14 @@ void SectionDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o,
         painter->drawImage(imgRect, img, img.rect());
 
         auto nameRect = option.rect;
-        
+
         auto cols = view_->header()->count();
         auto width = nameRect.width();
         for (int i = 1; i < cols; ++i) {
             width += view_->columnWidth(i);
         }
         nameRect.setWidth(width);
-        
+
         nameRect.adjust(level * indent + rect.height(), 0, 0, 0);
 
         painter->setFont(option.font);

--- a/src/qt/editor/workspacetreemodel.cpp
+++ b/src/qt/editor/workspacetreemodel.cpp
@@ -37,6 +37,7 @@
 
 #include <modules/qtwidgets/inviwoqtutils.h>
 #include <inviwo/qt/editor/workspaceannotationsqt.h>
+#include <modules/qtwidgets/editorsettings.h>
 
 #include <warn/push>
 #include <warn/ignore/all>
@@ -60,7 +61,7 @@ public:
     explicit TreeItem(TreeItem* parent);
     TreeItem(std::string_view caption, WorkspaceTreeModel::Type type);
     TreeItem(const std::filesystem::path& filename, InviwoApplication* app,
-             std::function<void(TreeItem*)> onChange, bool isExample);
+             std::function<void(TreeItem*)> onChange, bool readOnly);
 
     TreeItem(const TreeItem&) = delete;
     TreeItem& operator=(const TreeItem&) = delete;
@@ -286,6 +287,8 @@ WorkspaceTreeModel::WorkspaceTreeModel(InviwoApplication* app, QObject* parent)
     : QAbstractItemModel(parent), app_(app), root_{std::make_unique<TreeItem>(nullptr)} {
 
     addEntry(root_.get(), std::make_unique<TreeItem>(recent, Type::SubSection));
+    addEntry(root_.get(), std::make_unique<TreeItem>(restore, Type::SubSection));
+    addEntry(root_.get(), std::make_unique<TreeItem>(custom, Type::Section));
     addEntry(root_.get(), std::make_unique<TreeItem>(examples, Type::Section));
     addEntry(root_.get(), std::make_unique<TreeItem>(tests, Type::Section));
 }
@@ -407,7 +410,7 @@ QModelIndex WorkspaceTreeModel::getCategoryIndex(std::string_view category) {
 void WorkspaceTreeModel::updateRecentWorkspaces(const QStringList& recentFiles) {
     std::vector<std::unique_ptr<TreeItem>> items;
     for (auto& elem : recentFiles) {
-        const std::filesystem::path filename = utilqt::fromQString(elem);
+        const std::filesystem::path filename = utilqt::toPath(elem);
         if (std::filesystem::is_regular_file(filename)) {
             items.push_back(std::make_unique<TreeItem>(
                 filename, app_,
@@ -419,6 +422,80 @@ void WorkspaceTreeModel::updateRecentWorkspaces(const QStringList& recentFiles) 
         }
     }
     updateCategory(getCategory(recent), std::move(items));
+}
+
+void WorkspaceTreeModel::updateRestoreEntries() {
+    const auto restores = filesystem::getPath(PathType::Settings) / "autosaves";
+
+    if (!std::filesystem::is_directory(restores)) return;
+
+    std::filesystem::directory_iterator it(restores);
+
+    std::vector<std::filesystem::path> files{};
+    std::copy_if(it, end(it), std::back_inserter(files), [](const std::filesystem::path& path) {
+        return path.extension().string() == ".inv";
+    });
+
+    std::sort(files.begin(), files.end(),
+              [](const std::filesystem::path& a, const std::filesystem::path& b) {
+                  return std::filesystem::last_write_time(a) > std::filesystem::last_write_time(b);
+              });
+
+    std::vector<std::unique_ptr<TreeItem>> items;
+
+    std::transform(files.begin(), files.end(), std::back_inserter(items),
+                   [&](const std::filesystem::path& path) {
+                       return std::make_unique<TreeItem>(
+                           path, app_,
+                           [this](TreeItem* item) {
+                               auto id = getIndex(item);
+                               dataChanged(id, id);
+                           },
+                           true);
+                   });
+
+    updateCategory(getCategory(restore), std::move(items));
+}
+
+void WorkspaceTreeModel::updateCustomEntries() {
+    const auto& props = app_->getSettingsByType<EditorSettings>()->workspaceDirectories;
+
+    std::vector<std::unique_ptr<TreeItem>> items;
+    for (const auto* fileProp : props.getPropertiesByType<FileProperty>()) {
+        auto& path = fileProp->get();
+
+        if (!std::filesystem::is_directory(path)) continue;
+
+    
+        auto section = std::make_unique<TreeItem>(path.generic_string(), Type::SubSection);
+
+        std::filesystem::directory_iterator it(path);
+
+        std::vector<std::filesystem::path> files{};
+        std::copy_if(it, end(it), std::back_inserter(files), [](const std::filesystem::path& path) {
+            return path.extension().string() == ".inv";
+        });
+
+        std::sort(files.begin(), files.end(),
+                  [](const std::filesystem::path& a, const std::filesystem::path& b) {
+                      return std::filesystem::last_write_time(a) >
+                             std::filesystem::last_write_time(b);
+                  });
+
+        std::for_each(files.begin(), files.end(), [&](const std::filesystem::path& path) {
+            section->addChild(std::make_unique<TreeItem>(
+                path, app_,
+                [this](TreeItem* item) {
+                    auto id = getIndex(item);
+                    dataChanged(id, id);
+                },
+                false));
+        });
+        if (section->childCount() > 0) {
+            items.push_back(std::move(section));
+        }
+    }
+    updateCategory(getCategory(custom), std::move(items));
 }
 
 void WorkspaceTreeModel::updateModules(std::string_view category, ModulePath pathType,

--- a/src/qt/editor/workspacetreemodel.cpp
+++ b/src/qt/editor/workspacetreemodel.cpp
@@ -466,7 +466,6 @@ void WorkspaceTreeModel::updateCustomEntries() {
 
         if (!std::filesystem::is_directory(path)) continue;
 
-    
         auto section = std::make_unique<TreeItem>(path.generic_string(), Type::SubSection);
 
         std::filesystem::directory_iterator it(path);

--- a/src/qt/editor/workspacetreeview.cpp
+++ b/src/qt/editor/workspacetreeview.cpp
@@ -141,6 +141,7 @@ void SectionDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o,
         // enlarge and emphasize font of section headers
         option.font.setBold(true);
         option.font.setPointSizeF(option.font.pointSizeF() * 1.2);
+        option.textElideMode = Qt::ElideMiddle;
 
         QStyledItemDelegate::paint(painter, option, index);
     }


### PR DESCRIPTION
Fixes #...

Changes proposed in this PR:

More restore workspaces, and custom folders in the welcome widget
![image](https://github.com/inviwo/inviwo/assets/3638222/b1d74339-9296-418f-95a1-07c72335cb05)

Completion in the file property
![image](https://github.com/inviwo/inviwo/assets/3638222/b3837b9a-ba40-4fc3-9e7e-0976a68f00aa)

Removed  FileMode::DirectoryOnly (deprecated/removed by qt)

Better handing of the AcceptMode in FileProperty widget

Added AcceptMode and FileMode to the FileProperty

New editor settings:
![image](https://github.com/inviwo/inviwo/assets/3638222/ad285093-a472-4ef0-bbc5-ef7332259982)

FileProperty is no longer a TemplateProperty Just a Property. 