### PR TITLE
Core,Qt: prevent processor animation on paste and replace

### DIFF
--- a/include/inviwo/core/network/networkutils.h
+++ b/include/inviwo/core/network/networkutils.h
@@ -34,9 +34,13 @@
 #include <inviwo/core/network/processornetwork.h>
 #include <inviwo/core/util/stdextensions.h>
 
+#include <functional>
+
 namespace inviwo {
 
 namespace util {
+
+using OffsetCallback = std::function<ivec2(std::vector<Processor*>)>;
 
 namespace detail {
 
@@ -44,7 +48,7 @@ namespace detail {
  * Helper class for Copy/Pasting a network with sub parts referring to stuff outside of the network.
  */
 struct PartialProcessorNetwork : public Serializable {
-    PartialProcessorNetwork(ProcessorNetwork* network);
+    PartialProcessorNetwork(ProcessorNetwork* network, OffsetCallback callback = nullptr);
 
     std::vector<Processor*> getAddedProcessors() const;
 
@@ -54,6 +58,7 @@ struct PartialProcessorNetwork : public Serializable {
 private:
     ProcessorNetwork* network_;
     std::vector<Processor*> addedProcessors_;
+    OffsetCallback callback_;
 };
 
 }  // namespace detail
@@ -175,12 +180,13 @@ IVW_CORE_API void serializeSelected(ProcessorNetwork* network, std::ostream& os,
  * @param refPath a possible path to the original file of the PartialProcessorNetwork, for error
  * reporting
  * @param app The inviwo application
+ * @param offsetCallback  callback for determining an offset, which is applied to all added
+ * processors
+ * @return the appended processors.
  */
-// return the appended processors.
-
 IVW_CORE_API std::vector<Processor*> appendPartialProcessorNetwork(
     ProcessorNetwork* network, std::istream& is, const std::filesystem::path& refPath,
-    InviwoApplication* app);
+    InviwoApplication* app, OffsetCallback offsetCallback = nullptr);
 
 IVW_CORE_API std::vector<Processor*> appendProcessorNetwork(
     ProcessorNetwork* destinationNetwork, const std::filesystem::path& workspaceFile,

--- a/include/inviwo/core/network/networkutils.h
+++ b/include/inviwo/core/network/networkutils.h
@@ -36,9 +36,7 @@
 
 #include <functional>
 
-namespace inviwo {
-
-namespace util {
+namespace inviwo::util {
 
 using OffsetCallback = std::function<ivec2(std::vector<Processor*>)>;
 
@@ -48,7 +46,7 @@ namespace detail {
  * Helper class for Copy/Pasting a network with sub parts referring to stuff outside of the network.
  */
 struct PartialProcessorNetwork : public Serializable {
-    PartialProcessorNetwork(ProcessorNetwork* network, OffsetCallback callback = nullptr);
+    explicit PartialProcessorNetwork(ProcessorNetwork* network, OffsetCallback callback = nullptr);
 
     std::vector<Processor*> getAddedProcessors() const;
 
@@ -200,6 +198,4 @@ IVW_CORE_API std::shared_ptr<Processor> replaceProcessor(ProcessorNetwork* netwo
                                                          std::shared_ptr<Processor> newProcessor,
                                                          Processor* oldProcessor);
 
-}  // namespace util
-
-}  // namespace inviwo
+}  // namespace inviwo::util

--- a/include/inviwo/core/processors/processorutils.h
+++ b/include/inviwo/core/processors/processorutils.h
@@ -87,7 +87,7 @@ struct IVW_CORE_API GridPos {
     explicit GridPos(ivec2 pos) : pos_{pos} {}
 
     ivec2 operator+(const ivec2& rhs) const { return operator ivec2() + rhs; }
-    explicit operator ivec2() const { return pos_ * ivec2{25, 25}; }
+    operator ivec2() const { return pos_ * ivec2{25, 25}; }
 
 private:
     ivec2 pos_;

--- a/include/inviwo/core/processors/processorutils.h
+++ b/include/inviwo/core/processors/processorutils.h
@@ -86,6 +86,7 @@ struct IVW_CORE_API GridPos {
     GridPos(int x, int y) : pos_{x, y} {};
     explicit GridPos(ivec2 pos) : pos_{pos} {}
 
+    ivec2 operator+(const ivec2& rhs) { return ivec2(*this) + rhs; }
     operator ivec2() const { return pos_ * ivec2{25, 25}; }
 
 private:

--- a/include/inviwo/core/processors/processorutils.h
+++ b/include/inviwo/core/processors/processorutils.h
@@ -86,8 +86,8 @@ struct IVW_CORE_API GridPos {
     GridPos(int x, int y) : pos_{x, y} {};
     explicit GridPos(ivec2 pos) : pos_{pos} {}
 
-    ivec2 operator+(const ivec2& rhs) { return ivec2(*this) + rhs; }
-    operator ivec2() const { return pos_ * ivec2{25, 25}; }
+    ivec2 operator+(const ivec2& rhs) const { return operator ivec2() + rhs; }
+    explicit operator ivec2() const { return pos_ * ivec2{25, 25}; }
 
 private:
     ivec2 pos_;

--- a/include/inviwo/core/rendering/datavisualizer.h
+++ b/include/inviwo/core/rendering/datavisualizer.h
@@ -98,13 +98,13 @@ public:
      * @param filename The file to load in the source processor. The extension of the filename
      *        should be in the list of extensions returned by getSupportedFileExtensions.
      * @param network The network to add the processor to.
-     * @param initialPos the initial position for the processor
+     * @param origin the initial position for the processor
      * @return The added source processor and the outport in the source processor
      *         containing data from the given file.
      */
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const = 0;
+        const ivec2& origin) const = 0;
     /**
      * Adds a set of processors visualizing the data in the given outport.
      * Nothing will be added to the network if outport is not supported (isOutportSupported returns
@@ -124,12 +124,12 @@ public:
      * @param filename The file to load in the source processor. The extension of the filename
      *        should be in the list of extensions returned by getSupportedFileExtensions.
      * @param network The network to add the processor to.
-     * @param initialPos the initial position for the visualizer network
+     * @param origin the initial position for the visualizer network
      * @return A list of added processors.
      */
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const = 0;
+        const ivec2& origin) const = 0;
 };
 
 }  // namespace inviwo

--- a/include/inviwo/core/rendering/datavisualizer.h
+++ b/include/inviwo/core/rendering/datavisualizer.h
@@ -98,11 +98,13 @@ public:
      * @param filename The file to load in the source processor. The extension of the filename
      *        should be in the list of extensions returned by getSupportedFileExtensions.
      * @param network The network to add the processor to.
+     * @param initialPos the initial position for the processor
      * @return The added source processor and the outport in the source processor
      *         containing data from the given file.
      */
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const = 0;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const = 0;
     /**
      * Adds a set of processors visualizing the data in the given outport.
      * Nothing will be added to the network if outport is not supported (isOutportSupported returns
@@ -122,10 +124,12 @@ public:
      * @param filename The file to load in the source processor. The extension of the filename
      *        should be in the list of extensions returned by getSupportedFileExtensions.
      * @param network The network to add the processor to.
+     * @param initialPos the initial position for the visualizer network
      * @return A list of added processors.
      */
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const = 0;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const = 0;
 };
 
 }  // namespace inviwo

--- a/modules/base/include/modules/base/datavisualizer/imageinformationvisualizer.h
+++ b/modules/base/include/modules/base/datavisualizer/imageinformationvisualizer.h
@@ -59,12 +59,12 @@ public:
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/base/include/modules/base/datavisualizer/imageinformationvisualizer.h
+++ b/modules/base/include/modules/base/datavisualizer/imageinformationvisualizer.h
@@ -58,11 +58,13 @@ public:
     virtual bool hasVisualizerNetwork() const override;
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/base/include/modules/base/datavisualizer/imagetolayervisualizer.h
+++ b/modules/base/include/modules/base/datavisualizer/imagetolayervisualizer.h
@@ -55,11 +55,13 @@ public:
     virtual bool hasVisualizerNetwork() const override;
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
 };
 
 }  // namespace inviwo

--- a/modules/base/include/modules/base/datavisualizer/imagetolayervisualizer.h
+++ b/modules/base/include/modules/base/datavisualizer/imagetolayervisualizer.h
@@ -56,12 +56,12 @@ public:
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
 };
 
 }  // namespace inviwo

--- a/modules/base/include/modules/base/datavisualizer/layerinformationvisualizer.h
+++ b/modules/base/include/modules/base/datavisualizer/layerinformationvisualizer.h
@@ -56,12 +56,12 @@ public:
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/base/include/modules/base/datavisualizer/layerinformationvisualizer.h
+++ b/modules/base/include/modules/base/datavisualizer/layerinformationvisualizer.h
@@ -55,11 +55,13 @@ public:
     virtual bool hasVisualizerNetwork() const override;
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/base/include/modules/base/datavisualizer/layertoimagevisualizer.h
+++ b/modules/base/include/modules/base/datavisualizer/layertoimagevisualizer.h
@@ -55,11 +55,13 @@ public:
     virtual bool hasVisualizerNetwork() const override;
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
 };
 
 }  // namespace inviwo

--- a/modules/base/include/modules/base/datavisualizer/layertoimagevisualizer.h
+++ b/modules/base/include/modules/base/datavisualizer/layertoimagevisualizer.h
@@ -56,12 +56,12 @@ public:
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
 };
 
 }  // namespace inviwo

--- a/modules/base/include/modules/base/datavisualizer/meshinformationvisualizer.h
+++ b/modules/base/include/modules/base/datavisualizer/meshinformationvisualizer.h
@@ -59,12 +59,12 @@ public:
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/base/include/modules/base/datavisualizer/meshinformationvisualizer.h
+++ b/modules/base/include/modules/base/datavisualizer/meshinformationvisualizer.h
@@ -58,11 +58,13 @@ public:
     virtual bool hasVisualizerNetwork() const override;
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/base/include/modules/base/datavisualizer/volumeinformationvisualizer.h
+++ b/modules/base/include/modules/base/datavisualizer/volumeinformationvisualizer.h
@@ -59,12 +59,12 @@ public:
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/base/include/modules/base/datavisualizer/volumeinformationvisualizer.h
+++ b/modules/base/include/modules/base/datavisualizer/volumeinformationvisualizer.h
@@ -58,11 +58,13 @@ public:
     virtual bool hasVisualizerNetwork() const override;
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/base/src/datavisualizer/imageinformationvisualizer.cpp
+++ b/modules/base/src/datavisualizer/imageinformationvisualizer.cpp
@@ -85,8 +85,9 @@ std::pair<Processor*, Outport*> ImageInformationVisualizer::addSourceProcessor(
 
 std::vector<Processor*> ImageInformationVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* net) const {
+    const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto info = net->addProcessor(util::makeProcessor<ImageInformation>(GP{0, 3}));
+    auto info = net->addProcessor(util::makeProcessor<ImageInformation>(GP{0, 3} + initialPos));
     net->addConnection(outport, info->getInports()[0]);
 
     return {info};

--- a/modules/base/src/datavisualizer/imageinformationvisualizer.cpp
+++ b/modules/base/src/datavisualizer/imageinformationvisualizer.cpp
@@ -76,10 +76,11 @@ bool ImageInformationVisualizer::hasSourceProcessor() const { return true; }
 bool ImageInformationVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> ImageInformationVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
 
-    auto source = net->addProcessor(util::makeProcessor<ImageSource>(GP{0, 0}, app_, filename));
-    auto outport = source->getOutports().front();
+    auto* source =
+        net->addProcessor(util::makeProcessor<ImageSource>(GP{0, 0} + initialPos, app_, filename));
+    auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
@@ -87,16 +88,16 @@ std::vector<Processor*> ImageInformationVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* net) const {
     const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto info = net->addProcessor(util::makeProcessor<ImageInformation>(GP{0, 3} + initialPos));
+    auto* info = net->addProcessor(util::makeProcessor<ImageInformation>(GP{0, 3} + initialPos));
     net->addConnection(outport, info->getInports()[0]);
 
     return {info};
 }
 
 std::vector<Processor*> ImageInformationVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, net);
