### PR TITLE
Feature/python additions

### DIFF
--- a/include/inviwo/core/datastructures/datatraits.h
+++ b/include/inviwo/core/datastructures/datatraits.h
@@ -36,6 +36,7 @@
 #include <inviwo/core/util/glmfmt.h>
 #include <inviwo/core/util/introspection.h>
 #include <inviwo/core/util/colorconversion.h>
+#include <inviwo/core/util/defaultvalues.h>
 
 #include <type_traits>
 
@@ -135,6 +136,62 @@ struct DataTraits<T,
                                         DataFormat<T>::compsize);
     }
     static Document info(const T& data) {
+        Document doc;
+        doc.append("p", dataName());
+        doc.append("p", fmt::to_string(data));
+        return doc;
+    }
+};
+
+// Specializations for glm mat types
+template <glm::length_t C, glm::length_t R, typename T, glm::qualifier Q>
+struct DataTraits<glm::mat<C, R, T, Q>> {
+    static const std::string& classIdentifier() {
+        static const std::string classId{"org.inviwo." +
+                                         Defaultvalues<glm::mat<C, R, T, Q>>::getName()};
+        return classId;
+    }
+    static std::string_view dataName() {
+        static const std::string name{Defaultvalues<glm::mat<C, R, T, Q>>::getName()};
+        return name;
+    }
+    static uvec3 colorCode() {
+        uvec3 color{};
+
+        if constexpr (std::is_same_v<T, float>) {
+            color.r = 30;
+        } else if constexpr (std::is_same_v<T, double>) {
+            color.r = 60;
+        } else if constexpr (std::is_same_v<T, int>) {
+            color.r = 90;
+        } else if constexpr (std::is_same_v<T, unsigned int>) {
+            color.r = 120;
+        } else {
+            color.r = 240;
+        }
+
+        if constexpr (C==1) {
+            color.g = 60;
+        } else if constexpr (C==2) {
+            color.g = 90;
+        } else if constexpr (C==3) {
+            color.g = 120;
+        } else if constexpr (C==4) {
+            color.g = 150;
+        }
+
+        if constexpr (R == 1) {
+            color.b = 60;
+        } else if constexpr (R == 2) {
+            color.b = 90;
+        } else if constexpr (R == 3) {
+            color.b = 120;
+        } else if constexpr (R == 4) {
+            color.b = 150;
+        }
+        return color;
+    }
+    static Document info(const glm::mat<C, R, T, Q>& data) {
         Document doc;
         doc.append("p", dataName());
         doc.append("p", fmt::to_string(data));

--- a/include/inviwo/core/datastructures/datatraits.h
+++ b/include/inviwo/core/datastructures/datatraits.h
@@ -170,13 +170,13 @@ struct DataTraits<glm::mat<C, R, T, Q>> {
             color.r = 240;
         }
 
-        if constexpr (C==1) {
+        if constexpr (C == 1) {
             color.g = 60;
-        } else if constexpr (C==2) {
+        } else if constexpr (C == 2) {
             color.g = 90;
-        } else if constexpr (C==3) {
+        } else if constexpr (C == 3) {
             color.g = 120;
-        } else if constexpr (C==4) {
+        } else if constexpr (C == 4) {
             color.g = 150;
         }
 

--- a/modules/fontrendering/tests/regression/fonts/fonts.py
+++ b/modules/fontrendering/tests/regression/fonts/fonts.py
@@ -81,7 +81,7 @@ for i, (name, id) in enumerate(zip(fontNames, fontIdentifiers)):
     network.addConnection(prev.outports[0], p.inports[0])
     prev = p
 
-canvas.position = glm.ivec2(0, processorSpacing * len(fontNames) + 25)
+canvas.position.value = glm.ivec2(0, processorSpacing * len(fontNames) + 25)
 
 # connect last processor to canvas
 network.addConnection(prev.outports[0], canvas.inports[0])

--- a/modules/opengl/include/modules/opengl/openglutils.h
+++ b/modules/opengl/include/modules/opengl/openglutils.h
@@ -33,6 +33,7 @@
 
 #include <inviwo/core/datastructures/image/imagetypes.h>  // for Wrapping, InterpolationType
 #include <inviwo/core/util/glmvec.h>                      // for vec4, bvec4, ivec4, bvec2, bvec3
+#include <inviwo/core/util/glmmat.h>  
 #include <inviwo/core/util/moveonlyvalue.h>               // for MoveOnlyValue
 #include <inviwo/core/util/stdextensions.h>               // for make_array, index_of
 #include <modules/opengl/inviwoopengl.h>                  // for GLint, GLenum, GLboolean, GLAPI...
@@ -609,12 +610,13 @@ private:
 
 template <typename T>
 inline constexpr std::string_view glslTypeName() {
-    using types =
-        std::tuple<float, double, bool, uint32_t, int32_t, vec2, dvec2, bvec2, ivec2, uvec2, vec3,
-                   dvec3, bvec3, ivec3, uvec3, vec4, dvec4, bvec4, ivec4, uvec4>;
-    constexpr std::array<std::string_view, 20> names = {
-        "float", "double", "bool",  "uint",  "int",   "vec2", "dvec2", "bvec2", "ivec2", "uvec2",
-        "vec3",  "dvec3",  "bvec3", "ivec3", "uvec3", "vec4", "dvec4", "bvec4", "ivec4", "uvec4"};
+    using types = std::tuple<float, double, bool, uint32_t, int32_t, vec2, dvec2, bvec2, ivec2,
+                             uvec2, vec3, dvec3, bvec3, ivec3, uvec3, vec4, dvec4, bvec4, ivec4,
+                             uvec4, mat2, dmat2, mat3, dmat3, mat4, dmat4>;
+    constexpr std::array<std::string_view, 26> names = {
+        "float", "double", "bool",  "uint",  "int",   "vec2",  "dvec2", "bvec2", "ivec2",
+        "uvec2", "vec3",   "dvec3", "bvec3", "ivec3", "uvec3", "vec4",  "dvec4", "bvec4",
+        "ivec4", "uvec4",  "mat2",  "dmat2", "mat3",  "dmat3", "mat4",  "dmat4"};
 
     return names[util::index_of<T, types>()];
 }

--- a/modules/opengl/include/modules/opengl/openglutils.h
+++ b/modules/opengl/include/modules/opengl/openglutils.h
@@ -33,10 +33,10 @@
 
 #include <inviwo/core/datastructures/image/imagetypes.h>  // for Wrapping, InterpolationType
 #include <inviwo/core/util/glmvec.h>                      // for vec4, bvec4, ivec4, bvec2, bvec3
-#include <inviwo/core/util/glmmat.h>  
-#include <inviwo/core/util/moveonlyvalue.h>               // for MoveOnlyValue
-#include <inviwo/core/util/stdextensions.h>               // for make_array, index_of
-#include <modules/opengl/inviwoopengl.h>                  // for GLint, GLenum, GLboolean, GLAPI...
+#include <inviwo/core/util/glmmat.h>
+#include <inviwo/core/util/moveonlyvalue.h>  // for MoveOnlyValue
+#include <inviwo/core/util/stdextensions.h>  // for make_array, index_of
+#include <modules/opengl/inviwoopengl.h>     // for GLint, GLenum, GLboolean, GLAPI...
 
 #include <array>        // for array, operator==
 #include <cstddef>      // for size_t

--- a/modules/python3/CMakeLists.txt
+++ b/modules/python3/CMakeLists.txt
@@ -54,6 +54,19 @@ set(SCRIPT_FILES
 )
 ivw_group("Script Files" ${SCRIPT_FILES})
 
+# Add script files
+set(PYTHON_PROCESSORS_FILES
+    processors/MandelbrotNumpy.py
+    processors/MeshCreationTest.py
+    processors/PythonExample.py
+    processors/PythonImageExample.py
+    processors/PythonMeshExample.py
+    processors/PythonPickingExample.py
+    processors/PythonVolumeExample.py
+    processors/VolumeCreationTest.py
+)
+ivw_group("Python Processor Files" BASE processors ${PYTHON_PROCESSORS_FILES})
+
 # Add Unittests
 set(TEST_FILES
     tests/unittests/python3-unittest-main.cpp
@@ -69,7 +82,7 @@ set(TEST_FILES
 ivw_add_unittest(${TEST_FILES})
 
 # Create module
-ivw_create_module(${SOURCE_FILES} ${HEADER_FILES} ${SCRIPT_FILES})
+ivw_create_module(${SOURCE_FILES} ${HEADER_FILES} ${SCRIPT_FILES} ${PYTHON_PROCESSORS_FILES})
 
 find_package(pybind11 CONFIG REQUIRED)
 target_link_libraries(inviwo-module-python3 PUBLIC

--- a/modules/python3/bindings/CMakeLists.txt
+++ b/modules/python3/bindings/CMakeLists.txt
@@ -17,6 +17,7 @@ set(HEADER_FILES
     include/inviwopy/pydocument.h
     include/inviwopy/pyevent.h
     include/inviwopy/pyflags.h
+    include/inviwopy/pyglmmatports.h
     include/inviwopy/pyglmmattypes.h
     include/inviwopy/pyglmmattypesdouble.h
     include/inviwopy/pyglmmattypesfloat.h
@@ -66,6 +67,7 @@ set(SOURCE_FILES
     src/pydocument.cpp
     src/pyevent.cpp
     src/pyflags.cpp
+    src/pyglmmatports.cpp
     src/pyglmmattypes.cpp
     src/pyglmmattypesdouble.cpp
     src/pyglmmattypesfloat.cpp

--- a/modules/python3/bindings/include/inviwopy/pyglmmatports.h
+++ b/modules/python3/bindings/include/inviwopy/pyglmmatports.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2017-2023 Inviwo Foundation
+ * Copyright (c) 2023 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,73 +27,15 @@
  *
  *********************************************************************************/
 
-#include <inviwo/core/datastructures/datatraits.h>
+#pragma once
+
+#include <warn/push>
+#include <warn/ignore/shadow>
+#include <pybind11/pybind11.h>
+#include <warn/pop>
 
 namespace inviwo {
 
-uvec3 util::getDataFormatColor(NumericType t, size_t comp, size_t size) {
-    uvec3 color{};
-    switch (t) {
-        case NumericType::Float:
-            color.r = 30;
-            break;
-        case NumericType::SignedInteger:
-            color.r = 60;
-            break;
-        case NumericType::UnsignedInteger:
-            color.r = 90;
-            break;
-        default:
-            color.r = 0;
-            break;
-    }
-
-    switch (comp) {
-        case 1:
-            color.g = 30;
-            break;
-        case 2:
-            color.g = 60;
-            break;
-        case 3:
-            color.g = 90;
-            break;
-        case 4:
-            color.g = 120;
-            break;
-        default:
-            color.g = 0;
-            break;
-    }
-    switch (size) {
-        case 1:
-            color.b = 30;
-            break;
-        case 2:
-            color.b = 60;
-            break;
-        case 3:
-            color.b = 90;
-            break;
-        case 4:
-            color.b = 120;
-            break;
-        case 8:
-            color.b = 150;
-            break;
-        default:
-            color.b = 0;
-            break;
-    }
-    return color;
-}
-
-std::string util::appendIfNotEmpty(std::string_view a, std::string_view b) {
-    if (a.empty() || b.empty()) {
-        return std::string{a};
-    } else {
-        return std::string{a}.append(b);
-    }
-}
+void exposeGLMMatPorts(pybind11::module& m);
 
 }  // namespace inviwo

--- a/modules/python3/bindings/src/pydocument.cpp
+++ b/modules/python3/bindings/src/pydocument.cpp
@@ -126,6 +126,7 @@ void exposeDocument(pybind11::module& m) {
                  -> void { d.visit(before, after); });
 
     m.def("md2doc", &util::md2doc);
+    m.def("unindentMd2doc", &util::unindentMd2doc);
 }
 
 }  // namespace inviwo

--- a/modules/python3/bindings/src/pyglmmatports.cpp
+++ b/modules/python3/bindings/src/pyglmmatports.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2017-2023 Inviwo Foundation
+ * Copyright (c) 2023 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,73 +27,21 @@
  *
  *********************************************************************************/
 
-#include <inviwo/core/datastructures/datatraits.h>
+#include <inviwopy/pyglmmatports.h>
+#include <inviwopy/util/pyglmhelper.h>
+
+#include <inviwo/core/util/foreacharg.h>
+
+#include <inviwopy/pyglmmattypesfloat.h>
+#include <inviwopy/pyglmmattypesdouble.h>
+#include <inviwopy/pyglmmattypesint.h>
+#include <inviwopy/pyglmmattypesuint.h>
 
 namespace inviwo {
 
-uvec3 util::getDataFormatColor(NumericType t, size_t comp, size_t size) {
-    uvec3 color{};
-    switch (t) {
-        case NumericType::Float:
-            color.r = 30;
-            break;
-        case NumericType::SignedInteger:
-            color.r = 60;
-            break;
-        case NumericType::UnsignedInteger:
-            color.r = 90;
-            break;
-        default:
-            color.r = 0;
-            break;
-    }
-
-    switch (comp) {
-        case 1:
-            color.g = 30;
-            break;
-        case 2:
-            color.g = 60;
-            break;
-        case 3:
-            color.g = 90;
-            break;
-        case 4:
-            color.g = 120;
-            break;
-        default:
-            color.g = 0;
-            break;
-    }
-    switch (size) {
-        case 1:
-            color.b = 30;
-            break;
-        case 2:
-            color.b = 60;
-            break;
-        case 3:
-            color.b = 90;
-            break;
-        case 4:
-            color.b = 120;
-            break;
-        case 8:
-            color.b = 150;
-            break;
-        default:
-            color.b = 0;
-            break;
-    }
-    return color;
-}
-
-std::string util::appendIfNotEmpty(std::string_view a, std::string_view b) {
-    if (a.empty() || b.empty()) {
-        return std::string{a};
-    } else {
-        return std::string{a}.append(b);
-    }
+void exposeGLMMatPorts(pybind11::module& m) {
+    using types = std::tuple<mat2, mat3, mat4, dmat2, dmat3, dmat4>;
+    util::for_each_type<types>{}(ExposePortsFunctor{}, m);
 }
 
 }  // namespace inviwo

--- a/modules/python3/bindings/src/pyglmports.cpp
+++ b/modules/python3/bindings/src/pyglmports.cpp
@@ -28,6 +28,8 @@
  *********************************************************************************/
 
 #include <inviwopy/pyglmports.h>
+
+#include <inviwopy/pyglmmatports.h>
 #include <inviwopy/pyglmportsdouble.h>
 #include <inviwopy/pyglmportsfloat.h>
 #include <inviwopy/pyglmportsint.h>
@@ -40,6 +42,8 @@ void exposeGLMPorts(pybind11::module& m) {
     exposeGLMPortsFloat(m);
     exposeGLMPortsInt(m);
     exposeGLMPortsUint(m);
+
+    exposeGLMMatPorts(m);
 }
 
 }  // namespace inviwo

--- a/modules/python3/bindings/src/pypropertyowner.cpp
+++ b/modules/python3/bindings/src/pypropertyowner.cpp
@@ -79,8 +79,8 @@ void exposePropertyOwner(pybind11::module& m) {
                     throw py::attribute_error{fmt::format(
                         "The key '{0}' is a registered property of '{1}'.\nTo rebind the member "
                         "unregister (remove) the property from '{1}' first.\n"
-                        "If you were trying the set the 'value' of the '{0}' Property, you should "
-                        "usually assign to '{0}.value' instead.\n"
+                        "If you were trying to set the 'value' of the '{0}' property, you should "
+                        "assign to '{0}.value' instead.\n"
                         "See help({0}) for more details",
                         skey, path)};
                 }

--- a/modules/python3qt/src/pythoneditorwidget.cpp
+++ b/modules/python3qt/src/pythoneditorwidget.cpp
@@ -123,7 +123,7 @@ PythonEditorWidget::PythonEditorWidget(QWidget* parent, InviwoApplication* app)
         pythonOutput_ = new CodeEdit{this};
         outputCallbacks_ =
             utilqt::setPythonOutputSyntaxHighlight(pythonOutput_->syntaxHighlighter(), *settings);
-        // pythonOutput_->setReadOnly(true); this breaks Ctrl-C for unknown reasons. 
+        // pythonOutput_->setReadOnly(true); this breaks Ctrl-C for unknown reasons.
         pythonOutput_->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
     }
 

--- a/modules/python3qt/src/pythoneditorwidget.cpp
+++ b/modules/python3qt/src/pythoneditorwidget.cpp
@@ -123,7 +123,7 @@ PythonEditorWidget::PythonEditorWidget(QWidget* parent, InviwoApplication* app)
         pythonOutput_ = new CodeEdit{this};
         outputCallbacks_ =
             utilqt::setPythonOutputSyntaxHighlight(pythonOutput_->syntaxHighlighter(), *settings);
-        pythonOutput_->setReadOnly(true);
+        // pythonOutput_->setReadOnly(true); this breaks Ctrl-C for unknown reasons. 
         pythonOutput_->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
     }
 

--- a/modules/python3qt/templates/templateprocessor.py
+++ b/modules/python3qt/templates/templateprocessor.py
@@ -26,7 +26,7 @@ class {name}(ivw.Processor):
             category="Python",
             codeState=ivw.CodeState.Stable,
             tags=ivw.Tags.PY,
-            help=ivw.md2doc({name}.__doc__)
+            help=ivw.unindentMd2doc({name}.__doc__)
         )
 
     def getProcessorInfo(self):


### PR DESCRIPTION
Fixes #...

Changes proposed in this PR:
 * inviwopy.app.network.someprocessor.someordinalproperty = 5 will renerate an error, need to use .value
 * use unindentmd2doc in the python processor template to get the correct translation of a doc string
 * added support for inviwopy.glm.mat3Vector ports
 * also enabled some implicit conversion from python list/array to glm mat types