### PR TITLE
Core: Make ImageInport::hasData() consistent

### DIFF
--- a/.github/workflows/inviwo.yml
+++ b/.github/workflows/inviwo.yml
@@ -175,6 +175,12 @@ jobs:
     #  uses: mxschmitt/action-tmate@v3
     #  timeout-minutes: 60
     
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v3
+      with:
+        version: 6.4.2
+        dir: ${{ github.workspace }}
+
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
@@ -203,12 +209,6 @@ jobs:
         -name "GitHub"
         -username "inviwo"
         -password "${{ secrets.GITHUB_TOKEN }}"
-
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: 6.4.2
-        dir: ${{ github.workspace }}
     
     - name: Clone Inviwo
       uses: actions/checkout@v4

--- a/include/inviwo/core/ports/datainport.h
+++ b/include/inviwo/core/ports/datainport.h
@@ -78,7 +78,7 @@ public:
     virtual std::vector<std::shared_ptr<const T>> getVectorData() const;
     virtual std::vector<std::pair<Outport*, std::shared_ptr<const T>>> getSourceVectorData() const;
 
-    bool hasData() const;
+    virtual bool hasData() const;
 };
 
 template <typename T>

--- a/include/inviwo/core/ports/imageport.h
+++ b/include/inviwo/core/ports/imageport.h
@@ -323,8 +323,7 @@ std::vector<std::shared_ptr<const Image>> BaseImageInport<N>::getVectorData() co
 
     for (auto outport : this->connectedOutports_) {
         auto imgport = static_cast<ImageOutport*>(outport);
-        auto img = getImage(imgport);
-        if (img != nullptr) res.emplace_back(img);
+        if (auto img = getImage(imgport)) res.emplace_back(img);
     }
 
     return res;
@@ -337,8 +336,7 @@ BaseImageInport<N>::getSourceVectorData() const {
 
     for (auto outport : this->connectedOutports_) {
         auto imgport = static_cast<ImageOutport*>(outport);
-        auto img = getImage(imgport);
-        if (img != nullptr) res.emplace_back(imgport, img);
+        if (auto img = getImage(imgport)) res.emplace_back(imgport, img);
     }
 
     return res;
@@ -396,7 +394,10 @@ Document BaseImageInport<N>::getInfo() const {
 template <size_t N>
 bool BaseImageInport<N>::hasData() const {
     if constexpr (N == 0) {
-        return this->isConnected() && this->begin() != this->end();
+        return this->isConnected() && 
+               util::any_of(this->connectedOutports_, [this](Outport* p) {
+                   return getImage(static_cast<ImageOutport*>(p)) != nullptr;
+               });
     } else {
         // Note: Cannot use ImageOutport::hasData() as getData()
         // depends on the ImageInport

--- a/include/inviwo/core/ports/imageport.h
+++ b/include/inviwo/core/ports/imageport.h
@@ -394,15 +394,13 @@ Document BaseImageInport<N>::getInfo() const {
 template <size_t N>
 bool BaseImageInport<N>::hasData() const {
     if constexpr (N == 0) {
-        return this->isConnected() && 
-               util::any_of(this->connectedOutports_, [this](Outport* p) {
+        return this->isConnected() && util::any_of(this->connectedOutports_, [this](Outport* p) {
                    return getImage(static_cast<ImageOutport*>(p)) != nullptr;
                });
     } else {
         // Note: Cannot use ImageOutport::hasData() as getData()
         // depends on the ImageInport
-        return this->isConnected() &&
-               util::all_of(this->connectedOutports_, [this](Outport* p) {
+        return this->isConnected() && util::all_of(this->connectedOutports_, [this](Outport* p) {
                    return getImage(static_cast<ImageOutport*>(p)) != nullptr;
                });
     }

--- a/include/inviwo/core/ports/imageport.h
+++ b/include/inviwo/core/ports/imageport.h
@@ -324,7 +324,7 @@ std::vector<std::shared_ptr<const Image>> BaseImageInport<N>::getVectorData() co
     for (auto outport : this->connectedOutports_) {
         auto imgport = static_cast<ImageOutport*>(outport);
         auto img = getImage(imgport);
-        if (img != nullptr) res.push_back(getImage(imgport));
+        if (img != nullptr) res.emplace_back(img);
     }
 
     return res;
@@ -338,7 +338,7 @@ BaseImageInport<N>::getSourceVectorData() const {
     for (auto outport : this->connectedOutports_) {
         auto imgport = static_cast<ImageOutport*>(outport);
         auto img = getImage(imgport);
-        if (img != nullptr) res.emplace_back(imgport, getImage(imgport));
+        if (img != nullptr) res.emplace_back(imgport, img);
     }
 
     return res;

--- a/src/core/ports/imageport.cpp
+++ b/src/core/ports/imageport.cpp
@@ -177,7 +177,6 @@ void ImageOutport::disconnectFrom(Inport* inport) {
 
 void ImageOutport::connectTo(Inport* inport) {
     DataOutport<Image>::connectTo(inport);
-    requestedDimensions_[inport] = size2_t{0};
 }
 
 void ImageOutport::propagateEvent(Event* event, Inport* source) {

--- a/src/core/ports/imageport.cpp
+++ b/src/core/ports/imageport.cpp
@@ -175,9 +175,7 @@ void ImageOutport::disconnectFrom(Inport* inport) {
     DataOutport<Image>::disconnectFrom(inport);
 }
 
-void ImageOutport::connectTo(Inport* inport) {
-    DataOutport<Image>::connectTo(inport);
-}
+void ImageOutport::connectTo(Inport* inport) { DataOutport<Image>::connectTo(inport); }
 
 void ImageOutport::propagateEvent(Event* event, Inport* source) {
     if (event->hash() != ResizeEvent::chash()) {

--- a/tools/changelog-to-html.py
+++ b/tools/changelog-to-html.py
@@ -29,7 +29,6 @@
 import os
 import sys
 import argparse
-from distutils.version import StrictVersion
 import urllib.request
 import json
 


### PR DESCRIPTION
Fixes case where ImageInport::hasData() would return true even though ImageInport::getData() returns nullptr
