### PR TITLE
Core/Various: Create processors as shared_ptrs

### DIFF
--- a/include/inviwo/core/io/serialization/deserializer.h
+++ b/include/inviwo/core/io/serialization/deserializer.h
@@ -1234,7 +1234,7 @@ void Deserializer::deserialize(std::string_view key, std::shared_ptr<T>& data) {
                 for (auto base : registeredFactories_) {
                     if (base->hasKey(typeId)) {
                         if (auto factory = dynamic_cast<Factory<T, std::string_view>*>(base)) {
-                            if ((data = std::shared_ptr<T>(factory->create(typeId)))) {
+                            if ((data = factory->createShared(typeId))) {
                                 break;
                             }
                         }

--- a/include/inviwo/core/processors/compositeprocessorfactoryobject.h
+++ b/include/inviwo/core/processors/compositeprocessorfactoryobject.h
@@ -48,7 +48,7 @@ public:
     CompositeProcessorFactoryObject(const std::filesystem::path& filen);
     virtual ~CompositeProcessorFactoryObject() = default;
 
-    virtual std::unique_ptr<Processor> create(InviwoApplication* app) override;
+    virtual std::shared_ptr<Processor> create(InviwoApplication* app) const override;
 
     virtual Document getMetaInformation() const override;
 

--- a/include/inviwo/core/processors/processorfactory.h
+++ b/include/inviwo/core/processors/processorfactory.h
@@ -38,18 +38,26 @@ namespace inviwo {
 
 class InviwoApplication;
 
-class IVW_CORE_API ProcessorFactory : public Factory<Processor>,
-                                      public StandardFactory<Processor, ProcessorFactoryObject,
-                                                             std::string_view, InviwoApplication*> {
-    using Parent =
-        StandardFactory<Processor, ProcessorFactoryObject, std::string_view, InviwoApplication*>;
+class IVW_CORE_API ProcessorFactory
+    : public Factory<Processor, std::string_view>,
+      public Factory<Processor, std::string_view, InviwoApplication*>,
+      public FactoryRegister<ProcessorFactoryObject, std::string, std::string_view> {
+
+    using Register = FactoryRegister<ProcessorFactoryObject, std::string, std::string_view>;
 
 public:
     ProcessorFactory(InviwoApplication* app);
     virtual ~ProcessorFactory() = default;
     bool registerObject(ProcessorFactoryObject* processor) override;
-    using Parent::create;
+
+    virtual std::unique_ptr<Processor> create(std::string_view key,
+                                              InviwoApplication*) const override;
     virtual std::unique_ptr<Processor> create(std::string_view key) const override;
+
+    virtual std::shared_ptr<Processor> createShared(std::string_view key) const override;
+    virtual std::shared_ptr<Processor> createShared(std::string_view key,
+                                                    InviwoApplication*) const override;
+
     virtual bool hasKey(std::string_view key) const override;
 
 private:

--- a/include/inviwo/core/processors/processorfactoryobject.h
+++ b/include/inviwo/core/processors/processorfactoryobject.h
@@ -51,7 +51,7 @@ public:
         : info_(std::move(info)), typeName_{typeName} {}
     virtual ~ProcessorFactoryObject() = default;
 
-    virtual std::unique_ptr<Processor> create(InviwoApplication* app) = 0;
+    virtual std::shared_ptr<Processor> create(InviwoApplication* app) const = 0;
 
     const ProcessorInfo& getProcessorInfo() const { return info_; }
     const std::string& getClassIdentifier() const { return info_.classIdentifier; }
@@ -83,22 +83,23 @@ public:
                                  util::demangle(typeid(T).name())) {}
     virtual ~ProcessorFactoryObjectTemplate() = default;
 
-    virtual std::unique_ptr<Processor> create([[maybe_unused]] InviwoApplication* app) {
-        std::unique_ptr<Processor> p;
+    virtual std::shared_ptr<Processor> create(
+        [[maybe_unused]] InviwoApplication* app) const override {
+        std::shared_ptr<Processor> p;
 
         if constexpr (std::is_constructible_v<T, const std::string&, const std::string&,
                                               InviwoApplication*>) {
-            p = std::make_unique<T>(util::stripIdentifier(getDisplayName()), getDisplayName(), app);
+            p = std::make_shared<T>(util::stripIdentifier(getDisplayName()), getDisplayName(), app);
         } else if constexpr (std::is_constructible_v<T, const std::string&, const std::string&>) {
-            p = std::make_unique<T>(util::stripIdentifier(getDisplayName()), getDisplayName());
+            p = std::make_shared<T>(util::stripIdentifier(getDisplayName()), getDisplayName());
         } else if constexpr (std::is_constructible_v<T, const std::string&, InviwoApplication*>) {
-            p = std::make_unique<T>(util::stripIdentifier(getDisplayName()), app);
+            p = std::make_shared<T>(util::stripIdentifier(getDisplayName()), app);
         } else if constexpr (std::is_constructible_v<T, const std::string&>) {
-            p = std::make_unique<T>(util::stripIdentifier(getDisplayName()));
+            p = std::make_shared<T>(util::stripIdentifier(getDisplayName()));
         } else if constexpr (std::is_constructible_v<T, InviwoApplication*>) {
-            p = std::make_unique<T>(app);
+            p = std::make_shared<T>(app);
         } else {
-            p = std::make_unique<T>();
+            p = std::make_shared<T>();
         }
 
         if (p->getIdentifier().empty()) p->setIdentifier(util::stripIdentifier(getDisplayName()));

--- a/include/inviwo/core/util/factory.h
+++ b/include/inviwo/core/util/factory.h
@@ -96,6 +96,9 @@ public:
     Factory& operator=(Factory&&) = default;
 
     virtual std::unique_ptr<T> create(K key, Args... args) const = 0;
+    virtual std::shared_ptr<T> createShared(K key, Args... args) const {
+        return std::shared_ptr<T>(create(key, args...));
+    }
     virtual bool hasKey(K key) const = 0;
 };
 
@@ -108,7 +111,9 @@ class Factory<T, std::string_view, Args...> : public virtual FactoryBase {
 public:
     Factory() = default;
     virtual std::unique_ptr<T> create(std::string_view key, Args... args) const = 0;
-    virtual bool hasKey(std::string_view key) const = 0;
+    virtual std::shared_ptr<T> createShared(std::string_view key, Args... args) const {
+        return std::shared_ptr<T>(create(key, args...));
+    }
 };
 
 /**

--- a/modules/python3/bindings/src/pyinviwomodule.cpp
+++ b/modules/python3/bindings/src/pyinviwomodule.cpp
@@ -53,7 +53,7 @@ public:
                                  "PythonProcessor"}
         , pfo_(pfo) {}
 
-    virtual std::unique_ptr<Processor> create(InviwoApplication* app) override {
+    virtual std::shared_ptr<Processor> create(InviwoApplication* app) const override {
         return pfo_.cast<ProcessorFactoryObject*>()->create(app);
     }
 

--- a/modules/python3/bindings/src/pyprocessors.cpp
+++ b/modules/python3/bindings/src/pyprocessors.cpp
@@ -72,13 +72,13 @@ class ProcessorFactoryObjectTrampoline : public ProcessorFactoryObject,
 public:
     using ProcessorFactoryObject::ProcessorFactoryObject;
 
-    virtual pybind11::object createProcessor(InviwoApplication* app) {
+    virtual pybind11::object createProcessor(InviwoApplication* app) const {
         PYBIND11_OVERLOAD(pybind11::object, ProcessorFactoryObjectTrampoline, createProcessor, app);
     }
 
-    virtual std::unique_ptr<Processor> create(InviwoApplication* app) override {
+    virtual std::shared_ptr<Processor> create(InviwoApplication* app) const override {
         auto proc = createProcessor(app);
-        auto p = proc.cast<std::unique_ptr<Processor>>();
+        auto p = proc.cast<std::shared_ptr<Processor>>();
         return p;
     }
 };
@@ -158,10 +158,10 @@ void exposeProcessors(pybind11::module& m) {
     py::class_<ProcessorFactory>(m, "ProcessorFactory")
         .def("hasKey", &ProcessorFactory::hasKey)
         .def_property_readonly("keys", &ProcessorFactory::getKeys)
-        .def("create", [](ProcessorFactory* pf, std::string key) { return pf->create(key); })
+        .def("create", [](ProcessorFactory* pf, std::string key) { return pf->createShared(key); })
         .def("create",
              [](ProcessorFactory* pf, std::string key, ivec2 pos) {
-                 auto p = pf->create(key);
+                 auto p = pf->createShared(key);
                  if (!p) {
                      throw py::key_error("failed to create processor of type '" + key + "'");
                  }

--- a/modules/python3/include/modules/python3/pythonprocessorfactoryobject.h
+++ b/modules/python3/include/modules/python3/pythonprocessorfactoryobject.h
@@ -67,7 +67,7 @@ public:
     PythonProcessorFactoryObject(InviwoApplication* app, const std::filesystem::path& file);
     virtual ~PythonProcessorFactoryObject() = default;
 
-    virtual std::unique_ptr<Processor> create(InviwoApplication* app) override;
+    virtual std::shared_ptr<Processor> create(InviwoApplication* app) const override;
 
     virtual Document getMetaInformation() const override {
         Document doc;

--- a/modules/python3/src/pythonprocessorfactoryobject.cpp
+++ b/modules/python3/src/pythonprocessorfactoryobject.cpp
@@ -66,15 +66,15 @@ PythonProcessorFactoryObject::PythonProcessorFactoryObject(InviwoApplication* ap
     startFileObservation(file);
 }
 
-std::unique_ptr<Processor> PythonProcessorFactoryObject::create(InviwoApplication*) {
+std::shared_ptr<Processor> PythonProcessorFactoryObject::create(InviwoApplication*) const {
     namespace py = pybind11;
     const auto& pi = getProcessorInfo();
 
     try {
+        auto main = py::module::import("__main__");
         py::object proc =
-            py::module::import("__main__")
-                .attr(name_.c_str())(util::stripIdentifier(pi.displayName), pi.displayName);
-        return proc.cast<std::unique_ptr<Processor>>();
+            main.attr(name_.c_str())(util::stripIdentifier(pi.displayName), pi.displayName);
+        return proc.cast<std::shared_ptr<Processor>>();
 
     } catch (std::exception& e) {
         throw Exception(IVW_CONTEXT_CUSTOM("Python"),

--- a/src/core/processors/compositeprocessorfactoryobject.cpp
+++ b/src/core/processors/compositeprocessorfactoryobject.cpp
@@ -37,9 +37,9 @@ namespace inviwo {
 CompositeProcessorFactoryObject::CompositeProcessorFactoryObject(const std::filesystem::path& file)
     : ProcessorFactoryObject(makeProcessorInfo(file), "inviwo::CompositeProcessor"), file_{file} {}
 
-std::unique_ptr<Processor> CompositeProcessorFactoryObject::create(InviwoApplication* app) {
+std::shared_ptr<Processor> CompositeProcessorFactoryObject::create(InviwoApplication* app) const {
     auto pi = getProcessorInfo();
-    return std::make_unique<CompositeProcessor>(pi.displayName, pi.displayName, app, file_);
+    return std::make_shared<CompositeProcessor>(pi.displayName, pi.displayName, app, file_);
 }
 
 Document CompositeProcessorFactoryObject::getMetaInformation() const {

--- a/src/core/processors/compositeprocessorutils.cpp
+++ b/src/core/processors/compositeprocessorutils.cpp
@@ -91,7 +91,7 @@ void util::replaceSelectionWithCompositeProcessor(ProcessorNetwork& network) {
         for (auto& c : inConnections) {
             auto portId = c.first->getClassIdentifier();
 
-            if (auto source = std::shared_ptr<Processor>(pf->create(portId + ".metasource"))) {
+            if (auto source = pf->createShared(portId + ".metasource")) {
                 if (auto metasouce = dynamic_cast<CompositeSourceBase*>(source.get())) {
                     subNetwork.addProcessor(source);
                     bool optional = true;
@@ -140,7 +140,7 @@ void util::replaceSelectionWithCompositeProcessor(ProcessorNetwork& network) {
         for (auto& c : outConnections) {
             auto portId = c.first->getClassIdentifier();
 
-            if (auto sink = std::shared_ptr<Processor>(pf->create(portId + ".metasink"))) {
+            if (auto sink = std::shared_ptr<Processor>(pf->createShared(portId + ".metasink"))) {
                 if (auto metasink = dynamic_cast<CompositeSinkBase*>(sink.get())) {
                     subNetwork.addProcessor(sink);
                     subNetwork.addConnection(c.first, metasink->getInports().front());

--- a/src/qt/editor/helpwidget.cpp
+++ b/src/qt/editor/helpwidget.cpp
@@ -360,7 +360,8 @@ std::tuple<std::string, std::filesystem::path> loadIdUrl(const QUrl& url, Inviwo
 
     const auto processorClassIdentifier = utilqt::fromQString(list.front());
     try {
-        if (auto processor = app->getProcessorFactory()->create(processorClassIdentifier, app)) {
+        if (auto processor =
+                app->getProcessorFactory()->createShared(processorClassIdentifier, app)) {
             auto help = help::buildProcessorHelp(*processor);
             const auto& module = findModule(*app, processorClassIdentifier);
 

--- a/src/qt/editor/processorlistwidget.cpp
+++ b/src/qt/editor/processorlistwidget.cpp
@@ -350,7 +350,7 @@ std::shared_ptr<Processor> ProcessorTreeWidget::createProcessor(QString cid) {
     RenderContext::getPtr()->activateDefaultRenderContext();
     const auto className = utilqt::fromQString(cid);
     try {
-        if (auto p = app_->getProcessorFactory()->create(className)) {
+        if (auto p = app_->getProcessorFactory()->createShared(className)) {
             recordProcessorUse(className);
             return p;
         }

--- a/src/qt/editor/processorpreview.cpp
+++ b/src/qt/editor/processorpreview.cpp
@@ -56,7 +56,7 @@ namespace inviwo {
 
 QImage utilqt::generatePreview(std::string_view classIdentifier, ProcessorFactory* factory) {
     try {
-        if (auto processor = factory->create(classIdentifier)) {
+        if (auto processor = factory->createShared(classIdentifier)) {
             return utilqt::generatePreview(*processor);
         } else {
             return QImage();
@@ -151,7 +151,7 @@ QImage utilqt::generatePreview(Processor& processor) {
 
 QImage utilqt::generateProcessorPreview(const QString& classIdentifier, double opacity) {
     std::string cid = utilqt::fromQString(classIdentifier);
-    if (auto processor = InviwoApplication::getPtr()->getProcessorFactory()->create(cid)) {
+    if (auto processor = InviwoApplication::getPtr()->getProcessorFactory()->createShared(cid)) {
         return generateProcessorPreview(*processor, opacity);
     } else {
         return QImage{};

--- a/src/qt/editor/toolsmenu.cpp
+++ b/src/qt/editor/toolsmenu.cpp
@@ -93,7 +93,7 @@ void createProcessorDocMenu(InviwoApplication* app, QMenu* docsMenu) {
         for (auto& pfo : processors) {
             auto action = modMenu->addAction(utilqt::toQString(pfo->getDisplayName()));
             docsMenu->connect(action, &QAction::triggered, [pfo, factory]() {
-                const auto processor = factory->create(pfo->getClassIdentifier());
+                const auto processor = factory->createShared(pfo->getClassIdentifier());
                 const auto& inports = processor->getInports();
                 const auto& outports = processor->getOutports();
                 const auto& properties = processor->getPropertiesRecursive();
@@ -331,7 +331,7 @@ ToolsMenu::ToolsMenu(InviwoMainWindow* win) : QMenu(tr("&Tools"), win) {
 
         for (auto&& key : factory->getKeyView()) {
             try {
-                auto processor = factory->create(key, app);
+                auto processor = factory->createShared(key, app);
 
                 size_t indent = 0;
                 LambdaNetworkVisitor visitor{

--- a/tests/integrationtests/processorcreation-test.cpp
+++ b/tests/integrationtests/processorcreation-test.cpp
@@ -87,7 +87,7 @@ TEST_P(ProcessorCreationTests, ProcesorCreateAndResetAndAddToNetwork) {
     LGL_ERROR;
 
     LogErrorCheck checklog(GetParam());
-    auto s = std::shared_ptr<Processor>(factory_->create(GetParam()));
+    auto s = std::shared_ptr<Processor>(factory_->createShared(GetParam()));
 
     LGL_ERROR;
 


### PR DESCRIPTION
The processor factory will now create processors as shared_ptr so begin with. 
Before we only created the shared_ptr later in the processes. That menat that if you tried to use shared_from_this in the constructor that would fail and throw an exception. This will now work. 