### PR TITLE
Feature/packaging

### DIFF
--- a/cmake/pybind11.cmake
+++ b/cmake/pybind11.cmake
@@ -76,6 +76,8 @@ function(ivw_add_py_wrapper target)
         )
 
         set_property(GLOBAL APPEND PROPERTY IVW_PYMODULE_LIST ${target})
+    else()
+        message(FATAL_ERROR "Error: Adding Python wrapper for ${target} failed. Python3 module not enabled.")
     endif()
 endfunction()
 

--- a/cmake/vcpkghelpers.cmake
+++ b/cmake/vcpkghelpers.cmake
@@ -109,6 +109,7 @@ endfunction()
 # corresponding folders by globbing the vcpkg package folders. 
 # It will also try and install any transitive dependencies automatically 
 # We also automatically register the license file using the metadata found in vcpkg
+# Requires a Python3 interpreter.
 # Parameters:
 #  * OUT_COPYRIGHT retrieve the path the the COPYRIGHT file
 #  * OUT_VERSION get the package version from the vcpkg metadata
@@ -120,7 +121,15 @@ function(ivw_vcpkg_install name)
     endif()
 
     if(NOT Python3_Interpreter_FOUND)
-        return()
+        find_package(Python3 COMPONENTS Interpreter)
+        if(NOT Python3_FOUND OR 
+           NOT Python3_Interpreter_FOUND)
+            message(ERROR "Python3 not available.\n"
+                "Please install Python3. If you have a Python installation that is not found, consider "
+                "setting Python3_ROOT_DIR to the root directory of your Python 3 installation."
+            )
+            return ()
+        endif()
     endif()
 
     set(options EXT)

--- a/cmake/vcpkghelpers.cmake
+++ b/cmake/vcpkghelpers.cmake
@@ -104,6 +104,8 @@ function(ivw_private_vcpkg_install_helper)
     endforeach()
 endfunction()
 
+# Reset global variable used to show Python warning in ivw_vcpkg_install only once
+unset(ivwVcpkgInstallPythonWarningShownOnce CACHE)
 
 # A helper function to install vcpkg libraries. Will install dll/so, lib, pdb, etc. into the 
 # corresponding folders by globbing the vcpkg package folders. 
@@ -122,10 +124,14 @@ function(ivw_vcpkg_install name)
 
     find_package(Python3 COMPONENTS Interpreter)
     if(NOT Python3_Interpreter_FOUND)
-        message(WARNING "Python3 not available.\n"
-            "Please install Python3. If you have a Python installation that is not found, consider "
-            "setting Python3_ROOT_DIR to the root directory of your Python 3 installation."
-        )
+        if(NOT ivwVcpkgInstallPythonWarningShownOnce)
+            message(WARNING "Python3 not available.\n"
+                "Python is required to install vcpkg libraries. Please install Python3. If you "
+                "have a Python installation that is not found, consider "
+                "setting Python3_ROOT_DIR to the root directory of your Python 3 installation."
+            )
+            set(ivwVcpkgInstallPythonWarningShownOnce ON CACHE INTERNAL "vcpkg_install Python warning shown once")
+        endif()
         return ()
     endif()
 

--- a/cmake/vcpkghelpers.cmake
+++ b/cmake/vcpkghelpers.cmake
@@ -120,16 +120,13 @@ function(ivw_vcpkg_install name)
         return()
     endif()
 
+    find_package(Python3 COMPONENTS Interpreter)
     if(NOT Python3_Interpreter_FOUND)
-        find_package(Python3 COMPONENTS Interpreter)
-        if(NOT Python3_FOUND OR 
-           NOT Python3_Interpreter_FOUND)
-            message(ERROR "Python3 not available.\n"
-                "Please install Python3. If you have a Python installation that is not found, consider "
-                "setting Python3_ROOT_DIR to the root directory of your Python 3 installation."
-            )
-            return ()
-        endif()
+        message(WARNING "Python3 not available.\n"
+            "Please install Python3. If you have a Python installation that is not found, consider "
+            "setting Python3_ROOT_DIR to the root directory of your Python 3 installation."
+        )
+        return ()
     endif()
 
     set(options EXT)

--- a/modules/brushingandlinking/CMakeLists.txt
+++ b/modules/brushingandlinking/CMakeLists.txt
@@ -33,6 +33,6 @@ ivw_add_unittest(${TEST_FILES})
 # Create module
 ivw_create_module(${SOURCE_FILES} ${HEADER_FILES})
 
-if(IVW_ENABLE_PYTHON)
+if(IVW_ENABLE_PYTHON AND IVW_MODULE_PYTHON3)
     add_subdirectory(bindings)
 endif()


### PR DESCRIPTION
Fixes #1563 

Changes proposed in this PR:
 * `ivw_vcpkg_install()` uses find_package(Python3), if Python3 was not found yet
 * more verbose error handling in `ivw_add_py_wrapper()`

This has been tested on: Windows
