### PR TITLE
Feature/locale utf8

### DIFF
--- a/apps/inviwo/CMakeLists.txt
+++ b/apps/inviwo/CMakeLists.txt
@@ -29,7 +29,12 @@ list(REMOVE_ITEM enabled_modules InviwoGLFWModule)
 
 set(RES_FILES "")
 if(WIN32)
-    set(RES_FILES ${RES_FILES} "${IVW_RESOURCES_DIR}/inviwo.rc")
+    set(RES_FILES ${RES_FILES} 
+        "${IVW_RESOURCES_DIR}/inviwo.rc"
+        # manifest file for using UTF-8 codepages on Windows
+        # see https://learn.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page
+        "${IVW_RESOURCES_DIR}/inviwo.manifest"
+    )
 elseif(APPLE)
     set_source_files_properties(${IVW_ROOT_DIR}/resources/inviwo/inviwo_light.icns PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
     set(RES_FILES ${RES_FILES} ${IVW_ROOT_DIR}/resources/inviwo/inviwo_light.icns)

--- a/apps/minimals/glfw/CMakeLists.txt
+++ b/apps/minimals/glfw/CMakeLists.txt
@@ -18,8 +18,18 @@ foreach(module ${enabled_modules})
     endif()
 endforeach()
 
+set(RES_FILES "")
+if(WIN32)
+    set(RES_FILES ${RES_FILES} 
+        # manifest file for using UTF-8 codepages on Windows
+        # see https://learn.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page
+        "${IVW_RESOURCES_DIR}/inviwo.manifest"
+    )
+endif()
+source_group("Resource Files" FILES ${RES_FILES})
+
 # Create application
-add_executable(inviwo_glfwminimum MACOSX_BUNDLE WIN32 ${SOURCE_FILES})
+add_executable(inviwo_glfwminimum MACOSX_BUNDLE WIN32 ${SOURCE_FILES} ${RES_FILES})
 target_link_libraries(inviwo_glfwminimum PUBLIC inviwo::core inviwo::module::glfw)
 ivw_configure_application_module_dependencies(inviwo_glfwminimum ${enabled_modules})
 ivw_define_standard_definitions(inviwo_glfwminimum inviwo_glfwminimum)

--- a/apps/minimals/qt/CMakeLists.txt
+++ b/apps/minimals/qt/CMakeLists.txt
@@ -16,7 +16,12 @@ ivw_group("CMake Files" ${CMAKE_FILES})
 
 set(RES_FILES "")
 if(WIN32)
-    set(RES_FILES ${RES_FILES} "${IVW_RESOURCES_DIR}/inviwo.rc")
+    set(RES_FILES ${RES_FILES} 
+        "${IVW_RESOURCES_DIR}/inviwo.rc"
+        # manifest file for using UTF-8 codepages on Windows
+        # see https://learn.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page
+        "${IVW_RESOURCES_DIR}/inviwo.manifest"
+    )
 elseif(APPLE)
     set_source_files_properties(${IVW_ROOT_DIR}/resources/inviwo/inviwo_light.icns PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
     set(RES_FILES ${RES_FILES} ${IVW_ROOT_DIR}/resources/inviwo/inviwo_light.icns)

--- a/modules/qtwidgets/src/editorsettings.cpp
+++ b/modules/qtwidgets/src/editorsettings.cpp
@@ -43,12 +43,16 @@ EditorSettings::EditorSettings(InviwoApplication* app)
     , restoreFrequency("restoreFrequency", "Restore Frequency",
                        "Minutes between new backup files"_help, 10,
                        {1, ConstraintBehavior::Immutable}, {100, ConstraintBehavior::Ignore})
-
-    , workspaceDirectories("workspaceDirectories", "Workspace Directories",
-                           std::make_unique<FileProperty>("directory", "Directory")) {
+    , workspaceDirectories(
+          "workspaceDirectories", "Workspace Directories",
+          std::make_unique<FileProperty>("directory", "Directory", "Workspace directory"_help, "",
+                                         AcceptMode::Open, FileMode::Directory)) {
 
     addProperties(workspaceAuthor, numRecentFiles, numRestoreFiles, restoreFrequency,
                   workspaceDirectories);
+
+    workspaceDirectories.setHelp(
+        "Additional workspace directories listed on the Get Started screen."_help);
 
     load();
 }

--- a/modules/qtwidgets/src/properties/filepropertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/filepropertywidgetqt.cpp
@@ -168,8 +168,8 @@ void FilePropertyWidgetQt::dropEvent(QDropEvent* drop) {
     auto mimeData = drop->mimeData();
     if (mimeData->hasUrls()) {
         if (mimeData->urls().size() > 0) {
-            auto url = mimeData->urls().first();
-            property_->set(utilqt::fromQString(url.toLocalFile()));
+            auto url = mimeData->urls().front();
+            property_->set(utilqt::toPath(url.toLocalFile()));
 
             drop->accept();
         }
@@ -187,8 +187,8 @@ void FilePropertyWidgetQt::dragEnterEvent(QDragEnterEvent* event) {
                 auto mimeData = event->mimeData();
                 if (mimeData->hasUrls()) {
                     if (mimeData->urls().size() > 0) {
-                        auto url = mimeData->urls().first();
-                        auto file = url.toLocalFile().toStdString();
+                        auto url = mimeData->urls().front();
+                        std::filesystem::path file = utilqt::toPath(url.toLocalFile());
 
                         switch (property_->getFileMode()) {
                             case FileMode::AnyFile:

--- a/modules/webbrowser/src/webbrowsermodule.cpp
+++ b/modules/webbrowser/src/webbrowsermodule.cpp
@@ -194,7 +194,7 @@ WebBrowserModule::WebBrowserModule(InviwoApplication* app)
     auto locale = app->getUILocale().name();
     if (locale == "C") {
         // Crash when default locale "C" is used. Reproduce with GLFWMinimum application
-        locale = std::locale("en_US").name();
+        locale = std::locale("en_US.UTF-8").name();
     }
 
     void* sandbox_info = NULL;  // Windows specific

--- a/resources/inviwo.manifest
+++ b/resources/inviwo.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity type="win32" name="..." version="6.0.0.0"/>
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/src/core/io/serialization/deserializer.cpp
+++ b/src/core/io/serialization/deserializer.cpp
@@ -1,4 +1,4 @@
-/*********************************************************************************
+﻿/*********************************************************************************
  *
  * Inviwo - Interactive Visualization Workshop
  *
@@ -46,7 +46,7 @@ namespace inviwo {
 
 Deserializer::Deserializer(const std::filesystem::path& fileName) : SerializeBase(fileName) {
     try {
-        doc_->LoadFile();
+        doc_->LoadFile(TIXML_ENCODING_UTF8);
         rootElement_ = doc_->FirstChildElement();
         rootElement_->GetAttribute(std::string{SerializeConstants::VersionAttribute},
                                    &inviwoWorkspaceVersion_, false);

--- a/src/core/io/serialization/serializebase.cpp
+++ b/src/core/io/serialization/serializebase.cpp
@@ -71,7 +71,7 @@ std::string SerializeBase::nodeToString(const TxElement& node) {
         TiXmlPrinter printer;
         printer.SetIndent("    ");
         node.Accept(&printer);
-        return printer.CStr();
+        return printer.Str();
     } catch (TxException&) {
         return "No valid root node";
     }

--- a/src/core/io/serialization/serializer.cpp
+++ b/src/core/io/serialization/serializer.cpp
@@ -37,8 +37,8 @@ namespace inviwo {
 
 Serializer::Serializer(const std::filesystem::path& fileName) : SerializeBase(fileName) {
     try {
-        auto decl =
-            std::make_unique<TxDeclaration>(std::string{SerializeConstants::XmlVersion}, "UTF-8", "");
+        auto decl = std::make_unique<TxDeclaration>(std::string{SerializeConstants::XmlVersion},
+                                                    "UTF-8", "");
         doc_->LinkEndChild(decl.get());
         rootElement_ = new TxElement(SafeCStr{SerializeConstants::InviwoWorkspace});
 

--- a/src/core/io/serialization/serializer.cpp
+++ b/src/core/io/serialization/serializer.cpp
@@ -38,7 +38,7 @@ namespace inviwo {
 Serializer::Serializer(const std::filesystem::path& fileName) : SerializeBase(fileName) {
     try {
         auto decl =
-            std::make_unique<TxDeclaration>(std::string{SerializeConstants::XmlVersion}, "", "");
+            std::make_unique<TxDeclaration>(std::string{SerializeConstants::XmlVersion}, "UTF-8", "");
         doc_->LinkEndChild(decl.get());
         rootElement_ = new TxElement(SafeCStr{SerializeConstants::InviwoWorkspace});
 

--- a/src/core/network/processornetwork.cpp
+++ b/src/core/network/processornetwork.cpp
@@ -43,6 +43,7 @@
 #include <inviwo/core/network/networkedge.h>
 
 #include <fmt/format.h>
+#include <fmt/std.h>
 
 #include <algorithm>
 
@@ -432,10 +433,11 @@ void ProcessorNetwork::deserialize(Deserializer& d) {
     d.deserialize("ProcessorNetworkVersion", version);
 
     if (version != processorNetworkVersion_) {
-        LogNetworkSpecial((&d), LogLevel::Warn,
-                          "Loading old workspace ("
-                              << d.getFileName() << ") Processor Network version: " << version
-                              << ". Updating to version: " << processorNetworkVersion_ << ".");
+        LogNetworkSpecial(
+            (&d), LogLevel::Warn,
+            fmt::format(
+                "Loading old workspace ({}) Processor Network version: {}. Updating to version: .",
+                d.getFileName(), version, processorNetworkVersion_));
         ProcessorNetworkConverter nv(version);
         d.convertVersion(&nv);
     }

--- a/src/core/network/workspacemanager.cpp
+++ b/src/core/network/workspacemanager.cpp
@@ -217,12 +217,12 @@ Deserializer WorkspaceManager::createWorkspaceDeserializer(std::istream& stream,
             if (moduleInfo->version < module->getVersion()) {
                 auto converter = module->getConverter(moduleInfo->version);
                 deserializer.convertVersion(converter.get());
-                LogNetworkSpecial((&deserializer), LogLevel::Warn,
-                                  "Loading old workspace ("
-                                      << deserializer.getFileName() << ") "
-                                      << module->getIdentifier()
-                                      << "Module version: " << moduleInfo->version
-                                      << ". Updating to version: " << module->getVersion() << ".");
+                LogNetworkSpecial(
+                    (&deserializer), LogLevel::Warn,
+                    fmt::format(
+                        "Loading old workspace ({}) Module version: {}. Updating to version: {}.",
+                        deserializer.getFileName(), module->getIdentifier(), moduleInfo->version,
+                        module->getVersion()));
             }
         }
     }

--- a/src/qt/applicationbase/qtlocale.cpp
+++ b/src/qt/applicationbase/qtlocale.cpp
@@ -46,6 +46,9 @@ std::locale utilqt::getCurrentStdLocale() {
 #else
         std::string localeName(QLocale::system().name().toStdString());
 #endif
+        if (localeName.size() < 6 || localeName.substr(localeName.size() - 6) != ".UTF-8") {
+            localeName += ".UTF-8";
+        }
 
         // try to use the system locale provided by Qt
         std::vector<std::string> localeNames = {localeName, "en_US.UTF-8", "en_US.UTF8",

--- a/src/qt/applicationbase/qtlocale.cpp
+++ b/src/qt/applicationbase/qtlocale.cpp
@@ -46,7 +46,7 @@ std::locale utilqt::getCurrentStdLocale() {
 #else
         std::string localeName(QLocale::system().name().toStdString());
 #endif
-        if (localeName.size() < 6 || localeName.substr(localeName.size() - 6) != ".UTF-8") {
+        if (localeName.rfind('.') == std::string::npos) {
             localeName += ".UTF-8";
         }
 

--- a/src/qt/editor/inviwomainwindow.cpp
+++ b/src/qt/editor/inviwomainwindow.cpp
@@ -1304,7 +1304,7 @@ bool InviwoMainWindow::saveWorkspace(const std::filesystem::path& fileName) {
         });
         getNetworkEditor()->setModified(false);
         updateWindowTitle();
-        LogInfo("Workspace saved to: " << fileName);
+        LogInfo(fmt::format("Workspace saved to: {}", fileName));
         return true;
     } catch (const Exception& e) {
         util::logError(e.getContext(), "Unable to save network {} due to {}", fileName,

--- a/src/qt/editor/workspacetreemodel.cpp
+++ b/src/qt/editor/workspacetreemodel.cpp
@@ -212,7 +212,12 @@ QVariant TreeItem::data(int column, int role) const {
             case static_cast<int>(Role::Path):
                 return path_;
             case static_cast<int>(Role::FilePath):
-                return path_ + "/" + file_;
+                if (path_.endsWith("/")) {
+                    // path already ends with '/' in case of root directory '/' or disk drive 'C:/'
+                    return path_ + file_;
+                } else {
+                    return path_ + "/" + file_;
+                }
             case static_cast<int>(Role::isExample):
                 return isExample_;
 


### PR DESCRIPTION
Changes proposed in this PR:
 * use UTF-8 locale as default
 * serialization/deserialization defaults to UTF-8
 * logging a `std::filesystem::path` with `operator<<` uses the wrong code page for some reason. Switched to fmt::format instead.
     ```
     Workspace saved to: "D:/�������+fo.inv"   (before)
     Workspace saved to: "D:/äääööåå+fo.inv" (using fmt::format)
     ```
* fixed file type for custom workspace directories

This has been tested on: Windows