+    auto sourceAndOutport = addSourceProcessor(filename, net, initialPos);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
 
     processors.push_back(sourceAndOutport.first);

--- a/modules/base/src/datavisualizer/imageinformationvisualizer.cpp
+++ b/modules/base/src/datavisualizer/imageinformationvisualizer.cpp
@@ -76,28 +76,28 @@ bool ImageInformationVisualizer::hasSourceProcessor() const { return true; }
 bool ImageInformationVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> ImageInformationVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
 
     auto* source =
-        net->addProcessor(util::makeProcessor<ImageSource>(GP{0, 0} + initialPos, app_, filename));
+        net->addProcessor(util::makeProcessor<ImageSource>(GP{0, 0} + origin, app_, filename));
     auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
 std::vector<Processor*> ImageInformationVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* net) const {
-    const ivec2 initialPos = util::getPosition(outport->getProcessor());
+    const ivec2 origin = util::getPosition(outport->getProcessor());
 
-    auto* info = net->addProcessor(util::makeProcessor<ImageInformation>(GP{0, 3} + initialPos));
+    auto* info = net->addProcessor(util::makeProcessor<ImageInformation>(GP{0, 3} + origin));
     net->addConnection(outport, info->getInports()[0]);
 
     return {info};
 }
 
 std::vector<Processor*> ImageInformationVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, net, initialPos);
+    auto sourceAndOutport = addSourceProcessor(filename, net, origin);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
 
     processors.push_back(sourceAndOutport.first);

--- a/modules/base/src/datavisualizer/imagetolayervisualizer.cpp
+++ b/modules/base/src/datavisualizer/imagetolayervisualizer.cpp
@@ -81,7 +81,7 @@ std::vector<Processor*> ImageToLayerVisualizer::addVisualizerNetwork(Outport* ou
 
 std::vector<Processor*> ImageToLayerVisualizer::addSourceAndVisualizerNetwork(
     const std::filesystem::path&, ProcessorNetwork*, const ivec2&) const {
-    return {nullptr};
+    return {};
 }
 
 }  // namespace inviwo

--- a/modules/base/src/datavisualizer/imagetolayervisualizer.cpp
+++ b/modules/base/src/datavisualizer/imagetolayervisualizer.cpp
@@ -65,7 +65,7 @@ bool ImageToLayerVisualizer::hasSourceProcessor() const { return false; }
 bool ImageToLayerVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> ImageToLayerVisualizer::addSourceProcessor(
-    const std::filesystem::path&, ProcessorNetwork*) const {
+    const std::filesystem::path&, ProcessorNetwork*, const ivec2&) const {
     return {nullptr, nullptr};
 }
 
@@ -73,21 +73,15 @@ std::vector<Processor*> ImageToLayerVisualizer::addVisualizerNetwork(Outport* ou
                                                                      ProcessorNetwork* net) const {
     const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto info = net->addProcessor(util::makeProcessor<ImageToLayer>(GP{0, 3} + initialPos));
+    auto* info = net->addProcessor(util::makeProcessor<ImageToLayer>(GP{0, 3} + initialPos));
     net->addConnection(outport, info->getInports()[0]);
 
     return {info};
 }
 
 std::vector<Processor*> ImageToLayerVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
-
-    auto sourceAndOutport = addSourceProcessor(filename, net);
-    auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
-
-    processors.push_back(sourceAndOutport.first);
-
-    return processors;
+    const std::filesystem::path&, ProcessorNetwork*, const ivec2&) const {
+    return {nullptr};
 }
 
 }  // namespace inviwo

--- a/modules/base/src/datavisualizer/imagetolayervisualizer.cpp
+++ b/modules/base/src/datavisualizer/imagetolayervisualizer.cpp
@@ -71,8 +71,9 @@ std::pair<Processor*, Outport*> ImageToLayerVisualizer::addSourceProcessor(
 
 std::vector<Processor*> ImageToLayerVisualizer::addVisualizerNetwork(Outport* outport,
                                                                      ProcessorNetwork* net) const {
+    const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto info = net->addProcessor(util::makeProcessor<ImageToLayer>(GP{0, 3}));
+    auto info = net->addProcessor(util::makeProcessor<ImageToLayer>(GP{0, 3} + initialPos));
     net->addConnection(outport, info->getInports()[0]);
 
     return {info};

--- a/modules/base/src/datavisualizer/layerinformationvisualizer.cpp
+++ b/modules/base/src/datavisualizer/layerinformationvisualizer.cpp
@@ -72,10 +72,11 @@ bool LayerInformationVisualizer::hasSourceProcessor() const { return true; }
 bool LayerInformationVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> LayerInformationVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
 
-    auto source = net->addProcessor(util::makeProcessor<LayerSource>(GP{0, 0}, app_, filename));
-    auto outport = source->getOutports().front();
+    auto* source =
+        net->addProcessor(util::makeProcessor<LayerSource>(GP{0, 0} + initialPos, app_, filename));
+    auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
@@ -83,16 +84,16 @@ std::vector<Processor*> LayerInformationVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* net) const {
     const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto info = net->addProcessor(util::makeProcessor<LayerInformation>(GP{0, 3} + initialPos));
+    auto* info = net->addProcessor(util::makeProcessor<LayerInformation>(GP{0, 3} + initialPos));
     net->addConnection(outport, info->getInports()[0]);
 
     return {info};
 }
 
 std::vector<Processor*> LayerInformationVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, net);
+    auto sourceAndOutport = addSourceProcessor(filename, net, initialPos);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
 
     processors.push_back(sourceAndOutport.first);

--- a/modules/base/src/datavisualizer/layerinformationvisualizer.cpp
+++ b/modules/base/src/datavisualizer/layerinformationvisualizer.cpp
@@ -72,28 +72,28 @@ bool LayerInformationVisualizer::hasSourceProcessor() const { return true; }
 bool LayerInformationVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> LayerInformationVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
 
     auto* source =
-        net->addProcessor(util::makeProcessor<LayerSource>(GP{0, 0} + initialPos, app_, filename));
+        net->addProcessor(util::makeProcessor<LayerSource>(GP{0, 0} + origin, app_, filename));
     auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
 std::vector<Processor*> LayerInformationVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* net) const {
-    const ivec2 initialPos = util::getPosition(outport->getProcessor());
+    const ivec2 origin = util::getPosition(outport->getProcessor());
 
-    auto* info = net->addProcessor(util::makeProcessor<LayerInformation>(GP{0, 3} + initialPos));
+    auto* info = net->addProcessor(util::makeProcessor<LayerInformation>(GP{0, 3} + origin));
     net->addConnection(outport, info->getInports()[0]);
 
     return {info};
 }
 
 std::vector<Processor*> LayerInformationVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, net, initialPos);
+    auto sourceAndOutport = addSourceProcessor(filename, net, origin);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
 
     processors.push_back(sourceAndOutport.first);

--- a/modules/base/src/datavisualizer/layerinformationvisualizer.cpp
+++ b/modules/base/src/datavisualizer/layerinformationvisualizer.cpp
@@ -81,8 +81,9 @@ std::pair<Processor*, Outport*> LayerInformationVisualizer::addSourceProcessor(
 
 std::vector<Processor*> LayerInformationVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* net) const {
+    const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto info = net->addProcessor(util::makeProcessor<LayerInformation>(GP{0, 3}));
+    auto info = net->addProcessor(util::makeProcessor<LayerInformation>(GP{0, 3} + initialPos));
     net->addConnection(outport, info->getInports()[0]);
 
     return {info};

--- a/modules/base/src/datavisualizer/layertoimagevisualizer.cpp
+++ b/modules/base/src/datavisualizer/layertoimagevisualizer.cpp
@@ -65,7 +65,7 @@ bool LayerToImageVisualizer::hasSourceProcessor() const { return false; }
 bool LayerToImageVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> LayerToImageVisualizer::addSourceProcessor(
-    const std::filesystem::path&, ProcessorNetwork*) const {
+    const std::filesystem::path&, ProcessorNetwork*, const ivec2&) const {
     return {nullptr, nullptr};
 }
 
@@ -73,21 +73,15 @@ std::vector<Processor*> LayerToImageVisualizer::addVisualizerNetwork(Outport* ou
                                                                      ProcessorNetwork* net) const {
     const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto info = net->addProcessor(util::makeProcessor<LayerToImage>(GP{0, 3} + initialPos));
+    auto* info = net->addProcessor(util::makeProcessor<LayerToImage>(GP{0, 3} + initialPos));
     net->addConnection(outport, info->getInports()[0]);
 
     return {info};
 }
 
 std::vector<Processor*> LayerToImageVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
-
-    auto sourceAndOutport = addSourceProcessor(filename, net);
-    auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
-
-    processors.push_back(sourceAndOutport.first);
-
-    return processors;
+    const std::filesystem::path&, ProcessorNetwork*, const ivec2&) const {
+    return {nullptr};
 }
 
 }  // namespace inviwo

