### PR TITLE
Feature/python fixes

### DIFF
--- a/modules/python3/bindings/src/pypropertyowner.cpp
+++ b/modules/python3/bindings/src/pypropertyowner.cpp
@@ -62,36 +62,45 @@ void exposePropertyOwner(pybind11::module& m) {
         .def(
             "__setattr__",
             [](py::object po, py::object key, py::object value) {
-                const auto skey = py::str(key).cast<std::string>();
-                auto owner = po.cast<PropertyOwner*>();
-                if (owner->getPropertyByIdentifier(skey)) {
+                const auto isProperty = [&]() {
                     auto pyProperty =
                         py::module_::import("inviwopy").attr("properties").attr("Property");
-                    if (py::isinstance(po.attr(key), pyProperty)) {
-                        std::string path;
-                        const auto traverse = [&](auto& self, PropertyOwner* owner) -> void {
-                            if (owner) {
-                                self(self, owner->getOwner());
-                                path.append(owner->getIdentifier());
-                                path.push_back('.');
-                            }
-                        };
-                        traverse(traverse, owner->getOwner());
-                        path.append(owner->getIdentifier());
+                    return py::isinstance(po.attr(key), pyProperty);
+                };
 
-                        throw py::attribute_error{
-                            fmt::format("The key '{0}' is a registered property of '{1}'.\nTo "
-                                        "rebind the member "
-                                        "unregister (remove) the property from '{1}' first.\n"
-                                        "If you were trying to set the 'value' of the '{0}' "
-                                        "property, you should "
-                                        "assign to '{0}.value' instead.\n"
-                                        "See help({0}) for more details",
-                                        skey, path)};
+                const auto path = [](const PropertyOwner* owner) {
+                    std::string path;
+                    const auto traverse = [&](auto& self, const PropertyOwner* owner) -> void {
+                        if (owner) {
+                            self(self, owner->getOwner());
+                            path.append(owner->getIdentifier());
+                            path.push_back('.');
+                        }
+                    };
+                    traverse(traverse, owner->getOwner());
+                    path.append(owner->getIdentifier());
+                    return path;
+                };
+
+                auto builtins = py::module_::import("builtins");
+                auto type = builtins.attr("type");
+
+                const auto skey = py::str(key).cast<std::string>();
+                const auto owner = po.cast<PropertyOwner*>();
+                if (auto prop = owner->getPropertyByIdentifier(skey)) {
+                    if (isProperty()) {
+                        throw py::attribute_error{fmt::format(
+                            "The member '{0}' is a registered Property of type '{3}',\n"
+                            "in PropertyOwner '{1}' of type '{2}'.\n"
+                            "To rebind the member unregister (remove) the property from "
+                            "'{1}' first.\nIf you were trying to set the 'value' of the '{0}' "
+                            "property, you should assign to '{0}.value' instead.\nSee help({0}) "
+                            "for more details",
+                            skey, path(owner), type(po).attr("__name__").cast<std::string>(),
+                            prop->getClassIdentifier())};
                     }
                 }
 
-                auto builtins = py::module::import("builtins");
                 auto object = builtins.attr("object");
                 object.attr("__setattr__")(po, key, value);
             },

--- a/modules/python3/scripts/ivw/utils.py
+++ b/modules/python3/scripts/ivw/utils.py
@@ -39,9 +39,9 @@ def ensureDirectory(dir):
 def update():
     try:
         from inviwopy import qt
-        qt.update()
-    except:
-        pass
+    except Exception:
+        return
+    qt.update()
 
 
 def getCanvases():


### PR DESCRIPTION
Fixes #1027

Changes proposed in this PR:
 * the property ownership check was to aggressive when setting a class attribute of a property owner and caused false positives For example, `lookFrom`, `lookTo`, and `lookUp` from `CameraProperty` are exposed as `vec3` while properties with the same name exist as well.

This has been tested on: MSVC 17.8.1