### PR TITLE
Feature/dataminmaxgl

### DIFF
--- a/include/inviwo/core/algorithm/histogram1d.h
+++ b/include/inviwo/core/algorithm/histogram1d.h
@@ -101,6 +101,7 @@ std::pair<size_t, double> optimalBinCount(DataMapper dataMap, size_t bins) {
                                                     std::round(dataMap.dataRange.x) + 1.0);
             return intRangeBins(irange);
         }
+        return {bins, range};
     } else {
         // check whether number of bins exceeds the data range only if it is an integral type
         const auto irange = static_cast<std::size_t>(range + 1);
@@ -109,7 +110,6 @@ std::pair<size_t, double> optimalBinCount(DataMapper dataMap, size_t bins) {
         }
         return intRangeBins(irange);  // case 2.b
     }
-    return {bins, range};
 }
 
 }  // namespace detail

--- a/include/inviwo/core/datastructures/buffer/bufferram.h
+++ b/include/inviwo/core/datastructures/buffer/bufferram.h
@@ -450,8 +450,7 @@ IVW_CORE_API std::shared_ptr<BufferRAM> createBufferRAM(size_t size, const DataF
 template <BufferUsage U = BufferUsage::Static, typename T = vec3,
           BufferTarget Target = BufferTarget::Data>
 std::shared_ptr<BufferRAMPrecision<T, Target>> createBufferRAM(std::vector<T> data) {
-    return std::make_shared<BufferRAMPrecision<T, Target>>(std::move(data), DataFormat<T>::get(),
-                                                           U);
+    return std::make_shared<BufferRAMPrecision<T, Target>>(std::move(data), U);
 }
 
 /**

--- a/include/inviwo/core/datastructures/datamapper.h
+++ b/include/inviwo/core/datastructures/datamapper.h
@@ -51,15 +51,37 @@ class DataFormatBase;
  */
 class IVW_CORE_API DataMapper {
 public:
+    /**
+     * Signed fixed-point integers are normalized using either an asymmetric range
+     * [-2^(b-1), 2^(b-1) - 1] or a symmetric range [-2^(b-1) + 1, 2^(b-1) - 1], where b
+     * corresponds to the bit depth of the fixed-point integer.
+     *
+     * From version 4.2 and above, OpenGL uses a symmetric range to convert between normalized
+     * fixed-point integers and floating point values. For example, the range [-127, 127] is used
+     * for the normalization of 8bit signed integers instead of [-128, 127].
+     * In order to match the normalization of signed integer formats on the GPU, the symmetric
+     * normalization has to be used in the DataMapper for OpenGL >= 4.2.
+     *
+     * \see OpenGL 4.6 specification, Section 2.3.5 Fixed-Point Data Conversion
+     */
+    enum class SignedNormalization {
+        Asymmetric,  //!< uses an asymmetric range, i.e. [-2^(b-1), 2^(b-1) - 1]
+        Symmetric,   //!< uses a symmetric range, i.e. [-2^(b-1) + 1, 2^(b-1) - 1]
+    };
+
+    // asymetric
+
     DataMapper();
-    DataMapper(const DataFormatBase* format, Axis valueAxis = {});
+    DataMapper(const DataFormatBase* format,
+               SignedNormalization normalization = SignedNormalization::Asymmetric,
+               Axis valueAxis = {});
     explicit DataMapper(dvec2 dataRange, Axis valueAxis = {});
     DataMapper(dvec2 dataRange, dvec2 valueRange, Axis valueAxis = {});
     DataMapper(const DataMapper& rhs);
     DataMapper& operator=(const DataMapper& that);
 
     /**
-     * The ´dataRange´ is used to normalize the "raw" values to [0,1]
+     * The `dataRange` is used to normalize the "raw" values to [0,1]
      * Typically the minimum and maximum of the "raw" data is used. For 8 and 16 integer data that
      * is often the same or close to the same as the minimum and maximum of the data type. For data
      * where the minimum and maximum is far from the minimum and maximum of the data type, the
@@ -85,8 +107,11 @@ public:
      */
     Axis valueAxis;  ///< Name and Unit, i.e. "absorption", "Hounsfield".
 
-    static dvec2 defaultDataRangeFor(const DataFormatBase* format);
-    void initWithFormat(const DataFormatBase* format);
+    static dvec2 defaultDataRangeFor(
+        const DataFormatBase* format,
+        SignedNormalization normalization = SignedNormalization::Asymmetric);
+    void initWithFormat(const DataFormatBase* format,
+                        SignedNormalization normalization = SignedNormalization::Asymmetric);
 
     /**
      * Map from `dataRange` to the `valueRange`
@@ -116,12 +141,32 @@ public:
     }
 
     /**
+     * Map from `dataRange` to the Sign Normalized range [-1,1]
+     */
+    template <typename T>
+    util::same_extent_t<T, double> mapFromDataToSignNormalized(T val) const {
+        return util::linearMapToNormalized(static_cast<util::same_extent_t<T, double>>(val),
+                                           dataRange) *
+                   2.0 -
+               1.0;
+    }
+
+    /**
      * Map from Normalized range [0,1] to the `dataRange`
      */
     template <typename T>
     util::same_extent_t<T, double> mapFromNormalizedToData(T val) const {
         return util::linearMapFromNormalized(static_cast<util::same_extent_t<T, double>>(val),
                                              dataRange);
+    }
+
+    /**
+     * Map from Sign Normalized range [-1,1] to the `dataRange`
+     */
+    template <typename T>
+    util::same_extent_t<T, double> mapFromSignNormalizedToData(T val) const {
+        return util::linearMapFromNormalized(
+            (static_cast<util::same_extent_t<T, double>>(val) + 1.0) * 0.5, dataRange);
     }
 
     /**

--- a/include/inviwo/core/datastructures/datamapper.h
+++ b/include/inviwo/core/datastructures/datamapper.h
@@ -72,11 +72,11 @@ public:
     // asymetric
 
     DataMapper();
-    DataMapper(const DataFormatBase* format,
-               SignedNormalization normalization = SignedNormalization::Asymmetric,
-               Axis valueAxis = {});
-    explicit DataMapper(dvec2 dataRange, Axis valueAxis = {});
-    DataMapper(dvec2 dataRange, dvec2 valueRange, Axis valueAxis = {});
+    explicit DataMapper(const DataFormatBase* format,
+                        SignedNormalization normalization = SignedNormalization::Asymmetric,
+                        const Axis& valueAxis = {});
+    explicit DataMapper(dvec2 dataRange, const Axis& valueAxis = {});
+    DataMapper(dvec2 dataRange, dvec2 valueRange, const Axis& valueAxis = {});
     DataMapper(const DataMapper& rhs);
     DataMapper& operator=(const DataMapper& that);
 

--- a/include/inviwo/core/datastructures/datamapper.h
+++ b/include/inviwo/core/datastructures/datamapper.h
@@ -74,9 +74,9 @@ public:
     DataMapper();
     explicit DataMapper(const DataFormatBase* format,
                         SignedNormalization normalization = SignedNormalization::Asymmetric,
-                        const Axis& valueAxis = {});
-    explicit DataMapper(dvec2 dataRange, const Axis& valueAxis = {});
-    DataMapper(dvec2 dataRange, dvec2 valueRange, const Axis& valueAxis = {});
+                        Axis valueAxis = {});
+    explicit DataMapper(dvec2 dataRange, Axis valueAxis = {});
+    DataMapper(dvec2 dataRange, dvec2 valueRange, Axis valueAxis = {});
     DataMapper(const DataMapper& rhs);
     DataMapper& operator=(const DataMapper& that);
 

--- a/modules/basegl/CMakeLists.txt
+++ b/modules/basegl/CMakeLists.txt
@@ -3,6 +3,7 @@ ivw_module(BaseGL)
 
 # Add header files
 set(HEADER_FILES
+    include/modules/basegl/algorithm/dataminmaxgl.h
     include/modules/basegl/algorithm/entryexitpoints.h
     include/modules/basegl/algorithm/imageconvolution.h
     include/modules/basegl/algorithm/volumenormalization.h
@@ -133,6 +134,7 @@ ivw_group("Header Files" ${HEADER_FILES})
 
 # Add source files
 set(SOURCE_FILES
+    src/algorithm/dataminmaxgl.cpp
     src/algorithm/entryexitpoints.cpp
     src/algorithm/imageconvolution.cpp
     src/algorithm/volumenormalization.cpp
@@ -267,6 +269,10 @@ set(SHADER_FILES
     glsl/axisalignedcutplaneslice.frag
     glsl/axisalignedcutplaneslice.vert
     glsl/background.frag
+    glsl/compute/bufferminmax.comp
+    glsl/compute/layerminmax.comp
+    glsl/compute/linearminmax.comp
+    glsl/compute/volumeminmax.comp
     glsl/cubeglyph.frag
     glsl/cubeglyph.geom
     glsl/cubeglyph.vert

--- a/modules/basegl/glsl/compute/bufferminmax.comp
+++ b/modules/basegl/glsl/compute/bufferminmax.comp
@@ -1,0 +1,90 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2024 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+// Special handling for formats with 3 channels since those formats are usually padded to the
+// corresponding vec4 types when used with SSBOs, including arrays. To avoid padding, we instead
+// use linear arrays for 3 channels. For example `float sourceBuffer[]` instead of `vec3 sourceBuffer[]`. 
+// Note that this affects data access and indexing handled by GetValue()!
+//
+// See OpenGL 4.6 specification, Section 7.6.2.2 Standard Uniform Block Layout
+#if !defined BUFFER_DATATYPE
+#define BUFFER_DATATYPE vec4
+#endif
+#if !defined GetValue
+#define GetValue(value, index) value[index]
+#endif
+
+layout (std430, binding=0) readonly buffer SourceBufferObject {
+    BUFFER_DATATYPE sourceBuffer[];
+};
+
+layout (std430, binding=1) buffer BufferObject {
+    vec4 minmax[];
+};
+
+uniform uint arrayLength;
+
+shared vec4 workgroup_min[256 / 32];
+shared vec4 workgroup_max[256 / 32];
+
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+void main(){
+    uint threadId = gl_LocalInvocationIndex;
+    uint gridSize = gl_WorkGroupSize.x * gl_NumWorkGroups.x;
+    uint i = gl_WorkGroupID.x * gl_WorkGroupSize.x + threadId; 
+
+    vec4 minVal = vec4(1.0 / 0.0);
+    vec4 maxVal = vec4(-1.0 / 0.0);
+
+    while (i < arrayLength) {
+        vec4 val = GetValue(sourceBuffer, i);
+        minVal = min(minVal, val);
+        maxVal = max(maxVal, val);
+        i += gridSize;
+    }
+
+    minVal = subgroupMin(minVal);
+    maxVal = subgroupMax(maxVal);
+    if (subgroupElect()) {
+        workgroup_min[gl_SubgroupID] = minVal;
+        workgroup_max[gl_SubgroupID] = maxVal;
+    }
+    barrier();
+
+    if (gl_LocalInvocationIndex == 0) {
+        for (uint i = 0; i < gl_NumSubgroups; ++i) {
+            minVal = min(minVal, workgroup_min[i]);
+            maxVal = max(maxVal, workgroup_max[i]);
+        }
+        uint index = gl_WorkGroupID.x;
+        minmax[2 * index] = minVal;
+        minmax[2 * index + 1] = maxVal;
+    }
+}

--- a/modules/basegl/glsl/compute/bufferminmax.comp
+++ b/modules/basegl/glsl/compute/bufferminmax.comp
@@ -44,12 +44,14 @@ layout (std430, binding=0) readonly buffer SourceBufferObject {
     BUFFER_DATATYPE sourceBuffer[];
 };
 
-layout (std430, binding=1) buffer BufferObject {
+layout (std430, binding=1) restrict writeonly buffer BufferObject {
     vec4 minmax[];
 };
 
 uniform uint arrayLength;
 
+// Shared memory to store min/max values of each subgroup. That is 256 (local_size_x)
+// divided by 32 threads per subgroup (NVIDIA), or 64 threads on AMD hardware.
 shared vec4 workgroup_min[256 / 32];
 shared vec4 workgroup_max[256 / 32];
 
@@ -70,6 +72,7 @@ void main(){
         i += gridSize;
     }
 
+    // determine min/max values within the active threads, i.e. current subgroup
     minVal = subgroupMin(minVal);
     maxVal = subgroupMax(maxVal);
     if (subgroupElect()) {
@@ -78,6 +81,7 @@ void main(){
     }
     barrier();
 
+    // write back min/max of current work group into global buffer
     if (gl_LocalInvocationIndex == 0) {
         for (uint i = 0; i < gl_NumSubgroups; ++i) {
             minVal = min(minVal, workgroup_min[i]);

--- a/modules/basegl/glsl/compute/layerminmax.comp
+++ b/modules/basegl/glsl/compute/layerminmax.comp
@@ -1,0 +1,97 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2024 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#if !defined IMAGE_FORMAT
+#  define IMAGE_FORMAT r32f
+#endif
+#if !defined IMAGE_SOURCE
+#  define IMAGE_SOURCE image2D
+#endif
+
+// Need to use regular texture samplers for rgb formats, that is 3 channels, since there 
+// are no equivalent format/layout qualifiers and no support by imageLoad()/imageStore().
+//
+// See OpenGL 4.6 specification, Section 8.26 and Table 8.26
+// See https://www.khronos.org/opengl/wiki/Image_Load_Store#Format_qualifiers
+#if defined USE_IMAGE_SAMPLER
+#  define GetValue(gsampler, imageCoord) texelFetch(gsampler, imageCoord, 0)
+#  define GetSize(gsampler) textureSize(gsampler, 0)
+#else
+#  define GetValue(gimage, imageCoord) imageLoad(gimage, imageCoord)
+#  define GetSize(gimage) imageSize(gimage)
+#endif  // USE_IMAGE_SAMPLER
+
+#if defined USE_IMAGE_SAMPLER
+uniform IMAGE_SOURCE sourceImage;
+#else
+uniform layout(binding=0, IMAGE_FORMAT) readonly IMAGE_SOURCE sourceImage;
+#endif  // USE_IMAGE_SAMPLER
+
+layout (std430, binding=1) buffer BufferObject {
+    vec4 minmax[];
+};
+
+// 32x32 per workgroup
+shared vec4 workgroup_min[1024 / 32];
+shared vec4 workgroup_max[1024 / 32];
+
+layout(local_size_x = 32, local_size_y = 32, local_size_z = 1) in;
+
+void main(){
+    ivec2 layerDims = GetSize(sourceImage);
+
+    vec4 minVal = vec4(1.0 / 0.0);
+    vec4 maxVal = vec4(-1.0 / 0.0);
+
+    ivec2 layerIndex = ivec2(gl_GlobalInvocationID.x, gl_GlobalInvocationID.y);
+
+    if (all(lessThan(layerIndex, layerDims))) {
+        vec4 val = GetValue(sourceImage, layerIndex);
+        minVal = min(minVal, val);
+        maxVal = max(maxVal, val);
+    }
+
+    minVal = subgroupMin(minVal);
+    maxVal = subgroupMax(maxVal);
+    if (subgroupElect()) {
+        workgroup_min[gl_SubgroupID] = minVal;
+        workgroup_max[gl_SubgroupID] = maxVal;
+    }
+    barrier();
+
+    if (gl_LocalInvocationIndex == 0) {
+        for (uint i = 0; i < gl_NumSubgroups; ++i) {
+            minVal = min(minVal, workgroup_min[i]);
+            maxVal = max(maxVal, workgroup_max[i]);
+        }
+        uint index = gl_WorkGroupID.y * gl_NumWorkGroups.x + gl_WorkGroupID.x;
+        minmax[2 * index] = minVal;
+        minmax[2 * index + 1] = maxVal;
+    }
+}

--- a/modules/basegl/glsl/compute/layerminmax.comp
+++ b/modules/basegl/glsl/compute/layerminmax.comp
@@ -53,11 +53,12 @@ uniform IMAGE_SOURCE sourceImage;
 uniform layout(binding=0, IMAGE_FORMAT) readonly IMAGE_SOURCE sourceImage;
 #endif  // USE_IMAGE_SAMPLER
 
-layout (std430, binding=1) buffer BufferObject {
+layout (std430, binding=1) restrict writeonly buffer BufferObject {
     vec4 minmax[];
 };
 
-// 32x32 per workgroup
+// Shared memory to store min/max values of each subgroup. That is 32x32 (local_size_x * local_size_y)
+// divided by 32 threads per subgroup (NVIDIA), or 64 threads on AMD hardware.
 shared vec4 workgroup_min[1024 / 32];
 shared vec4 workgroup_max[1024 / 32];
 

--- a/modules/basegl/glsl/compute/linearminmax.comp
+++ b/modules/basegl/glsl/compute/linearminmax.comp
@@ -1,0 +1,72 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2024 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+layout (std430, binding=1) buffer BufferObject {
+    vec4 minmax[];
+};
+
+uniform uint arrayLength;
+
+shared vec4 workgroup_min[256 / 32];
+shared vec4 workgroup_max[256 / 32];
+
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+void main(){
+    uint threadId = gl_LocalInvocationIndex;
+    uint gridSize = gl_WorkGroupSize.x * gl_NumWorkGroups.x;
+    uint i = gl_WorkGroupID.x * gl_WorkGroupSize.x + threadId; 
+
+    vec4 minVal = vec4(1.0 / 0.0);
+    vec4 maxVal = vec4(-1.0 / 0.0);
+
+    while (i < arrayLength) {
+        minVal = min(minVal, minmax[2 * i]);
+        maxVal = max(maxVal, minmax[2 * i + 1]);
+        i += gridSize;
+    }
+
+    minVal = subgroupMin(minVal);
+    maxVal = subgroupMax(maxVal);
+    if (subgroupElect()) {
+        workgroup_min[gl_SubgroupID] = minVal;
+        workgroup_max[gl_SubgroupID] = maxVal;
+    }
+    barrier();
+
+    if (gl_LocalInvocationIndex == 0) {
+        for (uint i = 0; i < gl_NumSubgroups; ++i) {
+            minVal = min(minVal, workgroup_min[i]);
+            maxVal = max(maxVal, workgroup_max[i]);
+        }
+        uint index = gl_WorkGroupID.x;
+        minmax[2 * index] = minVal;
+        minmax[2 * index + 1] = maxVal;
+    }
+}

--- a/modules/basegl/glsl/compute/linearminmax.comp
+++ b/modules/basegl/glsl/compute/linearminmax.comp
@@ -33,6 +33,8 @@ layout (std430, binding=1) buffer BufferObject {
 
 uniform uint arrayLength;
 
+// Shared memory to store min/max values of each subgroup. That is 256 (local_size_x)
+// divided by 32 threads per subgroup (NVIDIA), or 64 threads on AMD hardware.
 shared vec4 workgroup_min[256 / 32];
 shared vec4 workgroup_max[256 / 32];
 
@@ -52,6 +54,7 @@ void main(){
         i += gridSize;
     }
 
+    // determine min/max values within the active threads, i.e. current subgroup
     minVal = subgroupMin(minVal);
     maxVal = subgroupMax(maxVal);
     if (subgroupElect()) {
@@ -60,6 +63,7 @@ void main(){
     }
     barrier();
 
+    // write back min/max of current work group into global buffer
     if (gl_LocalInvocationIndex == 0) {
         for (uint i = 0; i < gl_NumSubgroups; ++i) {
             minVal = min(minVal, workgroup_min[i]);

--- a/modules/basegl/glsl/compute/volumeminmax.comp
+++ b/modules/basegl/glsl/compute/volumeminmax.comp
@@ -1,0 +1,100 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2024 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#if !defined IMAGE_FORMAT
+#  define IMAGE_FORMAT r32f
+#endif
+#if !defined IMAGE_SOURCE
+#  define IMAGE_SOURCE image3D
+#endif
+
+// Need to use regular texture samplers and texelFetch for rgb formats, that is 3 channels, 
+// since there are no equivalent format/layout qualifiers and no support by 
+// imageLoad()/imageStore().
+//
+// See OpenGL 4.6 specification, Section 8.26 and Table 8.26
+// See https://www.khronos.org/opengl/wiki/Image_Load_Store#Format_qualifiers
+#if defined USE_IMAGE_SAMPLER
+#  define GetValue(gsampler, imageCoord) texelFetch(gsampler, imageCoord, 0)
+#  define GetSize(gsampler) textureSize(gsampler, 0)
+#else
+#  define GetValue(gimage, imageCoord) imageLoad(gimage, imageCoord)
+#  define GetSize(gimage) imageSize(gimage)
+#endif  // USE_IMAGE_SAMPLER
+
+#if defined USE_IMAGE_SAMPLER
+uniform IMAGE_SOURCE sourceImage;
+#else
+uniform layout(binding=0, IMAGE_FORMAT) readonly IMAGE_SOURCE sourceImage;
+#endif  // USE_IMAGE_SAMPLER
+
+layout (std430, binding=1) buffer BufferObject {
+    vec4 minmax[];
+};
+
+// 32x32 per workgroup
+shared vec4 workgroup_min[1024 / 32];
+shared vec4 workgroup_max[1024 / 32];
+
+layout(local_size_x = 32, local_size_y = 32, local_size_z = 1) in;
+
+void main(){
+    ivec3 volDims = GetSize(sourceImage);
+
+    vec4 minVal = vec4(1.0 / 0.0);
+    vec4 maxVal = vec4(-1.0 / 0.0);
+
+    ivec3 volIndex = ivec3(gl_GlobalInvocationID.x, gl_GlobalInvocationID.y, gl_GlobalInvocationID.z);
+
+    if (all(lessThan(volIndex, volDims))) {
+        for (int z = 0; z < volDims.z; ++z) {
+            vec4 val = GetValue(sourceImage, volIndex + ivec3(0, 0, z));
+            minVal = min(minVal, val);
+            maxVal = max(maxVal, val);
+        }
+    }
+
+    minVal = subgroupMin(minVal);
+    maxVal = subgroupMax(maxVal);
+    if (subgroupElect()) {
+        workgroup_min[gl_SubgroupID] = minVal;
+        workgroup_max[gl_SubgroupID] = maxVal;
+    }
+    barrier();
+
+    if (gl_LocalInvocationIndex == 0) {
+        for (uint i = 0; i < gl_NumSubgroups; ++i) {
+            minVal = min(minVal, workgroup_min[i]);
+            maxVal = max(maxVal, workgroup_max[i]);
+        }
+        uint index = gl_WorkGroupID.y * gl_NumWorkGroups.x + gl_WorkGroupID.x;
+        minmax[2 * index] = minVal;
+        minmax[2 * index + 1] = maxVal;
+    }
+}

--- a/modules/basegl/glsl/compute/volumeminmax.comp
+++ b/modules/basegl/glsl/compute/volumeminmax.comp
@@ -54,11 +54,12 @@ uniform IMAGE_SOURCE sourceImage;
 uniform layout(binding=0, IMAGE_FORMAT) readonly IMAGE_SOURCE sourceImage;
 #endif  // USE_IMAGE_SAMPLER
 
-layout (std430, binding=1) buffer BufferObject {
+layout (std430, binding=1) restrict writeonly buffer BufferObject {
     vec4 minmax[];
 };
 
-// 32x32 per workgroup
+// Shared memory to store min/max values of each subgroup. That is 32x32 (local_size_x * local_size_y)
+// divided by 32 threads per subgroup (NVIDIA), or 64 threads on AMD hardware.
 shared vec4 workgroup_min[1024 / 32];
 shared vec4 workgroup_max[1024 / 32];
 
@@ -80,6 +81,7 @@ void main(){
         }
     }
 
+    // determine min/max values within the active threads, i.e. current subgroup
     minVal = subgroupMin(minVal);
     maxVal = subgroupMax(maxVal);
     if (subgroupElect()) {
@@ -88,6 +90,7 @@ void main(){
     }
     barrier();
 
+    // write back min/max of current work group into global buffer
     if (gl_LocalInvocationIndex == 0) {
         for (uint i = 0; i < gl_NumSubgroups; ++i) {
             minVal = min(minVal, workgroup_min[i]);

--- a/modules/basegl/include/modules/basegl/algorithm/dataminmaxgl.h
+++ b/modules/basegl/include/modules/basegl/algorithm/dataminmaxgl.h
@@ -67,7 +67,11 @@ namespace utilgl {
 class IVW_MODULE_BASEGL_API DataMinMaxGL {
 public:
     DataMinMaxGL();
+    DataMinMaxGL(const DataMinMaxGL&) = default;
+    DataMinMaxGL(DataMinMaxGL&&) noexcept = default;
     ~DataMinMaxGL() = default;
+    DataMinMaxGL& operator=(const DataMinMaxGL&) = default;
+    DataMinMaxGL& operator=(DataMinMaxGL&&) noexcept = default;
 
     /**
      * Check whether the GPU supports compute shaders and the necessary OpenGL extensions.

--- a/modules/basegl/include/modules/basegl/algorithm/dataminmaxgl.h
+++ b/modules/basegl/include/modules/basegl/algorithm/dataminmaxgl.h
@@ -67,10 +67,10 @@ namespace utilgl {
 class IVW_MODULE_BASEGL_API DataMinMaxGL {
 public:
     DataMinMaxGL();
-    DataMinMaxGL(const DataMinMaxGL&) = default;
+    DataMinMaxGL(const DataMinMaxGL&) = delete;
     DataMinMaxGL(DataMinMaxGL&&) noexcept = default;
     ~DataMinMaxGL() = default;
-    DataMinMaxGL& operator=(const DataMinMaxGL&) = default;
+    DataMinMaxGL& operator=(const DataMinMaxGL&) = delete;
     DataMinMaxGL& operator=(DataMinMaxGL&&) noexcept = default;
 
     /**
@@ -100,7 +100,7 @@ private:
     Shader& getBufferMinMaxShader(const DataFormatBase* format);
     Shader& getLinearReduceShader();
 
-    const bool gpuSupport_;
+    bool gpuSupport_;
 
     Shader volumeMinMax_;
     Shader layerMinMax_;

--- a/modules/basegl/include/modules/basegl/algorithm/dataminmaxgl.h
+++ b/modules/basegl/include/modules/basegl/algorithm/dataminmaxgl.h
@@ -80,18 +80,18 @@ public:
      *      - NVIDIA: `GL_NV_gpu_shader5`
      *      - AMD: `GL_EXT_shader_explicit_arithmetic_types`
      *
-     * @return true if the GPU fullfills all requirements
+     * @return true if the GPU fulfills all requirements
      */
     static bool isSuppportedByGPU();
 
-    std::pair<dvec4, dvec4> minMax(const Volume* volume);
-    std::pair<dvec4, dvec4> minMax(const VolumeGL* volumeGL);
+    std::pair<dvec4, dvec4> minMax(const Volume& volume);
+    std::pair<dvec4, dvec4> minMax(const VolumeGL& volumeGL);
 
-    std::pair<dvec4, dvec4> minMax(const Layer* layer);
-    std::pair<dvec4, dvec4> minMax(const LayerGL* layerGL);
+    std::pair<dvec4, dvec4> minMax(const Layer& layer);
+    std::pair<dvec4, dvec4> minMax(const LayerGL& layerGL);
 
-    std::pair<dvec4, dvec4> minMax(const BufferBase* buffer);
-    std::pair<dvec4, dvec4> minMax(const BufferGL* bufferGL);
+    std::pair<dvec4, dvec4> minMax(const BufferBase& buffer);
+    std::pair<dvec4, dvec4> minMax(const BufferGL& bufferGL);
 
 private:
     Shader& getNdShader(Shader& shader, const GLFormat& glFormat, int nd);

--- a/modules/basegl/include/modules/basegl/algorithm/dataminmaxgl.h
+++ b/modules/basegl/include/modules/basegl/algorithm/dataminmaxgl.h
@@ -1,0 +1,113 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2024 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <modules/basegl/baseglmoduledefine.h>
+
+#include <inviwo/core/util/glmvec.h>
+#include <inviwo/core/util/formats.h>
+#include <modules/opengl/shader/shader.h>
+
+#include <utility>
+#include <string_view>
+#include <unordered_map>
+
+namespace inviwo {
+
+class Volume;
+class VolumeGL;
+class Layer;
+class LayerGL;
+class BufferBase;
+class BufferGL;
+struct GLFormat;
+class DataFormatBase;
+
+namespace utilgl {
+
+/**
+ * \brief Utility class for computing min and max values using OpenGL
+ *
+ * This class uses compute shaders to compute min and max values of Buffers, Layers, and Volumes.
+ * If compute shaders are not available, the corresponding CPU functions from
+ * modules/base/algorithm/dataminmax.h are used instead.
+ *
+ * The GPU needs to support the following OpenGL extensions:
+ *  + `GL_KHR_shader_subgroup`
+ *  + for 8bit and 16bit data type support for SSBOs (int8_t, i8vec2, ...)
+ *      - NVIDIA: `GL_NV_gpu_shader5`
+ *      - AMD: `GL_EXT_shader_explicit_arithmetic_types`
+ */
+class IVW_MODULE_BASEGL_API DataMinMaxGL {
+public:
+    DataMinMaxGL();
+    ~DataMinMaxGL() = default;
+
+    /**
+     * Check whether the GPU supports compute shaders and the necessary OpenGL extensions.
+     *  + `GL_KHR_shader_subgroup`
+     *  + for 8bit and 16bit data type support for SSBOs (int8_t, i8vec2, ...)
+     *      - NVIDIA: `GL_NV_gpu_shader5`
+     *      - AMD: `GL_EXT_shader_explicit_arithmetic_types`
+     *
+     * @return true if the GPU fullfills all requirements
+     */
+    static bool isSuppportedByGPU();
+
+    std::pair<dvec4, dvec4> minMax(const Volume* volume);
+    std::pair<dvec4, dvec4> minMax(const VolumeGL* volumeGL);
+
+    std::pair<dvec4, dvec4> minMax(const Layer* layer);
+    std::pair<dvec4, dvec4> minMax(const LayerGL* layerGL);
+
+    std::pair<dvec4, dvec4> minMax(const BufferBase* buffer);
+    std::pair<dvec4, dvec4> minMax(const BufferGL* bufferGL);
+
+private:
+    Shader& getNdShader(Shader& shader, const GLFormat& glFormat, int nd);
+    Shader& getVolumeMinMaxShader(const GLFormat& glFormat);
+    Shader& getLayerMinMaxShader(const GLFormat& glFormat);
+    Shader& getBufferMinMaxShader(const DataFormatBase* format);
+    Shader& getLinearReduceShader();
+
+    const bool gpuSupport_;
+
+    Shader volumeMinMax_;
+    Shader layerMinMax_;
+    Shader linearMinMax_;
+    Shader bufferMinMax_;
+
+    std::unordered_map<GLuint, DataFormatId> shaderDataFormat_;
+
+    const DataFormatBase* bufferFormat_ = nullptr;
+};
+
+}  // namespace utilgl
+
+}  // namespace inviwo

--- a/modules/basegl/src/algorithm/dataminmaxgl.cpp
+++ b/modules/basegl/src/algorithm/dataminmaxgl.cpp
@@ -92,13 +92,13 @@ std::string_view getImagePrefix(const GLFormat& glFormat) {
 
     // undo GL format normalization
     if (glFormat.normalization == utilgl::Normalization::Normalized) {
-        DataMapper dataMapper{DataFormatBase::get(GLFormats::get(glFormat))};
+        const DataMapper dataMapper{DataFormatBase::get(GLFormats::get(glFormat))};
 
         minmaxGL[0] = dataMapper.mapFromNormalizedToData(minmaxGL[0]);
         minmaxGL[1] = dataMapper.mapFromNormalizedToData(minmaxGL[1]);
     } else if (glFormat.normalization == utilgl::Normalization::SignNormalized) {
         using enum DataMapper::SignedNormalization;
-        DataMapper dataMapper{
+        const DataMapper dataMapper{
             DataFormatBase::get(GLFormats::get(glFormat)),
             OpenGLCapabilities::isSignedIntNormalizationSymmetric() ? Symmetric : Asymmetric};
 
@@ -124,15 +124,15 @@ std::string_view getImagePrefix(const GLFormat& glFormat) {
 
     // global buffer for min/max values for all work groups
     const size_t bufSize = 2 * glm::compMul(numGroups);
-    BufferObject buf(bufSize * sizeof(vec4), GLFormats::get(DataFormatId::Vec4Float32),
-                     GL_DYNAMIC_READ, GL_SHADER_STORAGE_BUFFER);
+    const BufferObject buf(bufSize * sizeof(vec4), GLFormats::get(DataFormatId::Vec4Float32),
+                           GL_DYNAMIC_READ, GL_SHADER_STORAGE_BUFFER);
     buf.bindBase(1);
 
     {
-        utilgl::Activate activateShader{&shader};
+        const utilgl::Activate activateShader{&shader};
 
         if (!useImageLoadStore) {
-            TextureUnit texUnit;
+            const TextureUnit texUnit;
             texUnit.activate();
             texture.bind();
             shader.setUniform("sourceImage", texUnit.getUnitNumber());
@@ -144,7 +144,7 @@ std::string_view getImagePrefix(const GLFormat& glFormat) {
     const std::uint32_t arrayLen = glm::compMul(numGroups);
     {
         glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
-        utilgl::Activate activateShader{&linearReduce};
+        const utilgl::Activate activateShader{&linearReduce};
         linearReduce.setUniform("arrayLength", arrayLen);
         glDispatchCompute(1, 1, 1);
     }
@@ -310,14 +310,14 @@ std::pair<dvec4, dvec4> DataMinMaxGL::minMax(const BufferGL* bufferGL) {
     LGL_ERROR;
     // global buffer for min/max values
     const size_t resultSize = 2;
-    BufferObject buf(resultSize * sizeof(vec4), GLFormats::get(DataFormatId::Vec4Float32),
+    const BufferObject buf(resultSize * sizeof(vec4), GLFormats::get(DataFormatId::Vec4Float32),
                      GL_DYNAMIC_READ, GL_SHADER_STORAGE_BUFFER);
     LGL_ERROR;
     buf.bindBase(1);
     LGL_ERROR;
 
     {
-        utilgl::Activate activateShade{&bufferMinMax};
+        const utilgl::Activate activateShade{&bufferMinMax};
         bufferMinMax.setUniform("arrayLength", bufferSize);
         glDispatchCompute(1, 1, 1);
     }

--- a/modules/basegl/src/algorithm/dataminmaxgl.cpp
+++ b/modules/basegl/src/algorithm/dataminmaxgl.cpp
@@ -1,0 +1,436 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2024 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <modules/basegl/algorithm/dataminmaxgl.h>
+
+#include <inviwo/core/datastructures/buffer/buffer.h>
+#include <inviwo/core/datastructures/image/layer.h>
+#include <inviwo/core/datastructures/volume/volume.h>
+#include <modules/opengl/openglcapabilities.h>
+#include <modules/opengl/buffer/buffergl.h>
+#include <modules/opengl/image/layergl.h>
+#include <modules/opengl/volume/volumegl.h>
+#include <modules/opengl/glformats.h>
+#include <modules/opengl/openglutils.h>
+#include <modules/opengl/volume/volumegl.h>
+#include <modules/opengl/buffer/buffergl.h>
+#include <modules/opengl/buffer/bufferobject.h>
+#include <modules/opengl/texture/texture2d.h>
+#include <modules/opengl/texture/texture3d.h>
+#include <modules/opengl/texture/textureunit.h>
+#include <modules/base/algorithm/dataminmax.h>
+
+#include <string_view>
+#include <array>
+
+namespace inviwo::utilgl {
+
+namespace detail {
+
+std::string_view getSamplerPrefix(const GLFormat& glFormat) {
+    if (glFormat.normalization != utilgl::Normalization::None) {
+        return {};
+    }
+    const auto* format = DataFormatBase::get(GLFormats::get(glFormat));
+    using namespace std::string_view_literals;
+    switch (format->getNumericType()) {
+        case NumericType::UnsignedInteger:
+            return "u"sv;
+        case NumericType::SignedInteger:
+            return "i"sv;
+        default:
+            return {};
+    }
+}
+
+std::string_view getImagePrefix(const GLFormat& glFormat) {
+    using namespace std::string_view_literals;
+    if (glFormat.layoutQualifier.ends_with("ui")) {
+        return "u"sv;
+    } else if (glFormat.layoutQualifier.ends_with("i")) {
+        return "i"sv;
+    } else {
+        return {};
+    }
+}
+
+[[nodiscard]] std::pair<dvec4, dvec4> downloadResultFromBuffer(const GLFormat& glFormat) {
+    std::array minmaxGL{vec4{0}, vec4{0}};
+    glGetBufferSubData(GL_SHADER_STORAGE_BUFFER, 0, 2 * sizeof(glm::vec4), minmaxGL.data());
+
+    if (glFormat.channels < 4) {
+        // reset alpha channel since imageLoad in the shader returns a = 1.0 for non-rgba formats
+        minmaxGL[0].a = 0.0;
+        minmaxGL[1].a = 0.0;
+    }
+
+    // undo GL format normalization
+    if (glFormat.normalization == utilgl::Normalization::Normalized) {
+        DataMapper dataMapper{DataFormatBase::get(GLFormats::get(glFormat))};
+
+        minmaxGL[0] = dataMapper.mapFromNormalizedToData(minmaxGL[0]);
+        minmaxGL[1] = dataMapper.mapFromNormalizedToData(minmaxGL[1]);
+    } else if (glFormat.normalization == utilgl::Normalization::SignNormalized) {
+        using enum DataMapper::SignedNormalization;
+        DataMapper dataMapper{
+            DataFormatBase::get(GLFormats::get(glFormat)),
+            OpenGLCapabilities::isSignedIntNormalizationSymmetric() ? Symmetric : Asymmetric};
+
+        minmaxGL[0] = dataMapper.mapFromSignNormalizedToData(minmaxGL[0]);
+        minmaxGL[1] = dataMapper.mapFromSignNormalizedToData(minmaxGL[1]);
+    }
+    return {minmaxGL[0], minmaxGL[1]};
+}
+
+[[nodiscard]] std::pair<dvec4, dvec4> reduce2D(Shader& shader, Shader& linearReduce, uvec2 dims,
+                                               const GLFormat& glFormat, const Texture& texture) {
+    const uvec3 groupSize{32, 32, 1};
+    const uvec3 numGroups{(uvec3{dims.x, dims.y, 1} + groupSize - uvec3{1}) / groupSize};
+
+    const bool useImageLoadStore = (glFormat.channels != 3);
+
+    LGL_ERROR;
+    if (useImageLoadStore) {
+        glBindImageTexture(0, texture.getID(), 0, GL_TRUE, 0, GL_READ_ONLY,
+                           glFormat.internalFormat);
+    }
+    LGL_ERROR;
+
+    // global buffer for min/max values for all work groups
+    const size_t bufSize = 2 * glm::compMul(numGroups);
+    BufferObject buf(bufSize * sizeof(vec4), GLFormats::get(DataFormatId::Vec4Float32),
+                     GL_DYNAMIC_READ, GL_SHADER_STORAGE_BUFFER);
+    buf.bindBase(1);
+
+    {
+        utilgl::Activate activateShader{&shader};
+
+        if (!useImageLoadStore) {
+            TextureUnit texUnit;
+            texUnit.activate();
+            texture.bind();
+            shader.setUniform("sourceImage", texUnit.getUnitNumber());
+            TextureUnit::setZeroUnit();
+        }
+
+        glDispatchCompute(numGroups.x, numGroups.y, numGroups.z);
+    }
+    const std::uint32_t arrayLen = glm::compMul(numGroups);
+    {
+        glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
+        utilgl::Activate activateShader{&linearReduce};
+        linearReduce.setUniform("arrayLength", arrayLen);
+        glDispatchCompute(1, 1, 1);
+    }
+
+    glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
+
+    return downloadResultFromBuffer(glFormat);
+}
+
+std::string_view glslDataType(DataFormatId id) {
+    using namespace std::string_view_literals;
+
+    // Special handling for formats with 3 channels since those formats are usually padded to the
+    // corresponding vec4 types when used with SSBOs, including arrays. To avoid padding, we instead
+    // use linear arrays for 3 channels. For example `float buf[]` instead of `vec3 buf[]`. Note
+    // that this affects data access and indexing!
+    //
+    // See OpenGL 4.6 specification, Section 7.6.2.2 Standard Uniform Block Layout
+    static constexpr auto size = static_cast<size_t>(DataFormatId::NumberOfFormats);
+    static constexpr std::array<std::string_view, size> glslType{{
+        // clang-format off
+        {},           // NotSpecialized
+        // 1 channels
+        "float"sv,    // Float32
+        {},           // Float64
+        "int8_t"sv,   // Int8
+        "int16_t"sv,  // Int16
+        "int"sv,      // Int32
+        {},           // Int64
+        "uint8_t"sv,  // UInt8
+        "uint16_t"sv, // UInt16
+        "uint"sv,     // UInt32
+        {},           // UInt64
+        // 2 channels
+        "vec2"sv,     // Vec2Float32
+        {},           // Vec2Float64
+        "i8vec2"sv,   // Vec2Int8
+        "i16vec2"sv,  // Vec2Int16
+        "int"sv,      // Vec2Int32
+        {},           // Vec2Int64
+        "u8vec2"sv,   // Vec2UInt8
+        "u16vec2"sv,  // Vec2UInt16
+        "uvec2"sv,    // Vec2UInt32
+        {},           // Vec2UInt64
+        // 3 channels (special case, use scalars to avoid padding)
+        "float"sv,    // Vec3Float32
+        {},           // Vec3Float64
+        "int8_t"sv,   // Vec3Int8
+        "int16_t"sv,  // Vec3Int16
+        "int"sv,      // Vec3Int32
+        {},           // Vec3Int64
+        "uint8_t"sv,  // Vec3UInt8
+        "uint16_t"sv, // Vec3UInt16
+        "uint"sv,     // Vec3UInt32
+        {},           // Vec4UInt64
+        // 4 channels
+        "vec4"sv,     // Vec4Float32
+        {},           // Vec4Float64
+        "i8vec4"sv,   // Vec4Int8
+        "i16vec4"sv,  // Vec4Int16
+        "ivec4"sv,    // Vec4Int32
+        {},           // Vec4Int64
+        "u8vec4"sv,   // Vec4UInt8
+        "u16vec4"sv,  // Vec4UInt16
+        "uvec4"sv,    // Vec4UInt32
+        {},           // Vec4UInt64
+        // clang-format on
+    }};
+
+    if (glslType[static_cast<size_t>(id)].empty()) {
+        throw OpenGLException(IVW_CONTEXT_CUSTOM("GLFormat"),
+                              "Error no GLSL data type found for selected data format: {}",
+                              DataFormatBase::get(id)->getString());
+    }
+    return glslType[static_cast<size_t>(id)];
+}
+
+std::string_view glslDataConversion(size_t numComponents) {
+    // Conversion from any data type with numComponents channels to vec4.
+    // Special case for 3 component types.
+    // See glslDataType()
+    using namespace std::string_view_literals;
+    static constexpr std::array<std::string_view, 4> conversion{{
+        "vec4(value[index], 0, 0, 0)"sv,
+        "vec4(value[index], 0, 0)"sv,
+        "vec4(value[3 * index], value[3 * index + 1], value[3 * index + 2], 0)"sv,
+        "value[index]"sv,
+    }};
+    return conversion[std::min(numComponents - 1, conversion.size())];
+}
+
+}  // namespace detail
+
+DataMinMaxGL::DataMinMaxGL()
+    : gpuSupport_{isSuppportedByGPU()}
+    , volumeMinMax_{{{ShaderType::Compute, "compute/volumeminmax.comp"}}, Shader::Build::No}
+    , layerMinMax_{{{ShaderType::Compute, "compute/layerminmax.comp"}}, Shader::Build::No}
+    , linearMinMax_{{{ShaderType::Compute, "compute/linearminmax.comp"}}, Shader::Build::No}
+    , bufferMinMax_{{{ShaderType::Compute, "compute/bufferminmax.comp"}}, Shader::Build::No} {}
+
+std::pair<dvec4, dvec4> DataMinMaxGL::minMax(const Volume* volume) {
+    if (!gpuSupport_) {
+        return util::volumeMinMax(volume);
+    }
+    return minMax(volume->getRepresentation<VolumeGL>());
+}
+
+std::pair<dvec4, dvec4> DataMinMaxGL::minMax(const VolumeGL* volumeGL) {
+    if (!gpuSupport_) {
+        return util::volumeMinMax(volumeGL->getOwner());
+    }
+
+    const auto& glFormat = GLFormats::get(volumeGL->getDataFormatId());
+
+    Shader& volumeMinMax = getVolumeMinMaxShader(glFormat);
+    Shader& linearReduce = getLinearReduceShader();
+
+    const uvec3 dims{volumeGL->getDimensions()};
+    // ignore z dimension since the compute shader iterates over all voxels in z direction
+    return detail::reduce2D(volumeMinMax, linearReduce, uvec2{dims}, glFormat,
+                            *volumeGL->getTexture());
+}
+
+std::pair<dvec4, dvec4> DataMinMaxGL::minMax(const Layer* layer) {
+    if (!gpuSupport_) {
+        return util::layerMinMax(layer);
+    }
+    return minMax(layer->getRepresentation<LayerGL>());
+}
+
+std::pair<dvec4, dvec4> DataMinMaxGL::minMax(const LayerGL* layerGL) {
+    if (!gpuSupport_) {
+        return util::layerMinMax(layerGL->getOwner());
+    }
+
+    const auto& glFormat = GLFormats::get(layerGL->getDataFormatId());
+
+    Shader& layerMinMax = getLayerMinMaxShader(glFormat);
+    Shader& linearReduce = getLinearReduceShader();
+
+    return detail::reduce2D(layerMinMax, linearReduce, layerGL->getDimensions(), glFormat,
+                            *layerGL->getTexture());
+}
+
+std::pair<dvec4, dvec4> DataMinMaxGL::minMax(const BufferBase* buffer) {
+    if (!gpuSupport_) {
+        return util::bufferMinMax(buffer);
+    }
+    return minMax(buffer->getRepresentation<BufferGL>());
+}
+
+std::pair<dvec4, dvec4> DataMinMaxGL::minMax(const BufferGL* bufferGL) {
+    if (!gpuSupport_) {
+        return util::bufferMinMax(bufferGL->getOwner());
+    }
+
+    Shader& bufferMinMax = getBufferMinMaxShader(bufferGL->getDataFormat());
+
+    LGL_ERROR;
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, bufferGL->getId());
+    const auto bufferSize = static_cast<std::uint32_t>(bufferGL->getSize());
+
+    LGL_ERROR;
+    // global buffer for min/max values
+    const size_t resultSize = 2;
+    BufferObject buf(resultSize * sizeof(vec4), GLFormats::get(DataFormatId::Vec4Float32),
+                     GL_DYNAMIC_READ, GL_SHADER_STORAGE_BUFFER);
+    LGL_ERROR;
+    buf.bindBase(1);
+    LGL_ERROR;
+
+    {
+        utilgl::Activate activateShade{&bufferMinMax};
+        bufferMinMax.setUniform("arrayLength", bufferSize);
+        glDispatchCompute(1, 1, 1);
+    }
+    LGL_ERROR;
+
+    // download result
+    glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
+
+    std::array minmaxGL{vec4{0}, vec4{0}};
+    glGetBufferSubData(GL_SHADER_STORAGE_BUFFER, 0, 2 * sizeof(glm::vec4), minmaxGL.data());
+
+    if (bufferGL->getDataFormat()->getComponents() < 4) {
+        // reset alpha channel since imageLoad in the shader returns a = 1.0 for non-rgba formats
+        minmaxGL[0].a = 0.0;
+        minmaxGL[1].a = 0.0;
+    }
+    return {minmaxGL[0], minmaxGL[1]};
+}
+
+Shader& DataMinMaxGL::getNdShader(Shader& shader, const GLFormat& glFormat, int nd) {
+    using enum ShaderObject::ExtensionBehavior;
+
+    auto* computeShader = shader.getComputeShaderObject();
+    if (!computeShader->hasShaderExtension("GL_KHR_shader_subgroup_basic")) {
+        computeShader->addShaderExtension("GL_KHR_shader_subgroup_basic", Require);
+        computeShader->addShaderExtension("GL_KHR_shader_subgroup_arithmetic", Require);
+        shader.invalidate();
+    }
+
+    const auto formatId = GLFormats::get(glFormat);
+    if (auto it = shaderDataFormat_.find(computeShader->getID());
+        it == shaderDataFormat_.end() || it->second != formatId) {
+
+        const bool useImageLoadStore = (glFormat.channels != 3);
+
+        StrBuffer buf;
+        if (useImageLoadStore) {
+            // use image and imageLoad()
+            computeShader->addShaderDefine("IMAGE_FORMAT", glFormat.layoutQualifier);
+            computeShader->removeShaderDefine("USE_IMAGE_SAMPLER");
+            buf.append("{}image{}D", detail::getImagePrefix(glFormat), nd);
+        } else {
+            // use regular texture sampler since imageLoad() does not support RGB formats
+            computeShader->addShaderDefine("USE_IMAGE_SAMPLER");
+            buf.append("{}sampler{}D", detail::getSamplerPrefix(glFormat), nd);
+        }
+        computeShader->addShaderDefine("IMAGE_SOURCE", buf);
+
+        shaderDataFormat_[computeShader->getID()] = formatId;
+        shader.invalidate();
+    }
+
+    if (!shader.isReady()) {
+        shader.build();
+    }
+    return shader;
+}
+
+Shader& DataMinMaxGL::getVolumeMinMaxShader(const GLFormat& glFormat) {
+    return getNdShader(volumeMinMax_, glFormat, 3);
+}
+
+Shader& DataMinMaxGL::getLayerMinMaxShader(const GLFormat& glFormat) {
+    return getNdShader(layerMinMax_, glFormat, 2);
+}
+
+bool DataMinMaxGL::isSuppportedByGPU() {
+    return OpenGLCapabilities::isComputeShadersSupported() &&
+           (OpenGLCapabilities::isExtensionSupported("GL_NV_gpu_shader5") ||
+            OpenGLCapabilities::isExtensionSupported("GL_EXT_shader_explicit_arithmetic_types")) &&
+           OpenGLCapabilities::isExtensionSupported("GL_KHR_shader_subgroup");
+}
+
+Shader& DataMinMaxGL::getBufferMinMaxShader(const DataFormatBase* format) {
+    using enum ShaderObject::ExtensionBehavior;
+
+    auto* computeShader = bufferMinMax_.getComputeShaderObject();
+    if (!computeShader->hasShaderExtension("GL_KHR_shader_subgroup_basic")) {
+        computeShader->addShaderExtension("GL_KHR_shader_subgroup_basic", Require);
+        computeShader->addShaderExtension("GL_KHR_shader_subgroup_arithmetic", Require);
+
+        // enable SSBO support for 8bit and 16bit data types (int8_t, uint16_t, i8vec2, ...)
+        // NVIDIA:
+        if (OpenGLCapabilities::isExtensionSupported("GL_NV_gpu_shader5")) {
+            computeShader->addShaderExtension("GL_NV_gpu_shader5", Require);
+        }
+        // AMD:
+        if (OpenGLCapabilities::isExtensionSupported("GL_EXT_shader_explicit_arithmetic_types")) {
+            computeShader->addShaderExtension("GL_EXT_shader_explicit_arithmetic_types", Require);
+        }
+        bufferMinMax_.invalidate();
+    }
+
+    if (!bufferMinMax_.isReady() || bufferFormat_ != format) {
+        bufferFormat_ = format;
+        computeShader->addShaderDefine("BUFFER_DATATYPE", detail::glslDataType(format->getId()));
+        computeShader->addShaderDefine("GetValue(value, index)",
+                                       detail::glslDataConversion(format->getComponents()));
+        bufferMinMax_.build();
+    }
+    return bufferMinMax_;
+}
+
+Shader& DataMinMaxGL::getLinearReduceShader() {
+    if (!linearMinMax_.isReady()) {
+        using enum ShaderObject::ExtensionBehavior;
+
+        auto* computeShader = linearMinMax_.getComputeShaderObject();
+        computeShader->addShaderExtension("GL_KHR_shader_subgroup_basic", Require);
+        computeShader->addShaderExtension("GL_KHR_shader_subgroup_arithmetic", Require);
+        linearMinMax_.build();
+    }
+    return linearMinMax_;
+}
+
+}  // namespace inviwo::utilgl

--- a/modules/opengl/include/modules/opengl/openglcapabilities.h
+++ b/modules/opengl/include/modules/opengl/openglcapabilities.h
@@ -67,7 +67,7 @@ public:
 
     enum class GlVendor { Nvidia, Amd, Intel, Unknown };
 
-    OpenGLCapabilities(OpenGLSettings* settings);
+    explicit OpenGLCapabilities(OpenGLSettings* settings);
     virtual ~OpenGLCapabilities();
 
     virtual void printInfo() override;
@@ -93,6 +93,15 @@ public:
     bool isGeometryShadersSupported() const;
     static bool isComputeShadersSupported();
     static bool isShaderStorageBuffersSupported();
+    /**
+     * The conversion from normalized fixed-point integers to floating-point values and back was
+     * changed to use a symmetric range in OpenGL 4.2. That is the range [-127, 127] is used
+     * for the normalization of 8bit signed integers instead of [-128, 127].
+     *
+     * \see DataMapper::SignedNormalization
+     * \see OpenGL 4.6 specification, Section 2.3.5 Fixed-Point Data Conversion
+     */
+    static bool isSignedIntNormalizationSymmetric();
 
     GLSLShaderVersion getCurrentShaderVersion();
     size_t getCurrentShaderIndex() const;

--- a/modules/opengl/src/openglcapabilities.cpp
+++ b/modules/opengl/src/openglcapabilities.cpp
@@ -263,6 +263,10 @@ bool OpenGLCapabilities::isShaderStorageBuffersSupported() {
            isExtensionSupported("ARB_shader_storage_buffer_object");
 }
 
+bool OpenGLCapabilities::isSignedIntNormalizationSymmetric() {
+    return OpenGLCapabilities::getOpenGLVersion() >= 420;
+}
+
 int OpenGLCapabilities::getMaxProgramLoopCount() const { return maxProgramLoopCount_; }
 int OpenGLCapabilities::getNumTexUnits() const { return numTexUnits_; }
 int OpenGLCapabilities::getMaxTexSize() const { return maxTexSize_; }

--- a/modules/opengl/src/shader/shaderutils.cpp
+++ b/modules/opengl/src/shader/shaderutils.cpp
@@ -53,6 +53,7 @@
 #include <inviwo/core/util/stringconversion.h>                // for StrBuffer, splitStringView
 #include <modules/opengl/inviwoopengl.h>                      // for LGL_ERROR
 #include <modules/opengl/glformats.h>
+#include <modules/opengl/openglcapabilities.h>
 #include <modules/opengl/openglexception.h>       // for OpenGLException
 #include <modules/opengl/shader/shader.h>         // for Shader
 #include <modules/opengl/shader/shadermanager.h>  // for ShaderManager
@@ -75,8 +76,11 @@ namespace utilgl {
 
 void setShaderUniforms(Shader& shader, const DataMapper& dataMapper, const DataFormatBase* format,
                        std::string_view name) {
+    using enum DataMapper::SignedNormalization;
+
     const dvec2 dataRange = dataMapper.dataRange;
-    const DataMapper defaultRange(format);
+    const DataMapper defaultRange(
+        format, OpenGLCapabilities::isSignedIntNormalizationSymmetric() ? Symmetric : Asymmetric);
 
     const double invRange = 1.0 / (dataRange.y - dataRange.x);
     const double defaultToDataRange =

--- a/src/core/datastructures/datamapper.cpp
+++ b/src/core/datastructures/datamapper.cpp
@@ -34,14 +34,14 @@ namespace inviwo {
 
 DataMapper::DataMapper() : DataMapper(DataUInt8::get(), SignedNormalization::Asymmetric) {}
 DataMapper::DataMapper(const DataFormatBase* format, SignedNormalization normalization,
-                       const Axis& aValueAxis)
+                       Axis aValueAxis)
     : dataRange{defaultDataRangeFor(format, normalization)}
     , valueRange{dataRange}
-    , valueAxis{aValueAxis} {}
-DataMapper::DataMapper(dvec2 aDataRange, const Axis& aValueAxis)
-    : dataRange{aDataRange}, valueRange{dataRange}, valueAxis{aValueAxis} {}
-DataMapper::DataMapper(dvec2 aDataRange, dvec2 aValueRange, const Axis& aValueAxis)
-    : dataRange{aDataRange}, valueRange{aValueRange}, valueAxis{aValueAxis} {}
+    , valueAxis{std::move(aValueAxis)} {}
+DataMapper::DataMapper(dvec2 aDataRange, Axis aValueAxis)
+    : dataRange{aDataRange}, valueRange{dataRange}, valueAxis{std::move(aValueAxis)} {}
+DataMapper::DataMapper(dvec2 aDataRange, dvec2 aValueRange, Axis aValueAxis)
+    : dataRange{aDataRange}, valueRange{aValueRange}, valueAxis{std::move(aValueAxis)} {}
 
 DataMapper::DataMapper(const DataMapper& rhs) = default;
 

--- a/src/core/datastructures/datamapper.cpp
+++ b/src/core/datastructures/datamapper.cpp
@@ -32,9 +32,12 @@
 
 namespace inviwo {
 
-DataMapper::DataMapper() : DataMapper(DataUInt8::get()) {}
-DataMapper::DataMapper(const DataFormatBase* format, Axis aValueAxis)
-    : dataRange{defaultDataRangeFor(format)}, valueRange{dataRange}, valueAxis{aValueAxis} {}
+DataMapper::DataMapper() : DataMapper(DataUInt8::get(), SignedNormalization::Asymmetric) {}
+DataMapper::DataMapper(const DataFormatBase* format, SignedNormalization normalization,
+                       Axis aValueAxis)
+    : dataRange{defaultDataRangeFor(format, normalization)}
+    , valueRange{dataRange}
+    , valueAxis{aValueAxis} {}
 DataMapper::DataMapper(dvec2 aDataRange, Axis aValueAxis)
     : dataRange{aDataRange}, valueRange{dataRange}, valueAxis{aValueAxis} {}
 DataMapper::DataMapper(dvec2 aDataRange, dvec2 aValueRange, Axis aValueAxis)
@@ -44,23 +47,28 @@ DataMapper::DataMapper(const DataMapper& rhs) = default;
 
 DataMapper& DataMapper::operator=(const DataMapper& that) = default;
 
-dvec2 DataMapper::defaultDataRangeFor(const DataFormatBase* format) {
+dvec2 DataMapper::defaultDataRangeFor(const DataFormatBase* format,
+                                      SignedNormalization normalization) {
     switch (format->getNumericType()) {
         case NumericType::Float:
             return {0.0, 1.0};
         case NumericType::UnsignedInteger:
             return {0.0, format->getMax()};
         case NumericType::SignedInteger:
-            return {format->getMin(), format->getMax()};
+            if (normalization == SignedNormalization::Symmetric) {
+                return {-format->getMax(), format->getMax()};
+            } else {
+                return {format->getMin(), format->getMax()};
+            }
         case NumericType::NotSpecialized:
             return {format->getMin(), format->getMax()};
     }
     return {format->getMin(), format->getMax()};
 }
 
-void DataMapper::initWithFormat(const DataFormatBase* format) {
+void DataMapper::initWithFormat(const DataFormatBase* format, SignedNormalization normalization) {
 
-    dataRange = defaultDataRangeFor(format);
+    dataRange = defaultDataRangeFor(format, normalization);
     valueRange = dataRange;
     valueAxis = {"", Unit{}};
 }

--- a/src/core/datastructures/datamapper.cpp
+++ b/src/core/datastructures/datamapper.cpp
@@ -34,13 +34,13 @@ namespace inviwo {
 
 DataMapper::DataMapper() : DataMapper(DataUInt8::get(), SignedNormalization::Asymmetric) {}
 DataMapper::DataMapper(const DataFormatBase* format, SignedNormalization normalization,
-                       Axis aValueAxis)
+                       const Axis& aValueAxis)
     : dataRange{defaultDataRangeFor(format, normalization)}
     , valueRange{dataRange}
     , valueAxis{aValueAxis} {}
-DataMapper::DataMapper(dvec2 aDataRange, Axis aValueAxis)
+DataMapper::DataMapper(dvec2 aDataRange, const Axis& aValueAxis)
     : dataRange{aDataRange}, valueRange{dataRange}, valueAxis{aValueAxis} {}
-DataMapper::DataMapper(dvec2 aDataRange, dvec2 aValueRange, Axis aValueAxis)
+DataMapper::DataMapper(dvec2 aDataRange, dvec2 aValueRange, const Axis& aValueAxis)
     : dataRange{aDataRange}, valueRange{aValueRange}, valueAxis{aValueAxis} {}
 
 DataMapper::DataMapper(const DataMapper& rhs) = default;

--- a/tests/integrationtests/CMakeLists.txt
+++ b/tests/integrationtests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCE_FILES
     propertycreation-test.cpp
     volume-test.cpp
     shader-test.cpp
+    dataminmaxgl-test.cpp
 )
 ivw_group("Source Files" ${SOURCE_FILES})
 
@@ -22,6 +23,7 @@ target_link_libraries(inviwo-integrationtests PRIVATE
     inviwo::core
     inviwo::module-system
     inviwo::module::opengl
+    inviwo::module::basegl
     inviwo::module::glfw
     inviwo::module::base
     inviwo::testutil

--- a/tests/integrationtests/dataminmaxgl-test.cpp
+++ b/tests/integrationtests/dataminmaxgl-test.cpp
@@ -1,0 +1,220 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2014-2024 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/core/datastructures/volume/volume.h>
+#include <inviwo/core/datastructures/volume/volumeram.h>
+#include <inviwo/core/datastructures/image/layer.h>
+#include <inviwo/core/datastructures/image/layerram.h>
+#include <inviwo/core/datastructures/buffer/buffer.h>
+#include <inviwo/core/datastructures/buffer/bufferram.h>
+#include <inviwo/core/io/datareaderfactory.h>
+#include <inviwo/core/common/inviwoapplication.h>
+#include <inviwo/core/util/filesystem.h>
+#include <inviwo/core/util/indexmapper.h>
+#include <modules/opengl/openglcapabilities.h>
+#include <modules/basegl/algorithm/dataminmaxgl.h>
+#include <modules/base/algorithm/dataminmax.h>
+
+#include <cmath>
+#include <ranges>
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <gtest/gtest.h>
+#include <warn/pop>
+
+namespace inviwo {
+
+class DataMinMaxGLTest : public ::testing::Test {
+public:
+    DataMinMaxGLTest() = default;
+
+protected:
+    virtual void SetUp() override {
+        if (!utilgl::DataMinMaxGL::isSuppportedByGPU()) {
+            GTEST_SKIP() << "Compute Shaders and/or necessary extensions not available. Skipping "
+                            "DataMinMaxGL tests.";
+        }
+        minmaxGL_ = std::make_unique<utilgl::DataMinMaxGL>();
+    }
+    void testVolume(std::string_view filename);
+    // void testVolume(std::string_view filename);
+    void test(std::shared_ptr<Volume> volume);
+    void test(std::shared_ptr<Layer> layer);
+    void test(std::shared_ptr<BufferBase> buffer);
+
+private:
+    std::unique_ptr<utilgl::DataMinMaxGL> minmaxGL_;
+};
+
+void DataMinMaxGLTest::testVolume(std::string_view filename) {
+    auto file = filesystem::getPath(PathType::Tests) / "volumes" / filename;
+    auto reader = InviwoApplication::getPtr()
+                      ->getDataReaderFactory()
+                      ->getReaderForTypeAndExtension<VolumeSequence>(file);
+    ASSERT_TRUE(reader.get() != nullptr);
+    auto volumeSeq = reader->readData(file);
+    ASSERT_EQ(1, volumeSeq->size());
+
+    test(volumeSeq->front());
+}
+
+void DataMinMaxGLTest::test(std::shared_ptr<Volume> volume) {
+    auto [refMin, refMax] = util::volumeMinMax(volume.get(), IgnoreSpecialValues::No);
+    auto [glMin, glMax] = minmaxGL_->minMax(volume.get());
+
+    EXPECT_EQ(refMin, glMin) << "Minimum values differ";
+    EXPECT_EQ(refMax, glMax) << "Maximum values differ";
+}
+
+void DataMinMaxGLTest::test(std::shared_ptr<Layer> layer) {
+    auto [refMin, refMax] = util::layerMinMax(layer.get(), IgnoreSpecialValues::No);
+    auto [glMin, glMax] = minmaxGL_->minMax(layer.get());
+
+    EXPECT_EQ(refMin, glMin) << "Minimum values differ";
+    EXPECT_EQ(refMax, glMax) << "Maximum values differ";
+}
+
+void DataMinMaxGLTest::test(std::shared_ptr<BufferBase> buffer) {
+    auto [refMin, refMax] = util::bufferMinMax(buffer.get(), IgnoreSpecialValues::No);
+    auto [glMin, glMax] = minmaxGL_->minMax(buffer.get());
+
+    EXPECT_EQ(refMin, glMin) << "Minimum values differ";
+    EXPECT_EQ(refMax, glMax) << "Maximum values differ";
+}
+
+template <typename T>
+[[nodiscard]] std::shared_ptr<Volume> createVolume(size3_t dims) {
+    using Type = T::type;
+    using ValueType = T::primitive;
+    auto volumeRam = std::make_shared<VolumeRAMPrecision<Type>>(VolumeReprConfig{
+        .dimensions = dims,
+        .format = T::get(),
+    });
+    auto data = volumeRam->getView();
+    util::IndexMapper3D im{dims};
+    for (auto i : std::views::iota(0u, data.size())) {
+        data[i] = Type{static_cast<ValueType>(1 + glm::compAdd(im(i)))};
+    }
+
+    return std::make_shared<Volume>(volumeRam);
+}
+
+template <typename T>
+[[nodiscard]] std::shared_ptr<Layer> createLayer(size2_t dims) {
+    using Type = T::type;
+    using ValueType = T::primitive;
+    auto layerRam = std::make_shared<LayerRAMPrecision<Type>>(LayerReprConfig{
+        .dimensions = dims,
+        .format = T::get(),
+    });
+    auto data = layerRam->getView();
+    util::IndexMapper2D im{dims};
+    for (auto i : std::views::iota(0u, data.size())) {
+        data[i] = Type{static_cast<ValueType>(1 + glm::compAdd(im(i)))};
+    }
+
+    return std::make_shared<Layer>(layerRam);
+}
+
+template <typename T>
+[[nodiscard]] std::shared_ptr<BufferBase> createBuffer(size_t size) {
+    using Type = T::type;
+    using ValueType = T::primitive;
+
+    std::vector<Type> data(size);
+    for (auto i : std::views::iota(0u, data.size())) {
+        data[i] = Type{static_cast<ValueType>(1 + i)};
+    }
+    auto bufferRam = createBufferRAM(data);
+    return std::make_shared<Buffer<Type>>(bufferRam);
+}
+
+// Test volume min/max
+TEST_F(DataMinMaxGLTest, VolumeUInt8) { test(createVolume<DataUInt8>({64, 20, 10})); }
+TEST_F(DataMinMaxGLTest, VolumeVec2UInt8) { test(createVolume<DataVec2UInt8>({64, 20, 10})); }
+TEST_F(DataMinMaxGLTest, VolumeVec3UInt8) { test(createVolume<DataVec3UInt8>({64, 20, 10})); }
+TEST_F(DataMinMaxGLTest, VolumeVec4UInt8) { test(createVolume<DataVec4UInt8>({64, 20, 10})); }
+
+TEST_F(DataMinMaxGLTest, VolumeInt8) { test(createVolume<DataInt8>({64, 20, 10})); }
+TEST_F(DataMinMaxGLTest, VolumeVec2Int8) { test(createVolume<DataVec2Int8>({64, 20, 10})); }
+TEST_F(DataMinMaxGLTest, VolumeVec3Int8) { test(createVolume<DataVec3Int8>({64, 20, 10})); }
+TEST_F(DataMinMaxGLTest, VolumeVec4Int8) { test(createVolume<DataVec4Int8>({64, 20, 10})); }
+
+TEST_F(DataMinMaxGLTest, VolumeFloat32) { test(createVolume<DataFloat32>({64, 20, 10})); }
+TEST_F(DataMinMaxGLTest, VolumeVec2Float32) { test(createVolume<DataVec2Float32>({64, 20, 10})); }
+TEST_F(DataMinMaxGLTest, VolumeVec3Float32) { test(createVolume<DataVec3Float32>({64, 20, 10})); }
+TEST_F(DataMinMaxGLTest, VolumeVec4Float32) { test(createVolume<DataVec4Float32>({64, 20, 10})); }
+
+// 8 bit
+TEST_F(DataMinMaxGLTest, VolumeTypeUINT8) { testVolume("testdata.UINT8.dat"); }
+TEST_F(DataMinMaxGLTest, VolumeTypeINT8) { testVolume("testdata.INT8.dat"); }
+
+// 16 bit
+TEST_F(DataMinMaxGLTest, VolumeTypeUINT16) { testVolume("testdata.UINT16.LittleEndian.dat"); }
+TEST_F(DataMinMaxGLTest, VolumeTypeINT16) { testVolume("testdata.INT16.LittleEndian.dat"); }
+
+// 32 bit
+TEST_F(DataMinMaxGLTest, VolumeTypeUINT32) { testVolume("testdata.UINT32.LittleEndian.dat"); }
+TEST_F(DataMinMaxGLTest, VolumeTypeINT32) { testVolume("testdata.INT32.LittleEndian.dat"); }
+TEST_F(DataMinMaxGLTest, VolumeTypeFLOAT32) { testVolume("testdata.FLOAT32.LittleEndian.dat"); }
+
+// Test layer min/max
+TEST_F(DataMinMaxGLTest, LayerUInt8) { test(createLayer<DataUInt8>({64, 20})); }
+TEST_F(DataMinMaxGLTest, LayerVec2UInt8) { test(createLayer<DataVec2UInt8>({64, 20})); }
+TEST_F(DataMinMaxGLTest, LayerVec3UInt8) { test(createLayer<DataVec3UInt8>({64, 20})); }
+TEST_F(DataMinMaxGLTest, LayerVec4UInt8) { test(createLayer<DataVec4UInt8>({64, 20})); }
+
+TEST_F(DataMinMaxGLTest, LayerInt8) { test(createLayer<DataInt8>({64, 20})); }
+TEST_F(DataMinMaxGLTest, LayerVec2Int8) { test(createLayer<DataVec2Int8>({64, 20})); }
+TEST_F(DataMinMaxGLTest, LayerVec3Int8) { test(createLayer<DataVec3Int8>({64, 20})); }
+TEST_F(DataMinMaxGLTest, LayerVec4Int8) { test(createLayer<DataVec4Int8>({64, 20})); }
+
+TEST_F(DataMinMaxGLTest, LayerFloat32) { test(createLayer<DataFloat32>({64, 20})); }
+TEST_F(DataMinMaxGLTest, LayerVec2Float32) { test(createLayer<DataVec2Float32>({64, 20})); }
+TEST_F(DataMinMaxGLTest, LayerVec3Float32) { test(createLayer<DataVec3Float32>({64, 20})); }
+TEST_F(DataMinMaxGLTest, LayerVec4Float32) { test(createLayer<DataVec4Float32>({64, 20})); }
+
+// Test buffer min/max
+TEST_F(DataMinMaxGLTest, BufferUInt8) { test(createBuffer<DataUInt8>(64)); }
+TEST_F(DataMinMaxGLTest, BufferVec2UInt8) { test(createBuffer<DataVec2UInt8>(64)); }
+TEST_F(DataMinMaxGLTest, BufferVec3UInt8) { test(createBuffer<DataVec3UInt8>(64)); }
+TEST_F(DataMinMaxGLTest, BufferVec4UInt8) { test(createBuffer<DataVec4UInt8>(64)); }
+
+TEST_F(DataMinMaxGLTest, BufferInt8) { test(createBuffer<DataInt8>(64)); }
+TEST_F(DataMinMaxGLTest, BufferVec2Int8) { test(createBuffer<DataVec2Int8>(64)); }
+TEST_F(DataMinMaxGLTest, BufferVec3Int8) { test(createBuffer<DataVec3Int8>(64)); }
+TEST_F(DataMinMaxGLTest, BufferVec4Int8) { test(createBuffer<DataVec4Int8>(64)); }
+
+TEST_F(DataMinMaxGLTest, BufferFloat32) { test(createBuffer<DataFloat32>(64)); }
+TEST_F(DataMinMaxGLTest, BufferVec2Float32) { test(createBuffer<DataVec2Float32>(64)); }
+TEST_F(DataMinMaxGLTest, BufferVec3Float32) { test(createBuffer<DataVec3Float32>(64)); }
+TEST_F(DataMinMaxGLTest, BufferVec4Float32) { test(createBuffer<DataVec4Float32>(64)); }
+
+}  // namespace inviwo

--- a/tests/integrationtests/dataminmaxgl-test.cpp
+++ b/tests/integrationtests/dataminmaxgl-test.cpp
@@ -65,9 +65,9 @@ protected:
     }
     void testVolume(std::string_view filename);
     // void testVolume(std::string_view filename);
-    void test(std::shared_ptr<Volume> volume);
-    void test(std::shared_ptr<Layer> layer);
-    void test(std::shared_ptr<BufferBase> buffer);
+    void test(const std::shared_ptr<Volume>& volume);
+    void test(const std::shared_ptr<Layer>& layer);
+    void test(const std::shared_ptr<BufferBase>& buffer);
 
 private:
     std::unique_ptr<utilgl::DataMinMaxGL> minmaxGL_;
@@ -85,7 +85,7 @@ void DataMinMaxGLTest::testVolume(std::string_view filename) {
     test(volumeSeq->front());
 }
 
-void DataMinMaxGLTest::test(std::shared_ptr<Volume> volume) {
+void DataMinMaxGLTest::test(const std::shared_ptr<Volume>& volume) {
     auto [refMin, refMax] = util::volumeMinMax(volume.get(), IgnoreSpecialValues::No);
     auto [glMin, glMax] = minmaxGL_->minMax(volume.get());
 
@@ -93,7 +93,7 @@ void DataMinMaxGLTest::test(std::shared_ptr<Volume> volume) {
     EXPECT_EQ(refMax, glMax) << "Maximum values differ";
 }
 
-void DataMinMaxGLTest::test(std::shared_ptr<Layer> layer) {
+void DataMinMaxGLTest::test(const std::shared_ptr<Layer>& layer) {
     auto [refMin, refMax] = util::layerMinMax(layer.get(), IgnoreSpecialValues::No);
     auto [glMin, glMax] = minmaxGL_->minMax(layer.get());
 
@@ -101,7 +101,7 @@ void DataMinMaxGLTest::test(std::shared_ptr<Layer> layer) {
     EXPECT_EQ(refMax, glMax) << "Maximum values differ";
 }
 
-void DataMinMaxGLTest::test(std::shared_ptr<BufferBase> buffer) {
+void DataMinMaxGLTest::test(const std::shared_ptr<BufferBase>& buffer) {
     auto [refMin, refMax] = util::bufferMinMax(buffer.get(), IgnoreSpecialValues::No);
     auto [glMin, glMax] = minmaxGL_->minMax(buffer.get());
 
@@ -118,7 +118,7 @@ template <typename T>
         .format = T::get(),
     });
     auto data = volumeRam->getView();
-    util::IndexMapper3D im{dims};
+    const util::IndexMapper3D im{dims};
     for (auto i : std::views::iota(0u, data.size())) {
         data[i] = Type{static_cast<ValueType>(1 + glm::compAdd(im(i)))};
     }
@@ -135,7 +135,7 @@ template <typename T>
         .format = T::get(),
     });
     auto data = layerRam->getView();
-    util::IndexMapper2D im{dims};
+    const util::IndexMapper2D im{dims};
     for (auto i : std::views::iota(0u, data.size())) {
         data[i] = Type{static_cast<ValueType>(1 + glm::compAdd(im(i)))};
     }

--- a/tests/integrationtests/dataminmaxgl-test.cpp
+++ b/tests/integrationtests/dataminmaxgl-test.cpp
@@ -87,7 +87,7 @@ void DataMinMaxGLTest::testVolume(std::string_view filename) {
 
 void DataMinMaxGLTest::test(const std::shared_ptr<Volume>& volume) {
     auto [refMin, refMax] = util::volumeMinMax(volume.get(), IgnoreSpecialValues::No);
-    auto [glMin, glMax] = minmaxGL_->minMax(volume.get());
+    auto [glMin, glMax] = minmaxGL_->minMax(*volume);
 
     EXPECT_EQ(refMin, glMin) << "Minimum values differ";
     EXPECT_EQ(refMax, glMax) << "Maximum values differ";
@@ -95,7 +95,7 @@ void DataMinMaxGLTest::test(const std::shared_ptr<Volume>& volume) {
 
 void DataMinMaxGLTest::test(const std::shared_ptr<Layer>& layer) {
     auto [refMin, refMax] = util::layerMinMax(layer.get(), IgnoreSpecialValues::No);
-    auto [glMin, glMax] = minmaxGL_->minMax(layer.get());
+    auto [glMin, glMax] = minmaxGL_->minMax(*layer);
 
     EXPECT_EQ(refMin, glMin) << "Minimum values differ";
     EXPECT_EQ(refMax, glMax) << "Maximum values differ";
@@ -103,7 +103,7 @@ void DataMinMaxGLTest::test(const std::shared_ptr<Layer>& layer) {
 
 void DataMinMaxGLTest::test(const std::shared_ptr<BufferBase>& buffer) {
     auto [refMin, refMax] = util::bufferMinMax(buffer.get(), IgnoreSpecialValues::No);
-    auto [glMin, glMax] = minmaxGL_->minMax(buffer.get());
+    auto [glMin, glMax] = minmaxGL_->minMax(*buffer);
 
     EXPECT_EQ(refMin, glMin) << "Minimum values differ";
     EXPECT_EQ(refMax, glMax) << "Maximum values differ";

--- a/tests/integrationtests/inviwo-integrationtests.cpp
+++ b/tests/integrationtests/inviwo-integrationtests.cpp
@@ -109,7 +109,7 @@ int main(int argc, char** argv) {
         ret = RUN_ALL_TESTS();
 
         if (ret) {
-            LogErrorCustom("UnitTestsModule::runAllTests",
+            LogErrorCustom("IntegrationTests::runAllTests",
                            "Some unit tests did not pass, see console output for details");
         }
 
@@ -117,14 +117,14 @@ int main(int argc, char** argv) {
         size_t errCountAfter = logCounter->getErrorCount();
 
         if (warnCount != warnCountAfter) {
-            LogWarnCustom("UnitTestsModule::runAllTest", "The integration test runs generated "
-                                                             << (warnCountAfter - warnCount)
-                                                             << " warnings");
+            LogWarnCustom("IntegrationTests::runAllTest", "The integration test runs generated "
+                                                              << (warnCountAfter - warnCount)
+                                                              << " warnings");
         }
         if (errCount != errCountAfter) {
-            LogWarnCustom("UnitTestsModule::runAllTest", "The  integration test runs generated "
-                                                             << (errCountAfter - errCount)
-                                                             << " errors");
+            LogWarnCustom("IntegrationTests::runAllTest", "The integration test runs generated "
+                                                              << (errCountAfter - errCount)
+                                                              << " errors");
         }
     }
 


### PR DESCRIPTION
Changes proposed in this PR:
 * symmetric and asymmetric normalization for signed fixed-point integers to match OpenGL behavior
 * added `utilgl::DataMinMaxGL` for determining min/max values of GL representations using compute shaders

This has been tested on: Windows, NVIDIA GPU