--- a/modules/base/src/datavisualizer/layertoimagevisualizer.cpp
+++ b/modules/base/src/datavisualizer/layertoimagevisualizer.cpp
@@ -71,8 +71,9 @@ std::pair<Processor*, Outport*> LayerToImageVisualizer::addSourceProcessor(
 
 std::vector<Processor*> LayerToImageVisualizer::addVisualizerNetwork(Outport* outport,
                                                                      ProcessorNetwork* net) const {
+    const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto info = net->addProcessor(util::makeProcessor<LayerToImage>(GP{0, 3}));
+    auto info = net->addProcessor(util::makeProcessor<LayerToImage>(GP{0, 3} + initialPos));
     net->addConnection(outport, info->getInports()[0]);
 
     return {info};

--- a/modules/base/src/datavisualizer/layertoimagevisualizer.cpp
+++ b/modules/base/src/datavisualizer/layertoimagevisualizer.cpp
@@ -81,7 +81,7 @@ std::vector<Processor*> LayerToImageVisualizer::addVisualizerNetwork(Outport* ou
 
 std::vector<Processor*> LayerToImageVisualizer::addSourceAndVisualizerNetwork(
     const std::filesystem::path&, ProcessorNetwork*, const ivec2&) const {
-    return {nullptr};
+    return {};
 }
 
 }  // namespace inviwo

--- a/modules/base/src/datavisualizer/meshinformationvisualizer.cpp
+++ b/modules/base/src/datavisualizer/meshinformationvisualizer.cpp
@@ -76,10 +76,11 @@ bool MeshInformationVisualizer::hasSourceProcessor() const { return true; }
 bool MeshInformationVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> MeshInformationVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
 
-    auto source = net->addProcessor(util::makeProcessor<MeshSource>(GP{0, 0}, app_, filename));
-    auto outport = source->getOutports().front();
+    auto* source =
+        net->addProcessor(util::makeProcessor<MeshSource>(GP{0, 0} + initialPos, app_, filename));
+    auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
@@ -87,7 +88,7 @@ std::vector<Processor*> MeshInformationVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* net) const {
     const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto info = net->addProcessor(util::makeProcessor<MeshInformation>(GP{0, 3} + initialPos));
+    auto* info = net->addProcessor(util::makeProcessor<MeshInformation>(GP{0, 3} + initialPos));
 
     net->addConnection(outport, info->getInports()[0]);
 
@@ -95,9 +96,9 @@ std::vector<Processor*> MeshInformationVisualizer::addVisualizerNetwork(
 }
 
 std::vector<Processor*> MeshInformationVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, net);
+    auto sourceAndOutport = addSourceProcessor(filename, net, initialPos);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
 
     processors.push_back(sourceAndOutport.first);

--- a/modules/base/src/datavisualizer/meshinformationvisualizer.cpp
+++ b/modules/base/src/datavisualizer/meshinformationvisualizer.cpp
@@ -85,8 +85,9 @@ std::pair<Processor*, Outport*> MeshInformationVisualizer::addSourceProcessor(
 
 std::vector<Processor*> MeshInformationVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* net) const {
+    const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto info = net->addProcessor(util::makeProcessor<MeshInformation>(GP{0, 3}));
+    auto info = net->addProcessor(util::makeProcessor<MeshInformation>(GP{0, 3} + initialPos));
 
     net->addConnection(outport, info->getInports()[0]);
 

--- a/modules/base/src/datavisualizer/meshinformationvisualizer.cpp
+++ b/modules/base/src/datavisualizer/meshinformationvisualizer.cpp
@@ -76,19 +76,19 @@ bool MeshInformationVisualizer::hasSourceProcessor() const { return true; }
 bool MeshInformationVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> MeshInformationVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
 
     auto* source =
-        net->addProcessor(util::makeProcessor<MeshSource>(GP{0, 0} + initialPos, app_, filename));
+        net->addProcessor(util::makeProcessor<MeshSource>(GP{0, 0} + origin, app_, filename));
     auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
 std::vector<Processor*> MeshInformationVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* net) const {
-    const ivec2 initialPos = util::getPosition(outport->getProcessor());
+    const ivec2 origin = util::getPosition(outport->getProcessor());
 
-    auto* info = net->addProcessor(util::makeProcessor<MeshInformation>(GP{0, 3} + initialPos));
+    auto* info = net->addProcessor(util::makeProcessor<MeshInformation>(GP{0, 3} + origin));
 
     net->addConnection(outport, info->getInports()[0]);
 
@@ -96,9 +96,9 @@ std::vector<Processor*> MeshInformationVisualizer::addVisualizerNetwork(
 }
 
 std::vector<Processor*> MeshInformationVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, net, initialPos);
+    auto sourceAndOutport = addSourceProcessor(filename, net, origin);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
 
     processors.push_back(sourceAndOutport.first);

--- a/modules/base/src/datavisualizer/volumeinformationvisualizer.cpp
+++ b/modules/base/src/datavisualizer/volumeinformationvisualizer.cpp
@@ -87,7 +87,9 @@ std::pair<Processor*, Outport*> VolumeInformationVisualizer::addSourceProcessor(
 
 std::vector<Processor*> VolumeInformationVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* net) const {
-    auto info = net->addProcessor(util::makeProcessor<VolumeInformation>(GP{0, 3}));
+    const ivec2 initialPos = util::getPosition(outport->getProcessor());
+
+    auto info = net->addProcessor(util::makeProcessor<VolumeInformation>(GP{0, 3} + initialPos));
 
     net->addConnection(outport, info->getInports()[0]);
 

--- a/modules/base/src/datavisualizer/volumeinformationvisualizer.cpp
+++ b/modules/base/src/datavisualizer/volumeinformationvisualizer.cpp
@@ -78,10 +78,11 @@ bool VolumeInformationVisualizer::hasSourceProcessor() const { return true; }
 bool VolumeInformationVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> VolumeInformationVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
 
-    auto source = net->addProcessor(util::makeProcessor<VolumeSource>(GP{0, 0}, app_, filename));
-    auto outport = source->getOutports().front();
+    auto* source =
+        net->addProcessor(util::makeProcessor<VolumeSource>(GP{0, 0} + initialPos, app_, filename));
+    auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
@@ -89,7 +90,7 @@ std::vector<Processor*> VolumeInformationVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* net) const {
     const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto info = net->addProcessor(util::makeProcessor<VolumeInformation>(GP{0, 3} + initialPos));
+    auto* info = net->addProcessor(util::makeProcessor<VolumeInformation>(GP{0, 3} + initialPos));
 
     net->addConnection(outport, info->getInports()[0]);
 
@@ -97,9 +98,9 @@ std::vector<Processor*> VolumeInformationVisualizer::addVisualizerNetwork(
 }
 
 std::vector<Processor*> VolumeInformationVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, net);
+    auto sourceAndOutport = addSourceProcessor(filename, net, initialPos);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
 
     processors.push_back(sourceAndOutport.first);

--- a/modules/base/src/datavisualizer/volumeinformationvisualizer.cpp
+++ b/modules/base/src/datavisualizer/volumeinformationvisualizer.cpp
@@ -78,19 +78,19 @@ bool VolumeInformationVisualizer::hasSourceProcessor() const { return true; }
 bool VolumeInformationVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> VolumeInformationVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
 
     auto* source =
-        net->addProcessor(util::makeProcessor<VolumeSource>(GP{0, 0} + initialPos, app_, filename));
+        net->addProcessor(util::makeProcessor<VolumeSource>(GP{0, 0} + origin, app_, filename));
     auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
 std::vector<Processor*> VolumeInformationVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* net) const {
-    const ivec2 initialPos = util::getPosition(outport->getProcessor());
+    const ivec2 origin = util::getPosition(outport->getProcessor());
 
-    auto* info = net->addProcessor(util::makeProcessor<VolumeInformation>(GP{0, 3} + initialPos));
+    auto* info = net->addProcessor(util::makeProcessor<VolumeInformation>(GP{0, 3} + origin));
 
     net->addConnection(outport, info->getInports()[0]);
 
@@ -98,9 +98,9 @@ std::vector<Processor*> VolumeInformationVisualizer::addVisualizerNetwork(
 }
 
 std::vector<Processor*> VolumeInformationVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, net, initialPos);
+    auto sourceAndOutport = addSourceProcessor(filename, net, origin);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
 
     processors.push_back(sourceAndOutport.first);

--- a/modules/basegl/include/modules/basegl/datavisualizer/imagebackgroundvisualizer.h
+++ b/modules/basegl/include/modules/basegl/datavisualizer/imagebackgroundvisualizer.h
@@ -59,12 +59,12 @@ public:
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/basegl/include/modules/basegl/datavisualizer/imagebackgroundvisualizer.h
+++ b/modules/basegl/include/modules/basegl/datavisualizer/imagebackgroundvisualizer.h
@@ -58,11 +58,13 @@ public:
     virtual bool hasVisualizerNetwork() const override;
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/basegl/include/modules/basegl/datavisualizer/imagevisualizer.h
+++ b/modules/basegl/include/modules/basegl/datavisualizer/imagevisualizer.h
@@ -59,11 +59,13 @@ public:
     virtual bool hasVisualizerNetwork() const override;
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/basegl/include/modules/basegl/datavisualizer/imagevisualizer.h
+++ b/modules/basegl/include/modules/basegl/datavisualizer/imagevisualizer.h
@@ -60,12 +60,12 @@ public:
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/basegl/include/modules/basegl/datavisualizer/layervisualizer.h
+++ b/modules/basegl/include/modules/basegl/datavisualizer/layervisualizer.h
@@ -56,12 +56,12 @@ public:
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/basegl/include/modules/basegl/datavisualizer/layervisualizer.h
+++ b/modules/basegl/include/modules/basegl/datavisualizer/layervisualizer.h
@@ -55,11 +55,13 @@ public:
     virtual bool hasVisualizerNetwork() const override;
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/basegl/include/modules/basegl/datavisualizer/meshvisualizer.h
+++ b/modules/basegl/include/modules/basegl/datavisualizer/meshvisualizer.h
@@ -59,12 +59,12 @@ public:
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/basegl/include/modules/basegl/datavisualizer/meshvisualizer.h
+++ b/modules/basegl/include/modules/basegl/datavisualizer/meshvisualizer.h
@@ -58,11 +58,13 @@ public:
     virtual bool hasVisualizerNetwork() const override;
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/basegl/include/modules/basegl/datavisualizer/volumeraycastvisualizer.h
+++ b/modules/basegl/include/modules/basegl/datavisualizer/volumeraycastvisualizer.h
@@ -59,11 +59,13 @@ public:
     virtual bool hasVisualizerNetwork() const override;
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/basegl/include/modules/basegl/datavisualizer/volumeraycastvisualizer.h
+++ b/modules/basegl/include/modules/basegl/datavisualizer/volumeraycastvisualizer.h
@@ -60,12 +60,12 @@ public:
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/basegl/include/modules/basegl/datavisualizer/volumeslicevisualizer.h
+++ b/modules/basegl/include/modules/basegl/datavisualizer/volumeslicevisualizer.h
@@ -59,11 +59,13 @@ public:
     virtual bool hasVisualizerNetwork() const override;
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/basegl/include/modules/basegl/datavisualizer/volumeslicevisualizer.h
+++ b/modules/basegl/include/modules/basegl/datavisualizer/volumeslicevisualizer.h
@@ -60,12 +60,12 @@ public:
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/basegl/src/datavisualizer/imagebackgroundvisualizer.cpp
+++ b/modules/basegl/src/datavisualizer/imagebackgroundvisualizer.cpp
@@ -81,24 +81,24 @@ bool ImageBackgroundVisualizer::hasSourceProcessor() const { return true; }
 bool ImageBackgroundVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> ImageBackgroundVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
 
     auto* source =
