### PR TITLE
Feature/cmake vcpkg

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
     url = https://github.com/petersteneteg/warn.git
 [submodule "ext/utf/utfcpp"]
     path = ext/utf/utfcpp
-    url = https://github.com/nemtrif/utfcpp
+    url = https://github.com/inviwo/utfcpp
 [submodule "ext/benchmark/benchmark"]
     path = ext/benchmark/benchmark
     url = https://github.com/google/benchmark.git

--- a/cmake/compileoptions.cmake
+++ b/cmake/compileoptions.cmake
@@ -30,7 +30,7 @@
 option(IVW_CFG_TREAT_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
 option(IVW_CFG_FORCE_ASSERTIONS "Force use of assertions when not in debug mode" OFF)
 if(CMAKE_GENERATOR STREQUAL "Xcode")
-    option(IVW_CFG_XCODE_ADDRESS_SANITIZER "Enable XCode Addess Sanatizer" OFF)
+    option(IVW_CFG_XCODE_ADDRESS_SANITIZER "Enable XCode Address Sanitizer" OFF)
     set(CMAKE_XCODE_SCHEME_ADDRESS_SANITIZER ${IVW_CFG_XCODE_ADDRESS_SANITIZER})
     set(CMAKE_XCODE_SCHEME_ADDRESS_SANITIZER_USE_AFTER_RETURN ${IVW_CFG_XCODE_ADDRESS_SANITIZER})
     set(CMAKE_XCODE_SCHEME_MAIN_THREAD_CHECKER_STOP ${IVW_CFG_XCODE_ADDRESS_SANITIZER})
@@ -154,6 +154,11 @@ function(ivw_define_standard_properties)
             target_link_options(${target} PRIVATE 
                 $<$<CONFIG:Debug,RelWithDebInfo>:/debug:fastlink>
             )
+
+            option(IVW_CFG_MSVC_ADDRESS_SANITIZER "Enable Visual Studio Address Sanitizer" OFF)
+            if(IVW_CFG_MSVC_ADDRESS_SANITIZER)
+                list(APPEND comp_opts "/fsanitize=address")
+            endif()
         endif()
         if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
             "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")

--- a/cmake/createmodule.cmake
+++ b/cmake/createmodule.cmake
@@ -92,13 +92,18 @@ function(ivw_create_module)
     add_library(${${mod}_target})
     add_library(${${mod}_alias} ALIAS ${${mod}_target})
 
