### PR TITLE
AnimationQt: Add support for using a presentation clicker

### DIFF
--- a/modules/animation/include/modules/animation/animationcontroller.h
+++ b/modules/animation/include/modules/animation/animationcontroller.h
@@ -85,6 +85,12 @@ public:
     // Pause and reset to start
     void stop();
 
+    void nextKeyframe();
+    void prevKeyframe();
+
+    void nextControlKeyframe();
+    void prevControlKeyframe();
+
     void setState(AnimationState newState);
 
     /// Advances the animation to the next time step in playing state.

--- a/modules/animation/include/modules/animation/animationcontroller.h
+++ b/modules/animation/include/modules/animation/animationcontroller.h
@@ -85,11 +85,31 @@ public:
     // Pause and reset to start
     void stop();
 
-    void nextKeyframe();
-    void prevKeyframe();
+    /*
+     * Set current time to that of the previous keyframe, if there is one.
+     * Equal to eval(getCurrentTime(), prevKeyframeTime).
+     * Does not alter current PlaybackDirection.
+     */
+    void jumpToPrevKeyframe();
+    /*
+     * Set current time to that of the next keyframe, if there is one.
+     * Equal to eval(getCurrentTime(), nextKeyframeTime).
+     * Does not alter current PlaybackDirection.
+     */
+    void jumpToNextKeyframe();
 
-    void nextControlKeyframe();
-    void prevControlKeyframe();
+    /*
+     * Set current time to that of the previous ControlTrack keyframe, if there is one.
+     * Equal to eval(getCurrentTime(), prevKeyframeTime).
+     * Does not alter current PlaybackDirection.
+     */
+    void jumpToPrevControlKeyframe();
+    /*
+     * Set current time to that of the next ControlTrack keyframe, if there is one.
+     * Equal to eval(getCurrentTime(), nextKeyframeTime).
+     * Does not alter current PlaybackDirection.
+     */
+    void jumpToNextControlKeyframe();
 
     void setState(AnimationState newState);
 

--- a/modules/animation/include/modules/animation/datastructures/animation.h
+++ b/modules/animation/include/modules/animation/datastructures/animation.h
@@ -171,6 +171,13 @@ public:
     iterator findTrack(Property* withMe);
 
     /**
+     * Find Track of a given type.
+     * @return All tracks of the specified type.
+     */
+    template<typename TrackType>
+    std::vector<TrackType*> getTracksOfType();
+
+    /**
      * Remove all tracks. Calls TrackObserver::notifyTrackRemoved for each removed track.
      */
     void clear();
@@ -229,6 +236,17 @@ private:
     std::string name_;
     AnimationManager* am_;
 };
+
+template <typename TrackType>
+std::vector<TrackType*> Animation::getTracksOfType() {
+    std::vector<TrackType*> tracks;
+    for (auto& track : *this) {
+        if (auto tr = dynamic_cast<TrackType*>(&track)) {
+            tracks.push_back(tr);
+        }
+    }
+    return tracks;
+}
 
 }  // namespace animation
 

--- a/modules/animation/include/modules/animation/datastructures/animation.h
+++ b/modules/animation/include/modules/animation/datastructures/animation.h
@@ -174,7 +174,7 @@ public:
      * Find Track of a given type.
      * @return All tracks of the specified type.
      */
-    template<typename TrackType>
+    template <typename TrackType>
     std::vector<TrackType*> getTracksOfType();
 
     /**

--- a/modules/animation/include/modules/animation/datastructures/animation.h
+++ b/modules/animation/include/modules/animation/datastructures/animation.h
@@ -207,14 +207,14 @@ public:
     Seconds getLastTime() const;
 
     /**
-     * Return time of closest previous Keyframe in all tracks, or at if no previous keyframe exist.
+     * Return time of closest previous Keyframe in all tracks if found.
      */
-    Seconds getPrevTime(Seconds at) const;
+    std::optional<Seconds> getPrevTime(Seconds at) const;
 
     /**
-     * Return time of closest next Keyframe in all tracks, or at if there is no next keyframe.
+     * Return time of closest next Keyframe in all tracks if found.
      */
-    Seconds getNextTime(Seconds at) const;
+    std::optional<Seconds> getNextTime(Seconds at) const;
 
     /**
      * Return the name of the Animation. Used for display in the GUI.

--- a/modules/animation/include/modules/animation/datastructures/animation.h
+++ b/modules/animation/include/modules/animation/datastructures/animation.h
@@ -39,8 +39,8 @@
 #include <modules/animation/datastructures/track.h>              // for Track
 #include <modules/animation/datastructures/trackobserver.h>      // for TrackObserver
 
-#include <cstddef>      // for size_t
-#include <memory>       // for unique_ptr
+#include <cstddef>  // for size_t
+#include <memory>   // for unique_ptr
 #include <ranges>
 #include <string>       // for string
 #include <string_view>  // for string_view
@@ -257,8 +257,9 @@ private:
 
 template <typename TrackType>
 bool Animation::hasTrackType() const {
-    return end() !=
-           std::find_if(begin(), end(), [](const auto& t) { return dynamic_cast<const TrackType*>(&t) != nullptr; });
+    return end() != std::find_if(begin(), end(), [](const auto& t) {
+               return dynamic_cast<const TrackType*>(&t) != nullptr;
+           });
 }
 
 template <typename TrackType>

--- a/modules/animation/include/modules/animation/datastructures/basekeyframesequence.h
+++ b/modules/animation/include/modules/animation/datastructures/basekeyframesequence.h
@@ -258,9 +258,8 @@ const Key& animation::BaseKeyframeSequence<Key>::getFirst() const {
 }
 template <typename Key>
 Seconds animation::BaseKeyframeSequence<Key>::getPrevTime(Seconds at) const {
-    auto it = std::lower_bound(begin(), end(), at, [](const auto& key, const auto& time) {
-        return key.getTime() < time;
-    });
+    auto it = std::lower_bound(
+        begin(), end(), at, [](const auto& key, const auto& time) { return key.getTime() < time; });
 
     if (it != begin()) {
         return std::prev(it)->getTime();
@@ -271,9 +270,8 @@ Seconds animation::BaseKeyframeSequence<Key>::getPrevTime(Seconds at) const {
 
 template <typename Key>
 Seconds animation::BaseKeyframeSequence<Key>::getNextTime(Seconds at) const {
-    auto it = std::upper_bound(begin(), end(), at, [](const auto& time, const auto& key) {
-        return time < key.getTime();
-    });
+    auto it = std::upper_bound(
+        begin(), end(), at, [](const auto& time, const auto& key) { return time < key.getTime(); });
 
     if (it != end()) {
         return it->getTime();

--- a/modules/animation/include/modules/animation/datastructures/basekeyframesequence.h
+++ b/modules/animation/include/modules/animation/datastructures/basekeyframesequence.h
@@ -83,14 +83,8 @@ public:
     virtual const Key& getLast() const override;
     virtual Key& getLast() override;
 
-    /*
-     * Return time of previous keyframe, or at if not found.
-     */
-    virtual Seconds getPrevTime(Seconds at) const final;
-    /*
-     * Return time of next keyframe, or at if not found.
-     */
-    virtual Seconds getNextTime(Seconds at) const final;
+    virtual std::optional<Seconds> getPrevTime(Seconds at) const final;
+    virtual std::optional<Seconds> getNextTime(Seconds at) const final;
 
     iterator begin();
     const_iterator begin() const;