-        net->addProcessor(util::makeProcessor<ImageSource>(GP{0, 0} + initialPos, app_, filename));
+        net->addProcessor(util::makeProcessor<ImageSource>(GP{0, 0} + origin, app_, filename));
     auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
 std::vector<Processor*> ImageBackgroundVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* net) const {
-    const ivec2 initialPos = util::getPosition(outport->getProcessor());
+    const ivec2 origin = util::getPosition(outport->getProcessor());
 
-    auto proc = util::makeProcessor<Background>(GP{0, 3} + initialPos);
+    auto proc = util::makeProcessor<Background>(GP{0, 3} + origin);
     proc->backgroundStyle_.setSelectedValue(Background::BackgroundStyle::Uniform);
     proc->bgColor1_ = vec4{1.0f, 1.0f, 1.0f, 1.0f};
     proc->blendMode_.setSelectedValue(Background::BlendMode::AlphaMixing);
     auto* bg = net->addProcessor(std::move(proc));
-    auto* cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 6} + initialPos));
+    auto* cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 6} + origin));
     net->addConnection(outport, bg->getInports()[0]);
     net->addConnection(bg->getOutports()[0], cvs->getInports()[0]);
 
@@ -110,9 +110,9 @@ std::vector<Processor*> ImageBackgroundVisualizer::addVisualizerNetwork(
 }
 
 std::vector<Processor*> ImageBackgroundVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, net, initialPos);
+    auto sourceAndOutport = addSourceProcessor(filename, net, origin);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
 
     net->addLink(sourceAndOutport.first->getPropertyByIdentifier("imageDimension_"),

--- a/modules/basegl/src/datavisualizer/imagebackgroundvisualizer.cpp
+++ b/modules/basegl/src/datavisualizer/imagebackgroundvisualizer.cpp
@@ -81,10 +81,11 @@ bool ImageBackgroundVisualizer::hasSourceProcessor() const { return true; }
 bool ImageBackgroundVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> ImageBackgroundVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
 
-    auto source = net->addProcessor(util::makeProcessor<ImageSource>(GP{0, 0}, app_, filename));
-    auto outport = source->getOutports().front();
+    auto* source =
+        net->addProcessor(util::makeProcessor<ImageSource>(GP{0, 0} + initialPos, app_, filename));
+    auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
@@ -96,12 +97,12 @@ std::vector<Processor*> ImageBackgroundVisualizer::addVisualizerNetwork(
     proc->backgroundStyle_.setSelectedValue(Background::BackgroundStyle::Uniform);
     proc->bgColor1_ = vec4{1.0f, 1.0f, 1.0f, 1.0f};
     proc->blendMode_.setSelectedValue(Background::BlendMode::AlphaMixing);
-    auto bg = net->addProcessor(std::move(proc));
-    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 6} + initialPos));
+    auto* bg = net->addProcessor(std::move(proc));
+    auto* cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 6} + initialPos));
     net->addConnection(outport, bg->getInports()[0]);
     net->addConnection(bg->getOutports()[0], cvs->getInports()[0]);
 
-    if (auto canvas = dynamic_cast<CanvasProcessor*>(cvs)) {
+    if (auto* canvas = dynamic_cast<CanvasProcessor*>(cvs)) {
         canvas->setCanvasSize(size2_t{768, 768});
     }
 
@@ -109,9 +110,9 @@ std::vector<Processor*> ImageBackgroundVisualizer::addVisualizerNetwork(
 }
 
 std::vector<Processor*> ImageBackgroundVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, net);
+    auto sourceAndOutport = addSourceProcessor(filename, net, initialPos);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
 
     net->addLink(sourceAndOutport.first->getPropertyByIdentifier("imageDimension_"),

--- a/modules/basegl/src/datavisualizer/imagebackgroundvisualizer.cpp
+++ b/modules/basegl/src/datavisualizer/imagebackgroundvisualizer.cpp
@@ -90,13 +90,14 @@ std::pair<Processor*, Outport*> ImageBackgroundVisualizer::addSourceProcessor(
 
 std::vector<Processor*> ImageBackgroundVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* net) const {
+    const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto proc = util::makeProcessor<Background>(GP{0, 3});
+    auto proc = util::makeProcessor<Background>(GP{0, 3} + initialPos);
     proc->backgroundStyle_.setSelectedValue(Background::BackgroundStyle::Uniform);
     proc->bgColor1_ = vec4{1.0f, 1.0f, 1.0f, 1.0f};
     proc->blendMode_.setSelectedValue(Background::BlendMode::AlphaMixing);
     auto bg = net->addProcessor(std::move(proc));
-    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 6}));
+    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 6} + initialPos));
     net->addConnection(outport, bg->getInports()[0]);
     net->addConnection(bg->getOutports()[0], cvs->getInports()[0]);
 

--- a/modules/basegl/src/datavisualizer/imagevisualizer.cpp
+++ b/modules/basegl/src/datavisualizer/imagevisualizer.cpp
@@ -75,10 +75,11 @@ bool ImageVisualizer::hasSourceProcessor() const { return true; }
 bool ImageVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> ImageVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
 
-    auto source = net->addProcessor(util::makeProcessor<ImageSource>(GP{0, 0}, app_, filename));
-    auto outport = source->getOutports().front();
+    auto* source =
+        net->addProcessor(util::makeProcessor<ImageSource>(GP{0, 0} + initialPos, app_, filename));
+    auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
@@ -86,10 +87,10 @@ std::vector<Processor*> ImageVisualizer::addVisualizerNetwork(Outport* outport,
                                                               ProcessorNetwork* net) const {
     const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 3} + initialPos));
+    auto* cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 3} + initialPos));
     net->addConnection(outport, cvs->getInports()[0]);
 
-    if (auto canvas = dynamic_cast<CanvasProcessor*>(cvs)) {
+    if (auto* canvas = dynamic_cast<CanvasProcessor*>(cvs)) {
         canvas->setCanvasSize(size2_t{768, 768});
     }
 
@@ -97,9 +98,9 @@ std::vector<Processor*> ImageVisualizer::addVisualizerNetwork(Outport* outport,
 }
 
 std::vector<Processor*> ImageVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, net);
+    auto sourceAndOutport = addSourceProcessor(filename, net, initialPos);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
 
     net->addLink(sourceAndOutport.first->getPropertyByIdentifier("imageDimension_"),

--- a/modules/basegl/src/datavisualizer/imagevisualizer.cpp
+++ b/modules/basegl/src/datavisualizer/imagevisualizer.cpp
@@ -84,8 +84,9 @@ std::pair<Processor*, Outport*> ImageVisualizer::addSourceProcessor(
 
 std::vector<Processor*> ImageVisualizer::addVisualizerNetwork(Outport* outport,
                                                               ProcessorNetwork* net) const {
+    const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 3}));
+    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 3} + initialPos));
     net->addConnection(outport, cvs->getInports()[0]);
 
     if (auto canvas = dynamic_cast<CanvasProcessor*>(cvs)) {

--- a/modules/basegl/src/datavisualizer/imagevisualizer.cpp
+++ b/modules/basegl/src/datavisualizer/imagevisualizer.cpp
@@ -75,19 +75,19 @@ bool ImageVisualizer::hasSourceProcessor() const { return true; }
 bool ImageVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> ImageVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
 
     auto* source =
-        net->addProcessor(util::makeProcessor<ImageSource>(GP{0, 0} + initialPos, app_, filename));
+        net->addProcessor(util::makeProcessor<ImageSource>(GP{0, 0} + origin, app_, filename));
     auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
 std::vector<Processor*> ImageVisualizer::addVisualizerNetwork(Outport* outport,
                                                               ProcessorNetwork* net) const {
-    const ivec2 initialPos = util::getPosition(outport->getProcessor());
+    const ivec2 origin = util::getPosition(outport->getProcessor());
 
-    auto* cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 3} + initialPos));
+    auto* cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 3} + origin));
     net->addConnection(outport, cvs->getInports()[0]);
 
     if (auto* canvas = dynamic_cast<CanvasProcessor*>(cvs)) {
@@ -98,9 +98,9 @@ std::vector<Processor*> ImageVisualizer::addVisualizerNetwork(Outport* outport,
 }
 
 std::vector<Processor*> ImageVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, net, initialPos);
+    auto sourceAndOutport = addSourceProcessor(filename, net, origin);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
 
     net->addLink(sourceAndOutport.first->getPropertyByIdentifier("imageDimension_"),

--- a/modules/basegl/src/datavisualizer/layervisualizer.cpp
+++ b/modules/basegl/src/datavisualizer/layervisualizer.cpp
@@ -75,21 +75,21 @@ bool LayerVisualizer::hasSourceProcessor() const { return true; }
 bool LayerVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> LayerVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
 
     auto* source =
-        net->addProcessor(util::makeProcessor<LayerSource>(GP{0, 0} + initialPos, app_, filename));
+        net->addProcessor(util::makeProcessor<LayerSource>(GP{0, 0} + origin, app_, filename));
     auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
 std::vector<Processor*> LayerVisualizer::addVisualizerNetwork(Outport* outport,
                                                               ProcessorNetwork* net) const {
-    const ivec2 initialPos = util::getPosition(outport->getProcessor());
+    const ivec2 origin = util::getPosition(outport->getProcessor());
 
-    auto* bak = net->addProcessor(util::makeProcessor<Background>(GP{1, 3} + initialPos));
-    auto* mrp = net->addProcessor(util::makeProcessor<LayerRenderer>(GP{0, 6} + initialPos));
-    auto* cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 9} + initialPos));
+    auto* bak = net->addProcessor(util::makeProcessor<Background>(GP{1, 3} + origin));
+    auto* mrp = net->addProcessor(util::makeProcessor<LayerRenderer>(GP{0, 6} + origin));
+    auto* cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 9} + origin));
 
     net->addConnection(bak->getOutports()[0], mrp->getInports()[1]);
     net->addConnection(mrp->getOutports()[0], cvs->getInports()[0]);
@@ -100,9 +100,9 @@ std::vector<Processor*> LayerVisualizer::addVisualizerNetwork(Outport* outport,
 }
 
 std::vector<Processor*> LayerVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, net, initialPos);
+    auto sourceAndOutport = addSourceProcessor(filename, net, origin);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
 
     processors.push_back(sourceAndOutport.first);

--- a/modules/basegl/src/datavisualizer/layervisualizer.cpp
+++ b/modules/basegl/src/datavisualizer/layervisualizer.cpp
@@ -75,10 +75,11 @@ bool LayerVisualizer::hasSourceProcessor() const { return true; }
 bool LayerVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> LayerVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
 
-    auto source = net->addProcessor(util::makeProcessor<LayerSource>(GP{0, 0}, app_, filename));
-    auto outport = source->getOutports().front();
+    auto* source =
+        net->addProcessor(util::makeProcessor<LayerSource>(GP{0, 0} + initialPos, app_, filename));
+    auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
@@ -86,9 +87,9 @@ std::vector<Processor*> LayerVisualizer::addVisualizerNetwork(Outport* outport,
                                                               ProcessorNetwork* net) const {
     const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto bak = net->addProcessor(util::makeProcessor<Background>(GP{1, 3} + initialPos));
-    auto mrp = net->addProcessor(util::makeProcessor<LayerRenderer>(GP{0, 6} + initialPos));
-    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 9} + initialPos));
+    auto* bak = net->addProcessor(util::makeProcessor<Background>(GP{1, 3} + initialPos));
+    auto* mrp = net->addProcessor(util::makeProcessor<LayerRenderer>(GP{0, 6} + initialPos));
+    auto* cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 9} + initialPos));
 
     net->addConnection(bak->getOutports()[0], mrp->getInports()[1]);
     net->addConnection(mrp->getOutports()[0], cvs->getInports()[0]);
