### PR TITLE
Animation: Fix bug causing state change in eval to be overridden

### DIFF
--- a/modules/animation/src/animationcontroller.cpp
+++ b/modules/animation/src/animationcontroller.cpp
@@ -368,11 +368,12 @@ void AnimationController::tick() {
         }
     }
 
+    // Update possible state change caused by playback mode.
+    // We need to do this before eval since eval must be able to change the state.
+    setState(newState);
+
     // Evaluate animation
     eval(currentTime_, newTime);
-
-    // May be in paused state
-    setState(newState);
 }
 
 void AnimationController::render() {


### PR DESCRIPTION
Changes proposed in this PR:
 * Change animation state caused by playback mode before eval. Otherwise, eval state change will be overridden.

