### PR TITLE
VolumeSequence

### DIFF
--- a/include/inviwo/core/datastructures/datasequence.h
+++ b/include/inviwo/core/datastructures/datasequence.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2023 Inviwo Foundation
+ * Copyright (c) 2023-2024 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/include/inviwo/core/datastructures/datasequence.h
+++ b/include/inviwo/core/datastructures/datasequence.h
@@ -1,0 +1,186 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2023 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <inviwo/core/common/inviwocoredefine.h>
+#include <inviwo/core/util/transformiterator.h>
+#include <inviwo/core/datastructures/datatraits.h>
+
+#include <vector>
+#include <memory>
+#include <utility>
+#include <span>
+
+#include <variant>
+
+namespace inviwo {
+
+template <typename Data>
+class DataSequence {
+
+    using DataVariant = std::variant<std::shared_ptr<const Data>, std::shared_ptr<Data>>;
+    std::vector<DataVariant> data_;
+
+    static constexpr auto getConstData =
+        [](const DataVariant& data) -> std::shared_ptr<const Data> {
+        return std::visit([](auto& d) -> std::shared_ptr<const Data> { return d; }, data);
+    };
+
+    static constexpr auto getData = [](DataVariant& data) -> std::shared_ptr<Data> {
+        if (std::holds_alternative<std::shared_ptr<Data>>(data)) {
+            return std::get<std::shared_ptr<Data>>(data);
+        } else {
+            return nullptr;
+        }
+    };
+
+    std::shared_ptr<const Data> get(const DataVariant& v) const { return getConstData(v); }
+    std::shared_ptr<Data> get(DataVariant& v) { return getData(v); }
+
+public:
+    using value_type = std::shared_ptr<Data>;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using iterator =
+        util::TransformIterator<decltype(getData), typename std::vector<DataVariant>::iterator>;
+    using const_iterator =
+        util::TransformIterator<decltype(getConstData),
+                                typename std::vector<DataVariant>::const_iterator>;
+
+    DataSequence() = default;
+
+    DataSequence(std::span<std::shared_ptr<Data>> data) {
+        for (auto item : data) {
+            data_.emplace_back(item);
+        }
+    }
+    DataSequence(std::span<std::shared_ptr<const Data>> data) {
+        for (auto item : data) {
+            data_.emplace_back(item);
+        }
+    }
+
+    DataSequence(const DataSequence& rhs) {
+        for (auto item : rhs.data_) {
+            data_.emplace_back(std::in_place_type_t<std::shared_ptr<Data>>{}, get(item)->clone());
+        }
+    }
+    DataSequence(DataSequence&&) noexcept = default;
+    DataSequence& operator=(const DataSequence& that) {
+        if (this != &that) {
+            DataSequence tmp(that);
+            swap(tmp);
+        }
+        return this;
+    }
+    DataSequence& operator=(DataSequence&&) noexcept = delete;
+
+    ~DataSequence() = default;
+
+    void push_back(std::shared_ptr<const Data> data) { data_.emplace_back(data); }
+    void push_back(std::shared_ptr<Data> data) { data_.emplace_back(data); }
+
+    template <typename... Args>
+    std::shared_ptr<Data> emplace_back(Args&&... args) {
+        return get(data_.emplace_back(std::in_place_type_t<std::shared_ptr<Data>>{},
+                                      std::forward<Args>(args)...));
+    }
+
+    void insert(iterator pos, std::shared_ptr<const Data> data) { data_.insert(pos.base(), data); }
+    void insert(iterator pos, std::shared_ptr<Data> data) { data_.insert(pos.base(), data); }
+
+    void insert(const_iterator pos, const_iterator srcBegin, const_iterator srcEnd) {
+        auto bpos = pos.base();
+        for (auto it = srcBegin; it != srcEnd; ++it) {
+            bpos = data_.insert(bpos, *it);
+            ++bpos;
+        }
+    }
+
+    void erase(iterator pos) { data_.erase(pos.base()); }
+    void erase(const_iterator begin, const_iterator end) { data_.erase(begin.base(), end.base()); }
+    void shrink_to_fit() { data_.shrink_to_fit(); }
+
+    iterator begin() { return util::makeTransformIterator(getData, data_.begin()); }
+    iterator end() { return util::makeTransformIterator(getData, data_.end()); }
+
+    const_iterator begin() const {
+        return util::makeTransformIterator(getConstData, data_.begin());
+    }
+    const_iterator end() const { return util::makeTransformIterator(getConstData, data_.end()); }
+
+    std::size_t size() const { return data_.size(); }
+
+    bool empty() const { return data_.empty(); }
+
+    void clear() { data_.clear(); }
+
+    void reserve(std::size_t n) { data_.reserve(n); }
+
+    std::shared_ptr<const Data> operator[](std::size_t n) const { return get(data_[n]); }
+
+    std::shared_ptr<Data> operator[](std::size_t n) { return get(data_[n]); }
+
+    std::shared_ptr<const Data> at(std::size_t n) const { return get(data_.at(n)); }
+    std::shared_ptr<Data> at(std::size_t n) { return get(data_.at(n)); }
+
+    std::shared_ptr<const Data> front() const { return get(data_.front()); }
+    std::shared_ptr<Data> front() { return get(data_.front()); }
+
+    std::shared_ptr<const Data> back() const { return get(data_.back()); }
+    std::shared_ptr<Data> back() { return get(data_.back()); }
+
+    void pop_back() { data_.pop_back(); }
+
+    void swap(DataSequence& other) { data_.swap(other.data_); }
+
+    void swap(std::vector<std::pair<std::shared_ptr<const Data>, std::shared_ptr<Data>>>& other) {
+        data_.swap(other);
+    }
+
+    void swap(std::vector<std::pair<std::shared_ptr<const Data>, std::shared_ptr<Data>>>&& other) {
+        data_.swap(other);
+    }
+};
+template <typename Data>
+struct DataTraits<DataSequence<Data>> {
+    static std::string classIdentifier() {
+        return util::appendIfNotEmpty(DataTraits<Data>::classIdentifier(), ".sequence");
+    }
+    static std::string dataName() {
+        return fmt::format("DataSequence<{}>", DataTraits<Data>::dataName());
+    }
+    static uvec3 colorCode() { return color::lighter(DataTraits<Data>::colorCode(), 1.12f); }
+    static Document info(const DataSequence<Data>& data) {
+        return detail::vectorInfo<Data>(data.size(), data.empty() ? nullptr : data.front().get(),
+                                        data.empty() ? nullptr : data.back().get());
+    }
+};
+
+}  // namespace inviwo