@@ -99,9 +100,9 @@ std::vector<Processor*> LayerVisualizer::addVisualizerNetwork(Outport* outport,
 }
 
 std::vector<Processor*> LayerVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, net);
+    auto sourceAndOutport = addSourceProcessor(filename, net, initialPos);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
 
     processors.push_back(sourceAndOutport.first);

--- a/modules/basegl/src/datavisualizer/layervisualizer.cpp
+++ b/modules/basegl/src/datavisualizer/layervisualizer.cpp
@@ -84,10 +84,11 @@ std::pair<Processor*, Outport*> LayerVisualizer::addSourceProcessor(
 
 std::vector<Processor*> LayerVisualizer::addVisualizerNetwork(Outport* outport,
                                                               ProcessorNetwork* net) const {
+    const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto bak = net->addProcessor(util::makeProcessor<Background>(GP{1, 3}));
-    auto mrp = net->addProcessor(util::makeProcessor<LayerRenderer>(GP{0, 6}));
-    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 9}));
+    auto bak = net->addProcessor(util::makeProcessor<Background>(GP{1, 3} + initialPos));
+    auto mrp = net->addProcessor(util::makeProcessor<LayerRenderer>(GP{0, 6} + initialPos));
+    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 9} + initialPos));
 
     net->addConnection(bak->getOutports()[0], mrp->getInports()[1]);
     net->addConnection(mrp->getOutports()[0], cvs->getInports()[0]);

--- a/modules/basegl/src/datavisualizer/meshvisualizer.cpp
+++ b/modules/basegl/src/datavisualizer/meshvisualizer.cpp
@@ -86,10 +86,11 @@ std::pair<Processor*, Outport*> MeshVisualizer::addSourceProcessor(
 
 std::vector<Processor*> MeshVisualizer::addVisualizerNetwork(Outport* outport,
                                                              ProcessorNetwork* net) const {
+    const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto bak = net->addProcessor(util::makeProcessor<Background>(GP{1, 3}));
-    auto mrp = net->addProcessor(util::makeProcessor<MeshRenderProcessorGL>(GP{0, 6}));
-    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 9}));
+    auto bak = net->addProcessor(util::makeProcessor<Background>(GP{1, 3} + initialPos));
+    auto mrp = net->addProcessor(util::makeProcessor<MeshRenderProcessorGL>(GP{0, 6} + initialPos));
+    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 9} + initialPos));
 
     net->addConnection(bak->getOutports()[0], mrp->getInports()[1]);
     net->addConnection(mrp->getOutports()[0], cvs->getInports()[0]);

--- a/modules/basegl/src/datavisualizer/meshvisualizer.cpp
+++ b/modules/basegl/src/datavisualizer/meshvisualizer.cpp
@@ -77,10 +77,11 @@ bool MeshVisualizer::hasSourceProcessor() const { return true; }
 bool MeshVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> MeshVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
 
-    auto source = net->addProcessor(util::makeProcessor<MeshSource>(GP{0, 0}, app_, filename));
-    auto outport = source->getOutports().front();
+    auto* source =
+        net->addProcessor(util::makeProcessor<MeshSource>(GP{0, 0} + initialPos, app_, filename));
+    auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
@@ -88,9 +89,10 @@ std::vector<Processor*> MeshVisualizer::addVisualizerNetwork(Outport* outport,
                                                              ProcessorNetwork* net) const {
     const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto bak = net->addProcessor(util::makeProcessor<Background>(GP{1, 3} + initialPos));
-    auto mrp = net->addProcessor(util::makeProcessor<MeshRenderProcessorGL>(GP{0, 6} + initialPos));
-    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 9} + initialPos));
+    auto* bak = net->addProcessor(util::makeProcessor<Background>(GP{1, 3} + initialPos));
+    auto* mrp =
+        net->addProcessor(util::makeProcessor<MeshRenderProcessorGL>(GP{0, 6} + initialPos));
+    auto* cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 9} + initialPos));
 
     net->addConnection(bak->getOutports()[0], mrp->getInports()[1]);
     net->addConnection(mrp->getOutports()[0], cvs->getInports()[0]);
@@ -101,9 +103,9 @@ std::vector<Processor*> MeshVisualizer::addVisualizerNetwork(Outport* outport,
 }
 
 std::vector<Processor*> MeshVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, net);
+    auto sourceAndOutport = addSourceProcessor(filename, net, initialPos);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
 
     processors.push_back(sourceAndOutport.first);

--- a/modules/basegl/src/datavisualizer/meshvisualizer.cpp
+++ b/modules/basegl/src/datavisualizer/meshvisualizer.cpp
@@ -77,22 +77,21 @@ bool MeshVisualizer::hasSourceProcessor() const { return true; }
 bool MeshVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> MeshVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
 
     auto* source =
-        net->addProcessor(util::makeProcessor<MeshSource>(GP{0, 0} + initialPos, app_, filename));
+        net->addProcessor(util::makeProcessor<MeshSource>(GP{0, 0} + origin, app_, filename));
     auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
 std::vector<Processor*> MeshVisualizer::addVisualizerNetwork(Outport* outport,
                                                              ProcessorNetwork* net) const {
-    const ivec2 initialPos = util::getPosition(outport->getProcessor());
+    const ivec2 origin = util::getPosition(outport->getProcessor());
 
-    auto* bak = net->addProcessor(util::makeProcessor<Background>(GP{1, 3} + initialPos));
-    auto* mrp =
-        net->addProcessor(util::makeProcessor<MeshRenderProcessorGL>(GP{0, 6} + initialPos));
-    auto* cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 9} + initialPos));
+    auto* bak = net->addProcessor(util::makeProcessor<Background>(GP{1, 3} + origin));
+    auto* mrp = net->addProcessor(util::makeProcessor<MeshRenderProcessorGL>(GP{0, 6} + origin));
+    auto* cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 9} + origin));
 
     net->addConnection(bak->getOutports()[0], mrp->getInports()[1]);
     net->addConnection(mrp->getOutports()[0], cvs->getInports()[0]);
@@ -103,9 +102,9 @@ std::vector<Processor*> MeshVisualizer::addVisualizerNetwork(Outport* outport,
 }
 
 std::vector<Processor*> MeshVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, net, initialPos);
+    auto sourceAndOutport = addSourceProcessor(filename, net, origin);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
 
     processors.push_back(sourceAndOutport.first);

--- a/modules/basegl/src/datavisualizer/volumeraycastvisualizer.cpp
+++ b/modules/basegl/src/datavisualizer/volumeraycastvisualizer.cpp
@@ -52,8 +52,8 @@
 #include <modules/basegl/processors/background.h>                // for Background
 #include <modules/basegl/processors/entryexitpointsprocessor.h>  // for EntryExitPoints
 #include <modules/basegl/processors/linerendererprocessor.h>     // for LineRendererProcessor
-#include <modules/basegl/processors/volumeraycaster.h>           // for VolumeRaycaster
-#include <modules/opengl/canvasprocessorgl.h>                    // for CanvasProcessorGL
+#include <modules/basegl/processors/raycasting/standardvolumeraycaster.h>  // for StandardVolume...
+#include <modules/opengl/canvasprocessorgl.h>                              // for CanvasProcessorGL
 
 #include <map>  // for map
 
@@ -100,15 +100,17 @@ std::pair<Processor*, Outport*> VolumeRaycastVisualizer::addSourceProcessor(
 
 std::vector<Processor*> VolumeRaycastVisualizer::addVisualizerNetwork(Outport* outport,
                                                                       ProcessorNetwork* net) const {
+    const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto cpg = net->addProcessor(util::makeProcessor<CubeProxyGeometry>(GP{1, 3}));
-    auto eep = net->addProcessor(util::makeProcessor<EntryExitPoints>(GP{1, 6}));
-    auto vrc = net->addProcessor(util::makeProcessor<VolumeRaycaster>(GP{0, 9}));
-    auto bak = net->addProcessor(util::makeProcessor<Background>(GP{0, 12}));
-    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 15}));
+    auto cpg = net->addProcessor(util::makeProcessor<CubeProxyGeometry>(GP{1, 3} + initialPos));
+    auto eep = net->addProcessor(util::makeProcessor<EntryExitPoints>(GP{1, 6} + initialPos));
+    auto vrc =
+        net->addProcessor(util::makeProcessor<StandardVolumeRaycaster>(GP{0, 9} + initialPos));
+    auto bak = net->addProcessor(util::makeProcessor<Background>(GP{0, 12} + initialPos));
+    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 15} + initialPos));
 
-    auto vbb = net->addProcessor(util::makeProcessor<VolumeBoundingBox>(GP{8, 3}));
-    auto lrp = net->addProcessor(util::makeProcessor<LineRendererProcessor>(GP{8, 6}));
+    auto vbb = net->addProcessor(util::makeProcessor<VolumeBoundingBox>(GP{8, 3} + initialPos));
+    auto lrp = net->addProcessor(util::makeProcessor<LineRendererProcessor>(GP{8, 6} + initialPos));
 
     util::trySetProperty<FloatVec4Property>(bak, "bgColor1", vec4(0.443f, 0.482f, 0.600f, 1.0f));
     util::trySetProperty<FloatVec4Property>(bak, "bgColor2", vec4(0.831f, 0.831f, 0.831f, 1.0f));

--- a/modules/basegl/src/datavisualizer/volumeraycastvisualizer.cpp
+++ b/modules/basegl/src/datavisualizer/volumeraycastvisualizer.cpp
@@ -91,10 +91,11 @@ bool VolumeRaycastVisualizer::hasSourceProcessor() const { return true; }
 bool VolumeRaycastVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> VolumeRaycastVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
 
-    auto source = net->addProcessor(util::makeProcessor<VolumeSource>(GP{0, 0}, app_, filename));
-    auto outport = source->getOutports().front();
+    auto* source =
+        net->addProcessor(util::makeProcessor<VolumeSource>(GP{0, 0} + initialPos, app_, filename));
+    auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
@@ -102,15 +103,16 @@ std::vector<Processor*> VolumeRaycastVisualizer::addVisualizerNetwork(Outport* o
                                                                       ProcessorNetwork* net) const {
     const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto cpg = net->addProcessor(util::makeProcessor<CubeProxyGeometry>(GP{1, 3} + initialPos));
-    auto eep = net->addProcessor(util::makeProcessor<EntryExitPoints>(GP{1, 6} + initialPos));
-    auto vrc =
+    auto* cpg = net->addProcessor(util::makeProcessor<CubeProxyGeometry>(GP{1, 3} + initialPos));
+    auto* eep = net->addProcessor(util::makeProcessor<EntryExitPoints>(GP{1, 6} + initialPos));
+    auto* vrc =
         net->addProcessor(util::makeProcessor<StandardVolumeRaycaster>(GP{0, 9} + initialPos));
-    auto bak = net->addProcessor(util::makeProcessor<Background>(GP{0, 12} + initialPos));
-    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 15} + initialPos));
+    auto* bak = net->addProcessor(util::makeProcessor<Background>(GP{0, 12} + initialPos));
+    auto* cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 15} + initialPos));
 