+    set(includesuffix "/include")
+    if(LEGACY)
+        set(includesuffix "")
+    endif()
+
     target_sources(${${mod}_target} 
         PUBLIC 
         FILE_SET HEADERS
         TYPE HEADERS
         BASE_DIRS 
             ${CMAKE_CURRENT_BINARY_DIR}/include
-            ${CMAKE_CURRENT_SOURCE_DIR}/include
+            ${CMAKE_CURRENT_SOURCE_DIR}${includesuffix}
         FILES 
             ${mod_header_files}
         PRIVATE

--- a/ext/ticpp/CMakeLists.txt
+++ b/ext/ticpp/CMakeLists.txt
@@ -60,6 +60,10 @@ target_sources(ticpp
         src/visitor.cpp
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" AND IVW_CFG_MSVC_ADDRESS_SANITIZER)
+    target_compile_options(ticpp PRIVATE "/fsanitize=address")
+endif()
+
 # Creates VS folder structure
 ivw_folder(ticpp ext)
 

--- a/ext/utf/CMakeLists.txt
+++ b/ext/utf/CMakeLists.txt
@@ -3,13 +3,17 @@
 
 add_subdirectory(utfcpp)
 
+if(NOT TARGET utf8cpp::utf8cpp)
+    add_library(utf8cpp::utf8cpp ALIAS utf8cpp)
+endif()
+
 set(HEADER_FILES 
-	${CMAKE_CURRENT_SOURCE_DIR}/utfcpp/source/utf8.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/utfcpp/source/utf8/checked.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/utfcpp/source/utf8/core.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/utfcpp/source/utf8/cpp11.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/utfcpp/source/utf8/cpp17.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/utfcpp/source/utf8/unchecked.h
+	${CMAKE_CURRENT_SOURCE_DIR}/utfcpp/utf8cpp/utf8.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/utfcpp/utf8cpp/utf8/checked.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/utfcpp/utf8cpp/utf8/core.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/utfcpp/utf8cpp/utf8/cpp11.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/utfcpp/utf8cpp/utf8/cpp17.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/utfcpp/utf8cpp/utf8/unchecked.h
 )
 set(DOC_FILES
 	${CMAKE_CURRENT_SOURCE_DIR}/LICENSE 

--- a/modules/fontrendering/CMakeLists.txt
+++ b/modules/fontrendering/CMakeLists.txt
@@ -70,5 +70,5 @@ target_link_libraries(inviwo-module-fontrendering
     PUBLIC 
         freetype
     PRIVATE
-        utf8cpp
+        utf8cpp::utf8cpp
 )

--- a/modules/fontrendering/src/textrenderer.cpp
+++ b/modules/fontrendering/src/textrenderer.cpp
@@ -69,8 +69,8 @@
 #include <glm/mat4x4.hpp>                // for operator*, mat
 #include <glm/vec3.hpp>                  // for vec<>::(anonymous)
 #include <glm/vec4.hpp>                  // for operator*, operator+
-#include <utf8cpp/utf8/checked.h>                // for iterator
-#include <utf8cpp/utf8/core.h>                   // for find_invalid
+#include <utf8cpp/utf8/checked.h>        // for iterator
+#include <utf8cpp/utf8/core.h>           // for find_invalid
 
 #include <fmt/std.h>
 

--- a/modules/fontrendering/src/textrenderer.cpp
+++ b/modules/fontrendering/src/textrenderer.cpp
@@ -69,8 +69,8 @@
 #include <glm/mat4x4.hpp>                // for operator*, mat
 #include <glm/vec3.hpp>                  // for vec<>::(anonymous)
 #include <glm/vec4.hpp>                  // for operator*, operator+
-#include <utf8/checked.h>                // for iterator
-#include <utf8/core.h>                   // for find_invalid
+#include <utf8cpp/utf8/checked.h>                // for iterator
+#include <utf8cpp/utf8/core.h>                   // for find_invalid
 
 #include <fmt/std.h>
 

--- a/modules/glfw/CMakeLists.txt
+++ b/modules/glfw/CMakeLists.txt
@@ -29,7 +29,7 @@ ivw_create_module(${SOURCE_FILES} ${HEADER_FILES})
 
 find_package(utf8cpp CONFIG REQUIRED)
 target_link_libraries(inviwo-module-glfw PRIVATE
-    utf8cpp
+    utf8cpp::utf8cpp
 )
 
 option(IVW_USE_EXTERNAL_GLFW "GLFW is provided externaly" OFF)

--- a/modules/glfw/src/glfwwindoweventmanager.cpp
+++ b/modules/glfw/src/glfwwindoweventmanager.cpp
@@ -45,8 +45,8 @@
 #include <GLFW/glfw3.h>   // for glfwGetWindowSize, GLFWwindow
 #include <flags/flags.h>  // for none
 #include <glm/vec2.hpp>   // for vec<>::(anonymous), operator/
-#include <utf8/core.h>
-#include <utf8/checked.h>
+#include <utf8cpp/utf8/core.h>
+#include <utf8cpp/utf8/checked.h>
 
 namespace inviwo {
 

--- a/modules/webbrowser/CMakeLists.txt
+++ b/modules/webbrowser/CMakeLists.txt
@@ -182,7 +182,7 @@ ivw_add_to_module_pack(${CMAKE_CURRENT_SOURCE_DIR}/data/js)
 
 find_package(utf8cpp CONFIG REQUIRED)
 target_link_libraries(inviwo-module-webbrowser PRIVATE
-    utf8cpp
+    utf8cpp::utf8cpp
 )
 
 ivw_register_license_file(NAME "Chromium Embedded Framework" VERSION ${CEF_VERSION} MODULE WebBrowser

--- a/modules/webbrowser/depends.cmake
+++ b/modules/webbrowser/depends.cmake
@@ -8,3 +8,8 @@ set(dependencies
 )
 
 set(protected ON)
+
+if(IVW_CFG_MSVC_ADDRESS_SANITIZER)
+    set(Disabled ON)
+    set(DisabledReason "Disabled since IVW_CFG_MSVC_ADDRESS_SANITIZER is ON")
+endif()

--- a/modules/webbrowser/src/interaction/cefinteractionhandler.cpp
+++ b/modules/webbrowser/src/interaction/cefinteractionhandler.cpp
@@ -61,8 +61,8 @@
 #include <type_traits>  // for enable_if<>::type
 #include <utility>      // for pair
 #include <vector>       // for vector
-#include <utf8/core.h>
-#include <utf8/checked.h>
+#include <utf8cpp/utf8/core.h>
+#include <utf8cpp/utf8/checked.h>
 
 namespace inviwo {
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -904,7 +904,7 @@ target_link_libraries(inviwo-core
     PRIVATE
         roaring::roaring
         inviwo::md4c
-        utf8cpp
+        utf8cpp::utf8cpp
 )
 
 # Core header files used in PCH file

--- a/src/core/algorithm/markdown.cpp
+++ b/src/core/algorithm/markdown.cpp
@@ -37,7 +37,7 @@
 #include <md4c/md4c.h>
 #include <warn/pop>
 
-#include <utf8/checked.h>
+#include <utf8cpp/utf8/checked.h>
 
 namespace inviwo {
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,7 @@
   "vcpkg-configuration": {
     "default-registry": {
       "kind": "builtin",
-      "baseline": "08cc145ed5858faa83160986b3f27f37c499d6ad"
+      "baseline": "a42af01b72c28a8e1d7b48107b33e4f286a55ef6"
     },
     "overlay-ports": [
       "./tools/vcpkg"


### PR DESCRIPTION
Fixes 
* fixed support for legacy modules (no include/src folders)

Changes proposed in this PR:
* updated vcpkg to latest commit since fmt/format was outdated (VS 17.8.1 deprecated checked iterators, https://github.com/fmtlib/fmt/issues/3540)
 * added CMake option (`IVW_CFG_MSVC_ADDRESS_SANITIZER`) for enabling ASAN within Visual Studio

This has been tested on: Windows, MSVC 17.8.1
