### PR TITLE
Volume: added HistogramToDataFrame processors

### DIFF
--- a/modules/volume/CMakeLists.txt
+++ b/modules/volume/CMakeLists.txt
@@ -2,6 +2,7 @@ ivw_module(Volume)
 
 set(HEADER_FILES
     include/inviwo/volume/algorithm/volumemap.h
+    include/inviwo/volume/processors/histogramtodataframe.h
     include/inviwo/volume/processors/volumeregionmapper.h
     include/inviwo/volume/processors/volumeregionstatistics.h
     include/inviwo/volume/processors/volumevoronoisegmentation.h
@@ -12,6 +13,7 @@ ivw_group("Header Files" ${HEADER_FILES})
 
 set(SOURCE_FILES
     src/algorithm/volumemap.cpp
+    src/processors/histogramtodataframe.cpp
     src/processors/volumeregionmapper.cpp
     src/processors/volumeregionstatistics.cpp
     src/processors/volumevoronoisegmentation.cpp

--- a/modules/volume/include/inviwo/volume/processors/histogramtodataframe.h
+++ b/modules/volume/include/inviwo/volume/processors/histogramtodataframe.h
@@ -1,0 +1,144 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2024 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#pragma once
+
+#include <inviwo/volume/volumemoduledefine.h>
+#include <inviwo/core/processors/processor.h>
+#include <inviwo/core/properties/ordinalproperty.h>
+#include <inviwo/core/processors/progressbarowner.h>
+#include <inviwo/core/properties/optionproperty.h>
+#include <inviwo/core/ports/datainport.h>
+#include <inviwo/core/datastructures/image/layer.h>
+#include <inviwo/core/datastructures/volume/volume.h>
+#include <inviwo/core/datastructures/histogram.h>
+#include <inviwo/core/datastructures/histogramtools.h>
+#include <inviwo/dataframe/datastructures/dataframe.h>
+
+namespace inviwo {
+
+template <typename T>
+class HistogramToDataFrame : public Processor, public ProgressBarOwner {
+public:
+    HistogramToDataFrame();
+
+    virtual void process() override;
+
+    virtual const ProcessorInfo getProcessorInfo() const override;
+
+private:
+    DataInport<T> inport_;
+    DataFrameOutport outport_;
+
+    OptionProperty<HistogramMode> histogramMode_;
+
+    std::shared_ptr<DataFrame> dataframe_;
+    HistogramCache::Result histogramResult_;
+};
+
+template <typename T>
+const ProcessorInfo HistogramToDataFrame<T>::getProcessorInfo() const {
+    return ProcessorTraits<HistogramToDataFrame<T>>::getProcessorInfo();
+}
+
+template <>
+struct ProcessorTraits<HistogramToDataFrame<Layer>> {
+    static ProcessorInfo getProcessorInfo() {
+        return {
+            "org.inviwo.LayerHistogramToDataFrame",       // Class identifier
+            "Layer Histogram To DataFrame",               // Display name
+            "Layer Operation",                            // Category
+            CodeState::Experimental,                      // Code state
+            Tags::CPU | Tag{"Histogram"} | Tag{"Layer"},  // Tags
+            R"(Returns the histograms of a Layer as a DataFrame)"_unindentHelp,
+        };
+    }
+};
+
+template <>
+struct ProcessorTraits<HistogramToDataFrame<Volume>> {
+    static ProcessorInfo getProcessorInfo() {
+        return {
+            "org.inviwo.VolumeHistogramToDataFrame",       // Class identifier
+            "Volume Histogram To DataFrame",               // Display name
+            "Volume Operation",                            // Category
+            CodeState::Experimental,                       // Code state
+            Tags::CPU | Tag{"Histogram"} | Tag{"Volume"},  // Tags
+            R"(Returns the histograms of a Volume as a DataFrame)"_unindentHelp,
+        };
+    }
+};
+
+namespace detail {
+
+IVW_MODULE_VOLUME_API std::shared_ptr<DataFrame> createDataFrame(
+    const std::vector<Histogram1D>& histograms, HistogramMode mode);
+
+}  // namespace detail
+
+template <typename T>
+HistogramToDataFrame<T>::HistogramToDataFrame()
+    : Processor{}
+    , inport_{"inport", "Input data"_help}
+    , outport_{"histogram", "DataFrame containing the histogram of the input data"_help}
+    , histogramMode_{
+          "histogramMode", "Histogram Mode",
+          OptionPropertyState<HistogramMode>{.options = {{"all", "All", HistogramMode::All},
+                                                         {"p99", "99%", HistogramMode::P99},
+                                                         {"p99", "99%", HistogramMode::P95},
+                                                         {"p99", "99%", HistogramMode::P90},
+                                                         {"log", "Log", HistogramMode::Log}}}
+              .setSelectedValue(HistogramMode::All)} {
+
+    addPorts(inport_, outport_);
+    addProperties(histogramMode_);
+}
+
+template <typename T>
+void HistogramToDataFrame<T>::process() {
+    histogramResult_ =
+        inport_.getData()->calculateHistograms([this](const std::vector<Histogram1D>& histograms) {
+            dataframe_ = detail::createDataFrame(histograms, histogramMode_);
+            getProgressBar().finishProgress();
+            outport_.setData(dataframe_);
+            outport_.invalidate(InvalidationLevel::Valid);
+        });
+
+    if (histogramResult_.progress == HistogramCache::Progress::NoData) {
+        dataframe_ = nullptr;
+        getProgressBar().finishProgress();
+    } else if (histogramResult_.progress == HistogramCache::Progress::Calculating) {
+        dataframe_ = nullptr;
+        updateProgress(0.0);
+    }
+
+    outport_.setData(dataframe_);
+}
+
+}  // namespace inviwo

--- a/modules/volume/src/processors/histogramtodataframe.cpp
+++ b/modules/volume/src/processors/histogramtodataframe.cpp
@@ -78,13 +78,13 @@ std::shared_ptr<DataFrame> createDataFrame(const std::vector<Histogram1D>& histo
 
     std::vector<double> binCenters(bins);
     std::ranges::generate(binCenters, [current = rangeMin, binSize]() mutable {
-        double v = current;
+        const double v = current;
         current += binSize;
         return v;
     });
-    std::string colName = !histograms[0].dataMap.valueAxis.name.empty()
-                              ? histograms[0].dataMap.valueAxis.name
-                              : "Scalars";
+    const std::string colName = !histograms[0].dataMap.valueAxis.name.empty()
+                                    ? histograms[0].dataMap.valueAxis.name
+                                    : "Scalars";
 
     dataframe->addColumn(colName, std::move(binCenters), histograms[0].dataMap.valueAxis.unit,
                          range);

--- a/modules/volume/src/processors/histogramtodataframe.cpp
+++ b/modules/volume/src/processors/histogramtodataframe.cpp
@@ -1,0 +1,100 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2024 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/volume/processors/histogramtodataframe.h>
+#include <inviwo/core/util/zip.h>
+
+#include <ranges>
+#include <fmt/core.h>
+
+namespace inviwo::detail {
+
+std::vector<double> scaleHistogram(const Histogram1D& hist, HistogramMode mode) {
+    std::vector<double> result(hist.counts.size());
+
+    if (mode == HistogramMode::Log) {
+        std::ranges::transform(hist.counts, result.begin(),
+                               [](auto& count) { return std::log10(1.0 + count); });
+    } else {
+        const double percentile = [&]() {
+            switch (mode) {
+                case HistogramMode::All:  // show all
+                    return hist.histStats.percentiles[100];
+                case HistogramMode::P99:  // show 99%
+                    return hist.histStats.percentiles[99];
+                case HistogramMode::P95:  // show 95%
+                    return hist.histStats.percentiles[95];
+                case HistogramMode::P90:  // show 90%
+                    return hist.histStats.percentiles[90];
+                default:
+                    return hist.histStats.percentiles[100];
+            }
+        }();
+        std::ranges::transform(hist.counts, result.begin(), [percentile](auto& count) {
+            return std::min<double>(count, percentile);
+        });
+    }
+    return result;
+}
+
+std::shared_ptr<DataFrame> createDataFrame(const std::vector<Histogram1D>& histograms,
+                                           HistogramMode mode) {
+    auto dataframe = std::make_shared<DataFrame>();
+
+    if (histograms.empty()) {
+        return dataframe;
+    }
+
+    const size_t bins = histograms[0].counts.size();
+    const dvec2 range{histograms[0].dataMap.valueRange};
+    const double binSize = (range.y - range.x) / static_cast<double>(bins - 1);
+    const double rangeMin = range.x + binSize * 0.5;
+
+    std::vector<double> binCenters(bins);
+    std::ranges::generate(binCenters, [current = rangeMin, binSize]() mutable {
+        double v = current;
+        current += binSize;
+        return v;
+    });
+    std::string colName = !histograms[0].dataMap.valueAxis.name.empty()
+                              ? histograms[0].dataMap.valueAxis.name
+                              : "Scalars";
+
+    dataframe->addColumn(colName, std::move(binCenters), histograms[0].dataMap.valueAxis.unit,
+                         range);
+
+    for (auto&& [index, hist] : util::enumerate<int>(histograms)) {
+        dataframe->addColumn(fmt::format("Channel{}", index), scaleHistogram(hist, mode));
+    }
+    dataframe->updateIndexBuffer();
+
+    return dataframe;
+}
+
+}  // namespace inviwo::detail

--- a/modules/volume/src/volumemodule.cpp
+++ b/modules/volume/src/volumemodule.cpp
@@ -27,10 +27,14 @@
  *
  *********************************************************************************/
 
+#include <inviwo/volume/processors/histogramtodataframe.h>
 #include <inviwo/volume/processors/volumeregionstatistics.h>
 #include <inviwo/volume/processors/volumeregionmapper.h>
 #include <inviwo/volume/processors/volumevoronoisegmentation.h>
 #include <inviwo/volume/volumemodule.h>
+
+#include <inviwo/core/ports/volumeport.h>
+#include <inviwo/core/ports/layerport.h>
 
 namespace inviwo {
 
@@ -38,6 +42,8 @@ VolumeModule::VolumeModule(InviwoApplication* app) : InviwoModule(app, "Volume")
     // Register objects that can be shared with the rest of inviwo here:
 
     // Processors
+    registerProcessor<HistogramToDataFrame<Layer>>();
+    registerProcessor<HistogramToDataFrame<Volume>>();
     registerProcessor<VolumeRegionMapper>();
     registerProcessor<VolumeRegionStatistics>();
     registerProcessor<VolumeVoronoiSegmentation>();


### PR DESCRIPTION
Changes proposed in this PR:
 * new `HistogramToDataFrame<T>` processor for `Layer` and `Volume`

<img src='https://github.com/user-attachments/assets/cd7bd38f-558b-4699-a734-c202a8a17b30' width='400px'>