-    auto vbb = net->addProcessor(util::makeProcessor<VolumeBoundingBox>(GP{8, 3} + initialPos));
-    auto lrp = net->addProcessor(util::makeProcessor<LineRendererProcessor>(GP{8, 6} + initialPos));
+    auto* vbb = net->addProcessor(util::makeProcessor<VolumeBoundingBox>(GP{8, 3} + initialPos));
+    auto* lrp =
+        net->addProcessor(util::makeProcessor<LineRendererProcessor>(GP{8, 6} + initialPos));
 
     util::trySetProperty<FloatVec4Property>(bak, "bgColor1", vec4(0.443f, 0.482f, 0.600f, 1.0f));
     util::trySetProperty<FloatVec4Property>(bak, "bgColor2", vec4(0.831f, 0.831f, 0.831f, 1.0f));
@@ -152,9 +154,9 @@ std::vector<Processor*> VolumeRaycastVisualizer::addVisualizerNetwork(Outport* o
 }
 
 std::vector<Processor*> VolumeRaycastVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, net);
+    auto sourceAndOutport = addSourceProcessor(filename, net, initialPos);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
 
     processors.push_back(sourceAndOutport.first);

--- a/modules/basegl/src/datavisualizer/volumeraycastvisualizer.cpp
+++ b/modules/basegl/src/datavisualizer/volumeraycastvisualizer.cpp
@@ -91,28 +91,26 @@ bool VolumeRaycastVisualizer::hasSourceProcessor() const { return true; }
 bool VolumeRaycastVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> VolumeRaycastVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
 
     auto* source =
-        net->addProcessor(util::makeProcessor<VolumeSource>(GP{0, 0} + initialPos, app_, filename));
+        net->addProcessor(util::makeProcessor<VolumeSource>(GP{0, 0} + origin, app_, filename));
     auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
 std::vector<Processor*> VolumeRaycastVisualizer::addVisualizerNetwork(Outport* outport,
                                                                       ProcessorNetwork* net) const {
-    const ivec2 initialPos = util::getPosition(outport->getProcessor());
+    const ivec2 origin = util::getPosition(outport->getProcessor());
 
-    auto* cpg = net->addProcessor(util::makeProcessor<CubeProxyGeometry>(GP{1, 3} + initialPos));
-    auto* eep = net->addProcessor(util::makeProcessor<EntryExitPoints>(GP{1, 6} + initialPos));
-    auto* vrc =
-        net->addProcessor(util::makeProcessor<StandardVolumeRaycaster>(GP{0, 9} + initialPos));
-    auto* bak = net->addProcessor(util::makeProcessor<Background>(GP{0, 12} + initialPos));
-    auto* cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 15} + initialPos));
+    auto* cpg = net->addProcessor(util::makeProcessor<CubeProxyGeometry>(GP{1, 3} + origin));
+    auto* eep = net->addProcessor(util::makeProcessor<EntryExitPoints>(GP{1, 6} + origin));
+    auto* vrc = net->addProcessor(util::makeProcessor<StandardVolumeRaycaster>(GP{0, 9} + origin));
+    auto* bak = net->addProcessor(util::makeProcessor<Background>(GP{0, 12} + origin));
+    auto* cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 15} + origin));
 
-    auto* vbb = net->addProcessor(util::makeProcessor<VolumeBoundingBox>(GP{8, 3} + initialPos));
-    auto* lrp =
-        net->addProcessor(util::makeProcessor<LineRendererProcessor>(GP{8, 6} + initialPos));
+    auto* vbb = net->addProcessor(util::makeProcessor<VolumeBoundingBox>(GP{8, 3} + origin));
+    auto* lrp = net->addProcessor(util::makeProcessor<LineRendererProcessor>(GP{8, 6} + origin));
 
     util::trySetProperty<FloatVec4Property>(bak, "bgColor1", vec4(0.443f, 0.482f, 0.600f, 1.0f));
     util::trySetProperty<FloatVec4Property>(bak, "bgColor2", vec4(0.831f, 0.831f, 0.831f, 1.0f));
@@ -154,9 +152,9 @@ std::vector<Processor*> VolumeRaycastVisualizer::addVisualizerNetwork(Outport* o
 }
 
 std::vector<Processor*> VolumeRaycastVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, net, initialPos);
+    auto sourceAndOutport = addSourceProcessor(filename, net, origin);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
 
     processors.push_back(sourceAndOutport.first);

--- a/modules/basegl/src/datavisualizer/volumeslicevisualizer.cpp
+++ b/modules/basegl/src/datavisualizer/volumeslicevisualizer.cpp
@@ -88,8 +88,10 @@ std::pair<Processor*, Outport*> VolumeSliceVisualizer::addSourceProcessor(
 
 std::vector<Processor*> VolumeSliceVisualizer::addVisualizerNetwork(Outport* outport,
                                                                     ProcessorNetwork* net) const {
-    auto vsl = net->addProcessor(util::makeProcessor<VolumeSliceGL>(GP{0, 3}));
-    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 6}));
+    const ivec2 initialPos = util::getPosition(outport->getProcessor());
+
+    auto vsl = net->addProcessor(util::makeProcessor<VolumeSliceGL>(GP{0, 3} + initialPos));
+    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 6} + initialPos));
 
     net->addConnection(outport, vsl->getInports()[0]);
     net->addConnection(vsl->getOutports()[0], cvs->getInports()[0]);

--- a/modules/basegl/src/datavisualizer/volumeslicevisualizer.cpp
+++ b/modules/basegl/src/datavisualizer/volumeslicevisualizer.cpp
@@ -79,20 +79,20 @@ bool VolumeSliceVisualizer::hasSourceProcessor() const { return true; }
 bool VolumeSliceVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> VolumeSliceVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
 
     auto* source =
-        net->addProcessor(util::makeProcessor<VolumeSource>(GP{0, 0} + initialPos, app_, filename));
+        net->addProcessor(util::makeProcessor<VolumeSource>(GP{0, 0} + origin, app_, filename));
     auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
 std::vector<Processor*> VolumeSliceVisualizer::addVisualizerNetwork(Outport* outport,
                                                                     ProcessorNetwork* net) const {
-    const ivec2 initialPos = util::getPosition(outport->getProcessor());
+    const ivec2 origin = util::getPosition(outport->getProcessor());
 
-    auto* vsl = net->addProcessor(util::makeProcessor<VolumeSliceGL>(GP{0, 3} + initialPos));
-    auto* cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 6} + initialPos));
+    auto* vsl = net->addProcessor(util::makeProcessor<VolumeSliceGL>(GP{0, 3} + origin));
+    auto* cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 6} + origin));
 
     net->addConnection(outport, vsl->getInports()[0]);
     net->addConnection(vsl->getOutports()[0], cvs->getInports()[0]);
@@ -105,9 +105,9 @@ std::vector<Processor*> VolumeSliceVisualizer::addVisualizerNetwork(Outport* out
 }
 
 std::vector<Processor*> VolumeSliceVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& origin) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, net, initialPos);
+    auto sourceAndOutport = addSourceProcessor(filename, net, origin);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
 
     processors.push_back(sourceAndOutport.first);

--- a/modules/basegl/src/datavisualizer/volumeslicevisualizer.cpp
+++ b/modules/basegl/src/datavisualizer/volumeslicevisualizer.cpp
@@ -79,10 +79,11 @@ bool VolumeSliceVisualizer::hasSourceProcessor() const { return true; }
 bool VolumeSliceVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> VolumeSliceVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
 
-    auto source = net->addProcessor(util::makeProcessor<VolumeSource>(GP{0, 0}, app_, filename));
-    auto outport = source->getOutports().front();
+    auto* source =
+        net->addProcessor(util::makeProcessor<VolumeSource>(GP{0, 0} + initialPos, app_, filename));
+    auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
@@ -90,8 +91,8 @@ std::vector<Processor*> VolumeSliceVisualizer::addVisualizerNetwork(Outport* out
                                                                     ProcessorNetwork* net) const {
     const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto vsl = net->addProcessor(util::makeProcessor<VolumeSliceGL>(GP{0, 3} + initialPos));
-    auto cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 6} + initialPos));
+    auto* vsl = net->addProcessor(util::makeProcessor<VolumeSliceGL>(GP{0, 3} + initialPos));
+    auto* cvs = net->addProcessor(util::makeProcessor<CanvasProcessorGL>(GP{0, 6} + initialPos));
 
     net->addConnection(outport, vsl->getInports()[0]);
     net->addConnection(vsl->getOutports()[0], cvs->getInports()[0]);
@@ -104,9 +105,9 @@ std::vector<Processor*> VolumeSliceVisualizer::addVisualizerNetwork(Outport* out
 }
 
 std::vector<Processor*> VolumeSliceVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* net) const {
+    const std::filesystem::path& filename, ProcessorNetwork* net, const ivec2& initialPos) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, net);
+    auto sourceAndOutport = addSourceProcessor(filename, net, initialPos);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, net);
 
     processors.push_back(sourceAndOutport.first);

--- a/modules/dataframeqt/include/inviwo/dataframeqt/datavisualizer/dataframetablevisualizer.h
+++ b/modules/dataframeqt/include/inviwo/dataframeqt/datavisualizer/dataframetablevisualizer.h
@@ -59,12 +59,12 @@ public:
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/dataframeqt/include/inviwo/dataframeqt/datavisualizer/dataframetablevisualizer.h
+++ b/modules/dataframeqt/include/inviwo/dataframeqt/datavisualizer/dataframetablevisualizer.h
@@ -58,11 +58,13 @@ public:
     virtual bool hasVisualizerNetwork() const override;
 
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/dataframeqt/src/datavisualizer/dataframetablevisualizer.cpp
+++ b/modules/dataframeqt/src/datavisualizer/dataframetablevisualizer.cpp
@@ -75,10 +75,12 @@ bool DataFrameTableVisualizer::hasSourceProcessor() const { return true; }
 bool DataFrameTableVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> DataFrameTableVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* network) const {
+    const std::filesystem::path& filename, ProcessorNetwork* network,
+    const ivec2& initialPos) const {
 
-    auto source = network->addProcessor(util::makeProcessor<CSVSource>(GP{0, 0}, filename));
-    auto outport = source->getOutports().front();
+    auto* source =
+        network->addProcessor(util::makeProcessor<CSVSource>(GP{0, 0} + initialPos, filename));
+    auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
@@ -86,16 +88,17 @@ std::vector<Processor*> DataFrameTableVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* network) const {
     const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto table = network->addProcessor(util::makeProcessor<DataFrameTable>(GP{0, 3} + initialPos));
+    auto* table = network->addProcessor(util::makeProcessor<DataFrameTable>(GP{0, 3} + initialPos));
     network->addConnection(outport, table->getInports()[0]);
 
     return {table};
 }
 
 std::vector<Processor*> DataFrameTableVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* network) const {
+    const std::filesystem::path& filename, ProcessorNetwork* network,
+    const ivec2& initialPos) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, network);
+    auto sourceAndOutport = addSourceProcessor(filename, network, initialPos);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, network);
 
     processors.push_back(sourceAndOutport.first);