--- a/include/inviwo/core/datastructures/datatraits.h
+++ b/include/inviwo/core/datastructures/datatraits.h
@@ -234,6 +234,19 @@ struct DataTraits<std::vector<T, A>> {
     }
 };
 template <typename T, typename A>
+struct DataTraits<std::vector<const T, A>> {
+    static std::string classIdentifier() {
+        return util::appendIfNotEmpty(DataTraits<T>::classIdentifier(), ".const_vector");
+    }
+    static std::string dataName() { return fmt::format("vector<const {}>", DataTraits<T>::dataName()); }
+    static uvec3 colorCode() { return color::lighter(DataTraits<T>::colorCode(), 1.12f); }
+    static Document info(const std::vector<const T, A>& data) {
+        return detail::vectorInfo<T>(data.size(), data.empty() ? nullptr : &data.front(),
+                                     data.empty() ? nullptr : &data.back());
+    }
+};
+
+template <typename T, typename A>
 struct DataTraits<std::vector<T*, A>> {
     static std::string classIdentifier() {
         return util::appendIfNotEmpty(DataTraits<T>::classIdentifier(), ".ptr.vector");
@@ -247,6 +260,22 @@ struct DataTraits<std::vector<T*, A>> {
                                      data.empty() ? nullptr : data.back());
     }
 };
+
+template <typename T, typename A>
+struct DataTraits<std::vector<const T*, A>> {
+    static std::string classIdentifier() {
+        return util::appendIfNotEmpty(DataTraits<T>::classIdentifier(), ".const_ptr.vector");
+    }
+    static std::string dataName() { return fmt::format("vector<const {}*>", DataTraits<T>::dataName()); }
+    static uvec3 colorCode() {
+        return glm::min(uvec3(30, 30, 30) + DataTraits<T>::colorCode(), uvec3(255));
+    }
+    static Document info(const std::vector<const T*, A>& data) {
+        return detail::vectorInfo<T>(data.size(), data.empty() ? nullptr : data.front(),
+                                     data.empty() ? nullptr : data.back());
+    }
+};
+
 template <typename T, typename D, typename A>
 struct DataTraits<std::vector<std::unique_ptr<T, D>, A>> {
     static std::string classIdentifier() {
@@ -263,6 +292,25 @@ struct DataTraits<std::vector<std::unique_ptr<T, D>, A>> {
                                      data.empty() ? nullptr : data.back().get());
     }
 };
