### PR TITLE
Feature/glformat

### DIFF
--- a/modules/opengl/include/modules/opengl/glformats.h
+++ b/modules/opengl/include/modules/opengl/glformats.h
@@ -58,16 +58,19 @@ struct IVW_MODULE_OPENGL_API GLFormat {
         , channels{0}
         , typeSize{0}
         , normalization{utilgl::Normalization::None}
+        , layoutQualifier{}
         , valid{false} {}
 
-    constexpr GLFormat(GLint format, GLint internalFormat, GLenum type, GLuint channels,
-                       GLuint typeSize, utilgl::Normalization normalization)
+    constexpr GLFormat(GLint format, GLint internalFormat, GLenum type,
+                       std::string_view layoutQualifier, GLuint channels, GLuint typeSize,
+                       utilgl::Normalization normalization)
         : format{format}
         , internalFormat{internalFormat}
         , type{type}
         , channels{channels}
         , typeSize{typeSize}
         , normalization{normalization}
+        , layoutQualifier{layoutQualifier}
         , valid{true} {}
 
     GLint format;
@@ -76,6 +79,7 @@ struct IVW_MODULE_OPENGL_API GLFormat {
     GLuint channels;
     GLuint typeSize;
     utilgl::Normalization normalization;
+    std::string_view layoutQualifier;
     bool valid;
 
     friend constexpr bool operator==(const GLFormat& a, const GLFormat& b) noexcept {
@@ -139,51 +143,51 @@ public:
 private:
     static constexpr std::array<GLFormat, size> formats_{{
         // clang-format off
-        {},                                                                                                 // NotSpecialized
+        {},                                                                                                                                   // NotSpecialized
         // 1 channels
-        {GL_RED,          GL_R32F,         GL_FLOAT,          1, 4, utilgl::Normalization::None},           // Float32
-        {},                                                                                                 // Float64
-        {GL_RED,          GL_R8_SNORM,     GL_BYTE,           1, 1, utilgl::Normalization::SignNormalized}, // Int8
-        {GL_RED,          GL_R16_SNORM,    GL_SHORT,          1, 2, utilgl::Normalization::SignNormalized}, // Int16
-        {GL_RED_INTEGER,  GL_R32I,         GL_INT,            1, 4, utilgl::Normalization::None},           // Int32
-        {},                                                                                                 // Int64
-        {GL_RED,          GL_R8,           GL_UNSIGNED_BYTE,  1, 1, utilgl::Normalization::Normalized},     // UInt8
-        {GL_RED,          GL_R16,          GL_UNSIGNED_SHORT, 1, 2, utilgl::Normalization::Normalized},     // UInt16
-        {GL_RED_INTEGER,  GL_R32UI,        GL_UNSIGNED_INT,   1, 4, utilgl::Normalization::None},           // UInt32
-        {},                                                                                                 // UInt64
+        {GL_RED,          GL_R32F,         GL_FLOAT,          std::string_view{"r32f"},         1, 4, utilgl::Normalization::None},           // Float32
+        {},                                                                                                                                   // Float64
+        {GL_RED,          GL_R8_SNORM,     GL_BYTE,           std::string_view{"r8_snorm"},     1, 1, utilgl::Normalization::SignNormalized}, // Int8
+        {GL_RED,          GL_R16_SNORM,    GL_SHORT,          std::string_view{"r16_snorm"},    1, 2, utilgl::Normalization::SignNormalized}, // Int16
+        {GL_RED_INTEGER,  GL_R32I,         GL_INT,            std::string_view{"r32i"},         1, 4, utilgl::Normalization::None},           // Int32
+        {},                                                                                                                                   // Int64
+        {GL_RED,          GL_R8,           GL_UNSIGNED_BYTE,  std::string_view{"r8"},           1, 1, utilgl::Normalization::Normalized},     // UInt8
+        {GL_RED,          GL_R16,          GL_UNSIGNED_SHORT, std::string_view{"r16"},          1, 2, utilgl::Normalization::Normalized},     // UInt16
+        {GL_RED_INTEGER,  GL_R32UI,        GL_UNSIGNED_INT,   std::string_view{"r32ui"},        1, 4, utilgl::Normalization::None},           // UInt32
+        {},                                                                                                                                   // UInt64
         // 2 channels
-        {GL_RG,           GL_RG32F,        GL_FLOAT,          2, 4, utilgl::Normalization::None},           // Vec2Float32
-        {},                                                                                                 // Vec2Float64
-        {GL_RG,           GL_RG8_SNORM,    GL_BYTE,           2, 1, utilgl::Normalization::SignNormalized}, // Vec2Int8
-        {GL_RG,           GL_RG16_SNORM,   GL_SHORT,          2, 2, utilgl::Normalization::SignNormalized}, // Vec2Int16
-        {GL_RG_INTEGER,   GL_RG32I,        GL_INT,            2, 4, utilgl::Normalization::None},           // Vec2Int32
-        {},                                                                                                 // Vec2Int64
-        {GL_RG,           GL_RG8,          GL_UNSIGNED_BYTE,  2, 1, utilgl::Normalization::Normalized},     // Vec2UInt8
-        {GL_RG,           GL_RG16,         GL_UNSIGNED_SHORT, 2, 2, utilgl::Normalization::Normalized},     // Vec2UInt16
-        {GL_RG_INTEGER,   GL_RG32UI,       GL_UNSIGNED_INT,   2, 4, utilgl::Normalization::None},           // Vec2UInt32
-        {},                                                                                                 // Vec2UInt64
+        {GL_RG,           GL_RG32F,        GL_FLOAT,          std::string_view{"rg32f"},        2, 4, utilgl::Normalization::None},           // Vec2Float32
+        {},                                                                                                                                   // Vec2Float64
+        {GL_RG,           GL_RG8_SNORM,    GL_BYTE,           std::string_view{"rg8_snorm"},    2, 1, utilgl::Normalization::SignNormalized}, // Vec2Int8
+        {GL_RG,           GL_RG16_SNORM,   GL_SHORT,          std::string_view{"rg16_snorm"},   2, 2, utilgl::Normalization::SignNormalized}, // Vec2Int16
+        {GL_RG_INTEGER,   GL_RG32I,        GL_INT,            std::string_view{"rg32i"},        2, 4, utilgl::Normalization::None},           // Vec2Int32
+        {},                                                                                                                                   // Vec2Int64
+        {GL_RG,           GL_RG8,          GL_UNSIGNED_BYTE,  std::string_view{"rg8"},          2, 1, utilgl::Normalization::Normalized},     // Vec2UInt8
+        {GL_RG,           GL_RG16,         GL_UNSIGNED_SHORT, std::string_view{"rg16"},         2, 2, utilgl::Normalization::Normalized},     // Vec2UInt16
+        {GL_RG_INTEGER,   GL_RG32UI,       GL_UNSIGNED_INT,   std::string_view{"rg32ui"},       2, 4, utilgl::Normalization::None},           // Vec2UInt32
+        {},                                                                                                                                   // Vec2UInt64
         // 3 channels
-        {GL_RGB,          GL_RGB32F,       GL_FLOAT,          3, 4, utilgl::Normalization::None},           // Vec3Float32
-        {},                                                                                                 // Vec3Float64
-        {GL_RGB,          GL_RGB8_SNORM,   GL_BYTE,           3, 1, utilgl::Normalization::SignNormalized}, // Vec3Int8
-        {GL_RGB,          GL_RGB16_SNORM,  GL_SHORT,          3, 2, utilgl::Normalization::SignNormalized}, // Vec3Int16
-        {GL_RGB_INTEGER,  GL_RGB32I,       GL_INT,            3, 4, utilgl::Normalization::None},           // Vec3Int32
-        {},                                                                                                 // Vec3Int64
-        {GL_RGB,          GL_RGB8,         GL_UNSIGNED_BYTE,  3, 1, utilgl::Normalization::Normalized},     // Vec3UInt8
-        {GL_RGB,          GL_RGB16,        GL_UNSIGNED_SHORT, 3, 2, utilgl::Normalization::Normalized},     // Vec3UInt16
-        {GL_RGB_INTEGER,  GL_RGB32UI,      GL_UNSIGNED_INT,   3, 4, utilgl::Normalization::None},           // Vec3UInt32
-        {},                                                                                                 // Vec4UInt64
+        {GL_RGB,          GL_RGB32F,       GL_FLOAT,          std::string_view{},               3, 4, utilgl::Normalization::None},           // Vec3Float32
+        {},                                                                                                                                   // Vec3Float64
+        {GL_RGB,          GL_RGB8_SNORM,   GL_BYTE,           std::string_view{},               3, 1, utilgl::Normalization::SignNormalized}, // Vec3Int8
+        {GL_RGB,          GL_RGB16_SNORM,  GL_SHORT,          std::string_view{},               3, 2, utilgl::Normalization::SignNormalized}, // Vec3Int16
+        {GL_RGB_INTEGER,  GL_RGB32I,       GL_INT,            std::string_view{},               3, 4, utilgl::Normalization::None},           // Vec3Int32
+        {},                                                                                                                                   // Vec3Int64
+        {GL_RGB,          GL_RGB8,         GL_UNSIGNED_BYTE,  std::string_view{},               3, 1, utilgl::Normalization::Normalized},     // Vec3UInt8
+        {GL_RGB,          GL_RGB16,        GL_UNSIGNED_SHORT, std::string_view{},               3, 2, utilgl::Normalization::Normalized},     // Vec3UInt16
+        {GL_RGB_INTEGER,  GL_RGB32UI,      GL_UNSIGNED_INT,   std::string_view{},               3, 4, utilgl::Normalization::None},           // Vec3UInt32
+        {},                                                                                                                                   // Vec4UInt64
         // 4 channels
-        {GL_RGBA,         GL_RGBA32F,      GL_FLOAT,          4, 4, utilgl::Normalization::None},           // Vec4Float32
-        {},                                                                                                 // Vec4Float64
-        {GL_RGBA,         GL_RGBA8_SNORM,  GL_BYTE,           4, 1, utilgl::Normalization::SignNormalized}, // Vec4Int8
-        {GL_RGBA,         GL_RGBA16_SNORM, GL_SHORT,          4, 2, utilgl::Normalization::SignNormalized}, // Vec4Int16
-        {GL_RGBA_INTEGER, GL_RGBA32I,      GL_INT,            4, 4, utilgl::Normalization::None},           // Vec4Int32
-        {},                                                                                                 // Vec4Int64
-        {GL_RGBA,         GL_RGBA8,        GL_UNSIGNED_BYTE,  4, 1, utilgl::Normalization::Normalized},     // Vec4UInt8
-        {GL_RGBA,         GL_RGBA16,       GL_UNSIGNED_SHORT, 4, 2, utilgl::Normalization::Normalized},     // Vec4UInt16
-        {GL_RGBA_INTEGER, GL_RGBA32UI,     GL_UNSIGNED_INT,   4, 4, utilgl::Normalization::None},           // Vec4UInt32
-        {}                                                                                                  // Vec4UInt64
+        {GL_RGBA,         GL_RGBA32F,      GL_FLOAT,          std::string_view{"rgba32f"},      4, 4, utilgl::Normalization::None},           // Vec4Float32
+        {},                                                                                                                                   // Vec4Float64
+        {GL_RGBA,         GL_RGBA8_SNORM,  GL_BYTE,           std::string_view{"rgba8_snorm"},  4, 1, utilgl::Normalization::SignNormalized}, // Vec4Int8
+        {GL_RGBA,         GL_RGBA16_SNORM, GL_SHORT,          std::string_view{"rgba16_snorm"}, 4, 2, utilgl::Normalization::SignNormalized}, // Vec4Int16
+        {GL_RGBA_INTEGER, GL_RGBA32I,      GL_INT,            std::string_view{"rgba32i"},      4, 4, utilgl::Normalization::None},           // Vec4Int32
+        {},                                                                                                                                   // Vec4Int64
+        {GL_RGBA,         GL_RGBA8,        GL_UNSIGNED_BYTE,  std::string_view{"rgba8"},        4, 1, utilgl::Normalization::Normalized},     // Vec4UInt8
+        {GL_RGBA,         GL_RGBA16,       GL_UNSIGNED_SHORT, std::string_view{"rgba16"},       4, 2, utilgl::Normalization::Normalized},     // Vec4UInt16
+        {GL_RGBA_INTEGER, GL_RGBA32UI,     GL_UNSIGNED_INT,   std::string_view{"rgba32ui"},     4, 4, utilgl::Normalization::None},           // Vec4UInt32
+        {}                                                                                                                                    // Vec4UInt64
         // clang-format on
     }};
 };

--- a/modules/opengl/src/shader/shaderobject.cpp
+++ b/modules/opengl/src/shader/shaderobject.cpp
@@ -626,8 +626,8 @@ void ShaderObject::addShaderDefine(std::string_view name, std::string_view value
         it->second = value;
     }
 }
-void ShaderObject::setShaderDefine(std::string_view name, bool exists, std::string_view value) {
-    if (exists) {
+void ShaderObject::setShaderDefine(std::string_view name, bool shouldAdd, std::string_view value) {
+    if (shouldAdd) {
         addShaderDefine(name, value);
     } else {
         removeShaderDefine(name);


### PR DESCRIPTION
Changes proposed in this PR:
 * `GLFormat` provides layout qualifier to be used in shaders in connection with image types (`imageLoad` and `imageStore()`)