--- a/modules/dataframeqt/src/datavisualizer/dataframetablevisualizer.cpp
+++ b/modules/dataframeqt/src/datavisualizer/dataframetablevisualizer.cpp
@@ -75,30 +75,28 @@ bool DataFrameTableVisualizer::hasSourceProcessor() const { return true; }
 bool DataFrameTableVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> DataFrameTableVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* network,
-    const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* network, const ivec2& origin) const {
 
     auto* source =
-        network->addProcessor(util::makeProcessor<CSVSource>(GP{0, 0} + initialPos, filename));
+        network->addProcessor(util::makeProcessor<CSVSource>(GP{0, 0} + origin, filename));
     auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
 std::vector<Processor*> DataFrameTableVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* network) const {
-    const ivec2 initialPos = util::getPosition(outport->getProcessor());
+    const ivec2 origin = util::getPosition(outport->getProcessor());
 
-    auto* table = network->addProcessor(util::makeProcessor<DataFrameTable>(GP{0, 3} + initialPos));
+    auto* table = network->addProcessor(util::makeProcessor<DataFrameTable>(GP{0, 3} + origin));
     network->addConnection(outport, table->getInports()[0]);
 
     return {table};
 }
 
 std::vector<Processor*> DataFrameTableVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* network,
-    const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* network, const ivec2& origin) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, network, initialPos);
+    auto sourceAndOutport = addSourceProcessor(filename, network, origin);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, network);
 
     processors.push_back(sourceAndOutport.first);

--- a/modules/dataframeqt/src/datavisualizer/dataframetablevisualizer.cpp
+++ b/modules/dataframeqt/src/datavisualizer/dataframetablevisualizer.cpp
@@ -84,8 +84,9 @@ std::pair<Processor*, Outport*> DataFrameTableVisualizer::addSourceProcessor(
 
 std::vector<Processor*> DataFrameTableVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* network) const {
+    const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto table = network->addProcessor(util::makeProcessor<DataFrameTable>(GP{0, 3}));
+    auto table = network->addProcessor(util::makeProcessor<DataFrameTable>(GP{0, 3} + initialPos));
     network->addConnection(outport, table->getInports()[0]);
 
     return {table};

--- a/modules/plottinggl/include/modules/plottinggl/datavisualizer/pcpdataframevisualizer.h
+++ b/modules/plottinggl/include/modules/plottinggl/datavisualizer/pcpdataframevisualizer.h
@@ -57,11 +57,13 @@ public:
     virtual bool hasSourceProcessor() const override;
     virtual bool hasVisualizerNetwork() const override;
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/plottinggl/include/modules/plottinggl/datavisualizer/pcpdataframevisualizer.h
+++ b/modules/plottinggl/include/modules/plottinggl/datavisualizer/pcpdataframevisualizer.h
@@ -58,12 +58,12 @@ public:
     virtual bool hasVisualizerNetwork() const override;
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/plottinggl/include/modules/plottinggl/datavisualizer/scatterplotdataframevisualizer.h
+++ b/modules/plottinggl/include/modules/plottinggl/datavisualizer/scatterplotdataframevisualizer.h
@@ -56,11 +56,13 @@ public:
     virtual bool hasSourceProcessor() const override;
     virtual bool hasVisualizerNetwork() const override;
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
-        const std::filesystem::path& filename, ProcessorNetwork* network) const override;
+        const std::filesystem::path& filename, ProcessorNetwork* network,
+        const ivec2& initialPos) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/plottinggl/include/modules/plottinggl/datavisualizer/scatterplotdataframevisualizer.h
+++ b/modules/plottinggl/include/modules/plottinggl/datavisualizer/scatterplotdataframevisualizer.h
@@ -57,12 +57,12 @@ public:
     virtual bool hasVisualizerNetwork() const override;
     virtual std::pair<Processor*, Outport*> addSourceProcessor(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
     virtual std::vector<Processor*> addVisualizerNetwork(Outport* outport,
                                                          ProcessorNetwork* network) const override;
     virtual std::vector<Processor*> addSourceAndVisualizerNetwork(
         const std::filesystem::path& filename, ProcessorNetwork* network,
-        const ivec2& initialPos) const override;
+        const ivec2& origin) const override;
 
 private:
     InviwoApplication* app_;

--- a/modules/plottinggl/src/datavisualizer/pcpdataframevisualizer.cpp
+++ b/modules/plottinggl/src/datavisualizer/pcpdataframevisualizer.cpp
@@ -82,10 +82,12 @@ bool PCPDataFrameVisualizer::hasSourceProcessor() const { return true; }
 bool PCPDataFrameVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> PCPDataFrameVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* network) const {
+    const std::filesystem::path& filename, ProcessorNetwork* network,
+    const ivec2& initialPos) const {
 
-    auto source = network->addProcessor(util::makeProcessor<CSVSource>(GP{0, 0}, filename));
-    auto outport = source->getOutports().front();
+    auto* source =
+        network->addProcessor(util::makeProcessor<CSVSource>(GP{0, 0} + initialPos, filename));
+    auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
@@ -93,17 +95,17 @@ std::vector<Processor*> PCPDataFrameVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* network) const {
     const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto pcp = network->addProcessor(
+    auto* pcp = network->addProcessor(
         util::makeProcessor<plot::ParallelCoordinates>(GP{0, 3} + initialPos));
 
     auto back = util::makeProcessor<Background>(GP{0, 6} + initialPos);
     back->backgroundStyle_.setSelectedValue(Background::BackgroundStyle::Uniform);
     back->bgColor1_ = vec4{1.0f, 1.0f, 1.0f, 1.0f};
-    auto bak = network->addProcessor(std::move(back));
+    auto* bak = network->addProcessor(std::move(back));
 
     auto canvas = util::makeProcessor<CanvasProcessorGL>(GP{0, 9} + initialPos);
     canvas->dimensions_ = ivec2{800, 400};
-    auto cvs = network->addProcessor(std::move(canvas));
+    auto* cvs = network->addProcessor(std::move(canvas));
 
     network->addConnection(pcp->getOutports()[0], bak->getInports()[0]);
     network->addConnection(bak->getOutports()[0], cvs->getInports()[0]);
@@ -113,9 +115,10 @@ std::vector<Processor*> PCPDataFrameVisualizer::addVisualizerNetwork(
 }
 
 std::vector<Processor*> PCPDataFrameVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* network) const {
+    const std::filesystem::path& filename, ProcessorNetwork* network,
+    const ivec2& initialPos) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, network);
+    auto sourceAndOutport = addSourceProcessor(filename, network, initialPos);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, network);
 
     processors.push_back(sourceAndOutport.first);

--- a/modules/plottinggl/src/datavisualizer/pcpdataframevisualizer.cpp
+++ b/modules/plottinggl/src/datavisualizer/pcpdataframevisualizer.cpp
@@ -82,28 +82,27 @@ bool PCPDataFrameVisualizer::hasSourceProcessor() const { return true; }
 bool PCPDataFrameVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> PCPDataFrameVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* network,
-    const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* network, const ivec2& origin) const {
 
     auto* source =
-        network->addProcessor(util::makeProcessor<CSVSource>(GP{0, 0} + initialPos, filename));
+        network->addProcessor(util::makeProcessor<CSVSource>(GP{0, 0} + origin, filename));
     auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
 std::vector<Processor*> PCPDataFrameVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* network) const {
-    const ivec2 initialPos = util::getPosition(outport->getProcessor());
+    const ivec2 origin = util::getPosition(outport->getProcessor());
 
-    auto* pcp = network->addProcessor(
-        util::makeProcessor<plot::ParallelCoordinates>(GP{0, 3} + initialPos));
+    auto* pcp =
+        network->addProcessor(util::makeProcessor<plot::ParallelCoordinates>(GP{0, 3} + origin));
 
-    auto back = util::makeProcessor<Background>(GP{0, 6} + initialPos);
+    auto back = util::makeProcessor<Background>(GP{0, 6} + origin);
     back->backgroundStyle_.setSelectedValue(Background::BackgroundStyle::Uniform);
     back->bgColor1_ = vec4{1.0f, 1.0f, 1.0f, 1.0f};
     auto* bak = network->addProcessor(std::move(back));
 
-    auto canvas = util::makeProcessor<CanvasProcessorGL>(GP{0, 9} + initialPos);
+    auto canvas = util::makeProcessor<CanvasProcessorGL>(GP{0, 9} + origin);
     canvas->dimensions_ = ivec2{800, 400};
     auto* cvs = network->addProcessor(std::move(canvas));
 
@@ -115,10 +114,9 @@ std::vector<Processor*> PCPDataFrameVisualizer::addVisualizerNetwork(
 }
 
 std::vector<Processor*> PCPDataFrameVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* network,
-    const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* network, const ivec2& origin) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, network, initialPos);
+    auto sourceAndOutport = addSourceProcessor(filename, network, origin);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, network);
 
     processors.push_back(sourceAndOutport.first);