@@ -257,14 +251,14 @@ const Key& animation::BaseKeyframeSequence<Key>::getFirst() const {
     return *keyframes_.front();
 }
 template <typename Key>
-Seconds animation::BaseKeyframeSequence<Key>::getPrevTime(Seconds at) const {
+std::optional<Seconds> animation::BaseKeyframeSequence<Key>::getPrevTime(Seconds at) const {
     auto it = std::lower_bound(
         begin(), end(), at, [](const auto& key, const auto& time) { return key.getTime() < time; });
 
     if (it != begin()) {
         return std::prev(it)->getTime();
     } else {
-        return at;
+        return std::nullopt;
     }
 }
 
@@ -276,7 +270,7 @@ Seconds animation::BaseKeyframeSequence<Key>::getNextTime(Seconds at) const {
     if (it != end()) {
         return it->getTime();
     } else {
-        return at;
+        return std::nullopt;
     }
 }
 

--- a/modules/animation/include/modules/animation/datastructures/basekeyframesequence.h
+++ b/modules/animation/include/modules/animation/datastructures/basekeyframesequence.h
@@ -263,7 +263,7 @@ std::optional<Seconds> animation::BaseKeyframeSequence<Key>::getPrevTime(Seconds
 }
 
 template <typename Key>
-Seconds animation::BaseKeyframeSequence<Key>::getNextTime(Seconds at) const {
+std::optional<Seconds> animation::BaseKeyframeSequence<Key>::getNextTime(Seconds at) const {
     auto it = std::upper_bound(
         begin(), end(), at, [](const auto& time, const auto& key) { return time < key.getTime(); });
 

--- a/modules/animation/include/modules/animation/datastructures/basekeyframesequence.h
+++ b/modules/animation/include/modules/animation/datastructures/basekeyframesequence.h
@@ -83,6 +83,15 @@ public:
     virtual const Key& getLast() const override;
     virtual Key& getLast() override;
 
+    /*
+     * Return time of previous keyframe, or at if not found.
+     */
+    virtual Seconds getPrevTime(Seconds at) const final;
+    /*
+     * Return time of next keyframe, or at if not found.
+     */
+    virtual Seconds getNextTime(Seconds at) const final;
+
     iterator begin();
     const_iterator begin() const;
     iterator end();
@@ -246,6 +255,31 @@ Key& BaseKeyframeSequence<Key>::getFirst() {
 template <typename Key>
 const Key& animation::BaseKeyframeSequence<Key>::getFirst() const {
     return *keyframes_.front();
+}
+template <typename Key>
+Seconds animation::BaseKeyframeSequence<Key>::getPrevTime(Seconds at) const {
+    auto it = std::lower_bound(begin(), end(), at, [](const auto& key, const auto& time) {
+        return key.getTime() < time;
+    });
+
+    if (it != begin()) {
+        return std::prev(it)->getTime();
+    } else {
+        return at;
+    }
+}
+
+template <typename Key>
+Seconds animation::BaseKeyframeSequence<Key>::getNextTime(Seconds at) const {
+    auto it = std::upper_bound(begin(), end(), at, [](const auto& time, const auto& key) {
+        return time < key.getTime();
+    });
+
+    if (it != end()) {
+        return it->getTime();
+    } else {
+        return at;
+    }
 }
 
 template <typename Key>

--- a/modules/animation/include/modules/animation/datastructures/basetrack.h
+++ b/modules/animation/include/modules/animation/datastructures/basetrack.h
@@ -102,14 +102,9 @@ public:
 
     virtual Seconds getFirstTime() const override;
     virtual Seconds getLastTime() const override;
-    /*
-     * Return time of previous keyframe, or at if not found.
-     */
-    virtual Seconds getPrevTime(Seconds at) const final;
-    /*
-     * Return time of next keyframe, or at if not found.
-     */
-    virtual Seconds getNextTime(Seconds at) const final;
+
+    virtual std::optional<Seconds> getPrevTime(Seconds at) const final;
+    virtual std::optional<Seconds> getNextTime(Seconds at) const final;
     virtual std::vector<Seconds> getAllTimes() const override;
 
     virtual size_t size() const override;
@@ -273,36 +268,30 @@ Seconds BaseTrack<Seq>::getLastTime() const {
     }
 }
 template <typename Seq>
-Seconds BaseTrack<Seq>::getPrevTime(Seconds at) const {
-    auto prevKeyframeTime = at;
+std::optional<Seconds> BaseTrack<Seq>::getPrevTime(Seconds at) const {
+    std::optional<Seconds> prevKeyframeTime = std::nullopt;
     for (auto& sequence : sequences_) {
-        auto t = sequence->getPrevTime(at);
-        bool found = t != at;
-        if (!found) {
-            continue;
-        }
-        if (at == prevKeyframeTime) {
-            prevKeyframeTime = t;
-        } else {
-            prevKeyframeTime = std::max(prevKeyframeTime, t);
+        if (auto t = sequence->getPrevTime(at)) {
+            if (!prevKeyframeTime) {
+                prevKeyframeTime = t;
+            } else {
+                prevKeyframeTime = std::max(prevKeyframeTime, t);
+            }
         }
     }
     return prevKeyframeTime;
 }
 
 template <typename Seq>
-Seconds BaseTrack<Seq>::getNextTime(Seconds at) const {
-    auto nextKeyframeTime = at;
+std::optional<Seconds> BaseTrack<Seq>::getNextTime(Seconds at) const {
+    std::optional<Seconds> nextKeyframeTime = std::nullopt;
     for (auto& sequence : sequences_) {
-        auto t = sequence->getNextTime(at);
-        bool found = t != at;
-        if (!found) {
-            continue;
-        }
-        if (at == nextKeyframeTime) {
-            nextKeyframeTime = t;
-        } else {
-            nextKeyframeTime = std::min(nextKeyframeTime, t);
+        if (auto t = sequence->getNextTime(at)) {
+            if (!nextKeyframeTime) {
+                nextKeyframeTime = t;
+            } else {
+                nextKeyframeTime = std::min(nextKeyframeTime, t);
+            }
         }
     }
     return nextKeyframeTime;

--- a/modules/animation/include/modules/animation/datastructures/basetrack.h
+++ b/modules/animation/include/modules/animation/datastructures/basetrack.h
@@ -102,6 +102,14 @@ public:
 
     virtual Seconds getFirstTime() const override;
     virtual Seconds getLastTime() const override;
+    /*
+     * Return time of previous keyframe, or at if not found.
+     */
+    virtual Seconds getPrevTime(Seconds at) const final;
+    /*
+     * Return time of next keyframe, or at if not found.
+     */
+    virtual Seconds getNextTime(Seconds at) const final;
     virtual std::vector<Seconds> getAllTimes() const override;
 
     virtual size_t size() const override;
@@ -264,6 +272,42 @@ Seconds BaseTrack<Seq>::getLastTime() const {
         return sequences_.back()->getLastTime();
     }
 }
+template <typename Seq>
+Seconds BaseTrack<Seq>::getPrevTime(Seconds at) const {
+    auto prevKeyframeTime = at;
+    for (auto& sequence : sequences_) {
+        auto t = sequence->getPrevTime(at);
+        bool found = t != at;
+        if (!found) {
+            continue;
+        }
+        if (at == prevKeyframeTime) {
+            prevKeyframeTime = t;
+        } else {
+            prevKeyframeTime = std::max(prevKeyframeTime, t);
+        }
+    }
+    return prevKeyframeTime;
+}
+
+template <typename Seq>
+Seconds BaseTrack<Seq>::getNextTime(Seconds at) const {
+    auto nextKeyframeTime = at;
+    for (auto& sequence : sequences_) {
+        auto t = sequence->getNextTime(at);
+        bool found = t != at;
+        if (!found) {
+            continue;
+        }
+        if (at == nextKeyframeTime) {
+            nextKeyframeTime = t;
+        } else {
+            nextKeyframeTime = std::min(nextKeyframeTime, t);
+        }
+    }
+    return nextKeyframeTime;
+}
+
 template <typename Seq>
 std::vector<Seconds> BaseTrack<Seq>::getAllTimes() const {
     std::vector<Seconds> result;

--- a/modules/animation/include/modules/animation/datastructures/keyframesequence.h
+++ b/modules/animation/include/modules/animation/datastructures/keyframesequence.h
@@ -74,6 +74,14 @@ public:
 
     Seconds getFirstTime() const;
     Seconds getLastTime() const;
+    /*
+     * Return time of previous keyframe, or at if not found.
+     */
+    virtual Seconds getPrevTime(Seconds at) const = 0;
+    /*
+     * Return time of next keyframe, or at if not found.
+     */
+    virtual Seconds getNextTime(Seconds at) const = 0;
     std::pair<Seconds, Seconds> getTimeSpan() const;
 
     /**

--- a/modules/animation/include/modules/animation/datastructures/keyframesequence.h
+++ b/modules/animation/include/modules/animation/datastructures/keyframesequence.h
@@ -75,13 +75,13 @@ public:
     Seconds getFirstTime() const;
     Seconds getLastTime() const;
     /*
-     * Return time of previous keyframe, or at if not found.
+     * Return time of previous keyframe, or false if not found.
      */
-    virtual Seconds getPrevTime(Seconds at) const = 0;
+    virtual std::optional<Seconds> getPrevTime(Seconds at) const = 0;
     /*
-     * Return time of next keyframe, or at if not found.
+     * Return time of next keyframe, or false if not found.
      */
-    virtual Seconds getNextTime(Seconds at) const = 0;
+    virtual std::optional<Seconds> getNextTime(Seconds at) const = 0;
     std::pair<Seconds, Seconds> getTimeSpan() const;
 
     /**

--- a/modules/animation/include/modules/animation/datastructures/track.h
+++ b/modules/animation/include/modules/animation/datastructures/track.h
@@ -99,6 +99,14 @@ public:
 
     virtual Seconds getFirstTime() const = 0;
     virtual Seconds getLastTime() const = 0;
+    /*
+     * Return time of previous keyframe, or at if not found.
+     */
+    virtual Seconds getPrevTime(Seconds at) const = 0;
+    /*
+     * Return time of next keyframe, or at if not found.
+     */
+    virtual Seconds getNextTime(Seconds at) const = 0;
     virtual std::vector<Seconds> getAllTimes() const = 0;
 
     /**

--- a/modules/animation/include/modules/animation/datastructures/track.h
+++ b/modules/animation/include/modules/animation/datastructures/track.h
@@ -100,13 +100,13 @@ public:
     virtual Seconds getFirstTime() const = 0;
     virtual Seconds getLastTime() const = 0;
     /*
-     * Return time of previous keyframe, or at if not found.
+     * Return time of previous keyframe if found.
      */
-    virtual Seconds getPrevTime(Seconds at) const = 0;
+    virtual std::optional<Seconds> getPrevTime(Seconds at) const = 0;
     /*
-     * Return time of next keyframe, or at if not found.
+     * Return time of next keyframe if found.
      */
-    virtual Seconds getNextTime(Seconds at) const = 0;
+    virtual std::optional<Seconds> getNextTime(Seconds at) const = 0;
     virtual std::vector<Seconds> getAllTimes() const = 0;
 
     /**

--- a/modules/animation/src/animationcontroller.cpp
+++ b/modules/animation/src/animationcontroller.cpp
@@ -310,8 +310,6 @@ void AnimationController::jumpToNextControlKeyframe() {
     }
 }
 
-
-
 void AnimationController::tick() {
     if (state_ != AnimationState::Playing) {
         setState(AnimationState::Paused);

--- a/modules/animation/src/animationcontroller.cpp
+++ b/modules/animation/src/animationcontroller.cpp
@@ -258,6 +258,50 @@ void AnimationController::stop() {
     eval(currentTime_, Seconds(0));
 }
 
+void AnimationController::nextKeyframe() {
+    auto times = animation_->getAllTimes();
+    auto it = std::upper_bound(times.begin(), times.end(), getCurrentTime());
+    if (it != times.end()) {
+        eval(getCurrentTime(), *it);
+    }
+}
+
+void AnimationController::prevKeyframe() {
+    auto times = animation_->getAllTimes();
+    auto it = std::lower_bound(times.begin(), times.end(), getCurrentTime());
+    if (it != times.begin()) {
+        eval(getCurrentTime(), *std::prev(it));
+    }
+}
+
+void AnimationController::nextControlKeyframe() {
+    std::vector<Seconds> times;
+    for (auto& track : animation_->getTracksOfType<ControlTrack>()) {
+        auto t = track->getAllTimes();
+        times.insert(times.end(), t.begin(), t.end());
+    }
+    std::sort(times.begin(), times.end());
+
+    auto it = std::upper_bound(times.begin(), times.end(), getCurrentTime());
+    if (it != times.end()) {
+        eval(getCurrentTime(), *it);
+    }
+}
+
+void AnimationController::prevControlKeyframe() {
+    std::vector<Seconds> times;
+    for (auto& track : animation_->getTracksOfType<ControlTrack>()) {
+        auto t = track->getAllTimes();
+        times.insert(times.end(), t.begin(), t.end());
+    }
+    std::sort(times.begin(), times.end());
+
+    auto it = std::lower_bound(times.begin(), times.end(), getCurrentTime());
+    if (it != times.begin()) {
+        eval(getCurrentTime(), *std::prev(it));
+    }
+}
+
 void AnimationController::tick() {
     if (state_ != AnimationState::Playing) {
         setState(AnimationState::Paused);

--- a/modules/animation/src/animationcontroller.cpp
+++ b/modules/animation/src/animationcontroller.cpp
@@ -259,54 +259,46 @@ void AnimationController::stop() {
 }
 
 void AnimationController::jumpToPrevKeyframe() {
-    auto prevKeyframeTime = animation_->getPrevTime(getCurrentTime());
-    if (getCurrentTime() != prevKeyframeTime) {
-        eval(getCurrentTime(), prevKeyframeTime);
+    if (auto prevKeyframeTime = animation_->getPrevTime(getCurrentTime())) {
+        eval(getCurrentTime(), *prevKeyframeTime);
     }
 }
 
 void AnimationController::jumpToNextKeyframe() {
-    auto nextKeyframeTime = animation_->getNextTime(getCurrentTime());
-    if (getCurrentTime() != nextKeyframeTime) {
-        eval(getCurrentTime(), nextKeyframeTime);
+    if (auto nextKeyframeTime = animation_->getNextTime(getCurrentTime())) {
+        eval(getCurrentTime(), *nextKeyframeTime);
     }
 }
 
 void AnimationController::jumpToPrevControlKeyframe() {
-    auto prevKeyframeTime = getCurrentTime();
+    std::optional<Seconds> prevKeyframeTime = std::nullopt;
     for (auto& track : animation_->getTracksOfType<ControlTrack>()) {
-        auto t = track.getPrevTime(getCurrentTime());
-        bool found = t != getCurrentTime();
-        if (!found) {
-            continue;
-        }
-        if (getCurrentTime() == prevKeyframeTime) {
-            prevKeyframeTime = t;
-        } else {
-            prevKeyframeTime = std::max(prevKeyframeTime, t);
+        if (auto t = track.getPrevTime(getCurrentTime())) {
+            if (!prevKeyframeTime) {
+                prevKeyframeTime = t;
+            } else {
+                *prevKeyframeTime = std::max(*prevKeyframeTime, *t);
+            }
         }
     }
-    if (getCurrentTime() != prevKeyframeTime) {
-        eval(getCurrentTime(), prevKeyframeTime);
+    if (prevKeyframeTime) {
+        eval(getCurrentTime(), *prevKeyframeTime);
     }
 }
 
 void AnimationController::jumpToNextControlKeyframe() {
-    auto nextKeyframeTime = getCurrentTime();
+    std::optional<Seconds> nextKeyframeTime = std::nullopt;
     for (auto& track : animation_->getTracksOfType<ControlTrack>()) {
-        auto t = track.getNextTime(getCurrentTime());
-        bool found = t != getCurrentTime();
-        if (!found) {
-            continue;
-        }
-        if (getCurrentTime() == nextKeyframeTime) {
-            nextKeyframeTime = t;
-        } else {
-            nextKeyframeTime = std::min(nextKeyframeTime, t);
+        if (auto t = track.getNextTime(getCurrentTime())) {
+            if (!nextKeyframeTime) {
+                nextKeyframeTime = t;
+            } else {
+                *nextKeyframeTime = std::min(*nextKeyframeTime, *t);
+            }
         }
     }
-    if (getCurrentTime() != nextKeyframeTime) {
-        eval(getCurrentTime(), nextKeyframeTime);
+    if (nextKeyframeTime) {
+        eval(getCurrentTime(), *nextKeyframeTime);
     }
 }
 

--- a/modules/animation/src/datastructures/animation.cpp
+++ b/modules/animation/src/datastructures/animation.cpp
@@ -266,6 +266,40 @@ Seconds Animation::getLastTime() const {
     return time;
 }
 
+Seconds Animation::getPrevTime(Seconds at) const {
+    auto prevKeyframeTime = at;
+    for (auto& track : tracks_) {
+        auto t = track->getPrevTime(at);
+        bool found = t != at;
+        if (!found) {
+            continue;
+        }
+        if (at == prevKeyframeTime) {
+            prevKeyframeTime = t;
+        } else {
+            prevKeyframeTime = std::max(prevKeyframeTime, t);
+        }
+    }
+    return prevKeyframeTime;
+}
+
+Seconds Animation::getNextTime(Seconds at) const {
+    auto nextKeyframeTime = at;
+    for (auto& track : tracks_) {
+        auto t = track->getNextTime(at);
+        bool found = t != at;
+        if (!found) {
+            continue;
+        }
+        if (at == nextKeyframeTime) {
+            nextKeyframeTime = t;
+        } else {
+            nextKeyframeTime = std::min(nextKeyframeTime, t);
+        }
+    }
+    return nextKeyframeTime;
+}
+
 const std::string& Animation::getName() const { return name_; }
 
 void inviwo::animation::Animation::setName(std::string_view name) {

--- a/modules/animation/src/datastructures/animation.cpp
+++ b/modules/animation/src/datastructures/animation.cpp
@@ -268,7 +268,7 @@ Seconds Animation::getLastTime() const {
 
 std::optional<Seconds> Animation::getPrevTime(Seconds at) const {
     std::optional<Seconds> prevKeyframeTime = std::nullopt;
-    for (auto& track : tracks_) {
+    for (const auto& track : tracks_) {
         if (auto t = track->getPrevTime(at)) {
             if (!prevKeyframeTime) {
                 prevKeyframeTime = t;
@@ -282,7 +282,7 @@ std::optional<Seconds> Animation::getPrevTime(Seconds at) const {
 
 std::optional<Seconds> Animation::getNextTime(Seconds at) const {
     std::optional<Seconds> nextKeyframeTime = std::nullopt;
-    for (auto& track : tracks_) {
+    for (const auto& track : tracks_) {
         if (auto t = track->getNextTime(at)) {
             if (!nextKeyframeTime) {
                 nextKeyframeTime = t;

--- a/modules/animation/src/datastructures/animation.cpp
+++ b/modules/animation/src/datastructures/animation.cpp
@@ -266,35 +266,29 @@ Seconds Animation::getLastTime() const {
     return time;
 }
 
-Seconds Animation::getPrevTime(Seconds at) const {
-    auto prevKeyframeTime = at;
+std::optional<Seconds> Animation::getPrevTime(Seconds at) const {
+    std::optional<Seconds> prevKeyframeTime = std::nullopt;
     for (auto& track : tracks_) {
-        auto t = track->getPrevTime(at);
-        bool found = t != at;
-        if (!found) {
-            continue;
-        }
-        if (at == prevKeyframeTime) {
-            prevKeyframeTime = t;
-        } else {
-            prevKeyframeTime = std::max(prevKeyframeTime, t);
+        if (auto t = track->getPrevTime(at)) {
+            if (!prevKeyframeTime) {
+                prevKeyframeTime = t;
+            } else {
+                *prevKeyframeTime = std::max(*prevKeyframeTime, *t);
+            }
         }
     }
     return prevKeyframeTime;
 }
 
-Seconds Animation::getNextTime(Seconds at) const {
-    auto nextKeyframeTime = at;
+std::optional<Seconds> Animation::getNextTime(Seconds at) const {
+    std::optional<Seconds> nextKeyframeTime = std::nullopt;
     for (auto& track : tracks_) {
-        auto t = track->getNextTime(at);
-        bool found = t != at;
-        if (!found) {
-            continue;
-        }
-        if (at == nextKeyframeTime) {
-            nextKeyframeTime = t;
-        } else {
-            nextKeyframeTime = std::min(nextKeyframeTime, t);
+        if (auto t = track->getNextTime(at)) {
+            if (!nextKeyframeTime) {
+                nextKeyframeTime = t;
+            } else {
+                *nextKeyframeTime = std::min(*nextKeyframeTime, *t);
+            }
         }
     }
     return nextKeyframeTime;

--- a/modules/animation/src/datastructures/controlkeyframe.cpp
+++ b/modules/animation/src/datastructures/controlkeyframe.cpp
@@ -67,7 +67,13 @@ AnimationTimeState ControlKeyframe::operator()(Seconds from, Seconds to,
                                                AnimationState state) const {
 
     if (state == AnimationState::Playing) {
-        if ((from <= getTime() && to >= getTime()) || (to <= getTime() && from >= getTime())) {
+        // Only apply action if we are coming to or passing over the keyframe.
+        // Do not apply action when the animation is starting
+        // exactly at the keyframe (from == getTime()) to allow for
+        // continuing an animation from the keyframe.
+        bool passedKeyframPlayingForward = (from < getTime() && to >= getTime());
+        bool passedKeyframePlayingBackward = (to <= getTime() && from > getTime());
+        if (passedKeyframPlayingForward || passedKeyframePlayingBackward) {
             // We passed over this keyframe
             switch (action_) {
                 case ControlAction::Pause:

--- a/modules/animation/src/datastructures/controlkeyframe.cpp
+++ b/modules/animation/src/datastructures/controlkeyframe.cpp
@@ -71,8 +71,8 @@ AnimationTimeState ControlKeyframe::operator()(Seconds from, Seconds to,
         // Do not apply action when the animation is starting
         // exactly at the keyframe (from == getTime()) to allow for
         // continuing an animation from the keyframe.
-        bool passedKeyframPlayingForward = (from < getTime() && to >= getTime());
-        bool passedKeyframePlayingBackward = (to <= getTime() && from > getTime());
+        const bool passedKeyframPlayingForward = (from < getTime() && to >= getTime());
+        const bool passedKeyframePlayingBackward = (to <= getTime() && from > getTime());
         if (passedKeyframPlayingForward || passedKeyframePlayingBackward) {
             // We passed over this keyframe
             switch (action_) {

--- a/modules/animation/src/datastructures/keyframesequence.cpp
+++ b/modules/animation/src/datastructures/keyframesequence.cpp
@@ -47,6 +47,7 @@ bool KeyframeSequence::isAnyKeyframeSelected() const {
 
 Seconds KeyframeSequence::getFirstTime() const { return getFirst().getTime(); }
 Seconds KeyframeSequence::getLastTime() const { return getLast().getTime(); }
+
 std::pair<Seconds, Seconds> KeyframeSequence::getTimeSpan() const {
     return {getFirstTime(), getLastTime()};
 }

--- a/modules/animation/tests/unittests/track-test.cpp
+++ b/modules/animation/tests/unittests/track-test.cpp
@@ -279,7 +279,7 @@ TEST(AnimationTests, ControlTrackTest) {
 
         auto state2 = animation(Seconds{1.0}, Seconds{2.0}, AnimationState::Playing);
         // Starting at control keyframe should not trigger it
-        EXPECT_EQ(AnimationState::Playing, state2.state); 
+        EXPECT_EQ(AnimationState::Playing, state2.state);
         EXPECT_EQ(Seconds{5}, state2.time);
 
         auto state3 = animation(Seconds{1.0}, animation.getLastTime(), AnimationState::Playing);
@@ -293,7 +293,7 @@ TEST(AnimationTests, ControlTrackTest) {
         EXPECT_EQ(Seconds{1}, state1.time);
 
         auto state2 = animation(Seconds{2.0}, Seconds{1.0}, AnimationState::Playing);
-        EXPECT_EQ(AnimationState::Paused, state2.state); 
+        EXPECT_EQ(AnimationState::Paused, state2.state);
         EXPECT_EQ(Seconds{1}, state2.time);
         // Time-jump to 5 seconds, skipping the pause-control keyframe at 1
         // This behaviour might be debatable, but taking time-jumping into consideration makes

--- a/modules/animation/tests/unittests/track-test.cpp
+++ b/modules/animation/tests/unittests/track-test.cpp
@@ -222,14 +222,14 @@ TEST(AnimationTests, AnimationTest) {
     EXPECT_EQ(Seconds{1.0}, animation.getFirstTime());
     EXPECT_EQ(Seconds{3.0}, animation.getLastTime());
 
-    EXPECT_EQ(Seconds{0.0}, animation.getPrevTime(Seconds{0.0}));
-    EXPECT_EQ(Seconds{1.0}, animation.getPrevTime(Seconds{1.0}));
+    EXPECT_EQ(std::nullopt, animation.getPrevTime(Seconds{0.0}));
+    EXPECT_EQ(std::nullopt, animation.getPrevTime(Seconds{1.0}));
     EXPECT_EQ(Seconds{1.0}, animation.getPrevTime(Seconds{2.0}));
     EXPECT_EQ(Seconds{3.0}, animation.getPrevTime(Seconds{4.0}));
 
     EXPECT_EQ(Seconds{1.0}, animation.getNextTime(Seconds{0.0}));
     EXPECT_EQ(Seconds{2.0}, animation.getNextTime(Seconds{1.0}));
-    EXPECT_EQ(Seconds{4.0}, animation.getNextTime(Seconds{4.0}));
+    EXPECT_EQ(std::nullopt, animation.getNextTime(Seconds{4.0}));
 
     animation[1][0].add(std::make_unique<ValueKeyframe<dvec3>>(Seconds{1.5}, dvec3(2.0)));
     animation[1][0].add(std::make_unique<ValueKeyframe<dvec3>>(Seconds{4.0}, dvec3(2.0)));

--- a/modules/animation/tests/unittests/track-test.cpp
+++ b/modules/animation/tests/unittests/track-test.cpp
@@ -222,10 +222,23 @@ TEST(AnimationTests, AnimationTest) {
     EXPECT_EQ(Seconds{1.0}, animation.getFirstTime());
     EXPECT_EQ(Seconds{3.0}, animation.getLastTime());
 
+    EXPECT_EQ(Seconds{0.0}, animation.getPrevTime(Seconds{0.0}));
+    EXPECT_EQ(Seconds{1.0}, animation.getPrevTime(Seconds{1.0}));
+    EXPECT_EQ(Seconds{1.0}, animation.getPrevTime(Seconds{2.0}));
+    EXPECT_EQ(Seconds{3.0}, animation.getPrevTime(Seconds{4.0}));
+
+    EXPECT_EQ(Seconds{1.0}, animation.getNextTime(Seconds{0.0}));
+    EXPECT_EQ(Seconds{2.0}, animation.getNextTime(Seconds{1.0}));
+    EXPECT_EQ(Seconds{4.0}, animation.getNextTime(Seconds{4.0}));
+
+    animation[1][0].add(std::make_unique<ValueKeyframe<dvec3>>(Seconds{1.5}, dvec3(2.0)));
     animation[1][0].add(std::make_unique<ValueKeyframe<dvec3>>(Seconds{4.0}, dvec3(2.0)));
 
     EXPECT_EQ(Seconds{1.0}, animation.getFirstTime());
     EXPECT_EQ(Seconds{4.0}, animation.getLastTime());
+    EXPECT_EQ(Seconds{1.5}, animation.getPrevTime(Seconds{2.0}));
+    EXPECT_EQ(Seconds{1.5}, animation.getNextTime(Seconds{1.0}));
+    EXPECT_EQ(Seconds{4.0}, animation.getNextTime(Seconds{3.0}));
 
     animation(Seconds{0.0}, Seconds{3.5}, AnimationState::Playing);
 

--- a/modules/animationqt/include/modules/animationqt/animationeditordockwidgetqt.h
+++ b/modules/animationqt/include/modules/animationqt/animationeditordockwidgetqt.h
@@ -86,10 +86,6 @@ protected:
     // Selected Animation in animationsList_ changed
     virtual void onAnimationChanged(AnimationController* controller, Animation* oldAnim,
                                     Animation* newAnim) override;
-    /*
-     * @return True if less than 0.5 seconds since last press, false otherwise.
-     */
-    bool isKeyDoublePressed() const;
 
     WorkspaceAnimations& animations_;
     AnimationController& controller_;
@@ -103,8 +99,6 @@ protected:
     TextLabelOverlay* overlay_;
     SequenceEditorPanel* sequenceEditorView_;
     QMainWindow* mainWindow_;
-    std::chrono::time_point<std::chrono::system_clock> lastKeyEventTimestamp_ =
-        std::chrono::system_clock::now();
     bool vScrolling_ = false;
 };
 

--- a/modules/animationqt/include/modules/animationqt/animationeditordockwidgetqt.h
+++ b/modules/animationqt/include/modules/animationqt/animationeditordockwidgetqt.h
@@ -77,6 +77,8 @@ public:
 
     virtual void closeEvent(QCloseEvent* event) override;
 
+    virtual QSize sizeHint() const override;
+
 protected:
     virtual void onStateChanged(AnimationController* controller, AnimationState prevState,
                                 AnimationState newState) override;

--- a/modules/animationqt/include/modules/animationqt/animationeditordockwidgetqt.h
+++ b/modules/animationqt/include/modules/animationqt/animationeditordockwidgetqt.h
@@ -84,6 +84,10 @@ protected:
     // Selected Animation in animationsList_ changed
     virtual void onAnimationChanged(AnimationController* controller, Animation* oldAnim,
                                     Animation* newAnim) override;
+    /*
+     * @return True if less than 0.5 seconds since last press, false otherwise.
+     */
+    bool isKeyDoublePressed() const;
 
     WorkspaceAnimations& animations_;
     AnimationController& controller_;
@@ -97,6 +101,8 @@ protected:
     TextLabelOverlay* overlay_;
     SequenceEditorPanel* sequenceEditorView_;
     QMainWindow* mainWindow_;
+    std::chrono::time_point<std::chrono::system_clock> lastKeyEventTimestamp_ =
+        std::chrono::system_clock::now();
     bool vScrolling_ = false;
 };
 

--- a/modules/animationqt/src/animationeditordockwidgetqt.cpp
+++ b/modules/animationqt/src/animationeditordockwidgetqt.cpp
@@ -316,7 +316,7 @@ AnimationEditorDockWidgetQt::AnimationEditorDockWidgetQt(
     {
         // For presentation, e.g, a clicker (Key_PageUp)
         auto* prevControlKeyframe = mainWindow_->addAction("Prev Control Keyframe");
-        prevControlKeyframe->setShortcut(Qt::Key_PageUp);  
+        prevControlKeyframe->setShortcut(Qt::Key_PageUp);
         prevControlKeyframe->setShortcutContext(Qt::WidgetWithChildrenShortcut);
         prevControlKeyframe->setToolTip("Previous Control Keyframe");
         connect(prevControlKeyframe, &QAction::triggered, [&]() {
@@ -352,9 +352,7 @@ AnimationEditorDockWidgetQt::AnimationEditorDockWidgetQt(
         prev->setShortcutContext(Qt::WidgetWithChildrenShortcut);
         prev->setToolTip("Prev Key");
         mainWindow_->addAction(prev);
-        connect(prev, &QAction::triggered, [&]() {
-            controller_.prevKeyframe();
-        });
+        connect(prev, &QAction::triggered, [&]() { controller_.prevKeyframe(); });
     }
 
     toolBar->addAction(playPause_);
@@ -372,8 +370,7 @@ AnimationEditorDockWidgetQt::AnimationEditorDockWidgetQt(
 
     {
         // For presentation, e.g, clicker (Key_PageDown)
-        auto* nextControlKeyframe = mainWindow_->addAction(
-            "Next Control Keyframe");
+        auto* nextControlKeyframe = mainWindow_->addAction("Next Control Keyframe");
         nextControlKeyframe->setShortcut(Qt::Key_PageDown);
         nextControlKeyframe->setShortcutContext(Qt::WidgetWithChildrenShortcut);
         nextControlKeyframe->setToolTip("Next Control Keyframe");

--- a/modules/animationqt/src/animationeditordockwidgetqt.cpp
+++ b/modules/animationqt/src/animationeditordockwidgetqt.cpp
@@ -322,9 +322,9 @@ AnimationEditorDockWidgetQt::AnimationEditorDockWidgetQt(
         connect(prevControlKeyframe, &QAction::triggered, [&]() {
             if (isKeyDoublePressed()) {
                 if (controller_.getAnimation().getTracksOfType<ControlTrack>().empty()) {
-                    controller_.prevKeyframe();
+                    controller_.jumpToPrevKeyframe();
                 } else {
-                    controller_.prevControlKeyframe();
+                    controller_.jumpToPrevControlKeyframe();
                 }
                 controller_.pause();
             } else {
@@ -352,7 +352,7 @@ AnimationEditorDockWidgetQt::AnimationEditorDockWidgetQt(
         prev->setShortcutContext(Qt::WidgetWithChildrenShortcut);
         prev->setToolTip("Prev Key");
         mainWindow_->addAction(prev);
-        connect(prev, &QAction::triggered, [&]() { controller_.prevKeyframe(); });
+        connect(prev, &QAction::triggered, [&]() { controller_.jumpToPrevKeyframe(); });
     }
 
     toolBar->addAction(playPause_);
@@ -365,7 +365,7 @@ AnimationEditorDockWidgetQt::AnimationEditorDockWidgetQt(
         next->setShortcutContext(Qt::WidgetWithChildrenShortcut);
         next->setToolTip("Next Key");
         mainWindow_->addAction(next);
-        connect(next, &QAction::triggered, [&]() { controller_.nextKeyframe(); });
+        connect(next, &QAction::triggered, [&]() { controller_.jumpToNextKeyframe(); });
     }
 
     {
@@ -378,9 +378,9 @@ AnimationEditorDockWidgetQt::AnimationEditorDockWidgetQt(
             if (isKeyDoublePressed()) {
                 // Jump to next keyframe
                 if (controller_.getAnimation().getTracksOfType<ControlTrack>().empty()) {
-                    controller_.nextKeyframe();
+                    controller_.jumpToNextKeyframe();
                 } else {
-                    controller_.nextControlKeyframe();
+                    controller_.jumpToNextControlKeyframe();
                 }
                 controller_.pause();
             } else {
@@ -415,8 +415,6 @@ AnimationEditorDockWidgetQt::AnimationEditorDockWidgetQt(
     }
 
     toolBar->addSeparator();
-
-    animationView_->setFocus();
 
     controller_.AnimationControllerObservable::addObserver(this);
 }

--- a/modules/animationqt/src/animationeditordockwidgetqt.cpp
+++ b/modules/animationqt/src/animationeditordockwidgetqt.cpp
@@ -171,7 +171,6 @@ AnimationEditorDockWidgetQt::AnimationEditorDockWidgetQt(
     , sequenceEditorView_{new SequenceEditorPanel(controller_, manager, editorFactory, this)}
     , mainWindow_{new QMainWindow()} {
 
-    resize(utilqt::emToPx(this, QSizeF(100, 40)));  // default size
     setAllowedAreas(Qt::BottomDockWidgetArea);
 
     setFloating(true);
@@ -451,6 +450,10 @@ void AnimationEditorDockWidgetQt::importAnimation() {
 }
 
 void AnimationEditorDockWidgetQt::closeEvent(QCloseEvent*) { controller_.pause(); }
+
+QSize AnimationEditorDockWidgetQt::sizeHint() const {
+    return utilqt::emToPx(this, QSizeF(100, 40)); // Default size
+ }
 
 void AnimationEditorDockWidgetQt::onStateChanged(AnimationController*, AnimationState,
                                                  AnimationState newState) {

--- a/modules/animationqt/src/animationeditordockwidgetqt.cpp
+++ b/modules/animationqt/src/animationeditordockwidgetqt.cpp
@@ -321,7 +321,7 @@ AnimationEditorDockWidgetQt::AnimationEditorDockWidgetQt(
         prevControlKeyframe->setToolTip("Previous Control Keyframe");
         connect(prevControlKeyframe, &QAction::triggered, [&]() {
             if (isKeyDoublePressed()) {
-                if (controller_.getAnimation().getTracksOfType<ControlTrack>().empty()) {
+                if (controller_.getAnimation().hasTrackType<ControlTrack>()) {
                     controller_.jumpToPrevKeyframe();
                 } else {
                     controller_.jumpToPrevControlKeyframe();

--- a/modules/animationqt/src/animationeditordockwidgetqt.cpp
+++ b/modules/animationqt/src/animationeditordockwidgetqt.cpp
@@ -482,7 +482,7 @@ void AnimationEditorDockWidgetQt::onAnimationChanged(AnimationController*, Anima
 bool AnimationEditorDockWidgetQt::isKeyDoublePressed() const {
     auto timestamp = std::chrono::system_clock::now();
     const std::chrono::duration<double> doublePressThreshold(0.500);
-    bool isDoublePress = (timestamp - lastKeyEventTimestamp_) < doublePressThreshold;
+    const bool isDoublePress = (timestamp - lastKeyEventTimestamp_) < doublePressThreshold;
     return isDoublePress;
 }
 

--- a/modules/animationqt/src/animationeditordockwidgetqt.cpp
+++ b/modules/animationqt/src/animationeditordockwidgetqt.cpp
@@ -301,6 +301,16 @@ AnimationEditorDockWidgetQt::AnimationEditorDockWidgetQt(
 
     toolBar->addSeparator();
 
+    // Double click if less than 0.5 seconds since last press
+    auto isKeyDoublePressed = [lastKeyEventTimestamp =
+                                   std::chrono::system_clock::now()]() mutable -> bool {
+        auto timestamp = std::chrono::system_clock::now();
+        const std::chrono::duration<double> doublePressThreshold(0.500);
+        const bool isDoublePress = (timestamp - lastKeyEventTimestamp) < doublePressThreshold;
+        lastKeyEventTimestamp = timestamp;
+        return isDoublePress;
+    };
+
     {
         auto* begin = toolBar->addAction(
             QIcon(":/animation/icons/arrow_media_next_player_previous_song_icon_128.svg"),
@@ -341,7 +351,6 @@ AnimationEditorDockWidgetQt::AnimationEditorDockWidgetQt(
                         break;
                 }
             }
-            lastKeyEventTimestamp_ = std::chrono::system_clock::now();
         });
     }
 
@@ -397,7 +406,6 @@ AnimationEditorDockWidgetQt::AnimationEditorDockWidgetQt(
                         break;
                 }
             }
-            lastKeyEventTimestamp_ = std::chrono::system_clock::now();
         });
     }
 
@@ -475,13 +483,6 @@ void AnimationEditorDockWidgetQt::onAnimationChanged(AnimationController*, Anima
             animationsList_->setCurrentIndex(selectedIndex);
         }
     }
-}
-
-bool AnimationEditorDockWidgetQt::isKeyDoublePressed() const {
-    auto timestamp = std::chrono::system_clock::now();
-    const std::chrono::duration<double> doublePressThreshold(0.500);
-    const bool isDoublePress = (timestamp - lastKeyEventTimestamp_) < doublePressThreshold;
-    return isDoublePress;
 }
 
 }  // namespace animation

--- a/modules/animationqt/src/animationeditordockwidgetqt.cpp
+++ b/modules/animationqt/src/animationeditordockwidgetqt.cpp
@@ -452,8 +452,8 @@ void AnimationEditorDockWidgetQt::importAnimation() {
 void AnimationEditorDockWidgetQt::closeEvent(QCloseEvent*) { controller_.pause(); }
 
 QSize AnimationEditorDockWidgetQt::sizeHint() const {
-    return utilqt::emToPx(this, QSizeF(100, 40)); // Default size
- }
+    return utilqt::emToPx(this, QSizeF(100, 40));  // Default size
+}
 
 void AnimationEditorDockWidgetQt::onStateChanged(AnimationController*, AnimationState,
                                                  AnimationState newState) {

--- a/modules/animationqt/src/animationeditorqt.cpp
+++ b/modules/animationqt/src/animationeditorqt.cpp
@@ -161,20 +161,9 @@ void AnimationEditorQt::keyPressEvent(QKeyEvent* keyEvent) {
                 animation.remove(&(seqqt->getKeyframeSequence()));
             }
         }
-    } else if (k == Qt::Key_Space) {
-        switch (controller_.getState()) {
-            case AnimationState::Paused:
-                controller_.play();
-                break;
-            case AnimationState::Playing:
-                controller_.pause();
-                break;
-            case AnimationState::Rendering:
-                break;
-            default:
-                break;
-        }
+        keyEvent->accept();
     }
+    QGraphicsScene::keyPressEvent(keyEvent);
 }
 
 void AnimationEditorQt::dragEnterEvent(QGraphicsSceneDragDropEvent* event) {

--- a/modules/qtwidgets/src/inviwodockwidget.cpp
+++ b/modules/qtwidgets/src/inviwodockwidget.cpp
@@ -75,6 +75,10 @@ InviwoDockWidget::~InviwoDockWidget() = default;
 void InviwoDockWidget::showEvent(QShowEvent* showEvent) {
     raise();
     QDockWidget::showEvent(showEvent);
+    // Workaround: set focus for floating dock widget
+    if (isFloating()) {
+        activateWindow();
+    }
 }
 
 void InviwoDockWidget::keyPressEvent(QKeyEvent* keyEvent) {

--- a/modules/qtwidgets/src/inviwodockwidgettitlebar.cpp
+++ b/modules/qtwidgets/src/inviwodockwidgettitlebar.cpp
@@ -76,6 +76,7 @@ InviwoDockWidgetTitleBar::InviwoDockWidgetTitleBar(QWidget* parent)
         stickyBtn_->setCheckable(true);
         stickyBtn_->setChecked(true);
         stickyBtn_->setIconSize(iconsize);
+        stickyBtn_->setFocusPolicy(Qt::FocusPolicy::NoFocus);
     }
     {
         floatBtn_ = new QToolButton();
@@ -86,6 +87,7 @@ InviwoDockWidgetTitleBar::InviwoDockWidgetTitleBar(QWidget* parent)
         floatBtn_->setCheckable(true);
         floatBtn_->setChecked(parent_->isFloating());
         floatBtn_->setIconSize(iconsize);
+        floatBtn_->setFocusPolicy(Qt::FocusPolicy::NoFocus);
     }
 
     {
@@ -94,6 +96,7 @@ InviwoDockWidgetTitleBar::InviwoDockWidgetTitleBar(QWidget* parent)
         icon.addFile(":/svgicons/close.svg", iconsize);
         closeBtn_->setIcon(icon);
         closeBtn_->setIconSize(iconsize);
+        closeBtn_->setFocusPolicy(Qt::FocusPolicy::NoFocus);
     }
 
     QHBoxLayout* layout = new QHBoxLayout(this);

--- a/modules/qtwidgets/src/tf/tfpropertydialog.cpp
+++ b/modules/qtwidgets/src/tf/tfpropertydialog.cpp
@@ -120,6 +120,7 @@ TFPropertyDialog::TFPropertyDialog(std::unique_ptr<TFPropertyConcept> model)
             const auto iconsize =
                 utilqt::emToPx(this, QSizeF(titlebar->getIconSize(), titlebar->getIconSize()));
             helpBtn->setIconSize(iconsize);
+            helpBtn->setFocusPolicy(Qt::FocusPolicy::NoFocus);
             layout->insertWidget(1, helpBtn);
 
             auto qtModule = util::getInviwoApplication(concept_->getProperty())


### PR DESCRIPTION
Clicking left/right on a presentation clicker animates to next (ControlTrack) keyframe. 
Double-clicking jumps to the next/prev (ControlTrack) keyframe

