### PR TITLE
Core,Qt: commandline arg to reset Qt window state

### DIFF
--- a/include/inviwo/qt/editor/inviwomainwindow.h
+++ b/include/inviwo/qt/editor/inviwomainwindow.h
@@ -275,6 +275,7 @@ private:
     TCLAP::SwitchArg updateExampleWorkspaces_;
     TCLAP::SwitchArg updateRegressionWorkspaces_;
     TCLAP::ValueArg<std::string> updateWorkspacesInPath_;
+    TCLAP::SwitchArg resetWindowState_;
 
     UndoManager undoManager_;
 


### PR DESCRIPTION
Fixes 
* ignores the previously stored window state and geometry of the Inviwo main window on startup. This should fix broken toolbars.