+
+template <typename T, typename D, typename A>
+struct DataTraits<std::vector<std::unique_ptr<const T, D>, A>> {
+    static std::string classIdentifier() {
+        return util::appendIfNotEmpty(DataTraits<T>::classIdentifier(), ".const_unique_ptr.vector");
+    }
+    static std::string dataName() {
+        return fmt::format("vector<unique_ptr<const {}>>", DataTraits<T>::dataName());
+    }
+    static uvec3 colorCode() {
+        return glm::min(uvec3(30, 30, 30) + DataTraits<T>::colorCode(), uvec3(255));
+    }
+    static Document info(const std::vector<std::unique_ptr<const T, D>, A>& data) {
+        return detail::vectorInfo<T>(data.size(), data.empty() ? nullptr : data.front().get(),
+                                     data.empty() ? nullptr : data.back().get());
+    }
+};
+
+
 template <typename T, typename A>
 struct DataTraits<std::vector<std::shared_ptr<T>, A>> {
     static std::string classIdentifier() {
@@ -275,6 +323,23 @@ struct DataTraits<std::vector<std::shared_ptr<T>, A>> {
         return glm::min(uvec3(30, 30, 30) + DataTraits<T>::colorCode(), uvec3(255));
     }
     static Document info(const std::vector<std::shared_ptr<T>, A>& data) {
+        return detail::vectorInfo<T>(data.size(), data.empty() ? nullptr : data.front().get(),
+                                     data.empty() ? nullptr : data.back().get());
+    }
+};
+
+template <typename T, typename A>
+struct DataTraits<std::vector<std::shared_ptr<const T>, A>> {
+    static std::string classIdentifier() {
+        return util::appendIfNotEmpty(DataTraits<T>::classIdentifier(), ".const_shared_ptr.vector");
+    }
+    static std::string dataName() {
+        return fmt::format("vector<shared_ptr<const {}>>", DataTraits<T>::dataName());
+    }
+    static uvec3 colorCode() {
+        return glm::min(uvec3(30, 30, 30) + DataTraits<T>::colorCode(), uvec3(255));
+    }
+    static Document info(const std::vector<std::shared_ptr<const T>, A>& data) {
         return detail::vectorInfo<T>(data.size(), data.empty() ? nullptr : data.front().get(),
                                      data.empty() ? nullptr : data.back().get());
     }

--- a/include/inviwo/core/datastructures/datatraits.h
+++ b/include/inviwo/core/datastructures/datatraits.h
@@ -238,7 +238,9 @@ struct DataTraits<std::vector<const T, A>> {
     static std::string classIdentifier() {
         return util::appendIfNotEmpty(DataTraits<T>::classIdentifier(), ".const_vector");
     }
-    static std::string dataName() { return fmt::format("vector<const {}>", DataTraits<T>::dataName()); }
+    static std::string dataName() {
+        return fmt::format("vector<const {}>", DataTraits<T>::dataName());
+    }
     static uvec3 colorCode() { return color::lighter(DataTraits<T>::colorCode(), 1.12f); }
     static Document info(const std::vector<const T, A>& data) {
         return detail::vectorInfo<T>(data.size(), data.empty() ? nullptr : &data.front(),
@@ -266,7 +268,9 @@ struct DataTraits<std::vector<const T*, A>> {
     static std::string classIdentifier() {
         return util::appendIfNotEmpty(DataTraits<T>::classIdentifier(), ".const_ptr.vector");
     }
-    static std::string dataName() { return fmt::format("vector<const {}*>", DataTraits<T>::dataName()); }
+    static std::string dataName() {
+        return fmt::format("vector<const {}*>", DataTraits<T>::dataName());
+    }
     static uvec3 colorCode() {
         return glm::min(uvec3(30, 30, 30) + DataTraits<T>::colorCode(), uvec3(255));
     }
@@ -309,7 +313,6 @@ struct DataTraits<std::vector<std::unique_ptr<const T, D>, A>> {
                                      data.empty() ? nullptr : data.back().get());
     }
 };
-
 
 template <typename T, typename A>
 struct DataTraits<std::vector<std::shared_ptr<T>, A>> {

--- a/include/inviwo/core/datastructures/volume/volume.h
+++ b/include/inviwo/core/datastructures/volume/volume.h
@@ -37,6 +37,7 @@
 #include <inviwo/core/datastructures/volume/volumeconfig.h>
 #include <inviwo/core/datastructures/datamapper.h>
 #include <inviwo/core/datastructures/representationtraits.h>
+#include <inviwo/core/datastructures/datasequence.h>
 #include <inviwo/core/datastructures/volume/volumerepresentation.h>
 #include <inviwo/core/datastructures/unitsystem.h>
 #include <inviwo/core/metadata/metadataowner.h>
@@ -189,7 +190,7 @@ const typename representation_traits<Volume, Kind>::type* Volume::getRep() const
     return getRepresentation<typename representation_traits<Volume, Kind>::type>();
 }
 
-using VolumeSequence = std::vector<std::shared_ptr<Volume>>;
+using VolumeSequence = DataSequence<Volume>;
 
 extern template class IVW_CORE_TMPL_EXP DataReaderType<Volume>;
 extern template class IVW_CORE_TMPL_EXP DataWriterType<Volume>;

--- a/include/inviwo/core/util/volumesequencesampler.h
+++ b/include/inviwo/core/util/volumesequencesampler.h
@@ -41,10 +41,10 @@ class IVW_CORE_API VolumeSequenceSampler : public Spatial4DSampler<3, double> {
         std::weak_ptr<Wrapper> next_;
         double duration_;
         double timestamp_;
-        std::shared_ptr<Volume> volume_;
+        std::shared_ptr<const Volume> volume_;
         VolumeDoubleSampler<4> sampler_;
 
-        Wrapper(std::shared_ptr<Volume> volume)
+        Wrapper(std::shared_ptr<const Volume> volume)
             : next_()
             , duration_(std::numeric_limits<double>::infinity())
             , timestamp_(std::numeric_limits<double>::infinity())
@@ -62,9 +62,7 @@ class IVW_CORE_API VolumeSequenceSampler : public Spatial4DSampler<3, double> {
     };
 
 public:
-    VolumeSequenceSampler(
-        std::shared_ptr<const std::vector<std::shared_ptr<Volume>>> volumeSequence,
-        bool allowLooping = true);
+    VolumeSequenceSampler(std::shared_ptr<const VolumeSequence> volumeSequence, bool allowLooping = true);
     virtual ~VolumeSequenceSampler();
 
     void setAllowedLooping(bool allowed = true) { allowLooping_ = allowed; }

--- a/include/inviwo/core/util/volumesequencesampler.h
+++ b/include/inviwo/core/util/volumesequencesampler.h
@@ -62,7 +62,8 @@ class IVW_CORE_API VolumeSequenceSampler : public Spatial4DSampler<3, double> {
     };
 
 public:
-    VolumeSequenceSampler(std::shared_ptr<const VolumeSequence> volumeSequence, bool allowLooping = true);
+    VolumeSequenceSampler(std::shared_ptr<const VolumeSequence> volumeSequence,
+                          bool allowLooping = true);
     virtual ~VolumeSequenceSampler();
 
     void setAllowedLooping(bool allowed = true) { allowLooping_ = allowed; }

--- a/include/inviwo/core/util/volumesequenceutils.h
+++ b/include/inviwo/core/util/volumesequenceutils.h
@@ -30,32 +30,28 @@
 #pragma once
 
 #include <inviwo/core/common/inviwocoredefine.h>
+#include <inviwo/core/datastructures/volume/volume.h>
 
 #include <vector>
 #include <memory>
 
 namespace inviwo {
 
-class Volume;
-using SharedVolume = std::shared_ptr<Volume>;
-using VolumeSequence = std::vector<SharedVolume>;
-
 namespace util {
 
-bool IVW_CORE_API hasTimestamps(const VolumeSequence& seq, bool checkfirstonly = true);
+IVW_CORE_API bool hasTimestamps(const VolumeSequence& seq, bool checkfirstonly = true);
 
-std::pair<double, double> IVW_CORE_API getTimestampRange(const VolumeSequence& seq,
+IVW_CORE_API std::pair<double, double> getTimestampRange(const VolumeSequence& seq,
                                                          bool sorted = true);
 
-bool IVW_CORE_API isSorted(const VolumeSequence& seq);
+IVW_CORE_API bool isSorted(const VolumeSequence& seq);
 VolumeSequence IVW_CORE_API sortSequence(const VolumeSequence& seq);
 
-std::pair<SharedVolume, SharedVolume> IVW_CORE_API getVolumesForTimestep(const VolumeSequence& seq,
-                                                                         double t,
-                                                                         bool sorted = true);
+IVW_CORE_API std::pair<std::shared_ptr<const Volume>, std::shared_ptr<const Volume>>
+getVolumesForTimestep(const VolumeSequence& seq, double t, bool sorted = true);
 
-bool IVW_CORE_API hasTimestamp(SharedVolume vol);
-double IVW_CORE_API getTimestamp(SharedVolume vol);
+bool IVW_CORE_API hasTimestamp(const std::shared_ptr<const Volume>& vol);
+double IVW_CORE_API getTimestamp(const std::shared_ptr<const Volume>& vol);
 }  // namespace util
 
 }  // namespace inviwo

--- a/modules/base/include/modules/base/io/datvolumesequencereader.h
+++ b/modules/base/include/modules/base/io/datvolumesequencereader.h
@@ -91,11 +91,8 @@ namespace inviwo {
  *     + Datfile: sequence1.dat
  *     + Datfile: sequence2.dat
  */
-class IVW_MODULE_BASE_API DatVolumeSequenceReader
-    : public DataReaderType<std::vector<std::shared_ptr<Volume>>> {
+class IVW_MODULE_BASE_API DatVolumeSequenceReader : public DataReaderType<VolumeSequence> {
 public:
-    using VolumeSequence = std::vector<std::shared_ptr<Volume>>;
-
     DatVolumeSequenceReader();
     DatVolumeSequenceReader(const DatVolumeSequenceReader& rhs);
     DatVolumeSequenceReader& operator=(const DatVolumeSequenceReader& that);

--- a/modules/base/include/modules/base/processors/vectorelementselectorprocessor.h
+++ b/modules/base/include/modules/base/processors/vectorelementselectorprocessor.h
@@ -31,6 +31,7 @@
 
 #include <inviwo/core/ports/datainport.h>
 #include <inviwo/core/ports/dataoutport.h>
+#include <inviwo/core/datastructures/datasequence.h>
 #include <inviwo/core/processors/processor.h>
 #include <inviwo/core/properties/ordinalproperty.h>
 #include <inviwo/core/properties/stringproperty.h>
@@ -55,7 +56,7 @@ public:
     void process() override;
 
 protected:
-    DataInport<std::vector<std::shared_ptr<T>>> inport_;
+    DataInport<DataSequence<T>> inport_;
     OutportType outport_;
     SequenceTimerProperty timeStep_;
 
@@ -73,19 +74,11 @@ VectorElementSelectorProcessor<T, OutportType>::VectorElementSelectorProcessor()
     , timestamp_("timestamp", "Timestamp", 0, std::numeric_limits<double>::lowest(),
                  std::numeric_limits<double>::max(), std::numeric_limits<double>::epsilon(),
                  InvalidationLevel::Valid, PropertySemantics("Text")) {
-    addPort(inport_);
-    addPort(outport_);
+    addPorts(inport_, outport_);
 
-    addProperty(timeStep_);
-    addProperty(name_);
-    addProperty(timestamp_);
-    name_.setVisible(false);
-    name_.setReadOnly(true);
-    name_.setCurrentStateAsDefault();
-
-    timestamp_.setVisible(false);
-    timestamp_.setReadOnly(true);
-    timestamp_.setCurrentStateAsDefault();
+    addProperties(timeStep_, name_, timestamp_);
+    name_.setVisible(false).setReadOnly(true).setCurrentStateAsDefault();
+    timestamp_.setVisible(false).setReadOnly(true).setCurrentStateAsDefault();
 
     // This needs to be added by the child class
     // timeStep_.index_.autoLinkToProperty<VectorElementSelectorProcessor<T>>("timeStep.selectedSequenceIndex");
@@ -143,6 +136,8 @@ void VectorElementSelectorProcessor<T, OutportType>::process() {
         size_t index = std::min(data->size() - 1, static_cast<size_t>(timeStep_.index_.get() - 1));
 
         outport_.setData((*data)[index]);
+    } else {
+        outport_.detachData();
     }
 }
 

--- a/modules/base/include/modules/base/processors/volumesequencesource.h
+++ b/modules/base/include/modules/base/processors/volumesequencesource.h
@@ -56,23 +56,6 @@ class DataReaderFactory;
 class Deserializer;
 class InviwoApplication;
 
-/** \docpage{org.inviwo.VolumeSequenceSource, Volume Vector Source}
- * ![](org.inviwo.VolumeSequenceSource.png?classIdentifier=org.inviwo.VolumeSequenceSource)
- * Loads a sequence of volume either from a 4D dataset or from a selection of 3D datasets. The
- * filename of the source data is available via MetaData.
- *
- * ### Outport
- *   * __data__ A sequence of volumes
- *
- * ### Properties
- *   * __Input type__ Select the input type, either select a single file to a 4D dataset or
- *                    use a folder
- *   * __Volume file__ If using single file mode, the file to load.
- *   * __Volume folder__ If using folder mode, the folder to look for data sets in.
- *   * __Filter__ If using folder mode, apply filter to the folder contents to find wanted
- *                data sets
- */
-
 /**
  * \class VolumeSequenceSource
  * \brief Loads a vector of volumes

--- a/modules/base/include/modules/base/processors/volumesource.h
+++ b/modules/base/include/modules/base/processors/volumesource.h
@@ -37,6 +37,7 @@
 #include <inviwo/core/properties/buttonproperty.h>              // for ButtonProperty
 #include <inviwo/core/properties/fileproperty.h>                // for FileProperty
 #include <inviwo/core/properties/optionproperty.h>              // for OptionProperty
+#include <inviwo/core/datastructures/volume/volume.h>
 #include <inviwo/core/util/fileextension.h>                     // for FileExtension, operator==
 #include <modules/base/properties/basisproperty.h>              // for BasisProperty
 #include <modules/base/properties/sequencetimerproperty.h>      // for SequenceTimerProperty
@@ -52,11 +53,9 @@ namespace inviwo {
 
 class Deserializer;
 class InviwoApplication;
-class Volume;
 
 class IVW_MODULE_BASE_API VolumeSource : public Processor {
 public:
-    using VolumeSequence = std::vector<std::shared_ptr<Volume>>;
     virtual const ProcessorInfo getProcessorInfo() const override;
     static const ProcessorInfo processorInfo_;
 

--- a/modules/base/include/modules/base/processors/volumesource.h
+++ b/modules/base/include/modules/base/processors/volumesource.h
@@ -31,12 +31,12 @@
 
 #include <modules/base/basemoduledefine.h>  // for IVW_MODULE_BASE_API
 
-#include <inviwo/core/ports/volumeport.h>                       // for VolumeOutport
-#include <inviwo/core/processors/processor.h>                   // for Processor
-#include <inviwo/core/processors/processorinfo.h>               // for ProcessorInfo
-#include <inviwo/core/properties/buttonproperty.h>              // for ButtonProperty
-#include <inviwo/core/properties/fileproperty.h>                // for FileProperty
-#include <inviwo/core/properties/optionproperty.h>              // for OptionProperty
+#include <inviwo/core/ports/volumeport.h>           // for VolumeOutport
+#include <inviwo/core/processors/processor.h>       // for Processor
+#include <inviwo/core/processors/processorinfo.h>   // for ProcessorInfo
+#include <inviwo/core/properties/buttonproperty.h>  // for ButtonProperty
+#include <inviwo/core/properties/fileproperty.h>    // for FileProperty
+#include <inviwo/core/properties/optionproperty.h>  // for OptionProperty
 #include <inviwo/core/datastructures/volume/volume.h>
 #include <inviwo/core/util/fileextension.h>                     // for FileExtension, operator==
 #include <modules/base/properties/basisproperty.h>              // for BasisProperty

--- a/modules/base/src/io/datvolumesequencereader.cpp
+++ b/modules/base/src/io/datvolumesequencereader.cpp
@@ -89,7 +89,7 @@ DatVolumeSequenceReader* DatVolumeSequenceReader::clone() const {
     return new DatVolumeSequenceReader(*this);
 }
 
-std::shared_ptr<DatVolumeSequenceReader::VolumeSequence> DatVolumeSequenceReader::readData(
+std::shared_ptr<VolumeSequence> DatVolumeSequenceReader::readData(
     const std::filesystem::path& filePath) {
 
     const auto fileDirectory = filePath.parent_path();

--- a/modules/base/src/processors/volumesequencesource.cpp
+++ b/modules/base/src/processors/volumesequencesource.cpp
@@ -70,7 +70,9 @@ const ProcessorInfo VolumeSequenceSource::processorInfo_{
     "Data Input",                     // Category
     CodeState::Stable,                // Code state
     Tags::CPU,                        // Tags
-};
+    R"(Loads a sequence of volume either from a 4D dataset or from a selection of 3D datasets. The
+       filename of the source data is available via MetaData.)"_unindentHelp};
+
 const ProcessorInfo VolumeSequenceSource::getProcessorInfo() const { return processorInfo_; }
 
 namespace {
@@ -92,14 +94,20 @@ std::optional<std::filesystem::path> getFirstFileInFolder(const std::filesystem:
 VolumeSequenceSource::VolumeSequenceSource(InviwoApplication* app)
     : Processor()
     , rf_{util::getDataReaderFactory(app)}
-    , outport_("data")
-    , inputType_("inputType", "Input type",
-                 {{"singlefile", "Single File", InputType::SingleFile},
-                  {"folder", "Folder", InputType::Folder}},
-                 1)
-    , file_("filename", "Volume file")
-    , folder_("folder", "Volume folder")
-    , filter_("filter_", "Filter", "*")
+    , outport_("data", "A sequence of volumes"_help)
+    , inputType_(
+          "inputType", "Input type",
+          "Select the input type, either select a single file to a 4D dataset or use a folder"_help,
+          {{"singlefile", "Single File", InputType::SingleFile},
+           {"folder", "Folder", InputType::Folder}},
+          1)
+    , file_("filename", "Volume file", "If using single file mode, the file to load"_help)
+    , folder_("folder", "Volume folder",
+              "If using folder mode, the folder to look for data sets in"_help)
+    , filter_(
+          "filter_", "Filter",
+          "If using folder mode, apply filter to the folder contents to find wanted data sets"_help,
+          "*")
     , reader_("reader", "Data Reader")
     , reload_("reload", "Reload data")
     , basis_("Basis", "Basis and offset")

--- a/modules/nifti/include/modules/nifti/niftireader.h
+++ b/modules/nifti/include/modules/nifti/niftireader.h
@@ -45,10 +45,8 @@ namespace inviwo {
  * \brief Volume data reader for Nifti-1 files.
  *
  */
-class IVW_MODULE_NIFTI_API NiftiReader
-    : public DataReaderType<std::vector<std::shared_ptr<Volume>>> {
+class IVW_MODULE_NIFTI_API NiftiReader : public DataReaderType<VolumeSequence> {
 public:
-    using VolumeSequence = std::vector<std::shared_ptr<Volume>>;
     NiftiReader();
     NiftiReader(const NiftiReader& rhs) = default;
     NiftiReader& operator=(const NiftiReader& that) = default;

--- a/modules/nifti/src/niftireader.cpp
+++ b/modules/nifti/src/niftireader.cpp
@@ -186,7 +186,7 @@ const DataFormatBase* niftiDataTypeToInviwoDataFormat(const nifti_image* niftiIm
 
     return DataFormatBase::get(type, components, precision);
 }
-std::shared_ptr<NiftiReader::VolumeSequence> NiftiReader::readData(
+std::shared_ptr<VolumeSequence> NiftiReader::readData(
     const std::filesystem::path& filePath) {
     checkExists(filePath);
 
@@ -393,7 +393,7 @@ std::shared_ptr<NiftiReader::VolumeSequence> NiftiReader::readData(
         }
     }
 
-    for (auto& vol : *volumes) {
+    for (auto vol : *volumes) {
         vol->dataMap_ = dm;
     }
 

--- a/modules/nifti/src/niftireader.cpp
+++ b/modules/nifti/src/niftireader.cpp
@@ -186,8 +186,7 @@ const DataFormatBase* niftiDataTypeToInviwoDataFormat(const nifti_image* niftiIm
 
     return DataFormatBase::get(type, components, precision);
 }
-std::shared_ptr<VolumeSequence> NiftiReader::readData(
-    const std::filesystem::path& filePath) {
+std::shared_ptr<VolumeSequence> NiftiReader::readData(const std::filesystem::path& filePath) {
     checkExists(filePath);
 
     /* read input dataset, but not data */

--- a/modules/python3/bindings/src/pyvolume.cpp
+++ b/modules/python3/bindings/src/pyvolume.cpp
@@ -144,7 +144,6 @@ void exposeVolume(pybind11::module& m) {
         .def_property_readonly(
             "data", static_cast<const py::array& (VolumePy::*)() const>(&VolumePy::data));
 
-
     py::class_<VolumeSequence>(m, "VolumeSequence", py::module_local(false))
         .def(py::init<>())
         .def(py::init<std::span<std::shared_ptr<const Volume>>>(), py::arg("volumes"))

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -46,6 +46,7 @@ set(HEADER_FILES
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/datagrouprepresentation.h
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/datamapper.h
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/datarepresentation.h
+    ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/datasequence.h
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/datatraits.h
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/diskrepresentation.h
     ${IVW_INCLUDE_DIR}/inviwo/core/datastructures/geometry/basicmesh.h
@@ -444,6 +445,7 @@ set(SOURCE_FILES
     datastructures/coordinatetransformer.cpp
     datastructures/datamapper.cpp
     datastructures/datarepresentation.cpp
+    datastructures/datasequence.cpp
     datastructures/datatraits.cpp
     datastructures/geometry/basicmesh.cpp
     datastructures/geometry/geometrytype.cpp

--- a/src/core/common/inviwocore.cpp
+++ b/src/core/common/inviwocore.cpp
@@ -31,11 +31,8 @@
 #include <inviwo/core/common/inviwoapplication.h>
 #include <inviwo/core/util/filesystem.h>
 #include <inviwo/core/util/foreacharg.h>
+#include <inviwo/core/datastructures/datasequence.h>
 
-#include <warn/push>
-#include <warn/ignore/unused-function>
-#include <inviwo/core/properties/optionproperty.h>
-#include <warn/pop>
 
 // Cameras
 #include <inviwo/core/datastructures/camera/camera.h>

--- a/src/core/common/inviwocore.cpp
+++ b/src/core/common/inviwocore.cpp
@@ -33,7 +33,6 @@
 #include <inviwo/core/util/foreacharg.h>
 #include <inviwo/core/datastructures/datasequence.h>
 
-
 // Cameras
 #include <inviwo/core/datastructures/camera/camera.h>
 #include <inviwo/core/datastructures/camera/orthographiccamera.h>

--- a/src/core/datastructures/datasequence.cpp
+++ b/src/core/datastructures/datasequence.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2023 Inviwo Foundation
+ * Copyright (c) 2023-2024 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/core/datastructures/datasequence.cpp
+++ b/src/core/datastructures/datasequence.cpp
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2012-2024 Inviwo Foundation
+ * Copyright (c) 2023 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,48 +27,9 @@
  *
  *********************************************************************************/
 
-#include <inviwo/core/interaction/events/resizeevent.h>
-
 #include <inviwo/core/datastructures/datasequence.h>
-#include <inviwo/core/processors/processor.h>
-#include <inviwo/core/ports/inport.h>
-#include <inviwo/core/ports/outport.h>
-#include <inviwo/core/ports/imageport.h>
-
-#include <inviwo/core/interaction/events/eventutil.h>
 
 namespace inviwo {
 
-ResizeEvent::ResizeEvent(size2_t canvasSize)
-    : Event(), size_(canvasSize), previousSize_(canvasSize) {}
-
-ResizeEvent::ResizeEvent(size2_t canvasSize, size2_t previousSize)
-    : Event(), size_(canvasSize), previousSize_(previousSize) {}
-
-ResizeEvent* ResizeEvent::clone() const { return new ResizeEvent(*this); }
-
-bool ResizeEvent::shouldPropagateTo(Inport* inport, Processor* processor, Outport* source) {
-    // Only propagate to image ports in the same port group.
-    if (processor->getPortGroup(inport) == processor->getPortGroup(source)) {
-        if (dynamic_cast<ImagePortBase*>(inport)) return true;
-        if (dynamic_cast<DataInport<DataSequence<Image>>*>(inport)) return true;
-    }
-    return false;
-}
-
-size2_t ResizeEvent::size() const { return size_; }
-
-size2_t ResizeEvent::previousSize() const { return previousSize_; }
-
-void ResizeEvent::setSize(size2_t csize) { size_ = csize; }
-
-void ResizeEvent::setPreviousSize(size2_t previousSize) { previousSize_ = previousSize; }
-
-uint64_t ResizeEvent::hash() const { return chash(); }
-
-void ResizeEvent::print(std::ostream& ss) const {
-    util::printEvent(ss, "ResizeEvent", std::make_pair("size", size_),
-                     std::make_pair("prev", previousSize_));
-}
 
 }  // namespace inviwo

--- a/src/core/datastructures/datasequence.cpp
+++ b/src/core/datastructures/datasequence.cpp
@@ -29,7 +29,4 @@
 
 #include <inviwo/core/datastructures/datasequence.h>
 
-namespace inviwo {
-
-
-}  // namespace inviwo
+namespace inviwo {}  // namespace inviwo

--- a/src/core/datastructures/image/image.cpp
+++ b/src/core/datastructures/image/image.cpp
@@ -346,6 +346,7 @@ dvec4 Image::readPixel(size2_t pos, LayerType layer, size_t index) const {
                                      });
 
     if (it != representations_.end()) {
+        it->second->update(false);
         return it->second->readPixel(pos, layer, index);
     } else {
         // Fallback. If no representation exist, create ImageRAM one

--- a/src/core/util/volumesequencesampler.cpp
+++ b/src/core/util/volumesequencesampler.cpp
@@ -32,15 +32,15 @@
 
 namespace inviwo {
 
-VolumeSequenceSampler::VolumeSequenceSampler(
-    std::shared_ptr<const std::vector<std::shared_ptr<Volume>>> volumeSequence, bool allowLooping)
+VolumeSequenceSampler::VolumeSequenceSampler(std::shared_ptr<const VolumeSequence> volumeSequence,
+                                             bool allowLooping)
     : Spatial4DSampler<3, double>(volumeSequence->front())
     , wrappers_()
     , allowLooping_(allowLooping)
     , timeRange_(0, 0)
     , totDuration_(0) {
 
-    for (const auto& vol : (*volumeSequence.get())) {
+    for (const auto& vol : *volumeSequence) {
         wrappers_.emplace_back(std::make_shared<Wrapper>(vol));
     }
 

--- a/src/core/util/volumesequenceutils.cpp
+++ b/src/core/util/volumesequenceutils.cpp
@@ -80,17 +80,22 @@ bool isSorted(const VolumeSequence& seq) {
 }
 
 VolumeSequence sortSequence(const VolumeSequence& seq) {
-    VolumeSequence sorted = seq;
-    std::sort(sorted.begin(), sorted.end(), [](const SharedVolume& a, const SharedVolume& b) {
-        auto t1 = getTimestamp(a);
-        auto t2 = getTimestamp(b);
-        return t1 < t2;
-    });
-    return sorted;
+    std::vector<std::shared_ptr<const Volume>> sorted;
+    for(auto&& item : seq) {
+        sorted.push_back(item);
+    }
+
+    std::sort(sorted.begin(), sorted.end(),
+              [](const std::shared_ptr<const Volume>& a, const std::shared_ptr<const Volume>& b) {
+                  auto t1 = getTimestamp(a);
+                  auto t2 = getTimestamp(b);
+                  return t1 < t2;
+              });
+    return VolumeSequence{sorted};
 }
 
-std::pair<SharedVolume, SharedVolume> getVolumesForTimestep(const VolumeSequence& seq, double t,
-                                                            bool sorted) {
+std::pair<std::shared_ptr<const Volume>, std::shared_ptr<const Volume>> getVolumesForTimestep(
+    const VolumeSequence& seq, double t, bool sorted) {
     if (seq.size() == 1) {
         return std::make_pair(seq.front(), seq.front());
     } else if (!hasTimestamps(seq)) {
@@ -106,7 +111,7 @@ std::pair<SharedVolume, SharedVolume> getVolumesForTimestep(const VolumeSequence
         return std::make_pair(seq[i], seq[i2]);
     } else if (sorted) {
         // find first volume with timestamp greater than t
-        auto it = std::find_if(seq.begin(), seq.end(), [t](const SharedVolume& v) {
+        auto it = std::find_if(seq.begin(), seq.end(), [t](const std::shared_ptr<const Volume>& v) {
             auto vt = getTimestamp(v);
             return t < vt;
         });
@@ -126,9 +131,11 @@ std::pair<SharedVolume, SharedVolume> getVolumesForTimestep(const VolumeSequence
     }
 }
 
-bool hasTimestamp(SharedVolume vol) { return vol->hasMetaData<DoubleMetaData>("timestamp"); }
+bool hasTimestamp(const std::shared_ptr<const Volume>& vol) {
+    return vol->hasMetaData<DoubleMetaData>("timestamp");
+}
 
-double getTimestamp(SharedVolume vol) {
+double getTimestamp(const std::shared_ptr<const Volume>& vol) {
     return vol->getMetaData<DoubleMetaData>("timestamp")->get();
 }
 

--- a/src/core/util/volumesequenceutils.cpp
+++ b/src/core/util/volumesequenceutils.cpp
@@ -81,7 +81,7 @@ bool isSorted(const VolumeSequence& seq) {
 
 VolumeSequence sortSequence(const VolumeSequence& seq) {
     std::vector<std::shared_ptr<const Volume>> sorted;
-    for(auto&& item : seq) {
+    for (auto&& item : seq) {
         sorted.push_back(item);
     }
 

--- a/tests/integrationtests/volume-test.cpp
+++ b/tests/integrationtests/volume-test.cpp
@@ -29,9 +29,8 @@
 
 #include <inviwo/core/datastructures/volume/volume.h>
 #include <inviwo/core/datastructures/volume/volumeram.h>
-#include <inviwo/core/io/datareaderfactory.h>
 #include <inviwo/core/datastructures/volume/volumeramprecision.h>
-#include <modules/opengl/volume/volumegl.h>
+#include <inviwo/core/io/datareaderfactory.h>
 #include <inviwo/core/common/inviwoapplication.h>
 #include <inviwo/core/util/filesystem.h>
 #include <inviwo/core/util/indexmapper.h>
@@ -73,7 +72,7 @@ void testDatVolumeLoad(std::string_view filename) {
 
     auto reader = InviwoApplication::getPtr()
                       ->getDataReaderFactory()
-                      ->getReaderForTypeAndExtension<std::vector<std::shared_ptr<Volume>>>(file);
+                      ->getReaderForTypeAndExtension<VolumeSequence>(file);
     ASSERT_TRUE(reader.get() != nullptr);
     auto volumeSeq = reader->readData(file);
     ASSERT_EQ(1, volumeSeq->size());
@@ -169,7 +168,7 @@ void testDatVolumeClone(std::string_view filename) {
     auto file = filesystem::getPath(PathType::Tests) / "volumes" / filename;
     auto reader = InviwoApplication::getPtr()
                       ->getDataReaderFactory()
-                      ->getReaderForTypeAndExtension<std::vector<std::shared_ptr<Volume>>>(file);
+                      ->getReaderForTypeAndExtension<VolumeSequence>(file);
     ASSERT_TRUE(reader.get() != nullptr);
     auto volumeSeq = reader->readData(file);
     ASSERT_EQ(1, volumeSeq->size());

--- a/tests/testutil/src/configurablegtesteventlistener.cpp
+++ b/tests/testutil/src/configurablegtesteventlistener.cpp
@@ -45,11 +45,13 @@ ConfigurableGTestEventListener& ConfigurableGTestEventListener::setup() {
     auto default_printer = listeners.Release(listeners.default_result_printer());
 
     auto listener = new ConfigurableGTestEventListener(default_printer);
-    listener->showEnvironment = false;
-    listener->showTestCases = false;
-    listener->showTestNames = false;
-    listener->showSuccesses = false;
-    listener->showInlineFailures = false;
+    if (std::getenv("INVIWO_TERSE_TEST_OUTPUT")) {
+        listener->showEnvironment = false;
+        listener->showTestCases = false;
+        listener->showTestNames = false;
+        listener->showSuccesses = false;
+        listener->showInlineFailures = false;
+    }
     listeners.Append(listener);
 
     return *listener;

--- a/tools/jenkins/util.groovy
+++ b/tools/jenkins/util.groovy
@@ -196,7 +196,7 @@ def warn(def state, refjob = 'daily/appleclang') {
 
 def unittest(def state) {
     if(state.env.disableUnittest) return
-    cmd('Unit Tests', 'build/bin', ['DISPLAY=:' + state.cfg.display]) {
+    cmd('Unit Tests', 'build/bin', ['DISPLAY=:' + state.cfg.display, 'INVIWO_TERSE_TEST_OUTPUT']) {
         checked(state, "Unit Test", false) {
             sh '''
                 rc=0

--- a/tools/jenkins/util.groovy
+++ b/tools/jenkins/util.groovy
@@ -196,7 +196,7 @@ def warn(def state, refjob = 'daily/appleclang') {
 
 def unittest(def state) {
     if(state.env.disableUnittest) return
-    cmd('Unit Tests', 'build/bin', ['DISPLAY=:' + state.cfg.display, 'INVIWO_TERSE_TEST_OUTPUT']) {
+    cmd('Unit Tests', 'build/bin', ['DISPLAY=:' + state.cfg.display, 'INVIWO_TERSE_TEST_OUTPUT=1']) {
         checked(state, "Unit Test", false) {
             sh '''
                 rc=0

--- a/tools/vcpkg/jhasse-poly2tri/cmake.patch
+++ b/tools/vcpkg/jhasse-poly2tri/cmake.patch
@@ -1,0 +1,56 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1a237b9..374e7e9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,15 +1,32 @@
+ cmake_minimum_required(VERSION 3.12)
+ 
++if(POLICY CMP0063)
++  cmake_policy(SET CMP0063 NEW)
++endif()
++
++set(CMAKE_CXX_VISIBILITY_PRESET hidden)
++set(CMAKE_VISIBILITY_INLINES_HIDDEN TRUE)
++
+ project(poly2tri LANGUAGES CXX)
+ set(CMAKE_CXX_STANDARD 14)
+ 
++set(INSTALL_BIN_DIR      "bin"                     CACHE PATH "Path where exe and dll will be installed")
++set(INSTALL_LIB_DIR      "lib"                     CACHE PATH "Path where lib will be installed")
++set(INSTALL_INCLUDE_DIR  "include/${PROJECT_NAME}" CACHE PATH "Path where headers will be installed")
++set(INSTALL_CMAKE_DIR    "share/${PROJECT_NAME}"   CACHE PATH "Path where cmake configs will be installed")
++
+ option(P2T_BUILD_TESTS "Build tests" OFF)
+ option(P2T_BUILD_TESTBED "Build the testbed application" OFF)
+ 
+ file(GLOB SOURCES poly2tri/common/*.cc poly2tri/sweep/*.cc)
+ file(GLOB HEADERS poly2tri/*.h poly2tri/common/*.h poly2tri/sweep/*.h)
++
+ add_library(poly2tri ${SOURCES} ${HEADERS})
+-target_include_directories(poly2tri INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
++target_include_directories(${PROJECT_NAME} PUBLIC
++    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/poly2tri>
++    $<INSTALL_INTERFACE:include>
++    $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
++)
+ 
+ get_target_property(poly2tri_target_type poly2tri TYPE)
+ if(poly2tri_target_type STREQUAL SHARED_LIBRARY)
+@@ -26,3 +43,17 @@ endif()
+ if(P2T_BUILD_TESTBED)
+     add_subdirectory(testbed)
+ endif()
++
++install(DIRECTORY poly2tri DESTINATION include FILES_MATCHING PATTERN "*.h")
++
++install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}Targets
++  RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
++  LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
++  ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
++)
++
++install (EXPORT ${PROJECT_NAME}Targets
++    FILE ${PROJECT_NAME}Config.cmake
++    NAMESPACE ${PROJECT_NAME}::
++    DESTINATION "${INSTALL_CMAKE_DIR}"
++)

--- a/tools/vcpkg/jhasse-poly2tri/portfile.cmake
+++ b/tools/vcpkg/jhasse-poly2tri/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO jhasse/poly2tri
+    REF 0171f030bd3d5c6747c29d93403546eed668a1b6
+    SHA512 b55d543ae7f9b447d3e0e39b66cf1ce55a48ed7949819db01d8adc0972182519c4b6b533e704a282da45a4d64f510fd33cd81ccb52307dc0e63622e83bcf0192
+    HEAD_REF master
+    PATCHES
+        cmake.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME poly2tri)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/tools/vcpkg/jhasse-poly2tri/reason.md
+++ b/tools/vcpkg/jhasse-poly2tri/reason.md
@@ -1,0 +1,2 @@
+Linked by assimp and does not produces a so on linux. Seems to be static only
+Add vcpkg_check_linkage(ONLY_STATIC_LIBRARY) to portfile.cmake

--- a/tools/vcpkg/jhasse-poly2tri/usage
+++ b/tools/vcpkg/jhasse-poly2tri/usage
@@ -1,0 +1,4 @@
+jhasse-poly2tri provides CMake targets:
+
+  find_package(poly2tri CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE poly2tri::poly2tri)

--- a/tools/vcpkg/jhasse-poly2tri/vcpkg.json
+++ b/tools/vcpkg/jhasse-poly2tri/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "jhasse-poly2tri",
+  "version-date": "2023-12-27",
+  "description": "Sweep-line algorithm for constrained Delaunay triangulation",
+  "homepage": "https://github.com/jhasse/poly2tri",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
Added a class for VolumeSequence instead of using a std::vector of shared_ptr Volume.

Fixes #Make it possible to create a VolumeSequence of shared_ptr<const Volume>

ensures that a const VolumeSequence returns const Volumes. i.e. it propagates const. 