--- a/modules/plottinggl/src/datavisualizer/pcpdataframevisualizer.cpp
+++ b/modules/plottinggl/src/datavisualizer/pcpdataframevisualizer.cpp
@@ -91,15 +91,17 @@ std::pair<Processor*, Outport*> PCPDataFrameVisualizer::addSourceProcessor(
 
 std::vector<Processor*> PCPDataFrameVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* network) const {
+    const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto pcp = network->addProcessor(util::makeProcessor<plot::ParallelCoordinates>(GP{0, 3}));
+    auto pcp = network->addProcessor(
+        util::makeProcessor<plot::ParallelCoordinates>(GP{0, 3} + initialPos));
 
-    auto back = util::makeProcessor<Background>(GP{0, 6});
+    auto back = util::makeProcessor<Background>(GP{0, 6} + initialPos);
     back->backgroundStyle_.setSelectedValue(Background::BackgroundStyle::Uniform);
     back->bgColor1_ = vec4{1.0f, 1.0f, 1.0f, 1.0f};
     auto bak = network->addProcessor(std::move(back));
 
-    auto canvas = util::makeProcessor<CanvasProcessorGL>(GP{0, 9});
+    auto canvas = util::makeProcessor<CanvasProcessorGL>(GP{0, 9} + initialPos);
     canvas->dimensions_ = ivec2{800, 400};
     auto cvs = network->addProcessor(std::move(canvas));
 

--- a/modules/plottinggl/src/datavisualizer/scatterplotdataframevisualizer.cpp
+++ b/modules/plottinggl/src/datavisualizer/scatterplotdataframevisualizer.cpp
@@ -91,15 +91,17 @@ std::pair<Processor*, Outport*> ScatterPlotDataFrameVisualizer::addSourceProcess
 
 std::vector<Processor*> ScatterPlotDataFrameVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* network) const {
+    const ivec2 initialPos = util::getPosition(outport->getProcessor());
 
-    auto scatter = network->addProcessor(util::makeProcessor<plot::ScatterPlotProcessor>(GP{0, 3}));
+    auto scatter = network->addProcessor(
+        util::makeProcessor<plot::ScatterPlotProcessor>(GP{0, 3} + initialPos));
 
-    auto background = util::makeProcessor<Background>(GP{0, 6});
+    auto background = util::makeProcessor<Background>(GP{0, 6} + initialPos);
     background->backgroundStyle_.setSelectedValue(Background::BackgroundStyle::Uniform);
     background->bgColor1_ = vec4{1.0f, 1.0f, 1.0f, 1.0f};
     auto bg = network->addProcessor(std::move(background));
 
-    auto canvas = util::makeProcessor<CanvasProcessorGL>(GP{0, 9});
+    auto canvas = util::makeProcessor<CanvasProcessorGL>(GP{0, 9} + initialPos);
     canvas->dimensions_ = ivec2{800, 400};
     auto cvs = network->addProcessor(std::move(canvas));
 

--- a/modules/plottinggl/src/datavisualizer/scatterplotdataframevisualizer.cpp
+++ b/modules/plottinggl/src/datavisualizer/scatterplotdataframevisualizer.cpp
@@ -82,28 +82,27 @@ bool ScatterPlotDataFrameVisualizer::hasSourceProcessor() const { return true; }
 bool ScatterPlotDataFrameVisualizer::hasVisualizerNetwork() const { return true; }
 
 std::pair<Processor*, Outport*> ScatterPlotDataFrameVisualizer::addSourceProcessor(
-    const std::filesystem::path& filename, ProcessorNetwork* network,
-    const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* network, const ivec2& origin) const {
 
     auto* source =
-        network->addProcessor(util::makeProcessor<CSVSource>(GP{0, 0} + initialPos, filename));
+        network->addProcessor(util::makeProcessor<CSVSource>(GP{0, 0} + origin, filename));
     auto* outport = source->getOutports().front();
     return {source, outport};
 }
 
 std::vector<Processor*> ScatterPlotDataFrameVisualizer::addVisualizerNetwork(
     Outport* outport, ProcessorNetwork* network) const {
-    const ivec2 initialPos = util::getPosition(outport->getProcessor());
+    const ivec2 origin = util::getPosition(outport->getProcessor());
 
-    auto* scatter = network->addProcessor(
-        util::makeProcessor<plot::ScatterPlotProcessor>(GP{0, 3} + initialPos));
+    auto* scatter =
+        network->addProcessor(util::makeProcessor<plot::ScatterPlotProcessor>(GP{0, 3} + origin));
 
-    auto background = util::makeProcessor<Background>(GP{0, 6} + initialPos);
+    auto background = util::makeProcessor<Background>(GP{0, 6} + origin);
     background->backgroundStyle_.setSelectedValue(Background::BackgroundStyle::Uniform);
     background->bgColor1_ = vec4{1.0f, 1.0f, 1.0f, 1.0f};
     auto* bg = network->addProcessor(std::move(background));
 
-    auto canvas = util::makeProcessor<CanvasProcessorGL>(GP{0, 9} + initialPos);
+    auto canvas = util::makeProcessor<CanvasProcessorGL>(GP{0, 9} + origin);
     canvas->dimensions_ = ivec2{800, 400};
     auto* cvs = network->addProcessor(std::move(canvas));
 
@@ -115,10 +114,9 @@ std::vector<Processor*> ScatterPlotDataFrameVisualizer::addVisualizerNetwork(
 }
 
 std::vector<Processor*> ScatterPlotDataFrameVisualizer::addSourceAndVisualizerNetwork(
-    const std::filesystem::path& filename, ProcessorNetwork* network,
-    const ivec2& initialPos) const {
+    const std::filesystem::path& filename, ProcessorNetwork* network, const ivec2& origin) const {
 
-    auto sourceAndOutport = addSourceProcessor(filename, network, initialPos);
+    auto sourceAndOutport = addSourceProcessor(filename, network, origin);
     auto processors = addVisualizerNetwork(sourceAndOutport.second, network);
 
     processors.push_back(sourceAndOutport.first);

--- a/src/core/network/networkutils.cpp
+++ b/src/core/network/networkutils.cpp
@@ -235,18 +235,20 @@ void serializeSelected(ProcessorNetwork* network, std::ostream& os,
 
 std::vector<Processor*> appendPartialProcessorNetwork(ProcessorNetwork* network, std::istream& is,
                                                       const std::filesystem::path& refPath,
-                                                      InviwoApplication* app) {
+                                                      InviwoApplication* app,
+                                                      OffsetCallback callback) {
     NetworkLock lock(network);
     auto deserializer = app->getWorkspaceManager()->createWorkspaceDeserializer(is, refPath);
 
-    detail::PartialProcessorNetwork ppc(network);
+    detail::PartialProcessorNetwork ppc(network, callback);
     deserializer.deserialize("ProcessorNetwork", ppc);
 
     return ppc.getAddedProcessors();
 }
 
-detail::PartialProcessorNetwork::PartialProcessorNetwork(ProcessorNetwork* network)
-    : network_(network) {}
+detail::PartialProcessorNetwork::PartialProcessorNetwork(ProcessorNetwork* network,
+                                                         OffsetCallback callback)
+    : network_(network), callback_{callback} {}
 
 std::vector<Processor*> detail::PartialProcessorNetwork::getAddedProcessors() const {
     return addedProcessors_;
@@ -339,12 +341,19 @@ void detail::PartialProcessorNetwork::deserialize(Deserializer& d) {
             m->setSelected(false);
         }
 
+        for (auto& p : processors) {
+            addedProcessors_.push_back(p.get());
+        }
+        if (callback_) {
+            const ivec2 offset = callback_(addedProcessors_);
+            offsetPosition(addedProcessors_, offset);
+        }
+
         std::map<std::string, std::string, std::less<>> processorIds;
         for (auto& p : processors) {
             auto orgId = p->getIdentifier();
             network_->addProcessor(p);
             processorIds[orgId] = p->getIdentifier();
-            addedProcessors_.push_back(p.get());
         }
 
         for (auto& c : internalConnections) {
@@ -438,9 +447,9 @@ std::shared_ptr<Processor> replaceProcessor(ProcessorNetwork* network,
                                             std::shared_ptr<Processor> newProcessor,
                                             Processor* oldProcessor) {
 
-    network->addProcessor(newProcessor);
-
     util::setPosition(newProcessor.get(), util::getPosition(oldProcessor));
+
+    network->addProcessor(newProcessor);
 
     NetworkLock lock(network);
 

--- a/src/core/network/networkutils.cpp
+++ b/src/core/network/networkutils.cpp
@@ -237,10 +237,10 @@ std::vector<Processor*> appendPartialProcessorNetwork(ProcessorNetwork* network,
                                                       const std::filesystem::path& refPath,
                                                       InviwoApplication* app,
                                                       OffsetCallback callback) {
-    NetworkLock lock(network);
+    const NetworkLock lock(network);
     auto deserializer = app->getWorkspaceManager()->createWorkspaceDeserializer(is, refPath);
 
-    detail::PartialProcessorNetwork ppc(network, callback);
+    detail::PartialProcessorNetwork ppc(network, std::move(callback));
     deserializer.deserialize("ProcessorNetwork", ppc);
 
     return ppc.getAddedProcessors();
@@ -248,7 +248,7 @@ std::vector<Processor*> appendPartialProcessorNetwork(ProcessorNetwork* network,
 
 detail::PartialProcessorNetwork::PartialProcessorNetwork(ProcessorNetwork* network,
                                                          OffsetCallback callback)
-    : network_(network), callback_{callback} {}
+    : network_(network), callback_{std::move(callback)} {}
 
 std::vector<Processor*> detail::PartialProcessorNetwork::getAddedProcessors() const {
     return addedProcessors_;
@@ -451,7 +451,7 @@ std::shared_ptr<Processor> replaceProcessor(ProcessorNetwork* network,
 
     network->addProcessor(newProcessor);
 
-    NetworkLock lock(network);
+    const NetworkLock lock(network);
 
     std::vector<PortConnection> newConnections;
     {

--- a/src/qt/editor/dataopener.cpp
+++ b/src/qt/editor/dataopener.cpp
@@ -127,7 +127,7 @@ void util::insertNetworkForData(const std::filesystem::path& dataFile, Processor
             added = visualizer->addSourceAndVisualizerNetwork(dataFile, net, initialPos);
         }
 
-        // offset all added processors 
+        // offset all added processors
         const auto bounds = util::getBoundingBox(added);
         const auto offset = -ivec2{bounds.first.x, bounds.first.y};
         util::offsetPosition(added, offset);

--- a/src/qt/editor/dataopener.cpp
+++ b/src/qt/editor/dataopener.cpp
@@ -115,18 +115,21 @@ void util::insertNetworkForData(const std::filesystem::path& dataFile, Processor
     auto addVisualizer = [&](DataVisualizer* visualizer, bool onlySource) {
         const auto orgBounds = util::getBoundingBox(net);
 
+        // position visualizer to the top right, add spacing of one grid cell
+        const ivec2 initialPos{ivec2{orgBounds.second.x, orgBounds.first.y} + ivec2{25, 0} +
+                               ivec2{150, 0}};
+
         std::vector<Processor*> added;
         if (onlySource || !visualizer->hasVisualizerNetwork()) {
-            auto addedAndSource = visualizer->addSourceProcessor(dataFile, net);
+            auto addedAndSource = visualizer->addSourceProcessor(dataFile, net, initialPos);
             added.push_back(addedAndSource.first);
         } else {
-            added = visualizer->addSourceAndVisualizerNetwork(dataFile, net);
+            added = visualizer->addSourceAndVisualizerNetwork(dataFile, net, initialPos);
         }
 
-        // add to top right
+        // offset all added processors 
         const auto bounds = util::getBoundingBox(added);
-        const auto offset = ivec2{orgBounds.second.x, orgBounds.first.y} + ivec2{25, 0} +
-                            ivec2{150, 0} - ivec2{bounds.first.x, bounds.first.y};
+        const auto offset = -ivec2{bounds.first.x, bounds.first.y};
         util::offsetPosition(added, offset);
     };
 

--- a/src/qt/editor/networkeditor.cpp
+++ b/src/qt/editor/networkeditor.cpp
@@ -966,7 +966,7 @@ void NetworkEditor::paste(const QMimeData& mimeData) {
     NetworkLock lock(network_);
     try {
         auto offsetCallback = [&, orgBounds = util::getBoundingBox(network_)](
-                                  std::vector<Processor*> added) -> ivec2 {
+                                  const std::vector<Processor*>& added) -> ivec2 {
             auto center = util::getCenterPosition(added);
             auto bounds = util::getBoundingBox(added);
 
@@ -987,7 +987,7 @@ void NetworkEditor::paste(const QMimeData& mimeData) {
                                    ivec2{0, ProcessorGraphicsItem::size_.height()};
                 offset = pastePos_.second - center;
             }
-            QPointF p = snapToGrid(utilqt::toQPoint(offset));
+            const QPointF p = snapToGrid(utilqt::toQPoint(offset));
             return ivec2{static_cast<int>(p.x()), static_cast<int>(p.y())};
         };
 


### PR DESCRIPTION
Fixes #1560 

Changes proposed in this PR:
* apply offsets to processors before adding them to the network to prevent animations added in 8b886ed
* initially position visualizer networks at the outport they were invoked from instead of (0, 0)