### PR TITLE
 virtual getDataFormat

### DIFF
--- a/include/inviwo/core/datastructures/buffer/bufferram.h
+++ b/include/inviwo/core/datastructures/buffer/bufferram.h
@@ -46,10 +46,6 @@ namespace inviwo {
  */
 class IVW_CORE_API BufferRAM : public BufferRepresentation {
 public:
-    BufferRAM(const DataFormatBase* format, BufferUsage usage = BufferUsage::Static,
-              BufferTarget target = BufferTarget::Data);
-    BufferRAM(const BufferRAM& rhs) = default;
-    BufferRAM& operator=(const BufferRAM& that) = default;
     virtual BufferRAM* clone() const override = 0;
     virtual ~BufferRAM() = default;
 
@@ -134,6 +130,11 @@ public:
     template <typename Result, template <class> class Predicate = dispatching::filter::All,
               typename Callable, typename... Args>
     auto dispatch(Callable&& callable, Args&&... args) const -> Result;
+
+protected:
+    BufferRAM(BufferUsage usage = BufferUsage::Static, BufferTarget target = BufferTarget::Data);
+    BufferRAM(const BufferRAM& rhs) = default;
+    BufferRAM& operator=(const BufferRAM& that) = default;
 };
 
 /**
@@ -152,6 +153,8 @@ public:
     BufferRAMPrecision<T, Target>& operator=(const BufferRAMPrecision<T, Target>& that) = default;
     virtual ~BufferRAMPrecision() = default;
     virtual BufferRAMPrecision<T, Target>* clone() const override;
+
+    virtual const DataFormatBase* getDataFormat() const override;
 
     virtual void setSize(size_t size) override;
     virtual size_t getSize() const override;
@@ -224,15 +227,19 @@ BufferRAMPrecision<T, Target>::BufferRAMPrecision(BufferUsage usage)
 
 template <typename T, BufferTarget Target>
 BufferRAMPrecision<T, Target>::BufferRAMPrecision(size_t size, BufferUsage usage)
-    : BufferRAM(DataFormat<T>::get(), usage, Target), data_(size) {}
+    : BufferRAM(usage, Target), data_(size) {}
 
 template <typename T, BufferTarget Target>
 BufferRAMPrecision<T, Target>::BufferRAMPrecision(std::vector<T> data, BufferUsage usage)
-    : BufferRAM(DataFormat<T>::get(), usage, Target), data_(std::move(data)) {}
+    : BufferRAM(usage, Target), data_(std::move(data)) {}
 
 template <typename T, BufferTarget Target>
 BufferRAMPrecision<T, Target>* BufferRAMPrecision<T, Target>::clone() const {
     return new BufferRAMPrecision<T, Target>(*this);
+}
+template <typename T, BufferTarget Target>
+const DataFormatBase* BufferRAMPrecision<T, Target>::getDataFormat() const {
+    return DataFormat<T>::get();
 }
 
 template <typename T, BufferTarget Target>

--- a/include/inviwo/core/datastructures/buffer/bufferrepresentation.h
+++ b/include/inviwo/core/datastructures/buffer/bufferrepresentation.h
@@ -44,6 +44,11 @@ class IVW_CORE_API BufferRepresentation : public DataRepresentation<BufferBase> 
 public:
     virtual BufferRepresentation* clone() const override = 0;
     virtual ~BufferRepresentation() = default;
+
+    virtual const DataFormatBase* getDataFormat() const = 0;
+    std::string getDataFormatString() const { return getDataFormat()->getString(); }
+    DataFormatId getDataFormatId() const { return getDataFormat()->getId(); }
+
     virtual void setSize(size_t size) = 0;
 
     /**
@@ -58,7 +63,7 @@ public:
     BufferTarget getBufferTarget() const;
 
 protected:
-    BufferRepresentation(const DataFormatBase* format, BufferUsage usage = BufferUsage::Static,
+    BufferRepresentation(BufferUsage usage = BufferUsage::Static,
                          BufferTarget target = BufferTarget::Data);
     BufferRepresentation(const BufferRepresentation& rhs) = default;
     BufferRepresentation& operator=(const BufferRepresentation& that) = default;

--- a/include/inviwo/core/datastructures/data.h
+++ b/include/inviwo/core/datastructures/data.h
@@ -33,6 +33,7 @@
 #include <inviwo/core/datastructures/representationfactory.h>
 #include <inviwo/core/datastructures/representationconverterfactory.h>
 #include <inviwo/core/datastructures/representationfactorymanager.h>
+#include <inviwo/core/datastructures/nodata.h>
 
 #include <inviwo/core/util/demangle.h>
 
@@ -211,13 +212,6 @@ private:
     // A pointer to the the most recently updated representation. Makes updates and creation faster.
     mutable std::shared_ptr<Repr> lastValidRepresentation_;
 };
-
-/*
- * Tag type for constructors indicating that you want a copy of only "meta" data not the actual
- * data.
- */
-struct NoData {};
-constexpr NoData noData{};
 
 template <typename Self, typename Repr>
 Data<Self, Repr>::Data(const Data<Self, Repr>& rhs) : lastValidRepresentation_{nullptr} {

--- a/include/inviwo/core/datastructures/datarepresentation.h
+++ b/include/inviwo/core/datastructures/datarepresentation.h
@@ -55,10 +55,6 @@ public:
     virtual DataRepresentation* clone() const = 0;
     virtual ~DataRepresentation() = default;
 
-    const DataFormatBase* getDataFormat() const;
-    std::string getDataFormatString() const;
-    DataFormatId getDataFormatId() const;
-
     virtual std::type_index getTypeIndex() const = 0;
 
     void setOwner(const Owner* owner);
@@ -69,39 +65,12 @@ public:
 
 protected:
     DataRepresentation() = default;
-    DataRepresentation(const DataFormatBase* format);
     DataRepresentation(const DataRepresentation& rhs) = default;
     DataRepresentation& operator=(const DataRepresentation& that) = default;
-    void setDataFormat(const DataFormatBase* format);
 
     bool isValid_ = true;
-    const DataFormatBase* dataFormatBase_ = DataUInt8::get();
     const Owner* owner_ = nullptr;
 };
-
-template <typename Owner>
-DataRepresentation<Owner>::DataRepresentation(const DataFormatBase* format)
-    : isValid_(true), dataFormatBase_(format), owner_(nullptr) {}
-
-template <typename Owner>
-const DataFormatBase* DataRepresentation<Owner>::getDataFormat() const {
-    return dataFormatBase_;
-}
-
-template <typename Owner>
-std::string DataRepresentation<Owner>::getDataFormatString() const {
-    return std::string(dataFormatBase_->getString());
-}
-
-template <typename Owner>
-DataFormatId DataRepresentation<Owner>::getDataFormatId() const {
-    return dataFormatBase_->getId();
-}
-
-template <typename Owner>
-void DataRepresentation<Owner>::setDataFormat(const DataFormatBase* format) {
-    dataFormatBase_ = format;
-}
 
 template <typename Owner>
 void DataRepresentation<Owner>::setOwner(const Owner* owner) {

--- a/include/inviwo/core/datastructures/datarepresentation.h
+++ b/include/inviwo/core/datastructures/datarepresentation.h
@@ -31,6 +31,7 @@
 
 #include <inviwo/core/util/formats.h>
 #include <inviwo/core/util/exception.h>
+#include <inviwo/core/datastructures/nodata.h>
 #include <typeindex>
 
 namespace inviwo {

--- a/include/inviwo/core/datastructures/image/layerdisk.h
+++ b/include/inviwo/core/datastructures/image/layerdisk.h
@@ -56,6 +56,8 @@ public:
     virtual LayerDisk* clone() const override;
     virtual ~LayerDisk();
 
+    virtual const DataFormatBase* getDataFormat() const override;
+
     virtual const size2_t& getDimensions() const override;
 
     /**
@@ -93,6 +95,7 @@ private:
     virtual void setDimensions(size2_t dimensions) override;
     // clang-format on
 
+    const DataFormatBase* dataFormatBase_;
     size2_t dimensions_;
     SwizzleMask swizzleMask_;
     InterpolationType interpolation_;

--- a/include/inviwo/core/datastructures/image/layerrepresentation.h
+++ b/include/inviwo/core/datastructures/image/layerrepresentation.h
@@ -45,6 +45,12 @@ public:
     virtual LayerRepresentation* clone() const = 0;
     virtual ~LayerRepresentation() = default;
 
+    LayerType getLayerType() const;
+    
+    virtual const DataFormatBase* getDataFormat() const = 0;
+    std::string getDataFormatString() const { return getDataFormat()->getString(); }
+    DataFormatId getDataFormatId() const { return getDataFormat()->getId(); }
+
     /**
      * Resize the representation to dimension. This is destructive, the data will not be
      * preserved. Use copyRepresentationsTo to update the data.
@@ -85,11 +91,8 @@ public:
      */
     virtual bool copyRepresentationsTo(LayerRepresentation*) const = 0;
 
-    LayerType getLayerType() const;
-
 protected:
-    LayerRepresentation(LayerType type = LayerType::Color,
-                        const DataFormatBase* format = DataVec4UInt8::get());
+    LayerRepresentation(LayerType type = LayerType::Color);
     LayerRepresentation(const LayerRepresentation& rhs) = default;
     LayerRepresentation& operator=(const LayerRepresentation& that) = default;
 

--- a/include/inviwo/core/datastructures/image/layerrepresentation.h
+++ b/include/inviwo/core/datastructures/image/layerrepresentation.h
@@ -46,7 +46,7 @@ public:
     virtual ~LayerRepresentation() = default;
 
     LayerType getLayerType() const;
-    
+
     virtual const DataFormatBase* getDataFormat() const = 0;
     std::string getDataFormatString() const { return getDataFormat()->getString(); }
     DataFormatId getDataFormatId() const { return getDataFormat()->getId(); }

--- a/include/inviwo/core/datastructures/nodata.h
+++ b/include/inviwo/core/datastructures/nodata.h
@@ -1,0 +1,42 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2023 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <inviwo/core/common/inviwocoredefine.h>
+
+namespace inviwo {
+
+/*
+ * Tag type for constructors indicating that you want a copy of only "meta" data not the actual
+ * data.
+ */
+struct IVW_CORE_API NoData {};
+constexpr NoData noData{};
+
+}

--- a/include/inviwo/core/datastructures/nodata.h
+++ b/include/inviwo/core/datastructures/nodata.h
@@ -39,4 +39,4 @@ namespace inviwo {
 struct IVW_CORE_API NoData {};
 constexpr NoData noData{};
 
-}
+}  // namespace inviwo

--- a/include/inviwo/core/datastructures/volume/volumedisk.h
+++ b/include/inviwo/core/datastructures/volume/volumedisk.h
@@ -61,6 +61,8 @@ public:
 
     virtual std::type_index getTypeIndex() const override final;
 
+    virtual const DataFormatBase* getDataFormat() const override;
+
     virtual void setDimensions(size3_t dimensions) override;
     virtual const size3_t& getDimensions() const override;
 
@@ -79,6 +81,7 @@ public:
     virtual Wrapping3D getWrapping() const override;
 
 private:
+    const DataFormatBase* dataFormatBase_;
     size3_t dimensions_;
     SwizzleMask swizzleMask_;
     InterpolationType interpolation_;

--- a/include/inviwo/core/datastructures/volume/volumeram.h
+++ b/include/inviwo/core/datastructures/volume/volumeram.h
@@ -189,7 +189,7 @@ public:
     VolumeRAMPrecision<T>& operator=(const VolumeRAMPrecision<T>& that);
     virtual VolumeRAMPrecision<T>* clone() const override;
     virtual ~VolumeRAMPrecision();
-    
+
     virtual const DataFormatBase* getDataFormat() const override;
 
     T* getDataTyped();
@@ -325,7 +325,7 @@ VolumeRAMPrecision<T>::VolumeRAMPrecision(const VolumeRAMPrecision<T>& rhs)
     , swizzleMask_{rhs.swizzleMask_}
     , interpolation_{rhs.interpolation_}
     , wrapping_{rhs.wrapping_} {
-    
+
     std::copy(rhs.getView().begin(), rhs.getView().end(), data_.get());
 }
 

--- a/include/inviwo/core/datastructures/volume/volumerepresentation.h
+++ b/include/inviwo/core/datastructures/volume/volumerepresentation.h
@@ -51,6 +51,9 @@ public:
     virtual void setDimensions(size3_t dimensions) = 0;
     virtual const size3_t& getDimensions() const = 0;
 
+    virtual const DataFormatBase* getDataFormat() const = 0;
+    std::string getDataFormatString() const { return getDataFormat()->getString(); }
+    DataFormatId getDataFormatId() const { return getDataFormat()->getId(); }
     /**
      * \brief update the swizzle mask of the color channels when sampling the volume
      *
@@ -67,7 +70,6 @@ public:
 
 protected:
     VolumeRepresentation() = default;
-    VolumeRepresentation(const DataFormatBase* format);
     VolumeRepresentation(const VolumeRepresentation& rhs) = default;
     VolumeRepresentation& operator=(const VolumeRepresentation& that) = default;
 };

--- a/modules/opencl/include/modules/opencl/buffer/buffercl.h
+++ b/modules/opencl/include/modules/opencl/buffer/buffercl.h
@@ -56,6 +56,9 @@ public:
     virtual ~BufferCL();
 
     virtual BufferCL* clone() const override;
+
+    virtual const DataFormatBase* getDataFormat() const override { return dataFormatBase_; }
+
     virtual size_t getSize() const override;
     virtual void setSize(size_t size) override;
 
@@ -80,6 +83,7 @@ public:
     void download(void* data) const;
 
 protected:
+    const DataFormatBase* dataFormatBase_;
     cl_mem_flags readWriteFlag_;
     size_t size_;
     std::unique_ptr<cl::Buffer> clBuffer_;

--- a/modules/opencl/include/modules/opencl/buffer/bufferclgl.h
+++ b/modules/opencl/include/modules/opencl/buffer/bufferclgl.h
@@ -47,11 +47,13 @@ class IVW_MODULE_OPENCL_API BufferCLGL : public BufferCLBase,
                                          public BufferRepresentation,
                                          public BufferObjectObserver {
 public:
-    BufferCLGL(size_t size, const DataFormatBase* format, BufferUsage usage,
-               std::shared_ptr<BufferObject> data, cl_mem_flags readWriteFlag = CL_MEM_READ_WRITE);
+    BufferCLGL(std::shared_ptr<BufferObject> data, BufferUsage usage,
+               cl_mem_flags readWriteFlag = CL_MEM_READ_WRITE);
     BufferCLGL(const BufferCLGL& rhs);
     virtual ~BufferCLGL();
     virtual BufferCLGL* clone() const override;
+
+    virtual const DataFormatBase* getDataFormat() const override;
 
     virtual size_t getSize() const override;
     virtual void setSize(size_t size) override;
@@ -105,7 +107,6 @@ protected:
 
     std::shared_ptr<BufferObject> bufferObject_;
     cl_mem_flags readWriteFlag_;
-    size_t size_;
     std::shared_ptr<cl::BufferGL> clBuffer_;  ///< Potentially shared with other BufferCLGL
 };
 

--- a/modules/opencl/include/modules/opencl/image/layercl.h
+++ b/modules/opencl/include/modules/opencl/image/layercl.h
@@ -48,6 +48,8 @@ public:
 
     virtual LayerCL* clone() const override;
 
+    virtual const DataFormatBase* getDataFormat() const override { return dataFormatBase_; }
+
     void initialize(const void* texels);
     void upload(const void* data);
     /**
@@ -91,6 +93,7 @@ public:
     virtual Wrapping2D getWrapping() const override;
 
 protected:
+    const DataFormatBase* dataFormatBase_;
     size2_t dimensions_;
     cl::ImageFormat layerFormat_;
     std::unique_ptr<cl::Image2D> clImage_;

--- a/modules/opencl/include/modules/opencl/image/layerclgl.h
+++ b/modules/opencl/include/modules/opencl/image/layerclgl.h
@@ -63,6 +63,8 @@ public:
     LayerCLGL(const LayerCLGL& rhs);
     virtual LayerCLGL* clone() const override;
 
+    virtual const DataFormatBase* getDataFormat() const override;
+
     void initialize(Texture2D* texture);
     void deinitialize();
 

--- a/modules/opencl/include/modules/opencl/volume/volumecl.h
+++ b/modules/opencl/include/modules/opencl/volume/volumecl.h
@@ -47,6 +47,8 @@ public:
 
     virtual VolumeCL* clone() const override;
 
+    virtual const DataFormatBase* getDataFormat() const override { return dataFormatBase_; }
+
     virtual const size3_t& getDimensions() const override;
     virtual void setDimensions(size3_t dimensions) override;
 
@@ -81,6 +83,7 @@ public:
 
 protected:
     void initialize(const void* voxels);
+    const DataFormatBase* dataFormatBase_;
     size3_t dimensions_;
     cl::ImageFormat imageFormat_;
     std::unique_ptr<cl::Image3D> clImage_;

--- a/modules/opencl/include/modules/opencl/volume/volumeclgl.h
+++ b/modules/opencl/include/modules/opencl/volume/volumeclgl.h
@@ -62,6 +62,8 @@ public:
     virtual VolumeCLGL* clone() const override;
     virtual ~VolumeCLGL();
 
+    virtual const DataFormatBase* getDataFormat() const override;
+
     virtual const size3_t& getDimensions() const override;
     virtual void setDimensions(size3_t dimensions) override;
 

--- a/modules/opencl/src/buffer/buffercl.cpp
+++ b/modules/opencl/src/buffer/buffercl.cpp
@@ -34,10 +34,11 @@ namespace inviwo {
 
 BufferCL::BufferCL(size_t size, const DataFormatBase* format, BufferUsage usage, const void* data,
                    cl_mem_flags readWriteFlag)
-    : BufferCLBase()
-    , BufferRepresentation(format, usage)
-    , readWriteFlag_(readWriteFlag)
-    , size_(size) {
+    : BufferCLBase{}
+    , BufferRepresentation{usage}
+    , dataFormatBase_{format}
+    , readWriteFlag_{readWriteFlag}
+    , size_{size} {
     // Generate a new buffer
     if (data != nullptr) {
         // CL_MEM_COPY_HOST_PTR can be used with CL_MEM_ALLOC_HOST_PTR to initialize the contents of
@@ -56,6 +57,7 @@ BufferCL::BufferCL(size_t size, const DataFormatBase* format, BufferUsage usage,
 BufferCL::BufferCL(const BufferCL& rhs)
     : BufferCLBase(rhs)
     , BufferRepresentation(rhs)
+    , dataFormatBase_{rhs.dataFormatBase_}
     , readWriteFlag_(rhs.readWriteFlag_)
     , size_(rhs.size_) {
     clBuffer_ =

--- a/modules/opencl/src/buffer/bufferclglconverter.cpp
+++ b/modules/opencl/src/buffer/bufferclglconverter.cpp
@@ -70,8 +70,7 @@ void BufferCLGL2GLConverter::update(std::shared_ptr<const BufferCLGL> source,
 
 std::shared_ptr<BufferCLGL> BufferGL2CLGLConverter::createFrom(
     std::shared_ptr<const BufferGL> src) const {
-    return std::make_shared<BufferCLGL>(src->getSize(), src->getDataFormat(), src->getBufferUsage(),
-                                        src->getBufferObject());
+    return std::make_shared<BufferCLGL>(src->getBufferObject(), src->getBufferUsage());
 }
 
 void BufferGL2CLGLConverter::update(std::shared_ptr<const BufferGL> src,

--- a/modules/opencl/src/image/layercl.cpp
+++ b/modules/opencl/src/image/layercl.cpp
@@ -38,7 +38,8 @@ LayerCL::LayerCL(size2_t dimensions, LayerType type, const DataFormatBase* forma
                  const SwizzleMask& swizzleMask, InterpolationType interpolation,
                  const Wrapping2D& wrapping, const void* data)
     : LayerCLBase()
-    , LayerRepresentation(type, format)
+    , LayerRepresentation(type)
+    , dataFormatBase_{format}
     , dimensions_(dimensions)
     , layerFormat_(dataFormatToCLImageFormat(format->getId()))
     , swizzleMask_(swizzleMask)
@@ -50,6 +51,7 @@ LayerCL::LayerCL(size2_t dimensions, LayerType type, const DataFormatBase* forma
 LayerCL::LayerCL(const LayerCL& rhs)
     : LayerCLBase(rhs)
     , LayerRepresentation(rhs)
+    , dataFormatBase_{rhs.dataFormatBase_}
     , dimensions_(rhs.dimensions_)
     , layerFormat_(rhs.layerFormat_)
     , swizzleMask_(rhs.swizzleMask_)

--- a/modules/opencl/src/image/layerclgl.cpp
+++ b/modules/opencl/src/image/layerclgl.cpp
@@ -37,7 +37,7 @@ namespace inviwo {
 CLTextureSharingMap LayerCLGL::clImageSharingMap_;
 
 LayerCLGL::LayerCLGL(std::shared_ptr<Texture2D> data, LayerType type)
-    : LayerCLBase(), LayerRepresentation(type, data->getDataFormat()), texture_(data) {
+    : LayerCLBase(), LayerRepresentation(type), texture_(data) {
 
     IVW_ASSERT(texture_, "Texture should never be nullptr");
 
@@ -63,6 +63,8 @@ LayerCLGL::LayerCLGL(const LayerCLGL& rhs)
 }
 
 LayerCLGL::~LayerCLGL() { deinitialize(); }
+
+const DataFormatBase* LayerCLGL::getDataFormat() const { return texture_->getDataFormat(); }
 
 void LayerCLGL::initialize(Texture2D* texture) {
     ivwAssert(texture != 0, "Cannot initialize with null OpenGL texture");

--- a/modules/opencl/src/image/layerclgl.cpp
+++ b/modules/opencl/src/image/layerclgl.cpp
@@ -41,18 +41,15 @@ LayerCLGL::LayerCLGL(std::shared_ptr<Texture2D> data, LayerType type)
 
     IVW_ASSERT(texture_, "Texture should never be nullptr");
 
-    if (texture_) {
-        initialize(texture_.get());
-        CLTextureSharingMap::iterator it = LayerCLGL::clImageSharingMap_.find(texture_);
+    initialize(texture_.get());
+    CLTextureSharingMap::iterator it = LayerCLGL::clImageSharingMap_.find(texture_);
 
-        if (it == LayerCLGL::clImageSharingMap_.end()) {
-            clImage_ =
-                std::make_shared<cl::Image2DGL>(OpenCL::getPtr()->getContext(), CL_MEM_READ_WRITE,
-                                                GL_TEXTURE_2D, 0, texture_->getID());
-            LayerCLGL::clImageSharingMap_.insert(TextureCLImageSharingPair(texture_, clImage_));
-        } else {
-            clImage_ = it->second;
-        }
+    if (it == LayerCLGL::clImageSharingMap_.end()) {
+        clImage_ = std::make_shared<cl::Image2DGL>(
+            OpenCL::getPtr()->getContext(), CL_MEM_READ_WRITE, GL_TEXTURE_2D, 0, texture_->getID());
+        LayerCLGL::clImageSharingMap_.insert(TextureCLImageSharingPair(texture_, clImage_));
+    } else {
+        clImage_ = it->second;
     }
 }
 

--- a/modules/opencl/src/volume/volumecl.cpp
+++ b/modules/opencl/src/volume/volumecl.cpp
@@ -37,11 +37,12 @@ namespace inviwo {
 VolumeCL::VolumeCL(size3_t dimensions, const DataFormatBase* format, const void* data,
                    const SwizzleMask& swizzleMask, InterpolationType interpolation,
                    const Wrapping3D& wrapping)
-    : VolumeCLBase()
-    , VolumeRepresentation(format)
-    , dimensions_(dimensions)
-    , imageFormat_(dataFormatToCLImageFormat(format->getId()))
-    , swizzleMask_(swizzleMask)
+    : VolumeCLBase{}
+    , VolumeRepresentation{}
+    , dataFormatBase_{format}
+    , dimensions_{dimensions}
+    , imageFormat_{dataFormatToCLImageFormat(format->getId())}
+    , swizzleMask_{swizzleMask}
     , interpolation_{interpolation}
     , wrapping_{wrapping} {
 
@@ -49,11 +50,12 @@ VolumeCL::VolumeCL(size3_t dimensions, const DataFormatBase* format, const void*
 }
 
 VolumeCL::VolumeCL(const VolumeCL& rhs)
-    : VolumeCLBase(rhs)
-    , VolumeRepresentation(rhs)
-    , dimensions_(rhs.dimensions_)
-    , imageFormat_(rhs.imageFormat_)
-    , swizzleMask_(rhs.swizzleMask_)
+    : VolumeCLBase{rhs}
+    , VolumeRepresentation{rhs}
+    , dataFormatBase_{rhs.dataFormatBase_}
+    , dimensions_{rhs.dimensions_}
+    , imageFormat_{rhs.imageFormat_}
+    , swizzleMask_{rhs.swizzleMask_}
     , interpolation_{rhs.interpolation_}
     , wrapping_{rhs.wrapping_} {
 

--- a/modules/opencl/src/volume/volumeclgl.cpp
+++ b/modules/opencl/src/volume/volumeclgl.cpp
@@ -34,8 +34,7 @@
 namespace inviwo {
 CLTexture3DSharingMap VolumeCLGL::clVolumeSharingMap_;
 
-VolumeCLGL::VolumeCLGL(Texture3D* data)
-    : VolumeCLBase(), VolumeRepresentation(data->getDataFormat()), texture_(data) {
+VolumeCLGL::VolumeCLGL(Texture3D* data) : VolumeCLBase(), VolumeRepresentation(), texture_(data) {
 
     IVW_ASSERT(texture_, "The texture should never be nullptr.");
 
@@ -43,7 +42,7 @@ VolumeCLGL::VolumeCLGL(Texture3D* data)
 }
 
 VolumeCLGL::VolumeCLGL(std::shared_ptr<Texture3D> data)
-    : VolumeCLBase(), VolumeRepresentation(data->getDataFormat()), texture_(data) {
+    : VolumeCLBase(), VolumeRepresentation(), texture_(data) {
 
     IVW_ASSERT(texture_, "The texture should never be nullptr.");
 
@@ -56,6 +55,8 @@ VolumeCLGL::VolumeCLGL(const VolumeCLGL& rhs)
 }
 
 VolumeCLGL::~VolumeCLGL() { deinitialize(); }
+
+const DataFormatBase* VolumeCLGL::getDataFormat() const { return texture_->getDataFormat(); }
 
 void VolumeCLGL::initialize() {
     if (texture_) {

--- a/modules/opengl/include/modules/opengl/buffer/buffergl.h
+++ b/modules/opengl/include/modules/opengl/buffer/buffergl.h
@@ -64,6 +64,8 @@ public:
     virtual ~BufferGL();
     virtual BufferGL* clone() const override;
 
+    virtual const DataFormatBase* getDataFormat() const override;
+
     /**
      * \brief set the size of the buffer
      * Note that the internal BufferObject is only growing in size and never shrinking to avoid

--- a/modules/opengl/include/modules/opengl/image/layergl.h
+++ b/modules/opengl/include/modules/opengl/image/layergl.h
@@ -63,6 +63,8 @@ public:
     virtual ~LayerGL();
     virtual LayerGL* clone() const override;
 
+    virtual const DataFormatBase* getDataFormat() const override;
+
     virtual void setDimensions(size2_t dimensions) override;
     virtual const size2_t& getDimensions() const override;
 

--- a/modules/opengl/include/modules/opengl/volume/volumegl.h
+++ b/modules/opengl/include/modules/opengl/volume/volumegl.h
@@ -69,6 +69,8 @@ public:
     virtual ~VolumeGL();
     virtual VolumeGL* clone() const override;
 
+    virtual const DataFormatBase* getDataFormat() const override;
+
     void bindTexture(GLenum texUnit) const;
     void unbindTexture() const;
 

--- a/modules/opengl/src/buffer/buffergl.cpp
+++ b/modules/opengl/src/buffer/buffergl.cpp
@@ -41,7 +41,7 @@ namespace inviwo {
 
 BufferGL::BufferGL(size_t size, const DataFormatBase* format, BufferUsage usage,
                    BufferTarget target, std::shared_ptr<BufferObject> data)
-    : BufferRepresentation(format, usage, target)
+    : BufferRepresentation(usage, target)
     , buffer_(data
                   ? data
                   : std::make_shared<BufferObject>(size * format->getSize(), format, usage, target))
@@ -57,6 +57,8 @@ BufferGL::BufferGL(const BufferGL& rhs)
 BufferGL::~BufferGL() = default;
 
 BufferGL* BufferGL::clone() const { return new BufferGL(*this); }
+
+const DataFormatBase* BufferGL::getDataFormat() const { return buffer_->getDataFormat(); }
 
 size_t BufferGL::getSize() const { return size_; }
 

--- a/modules/opengl/src/image/layergl.cpp
+++ b/modules/opengl/src/image/layergl.cpp
@@ -45,16 +45,16 @@ namespace inviwo {
 class DataFormatBase;
 
 LayerGL::LayerGL(std::shared_ptr<Texture2D> tex, LayerType type)
-    : LayerRepresentation{type, tex->getDataFormat()}, texture_{tex} {
+    : LayerRepresentation{type}, texture_{tex} {
     IVW_ASSERT(texture_, "Texture should never be nullptr");
 }
 
 LayerGL::LayerGL(size2_t dimensions, LayerType type, const DataFormatBase* format,
                  const SwizzleMask& swizzleMask, InterpolationType interpolation,
                  const Wrapping2D& wrap)
-    : LayerRepresentation{type, format}, texture_(nullptr) {
+    : LayerRepresentation{type}, texture_(nullptr) {
 
-    const auto& glFormat = GLFormats::get(getDataFormatId());
+    const auto& glFormat = GLFormats::get(format->getId());
     if (getLayerType() == LayerType::Depth) {
         texture_ = std::make_shared<Texture2D>(dimensions, GL_DEPTH_COMPONENT,
                                                GL_DEPTH_COMPONENT32F, glFormat.type, GL_NEAREST,
@@ -74,13 +74,14 @@ LayerGL& LayerGL::operator=(const LayerGL& rhs) {
         LayerRepresentation::operator=(rhs);
         texture_ = std::shared_ptr<Texture2D>(rhs.texture_->clone());
     }
-
     return *this;
 }
 
 LayerGL::~LayerGL() = default;
 
 LayerGL* LayerGL::clone() const { return new LayerGL(*this); }
+
+const DataFormatBase* LayerGL::getDataFormat() const { return texture_->getDataFormat(); }
 
 void LayerGL::bindTexture(GLenum texUnit) const {
     texUnit_ = texUnit;

--- a/modules/opengl/src/volume/volumegl.cpp
+++ b/modules/opengl/src/volume/volumegl.cpp
@@ -45,7 +45,7 @@ namespace inviwo {
 VolumeGL::VolumeGL(size3_t dimensions, const DataFormatBase* format, const SwizzleMask& swizzleMask,
                    InterpolationType interpolation, const Wrapping3D& wrapping,
                    bool initializeTexture)
-    : VolumeRepresentation{format}
+    : VolumeRepresentation{}
     , texture_{std::make_shared<Texture3D>(dimensions, GLFormats::get(format->getId()),
                                            utilgl::convertInterpolationToGL(interpolation),
                                            swizzleMask, utilgl::convertWrappingToGL(wrapping))} {
@@ -54,9 +54,7 @@ VolumeGL::VolumeGL(size3_t dimensions, const DataFormatBase* format, const Swizz
     }
 }
 
-VolumeGL::VolumeGL(std::shared_ptr<Texture3D> tex)
-    : VolumeRepresentation(tex->getDataFormat()), texture_(tex) {
-
+VolumeGL::VolumeGL(std::shared_ptr<Texture3D> tex) : VolumeRepresentation{}, texture_(tex) {
     IVW_ASSERT(texture_, "The texture should never be nullptr.");
 }
 
@@ -74,6 +72,8 @@ VolumeGL& VolumeGL::operator=(const VolumeGL& rhs) {
 VolumeGL::~VolumeGL() = default;
 
 VolumeGL* VolumeGL::clone() const { return new VolumeGL(*this); }
+
+const DataFormatBase* VolumeGL::getDataFormat() const { return texture_->getDataFormat(); }
 
 void VolumeGL::bindTexture(GLenum texUnit) const {
     glActiveTexture(texUnit);

--- a/modules/python3/include/modules/python3/layerpy.h
+++ b/modules/python3/include/modules/python3/layerpy.h
@@ -65,6 +65,8 @@ public:
     LayerPy* clone() const override;
     std::type_index getTypeIndex() const override final;
 
+    virtual const DataFormatBase* getDataFormat() const override;
+
     virtual void setDimensions(size2_t dimensions) override;
     virtual const size2_t& getDimensions() const override;
 

--- a/modules/python3/include/modules/python3/volumepy.h
+++ b/modules/python3/include/modules/python3/volumepy.h
@@ -64,6 +64,8 @@ public:
     VolumePy* clone() const override;
     std::type_index getTypeIndex() const override;
 
+    virtual const DataFormatBase* getDataFormat() const override;
+
     virtual void setDimensions(size3_t dimensions) override;
     virtual const size3_t& getDimensions() const override;
 

--- a/modules/python3/src/layerpy.cpp
+++ b/modules/python3/src/layerpy.cpp
@@ -63,7 +63,7 @@ const DataFormatBase* format(pybind11::array data) {
 
 LayerPy::LayerPy(pybind11::array data, LayerType type, const SwizzleMask& swizzleMask,
                  InterpolationType interpolation, const Wrapping2D& wrapping)
-    : LayerRepresentation(type, format(data))
+    : LayerRepresentation(type)
     , swizzleMask_{swizzleMask}
     , interpolation_{interpolation}
     , wrapping_{wrapping}
@@ -73,7 +73,7 @@ LayerPy::LayerPy(pybind11::array data, LayerType type, const SwizzleMask& swizzl
 LayerPy::LayerPy(size2_t dimensions, LayerType type, const DataFormatBase* format,
                  const SwizzleMask& swizzleMask, InterpolationType interpolation,
                  const Wrapping2D& wrapping)
-    : LayerRepresentation(type, format)
+    : LayerRepresentation(type)
     , swizzleMask_{swizzleMask}
     , interpolation_{interpolation}
     , wrapping_{wrapping}
@@ -95,6 +95,10 @@ void LayerPy::setDimensions(size2_t dimensions) {
                                                                 getDataFormat()->getComponents()});
         dims_ = dimensions;
     }
+}
+
+const DataFormatBase* LayerPy::getDataFormat() const {
+    return format(data_);
 }
 
 const size2_t& LayerPy::getDimensions() const { return dims_; }

--- a/modules/python3/src/layerpy.cpp
+++ b/modules/python3/src/layerpy.cpp
@@ -97,9 +97,7 @@ void LayerPy::setDimensions(size2_t dimensions) {
     }
 }
 
-const DataFormatBase* LayerPy::getDataFormat() const {
-    return format(data_);
-}
+const DataFormatBase* LayerPy::getDataFormat() const { return format(data_); }
 
 const size2_t& LayerPy::getDimensions() const { return dims_; }
 

--- a/modules/python3/src/volumepy.cpp
+++ b/modules/python3/src/volumepy.cpp
@@ -66,7 +66,7 @@ const DataFormatBase* format(pybind11::array data) {
 
 VolumePy::VolumePy(pybind11::array data, const SwizzleMask& swizzleMask,
                    InterpolationType interpolation, const Wrapping3D& wrapping)
-    : VolumeRepresentation(format(data))
+    : VolumeRepresentation()
     , swizzleMask_{swizzleMask}
     , interpolation_{interpolation}
     , wrapping_{wrapping}
@@ -75,7 +75,7 @@ VolumePy::VolumePy(pybind11::array data, const SwizzleMask& swizzleMask,
 
 VolumePy::VolumePy(size3_t dimensions, const DataFormatBase* format, const SwizzleMask& swizzleMask,
                    InterpolationType interpolation, const Wrapping3D& wrapping)
-    : VolumeRepresentation(format)
+    : VolumeRepresentation()
     , swizzleMask_{swizzleMask}
     , interpolation_{interpolation}
     , wrapping_{wrapping}
@@ -88,6 +88,8 @@ VolumePy::VolumePy(size3_t dimensions, const DataFormatBase* format, const Swizz
 VolumePy* VolumePy::clone() const { return new VolumePy(*this); }
 
 std::type_index VolumePy::getTypeIndex() const { return std::type_index(typeid(VolumePy)); }
+
+const DataFormatBase* VolumePy::getDataFormat() const { return format(data_); }
 
 void VolumePy::setDimensions(size3_t dimensions) {
     if (dimensions != dims_) {

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -79,6 +79,7 @@ set(HEADER_FILES
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/light/lightingstate.h
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/light/pointlight.h
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/light/spotlight.h
+    ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/nodata.h
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/representationconverter.h
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/representationconverterfactory.h
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/representationconvertermetafactory.h

--- a/src/core/datastructures/buffer/bufferram.cpp
+++ b/src/core/datastructures/buffer/bufferram.cpp
@@ -36,8 +36,8 @@
 
 namespace inviwo {
 
-BufferRAM::BufferRAM(const DataFormatBase* format, BufferUsage usage, BufferTarget target)
-    : BufferRepresentation(format, usage, target) {}
+BufferRAM::BufferRAM(BufferUsage usage, BufferTarget target)
+    : BufferRepresentation(usage, target) {}
 
 std::type_index BufferRAM::getTypeIndex() const { return std::type_index(typeid(BufferRAM)); }
 

--- a/src/core/datastructures/buffer/bufferrepresentation.cpp
+++ b/src/core/datastructures/buffer/bufferrepresentation.cpp
@@ -31,9 +31,8 @@
 
 namespace inviwo {
 
-BufferRepresentation::BufferRepresentation(const DataFormatBase* format, BufferUsage usage,
-                                           BufferTarget target)
-    : DataRepresentation(format), usage_(usage), target_(target) {}
+BufferRepresentation::BufferRepresentation(BufferUsage usage, BufferTarget target)
+    : DataRepresentation{}, usage_(usage), target_(target) {}
 
 size_t BufferRepresentation::getSizeOfElement() const { return getDataFormat()->getSize(); }
 

--- a/src/core/datastructures/image/layerdisk.cpp
+++ b/src/core/datastructures/image/layerdisk.cpp
@@ -34,8 +34,9 @@ namespace inviwo {
 LayerDisk::LayerDisk(size2_t dimensions, const DataFormatBase* format, LayerType type,
                      const SwizzleMask& swizzleMask, InterpolationType interpolation,
                      const Wrapping2D& wrapping)
-    : LayerRepresentation(type, format)
+    : LayerRepresentation(type)
     , DiskRepresentation<LayerRepresentation, LayerDisk>()
+    , dataFormatBase_{format}
     , dimensions_(dimensions)
     , swizzleMask_(swizzleMask)
     , interpolation_{interpolation}
@@ -44,8 +45,9 @@ LayerDisk::LayerDisk(size2_t dimensions, const DataFormatBase* format, LayerType
 LayerDisk::LayerDisk(std::string url, size2_t dimensions, const DataFormatBase* format,
                      LayerType type, const SwizzleMask& swizzleMask,
                      InterpolationType interpolation, const Wrapping2D& wrapping)
-    : LayerRepresentation(type, format)
+    : LayerRepresentation(type)
     , DiskRepresentation<LayerRepresentation, LayerDisk>(url)
+    , dataFormatBase_{format}
     , dimensions_(dimensions)
     , swizzleMask_(swizzleMask)
     , interpolation_{interpolation}
@@ -55,13 +57,15 @@ LayerDisk::~LayerDisk() = default;
 
 LayerDisk* LayerDisk::clone() const { return new LayerDisk(*this); }
 
+const DataFormatBase* LayerDisk::getDataFormat() const { return dataFormatBase_; }
+
 void LayerDisk::setDimensions(size2_t dimensions) { dimensions_ = dimensions; }
 
 const size2_t& LayerDisk::getDimensions() const { return dimensions_; }
 
 bool LayerDisk::copyRepresentationsTo(LayerRepresentation*) const { return false; }
 
-void LayerDisk::updateDataFormat(const DataFormatBase* format) { setDataFormat(format); }
+void LayerDisk::updateDataFormat(const DataFormatBase* format) { dataFormatBase_ = format; }
 
 std::type_index LayerDisk::getTypeIndex() const { return std::type_index(typeid(LayerDisk)); }
 

--- a/src/core/datastructures/image/layerram.cpp
+++ b/src/core/datastructures/image/layerram.cpp
@@ -33,8 +33,7 @@
 
 namespace inviwo {
 
-LayerRAM::LayerRAM(LayerType type, const DataFormatBase* format)
-    : LayerRepresentation(type, format) {}
+LayerRAM::LayerRAM(LayerType type) : LayerRepresentation(type) {}
 
 bool LayerRAM::copyRepresentationsTo(LayerRepresentation* targetLayerRam) const {
     // We use a LayerRamResizer to copy/resize one representation into another.

--- a/src/core/datastructures/image/layerrepresentation.cpp
+++ b/src/core/datastructures/image/layerrepresentation.cpp
@@ -32,8 +32,7 @@
 
 namespace inviwo {
 
-LayerRepresentation::LayerRepresentation(LayerType type, const DataFormatBase* format)
-    : DataRepresentation(format), layerType_(type) {}
+LayerRepresentation::LayerRepresentation(LayerType type) : DataRepresentation{}, layerType_{type} {}
 
 LayerType LayerRepresentation::getLayerType() const { return layerType_; }
 

--- a/src/core/datastructures/volume/volumedisk.cpp
+++ b/src/core/datastructures/volume/volumedisk.cpp
@@ -34,26 +34,30 @@ namespace inviwo {
 VolumeDisk::VolumeDisk(size3_t dimensions, const DataFormatBase* format,
                        const SwizzleMask& swizzleMask, InterpolationType interpolation,
                        const Wrapping3D& wrapping)
-    : VolumeRepresentation(format)
-    , DiskRepresentation<VolumeRepresentation, VolumeDisk>()
-    , dimensions_(dimensions)
-    , swizzleMask_(swizzleMask)
+    : VolumeRepresentation{}
+    , DiskRepresentation<VolumeRepresentation, VolumeDisk>{}
+    , dataFormatBase_{format}
+    , dimensions_{dimensions}
+    , swizzleMask_{swizzleMask}
     , interpolation_{interpolation}
     , wrapping_{wrapping} {}
 
 VolumeDisk::VolumeDisk(const std::filesystem::path& srcFile, size3_t dimensions,
                        const DataFormatBase* format, const SwizzleMask& swizzleMask,
                        InterpolationType interpolation, const Wrapping3D& wrapping)
-    : VolumeRepresentation(format)
-    , DiskRepresentation<VolumeRepresentation, VolumeDisk>(srcFile)
-    , dimensions_(dimensions)
-    , swizzleMask_(swizzleMask)
+    : VolumeRepresentation{}
+    , DiskRepresentation<VolumeRepresentation, VolumeDisk>{srcFile}
+    , dataFormatBase_{format}
+    , dimensions_{dimensions}
+    , swizzleMask_{swizzleMask}
     , interpolation_{interpolation}
     , wrapping_{wrapping} {}
 
 VolumeDisk* VolumeDisk::clone() const { return new VolumeDisk(*this); }
 
 std::type_index VolumeDisk::getTypeIndex() const { return std::type_index(typeid(VolumeDisk)); }
+
+const DataFormatBase* VolumeDisk::getDataFormat() const { return dataFormatBase_; }
 
 void VolumeDisk::setDimensions(size3_t) {
     throw Exception("Can not set dimension of a Volume Disk", IVW_CONTEXT);

--- a/src/core/datastructures/volume/volumeram.cpp
+++ b/src/core/datastructures/volume/volumeram.cpp
@@ -32,8 +32,6 @@
 
 namespace inviwo {
 
-VolumeRAM::VolumeRAM(const DataFormatBase* format) : VolumeRepresentation(format) {}
-
 std::type_index VolumeRAM::getTypeIndex() const { return std::type_index(typeid(VolumeRAM)); }
 
 struct VolumeRamCreationDispatcher {

--- a/src/core/datastructures/volume/volumerepresentation.cpp
+++ b/src/core/datastructures/volume/volumerepresentation.cpp
@@ -32,7 +32,4 @@
 
 namespace inviwo {
 
-VolumeRepresentation::VolumeRepresentation(const DataFormatBase* format)
-    : DataRepresentation(format) {}
-
 }  // namespace inviwo

--- a/src/core/datastructures/volume/volumerepresentation.cpp
+++ b/src/core/datastructures/volume/volumerepresentation.cpp
@@ -30,6 +30,4 @@
 #include <inviwo/core/datastructures/volume/volumerepresentation.h>
 #include <inviwo/core/datastructures/datarepresentation.h>
 
-namespace inviwo {
-
-}  // namespace inviwo
+namespace inviwo {}  // namespace inviwo


### PR DESCRIPTION
Remove dataFormat from DataRepresentation. Now each representation has a virtual getDataFormat that each Leaf class has to implement. 
This avoids duplication of state 

Move the NoData tag to it's own file

added a NoData copy Constructor to VolumeRAMPrecision and LayerRAMPrecision