### PR TITLE
json: Fix serialization of StringProperty

### DIFF
--- a/modules/json/CMakeLists.txt
+++ b/modules/json/CMakeLists.txt
@@ -14,6 +14,7 @@ set(HEADER_FILES
     include/modules/json/io/json/propertyjsonconverter.h
     include/modules/json/io/json/propertyjsonconverterfactory.h
     include/modules/json/io/json/propertyjsonconverterfactoryobject.h
+    include/modules/json/io/json/stringpropertyjsonconverter.h
     include/modules/json/io/json/templatepropertyjsonconverter.h
     include/modules/json/jsonmodule.h
     include/modules/json/jsonmoduledefine.h
@@ -28,6 +29,7 @@ set(SOURCE_FILES
     src/io/json/ordinalrefpropertyjsonconverter.cpp
     src/io/json/propertyjsonconverterfactory.cpp
     src/io/json/propertyjsonconverterfactoryobject.cpp
+    src/io/json/stringpropertyjsonconverter.cpp
     src/jsonmodule.cpp
 )
 ivw_group("Source Files" ${SOURCE_FILES})

--- a/modules/json/include/modules/json/io/json/stringpropertyjsonconverter.h
+++ b/modules/json/include/modules/json/io/json/stringpropertyjsonconverter.h
@@ -1,0 +1,67 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2024 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <modules/json/jsonmoduledefine.h>  // for IVW_MODULE_JSON_API
+
+#include <nlohmann/json.hpp>  // for json
+
+namespace inviwo {
+class StringProperty;
+
+using json = ::nlohmann::json;
+
+/**
+ * Converts an StringProperty to a JSON object.
+ * Produces layout according to the members of StringProperty:
+ * { {"value": val} }
+ * @see StringProperty
+ *
+ * Usage example:
+ * \code{.cpp}
+ * StringProperty p;
+ * json j = p;
+ * \endcode
+ */
+IVW_MODULE_JSON_API void to_json(json& j, const StringProperty& p);
+
+/**
+ * Converts a JSON object to an StringProperty.
+ * Expects object layout according to the members of StringProperty:
+ * { {"value": val} }
+ * @see StringProperty
+ *
+ * Usage example:
+ * \code{.cpp}
+ * auto p = j.get<StringProperty>();
+ * \endcode
+ */
+IVW_MODULE_JSON_API void from_json(const json& j, StringProperty& p);
+
+}  // namespace inviwo

--- a/modules/json/src/io/json/stringpropertyjsonconverter.cpp
+++ b/modules/json/src/io/json/stringpropertyjsonconverter.cpp
@@ -1,0 +1,43 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2024 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <modules/json/io/json/stringpropertyjsonconverter.h>
+
+#include <inviwo/core/properties/stringproperty.h>  // for StringProperty
+
+namespace inviwo {
+
+void to_json(json& j, const StringProperty& p) { j = json{{"value", p.get()}}; }
+
+void from_json(const json& j, StringProperty& p) {
+    auto value = j.value("value", p.get());
+    p.set(value);
+}
+
+}  // namespace inviwo

--- a/modules/json/src/jsonmodule.cpp
+++ b/modules/json/src/jsonmodule.cpp
@@ -53,6 +53,7 @@
 #include <modules/json/io/json/ordinalrefpropertyjsonconverter.h>     // for to_json
 #include <modules/json/io/json/propertyjsonconverterfactory.h>        // for PropertyJSONConvert...
 #include <modules/json/io/json/propertyjsonconverterfactoryobject.h>  // for PropertyJSONConvert...
+#include <modules/json/io/json/stringpropertyjsonconverter.h>         // for to_json
 #include <modules/json/io/json/templatepropertyjsonconverter.h>       // for to_json
 
 #include <cstddef>      // for size_t


### PR DESCRIPTION
Ensure that StringProperty is serialized the same way as other template properties:

{
    "value": value
}

Some changes in Inviwo have made it serialize directly to a string (without "value"), which was originally the case


