### PR TITLE
Changed auto pointer to Processor pointer in qtminimum to compile on gcc 11.3.0

### DIFF
--- a/apps/minimals/qt/qtminimum.cpp
+++ b/apps/minimals/qt/qtminimum.cpp
@@ -125,7 +125,7 @@ int main(int argc, char** argv) {
             inviwoApp.getProcessorNetwork()->addObserver(&obs);
             inviwoApp.getProcessorNetworkEvaluator()->addObserver(&obs);
             inviwoApp.getProcessorNetwork()->forEachProcessor(
-                [&](auto* p) { p->ProcessorObservable::addObserver(&obs); });
+                [&](inviwo::Processor* p) { p->ProcessorObservable::addObserver(&obs); });
         },
         200);
 


### PR DESCRIPTION
Changes proposed in this PR:
 * Change type of pointer in qtminimum.cpp

Code compiled and tested on:
Ubuntu 22.04.1 LTS / gcc 11.3.0 / Qt6
