### PR TITLE
Feature/logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,65 @@
 Here we document changes that affect the public API or changes that needs to be communicated to other developers. 
 
+## 2025-01-19 New Logging functions
+The existing macro based logging functions `LogInfo`, `LogWarn`, `LogError` and there `_Custom` versions are superseded a new
+API that takes advantage of `std::source_location`, meaning, we no longer need any macros. 
+
+The new log functions all live in the `inviwo::log` namespace. They either take an explicit `SourceContext` argument, or automatically extract one from the call site. All functions that take a `fmt::format_string` do compile time format checks.
+
+#### Basic logging
+ * ```cpp
+   log::info(fmt::format_string<Args...>, Args&&...)
+   ```
+ * ```cpp
+   log::warn(fmt::format_string<Args...>, Args&&...)
+   ```
+ * ```cpp
+   log::error(fmt::format_string<Args...>, Args&&...)
+   ```
+
+#### Runtime Log Level
+ * ```cpp
+   log::report(LogLevel, SourceContext, fmt::format_string, Args&&...)
+   ```
+ * ```cpp
+   log::report(LogLevel, SourceContext, std::string_view)
+   ```
+ * ```cpp
+   log::report(LogLevel, std::string_view)
+   ```
+ * ```cpp
+   log::message(LogLevel level, fmt::format_string<Args...>, Args&&...)
+   ```
+ 
+#### Log Exceptions
+ * ```cpp
+   log::exception(const Exception&)
+   ```
+ * ```cpp
+   log::exception(const std::exception&)
+   ```
+ * ```cpp
+   log::exception(std::string_view)
+   ```
+ * ```cpp
+   log::exception()
+   ```
+
+#### Log to a custom logger
+ * ```cpp
+   log::report(Logger&, LogLevel, SourceContext, fmt::format_string, Args&&...)
+   ```
+ * ```cpp
+   log::report(Logger&, LogLevel, SourceContext, std::string_view)
+   ```
+ * ```cpp
+   log::report(Logger&, LogLevel, std::string_view)
+   ```
+ * ```cpp
+   log::message(Logger&, LogLevel level, fmt::format_string<Args...>, Args&&...)
+   ```
+
+
 ## 2024-12-09 __Breaking__ change: string_view class identifiers
 All base classes that have a `virtual std::string getClassIdentifier() const` were refactored into `virtual std::string_view getClassIdentifier() const`. This is done to avoid string allocations. 
 If you have a class that derives from `Inport`, `Outport`, `Property`, `Metadata`, `Camera`, `animation::Track` or `animation::Interpolation` and with a override of 
@@ -171,7 +231,7 @@ This change potentially breaks existing Python processors handling either image 
 *Note:* Numpy arrays must be C-contiguous in order to be used by Inviwo. If they are not, the conversion from Numpy to Inviwo will fail and throw an exception (`Buffer`, `LayerPy`, `VolumePy`, etc.). Bear in mind that in Python the right-most index is the fastest.
 ```python
 l = [ [ 0, 1, 2 ], [ 3, 4, 5 ] ]
-print(l[0][2]) # [2] refers to the fastest running index
+const ProcessorInfo& ::getProcessorInfo() const { return processorInfo_; }l[0][2]) # [2] refers to the fastest running index
 
 n = numpy.array(l)
 print(n.flatten()) # -> [ 0, 1, 2, 3, 4, 5 ]

--- a/apps/inviwo/inviwo.cpp
+++ b/apps/inviwo/inviwo.cpp
@@ -77,6 +77,7 @@ int main(int argc, char** argv) {
     inviwo::utilqt::configureInviwoDefaultNames();
     inviwo::utilqt::configureFileSystemObserver(inviwoApp);
     inviwo::utilqt::configurePostEnqueueFront(inviwoApp);
+    inviwo::utilqt::configureAssertionHandler(inviwoApp);
     inviwo::utilqt::setStyleSheetFile(":/stylesheets/inviwo.qss");
     inviwo::utilqt::configurePalette();
     inviwoApp.setUILocale(inviwo::utilqt::getCurrentStdLocale());

--- a/apps/inviwo/inviwo.cpp
+++ b/apps/inviwo/inviwo.cpp
@@ -85,7 +85,7 @@ int main(int argc, char** argv) {
 
     inviwo::InviwoMainWindow mainWin(&inviwoApp);
     inviwoApp.printApplicationInfo();
-    inviwo::log::user::info("Qt Version {}", QT_VERSION_STR);
+    inviwo::log::info("Qt Version {}", QT_VERSION_STR);
 
     // initialize and show splash screen
     inviwo::InviwoSplashScreen splashScreen(clp.getShowSplashScreen());
@@ -127,10 +127,10 @@ int main(int argc, char** argv) {
     inviwo::util::OnScopeExit clearNetwork([&]() { inviwoApp.getProcessorNetwork()->clear(); });
 
     if (auto numErrors = logCounter->getWarnCount()) {
-        inviwo::log::user::warn("{} warnings generated during startup", numErrors);
+        inviwo::log::warn("{} warnings generated during startup", numErrors);
     }
     if (auto numErrors = logCounter->getErrorCount()) {
-        inviwo::log::user::warn("{} errors generated during startup", numErrors);
+        inviwo::log::warn("{} errors generated during startup", numErrors);
     }
     logCounter.reset();
 
@@ -146,7 +146,7 @@ int main(int argc, char** argv) {
         try {
             return qtApp.exec();
         } catch (const inviwo::Exception& e) {
-            inviwo::log::user::exception(e);
+            inviwo::log::exception(e);
             const auto message = fmt::format("{}\nApplication state might be corrupted, be warned.",
                                              e.getFullMessage(10));
             auto res =
@@ -158,7 +158,7 @@ int main(int argc, char** argv) {
             }
 
         } catch (const std::exception& e) {
-            inviwo::log::user::exception(e);
+            inviwo::log::exception(e);
             const auto message =
                 fmt::format("{}\nApplication state might be corrupted, be warned.", e.what());
             auto res =
@@ -169,7 +169,7 @@ int main(int argc, char** argv) {
                 return 1;
             }
         } catch (...) {
-            inviwo::log::user::exception("Uncaught exception, terminating");
+            inviwo::log::exception("Uncaught exception, terminating");
             QMessageBox::critical(nullptr, "Fatal Error", "Uncaught exception, terminating");
             return 1;
         }

--- a/apps/inviwo/inviwo.cpp
+++ b/apps/inviwo/inviwo.cpp
@@ -85,7 +85,7 @@ int main(int argc, char** argv) {
 
     inviwo::InviwoMainWindow mainWin(&inviwoApp);
     inviwoApp.printApplicationInfo();
-    LogInfoCustom("InviwoInfo", "Qt Version " << QT_VERSION_STR);
+    inviwo::log::user::info("Qt Version {}", QT_VERSION_STR);
 
     // initialize and show splash screen
     inviwo::InviwoSplashScreen splashScreen(clp.getShowSplashScreen());
@@ -127,10 +127,10 @@ int main(int argc, char** argv) {
     inviwo::util::OnScopeExit clearNetwork([&]() { inviwoApp.getProcessorNetwork()->clear(); });
 
     if (auto numErrors = logCounter->getWarnCount()) {
-        LogWarnCustom("inviwo.cpp", numErrors << " warnings generated during startup");
+        inviwo::log::user::warn("{} warnings generated during startup", numErrors);
     }
     if (auto numErrors = logCounter->getErrorCount()) {
-        LogErrorCustom("inviwo.cpp", numErrors << " errors generated during startup");
+        inviwo::log::user::warn("{} errors generated during startup", numErrors);
     }
     logCounter.reset();
 
@@ -146,7 +146,7 @@ int main(int argc, char** argv) {
         try {
             return qtApp.exec();
         } catch (const inviwo::Exception& e) {
-            inviwo::util::log(e.getContext(), e.getFullMessage(), inviwo::LogLevel::Error);
+            inviwo::log::user::exception(e);
             const auto message = fmt::format("{}\nApplication state might be corrupted, be warned.",
                                              e.getFullMessage(10));
             auto res =
@@ -158,7 +158,7 @@ int main(int argc, char** argv) {
             }
 
         } catch (const std::exception& e) {
-            inviwo::util::log(IVW_CONTEXT_CUSTOM("Inviwo"), e.what(), inviwo::LogLevel::Error);
+            inviwo::log::user::exception(e);
             const auto message =
                 fmt::format("{}\nApplication state might be corrupted, be warned.", e.what());
             auto res =
@@ -169,8 +169,7 @@ int main(int argc, char** argv) {
                 return 1;
             }
         } catch (...) {
-            inviwo::util::log(IVW_CONTEXT_CUSTOM("Inviwo"), "Uncaught exception, terminating",
-                              inviwo::LogLevel::Error);
+            inviwo::log::user::exception("Uncaught exception, terminating");
             QMessageBox::critical(nullptr, "Fatal Error", "Uncaught exception, terminating");
             return 1;
         }

--- a/apps/inviwo_glfwminimum/glfwminimum.cpp
+++ b/apps/inviwo_glfwminimum/glfwminimum.cpp
@@ -151,18 +151,17 @@ int main(int argc, char** argv) {
                 try {
                     throw;
                 } catch (const IgnoreException& e) {
-                    util::logError(e.getContext(), "Incomplete network loading {} due to {}",
-                                   workspace, e.getMessage());
+                    log::user::exception(e, "Incomplete network loading {} due to {}", workspace,
+                                         e.getMessage());
                 }
             });
         }
-    } catch (const AbortException& exception) {
-        util::logError(exception.getContext(), "Unable to load network {} due to {}", workspace,
-                       exception.getMessage());
+    } catch (const AbortException& e) {
+        log::user::exception(e, "Unable to load network {} due to {}", workspace, e.getMessage());
         return 1;
-    } catch (const IgnoreException& exception) {
-        util::logError(exception.getContext(), "Incomplete network loading {} due to {}", workspace,
-                       exception.getMessage(), LogLevel::Error);
+    } catch (const IgnoreException& e) {
+        log::user::exception(e, "Incomplete network loading {} due to {}", workspace,
+                             e.getMessage(), LogLevel::Error);
         return 1;
     }
 

--- a/apps/inviwo_glfwminimum/glfwminimum.cpp
+++ b/apps/inviwo_glfwminimum/glfwminimum.cpp
@@ -151,17 +151,17 @@ int main(int argc, char** argv) {
                 try {
                     throw;
                 } catch (const IgnoreException& e) {
-                    log::user::exception(e, "Incomplete network loading {} due to {}", workspace,
-                                         e.getMessage());
+                    log::exception(e, "Incomplete network loading {} due to {}", workspace,
+                                   e.getMessage());
                 }
             });
         }
     } catch (const AbortException& e) {
-        log::user::exception(e, "Unable to load network {} due to {}", workspace, e.getMessage());
+        log::exception(e, "Unable to load network {} due to {}", workspace, e.getMessage());
         return 1;
     } catch (const IgnoreException& e) {
-        log::user::exception(e, "Incomplete network loading {} due to {}", workspace,
-                             e.getMessage(), LogLevel::Error);
+        log::exception(e, "Incomplete network loading {} due to {}", workspace, e.getMessage(),
+                       LogLevel::Error);
         return 1;
     }
 

--- a/apps/inviwo_qtminimum/qtminimum.cpp
+++ b/apps/inviwo_qtminimum/qtminimum.cpp
@@ -88,7 +88,7 @@ int main(int argc, char** argv) {
     inviwoApp.setUILocale(inviwo::utilqt::getCurrentStdLocale());
 
     inviwoApp.printApplicationInfo();
-    LogInfoCustom("InviwoInfo", "Qt Version " << QT_VERSION_STR);
+    inviwo::log::user::info("Qt Version {}", QT_VERSION_STR);
 
     inviwoApp.setProgressCallback([&logger](std::string_view m) {
         logger.log("InviwoApplication", inviwo::LogLevel::Info, inviwo::LogAudience::User, "", "",
@@ -215,19 +215,18 @@ int main(int argc, char** argv) {
                 try {
                     throw;
                 } catch (const inviwo::IgnoreException& e) {
-                    inviwo::util::logError(e.getContext(),
-                                           "Incomplete network loading {} due to {}", workspace,
-                                           e.getMessage());
+                    inviwo::log::error("Incomplete network loading {} due to:", workspace);
+                    inviwo::log::exception(e);
                 }
             });
         }
-    } catch (const inviwo::AbortException& exception) {
-        inviwo::util::logError(exception.getContext(), "Unable to load network {} due to {}",
-                               workspace, exception.getMessage());
+    } catch (const inviwo::AbortException& e) {
+        inviwo::log::error("Unable to load network {} due to:", workspace);
+        inviwo::log::exception(e);
         return 1;
-    } catch (const inviwo::IgnoreException& exception) {
-        inviwo::util::logError(exception.getContext(), "Incomplete network loading {} due to {}",
-                               workspace, exception.getMessage());
+    } catch (const inviwo::IgnoreException& e) {
+        inviwo::log::error("Incomplete network loading {} due to:", workspace);
+        inviwo::log::exception(e);
         return 1;
     }
 

--- a/apps/inviwo_qtminimum/qtminimum.cpp
+++ b/apps/inviwo_qtminimum/qtminimum.cpp
@@ -88,7 +88,7 @@ int main(int argc, char** argv) {
     inviwoApp.setUILocale(inviwo::utilqt::getCurrentStdLocale());
 
     inviwoApp.printApplicationInfo();
-    inviwo::log::user::info("Qt Version {}", QT_VERSION_STR);
+    inviwo::log::info("Qt Version {}", QT_VERSION_STR);
 
     inviwoApp.setProgressCallback([&logger](std::string_view m) {
         logger.log("InviwoApplication", inviwo::LogLevel::Info, inviwo::LogAudience::User, "", "",

--- a/apps/inviwo_qtminimum/qtminimum.cpp
+++ b/apps/inviwo_qtminimum/qtminimum.cpp
@@ -84,6 +84,7 @@ int main(int argc, char** argv) {
     inviwo::utilqt::configureInviwoDefaultNames();
     inviwo::utilqt::configureFileSystemObserver(inviwoApp);
     inviwo::utilqt::configurePostEnqueueFront(inviwoApp);
+    inviwo::utilqt::configureAssertionHandler(inviwoApp);
     inviwo::utilqt::setStyleSheetFile(":/stylesheets/inviwo.qss");
     inviwoApp.setUILocale(inviwo::utilqt::getCurrentStdLocale());
 

--- a/apps/inviwopyapp/inviwo.py
+++ b/apps/inviwopyapp/inviwo.py
@@ -119,6 +119,7 @@ class Inviwo:
         configureQtNames(self.qtApp)
         inviwopy.qt.configureFileSystemObserver(self.inviwoApp)
         inviwopy.qt.configurePostEnqueueFront(self.inviwoApp)
+        inviwopy.qo.onfigureAssertionHandler(self.inviwoApp);
         inviwopy.qt.setStyleSheetFile(pathlib.Path(":/stylesheets/inviwo.qss"))
 
         self.propertyListWidget = inviwopy.qt.PropertyListWidget(self.inviwoApp)

--- a/include/inviwo/core/common/inviwoapplication.h
+++ b/include/inviwo/core/common/inviwoapplication.h
@@ -443,6 +443,12 @@ public:
      */
     void setLayerRamResizer(LayerRamResizer* obj);
 
+    void setAssertionHandler(
+        std::function<void(std::string_view message, SourceContext context)> assertionHandler);
+
+    const std::function<void(std::string_view message, SourceContext context)>&
+    getAssertionHandler() const;
+
 protected:
     struct Queue {
         // Task queue
@@ -507,6 +513,7 @@ protected:
     WorkspaceManager::DeserializationHandle presetsDeserializationHandle_;
     std::unique_ptr<TimerThread> timerThread_;
     LayerRamResizer* layerRamResizer_;
+    std::function<void(std::string_view message, SourceContext context)> assertionHandler_;
 
 private:
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/include/inviwo/core/common/inviwomodule.h
+++ b/include/inviwo/core/common/inviwomodule.h
@@ -414,11 +414,11 @@ void InviwoModule::registerPort() {
     try {
         registerPortInternal<T>();
     } catch (const Exception& e) {
-        LogError(fmt::format(
+        log::user::error(
             "Error registering port '{0}' in module {1}. Reason: {2}. Have you provided a "
             "DataTraits<{0}> specialization?",
             util::parseTypeIdName(typeid(typename T::type).name()), getIdentifier(),
-            e.getMessage()));
+            e.getMessage());
     }
 }
 

--- a/include/inviwo/core/common/inviwomodule.h
+++ b/include/inviwo/core/common/inviwomodule.h
@@ -414,7 +414,7 @@ void InviwoModule::registerPort() {
     try {
         registerPortInternal<T>();
     } catch (const Exception& e) {
-        log::user::error(
+        log::error(
             "Error registering port '{0}' in module {1}. Reason: {2}. Have you provided a "
             "DataTraits<{0}> specialization?",
             util::parseTypeIdName(typeid(typename T::type).name()), getIdentifier(),

--- a/include/inviwo/core/datastructures/buffer/buffer.h
+++ b/include/inviwo/core/datastructures/buffer/buffer.h
@@ -190,9 +190,9 @@ Buffer<T, Target>* Buffer<T, Target>::clone() const {
 template <typename T, BufferTarget Target>
 const BufferRAMPrecision<T, Target>* Buffer<T, Target>::getRAMRepresentation() const {
     auto bufferRAM = getRepresentation<BufferRAM>();
-    ivwAssert(bufferRAM->getDataFormat() == DataFormat<T>::get(),
+    IVW_ASSERT(bufferRAM->getDataFormat() == DataFormat<T>::get(),
               "Invalid format for buffer representation");
-    ivwAssert(bufferRAM->getBufferTarget() == Target, "Invalid target for buffer representation");
+    IVW_ASSERT(bufferRAM->getBufferTarget() == Target, "Invalid target for buffer representation");
 
     return static_cast<const BufferRAMPrecision<T, Target>*>(bufferRAM);
 }
@@ -200,9 +200,9 @@ const BufferRAMPrecision<T, Target>* Buffer<T, Target>::getRAMRepresentation() c
 template <typename T, BufferTarget Target>
 BufferRAMPrecision<T, Target>* Buffer<T, Target>::getEditableRAMRepresentation() {
     auto bufferRAM = getEditableRepresentation<BufferRAM>();
-    ivwAssert(bufferRAM->getDataFormat() == DataFormat<T>::get(),
+    IVW_ASSERT(bufferRAM->getDataFormat() == DataFormat<T>::get(),
               "Invalid format for buffer representation");
-    ivwAssert(bufferRAM->getBufferTarget() == Target, "Invalid target for buffer representation");
+    IVW_ASSERT(bufferRAM->getBufferTarget() == Target, "Invalid target for buffer representation");
 
     return static_cast<BufferRAMPrecision<T, Target>*>(bufferRAM);
 }

--- a/include/inviwo/core/datastructures/buffer/buffer.h
+++ b/include/inviwo/core/datastructures/buffer/buffer.h
@@ -191,7 +191,7 @@ template <typename T, BufferTarget Target>
 const BufferRAMPrecision<T, Target>* Buffer<T, Target>::getRAMRepresentation() const {
     auto bufferRAM = getRepresentation<BufferRAM>();
     IVW_ASSERT(bufferRAM->getDataFormat() == DataFormat<T>::get(),
-              "Invalid format for buffer representation");
+               "Invalid format for buffer representation");
     IVW_ASSERT(bufferRAM->getBufferTarget() == Target, "Invalid target for buffer representation");
 
     return static_cast<const BufferRAMPrecision<T, Target>*>(bufferRAM);
@@ -201,7 +201,7 @@ template <typename T, BufferTarget Target>
 BufferRAMPrecision<T, Target>* Buffer<T, Target>::getEditableRAMRepresentation() {
     auto bufferRAM = getEditableRepresentation<BufferRAM>();
     IVW_ASSERT(bufferRAM->getDataFormat() == DataFormat<T>::get(),
-              "Invalid format for buffer representation");
+               "Invalid format for buffer representation");
     IVW_ASSERT(bufferRAM->getBufferTarget() == Target, "Invalid target for buffer representation");
 
     return static_cast<BufferRAMPrecision<T, Target>*>(bufferRAM);

--- a/include/inviwo/core/io/serialization/deserializer.h
+++ b/include/inviwo/core/io/serialization/deserializer.h
@@ -65,10 +65,11 @@ class InviwoApplication;
 
 namespace detail {
 template <typename T>
-concept is_transparent = requires { typename T::key_compare::is_transparent; } || requires {
-    typename T::hasher::is_transparent;
-    typename T::key_equal::is_transparent;
-};
+concept is_transparent = requires { typename T::key_compare::is_transparent; } ||
+                         requires {
+                             typename T::hasher::is_transparent;
+                             typename T::key_equal::is_transparent;
+                         };
 }  // namespace detail
 
 namespace deserializer {
@@ -263,23 +264,23 @@ public:
     template <typename C, typename T = typename C::value_type, typename... Funcs>
         requires requires(T& t, size_t i, std::string_view s,
                           deserializer::IndexFunctions<Funcs...> f) {
-            { std::invoke(f.makeNew) } -> std::same_as<T>;
-            { std::invoke(f.onNew, t, i) };
-            { std::invoke(f.onRemove, t) };
-        }
+                     { std::invoke(f.makeNew) } -> std::same_as<T>;
+                     { std::invoke(f.onNew, t, i) };
+                     { std::invoke(f.onRemove, t) };
+                 }
     void deserialize(std::string_view key, C& container, std::string_view itemKey,
                      deserializer::IndexFunctions<Funcs...> f);
 
     template <typename C, typename T = typename C::value_type, typename... Funcs>
         requires requires(T& t, size_t i, std::string_view s,
                           deserializer::IdentifierFunctions<Funcs...> f) {
-            { std::invoke(f.getID, t) } -> std::same_as<std::string_view>;
-            { std::invoke(f.makeNew) } -> std::same_as<T>;
-            { std::invoke(f.filter, s, i) } -> std::same_as<bool>;
-            { std::invoke(f.onNew, t, i) };
-            { std::invoke(f.onRemove, s) };
-            { std::invoke(f.onMove, t, i) };
-        }
+                     { std::invoke(f.getID, t) } -> std::same_as<std::string_view>;
+                     { std::invoke(f.makeNew) } -> std::same_as<T>;
+                     { std::invoke(f.filter, s, i) } -> std::same_as<bool>;
+                     { std::invoke(f.onNew, t, i) };
+                     { std::invoke(f.onRemove, s) };
+                     { std::invoke(f.onMove, t, i) };
+                 }
     void deserialize(std::string_view key, C& container, std::string_view itemKey,
                      deserializer::IdentifierFunctions<Funcs...> f);
 
@@ -287,12 +288,12 @@ public:
               typename... Funcs>
         requires requires(const K& k, T& t, size_t i, std::string_view s,
                           deserializer::MapFunctions<Funcs...> f) {
-            { std::invoke(f.idTransform, s) } -> std::same_as<K>;
-            { std::invoke(f.makeNew) } -> std::same_as<T>;
-            { std::invoke(f.filter, k) } -> std::same_as<bool>;
-            { std::invoke(f.onNew, k, t) };
-            { std::invoke(f.onRemove, k) };
-        }
+                     { std::invoke(f.idTransform, s) } -> std::same_as<K>;
+                     { std::invoke(f.makeNew) } -> std::same_as<T>;
+                     { std::invoke(f.filter, k) } -> std::same_as<bool>;
+                     { std::invoke(f.onNew, k, t) };
+                     { std::invoke(f.onRemove, k) };
+                 }
     void deserialize(std::string_view key, C& container, std::string_view itemKey,
                      deserializer::MapFunctions<Funcs...> f);
 
@@ -356,8 +357,8 @@ public:
     template <class T>
     void deserialize(std::string_view key, T& sObj)
         requires requires(T& t, Deserializer& d) {
-            { t.deserialize(d) };
-        };
+                     { t.deserialize(d) };
+                 };
 
     std::optional<std::string_view> attribute(std::string_view key) const;
     std::optional<std::string_view> attribute(std::string_view child, std::string_view key) const;
@@ -719,13 +720,13 @@ void reorder(Functions& f, C& list, const std::pmr::vector<std::string_view>& or
 template <typename C, typename T, typename... Funcs>
     requires requires(T& t, size_t i, std::string_view s,
                       deserializer::IdentifierFunctions<Funcs...> f) {
-        { std::invoke(f.getID, t) } -> std::same_as<std::string_view>;
-        { std::invoke(f.makeNew) } -> std::same_as<T>;
-        { std::invoke(f.filter, s, i) } -> std::same_as<bool>;
-        { std::invoke(f.onNew, t, i) };
-        { std::invoke(f.onRemove, s) };
-        { std::invoke(f.onMove, t, i) };
-    }
+                 { std::invoke(f.getID, t) } -> std::same_as<std::string_view>;
+                 { std::invoke(f.makeNew) } -> std::same_as<T>;
+                 { std::invoke(f.filter, s, i) } -> std::same_as<bool>;
+                 { std::invoke(f.onNew, t, i) };
+                 { std::invoke(f.onRemove, s) };
+                 { std::invoke(f.onMove, t, i) };
+             }
 void Deserializer::deserialize(std::string_view key, C& container, std::string_view itemKey,
                                deserializer::IdentifierFunctions<Funcs...> f) {
 
@@ -771,10 +772,10 @@ void Deserializer::deserialize(std::string_view key, C& container, std::string_v
 template <typename C, typename T, typename... Funcs>
     requires requires(T& t, size_t i, std::string_view s,
                       deserializer::IndexFunctions<Funcs...> f) {
-        { std::invoke(f.makeNew) } -> std::same_as<T>;
-        { std::invoke(f.onNew, t, i) };
-        { std::invoke(f.onRemove, t) };
-    }
+                 { std::invoke(f.makeNew) } -> std::same_as<T>;
+                 { std::invoke(f.onNew, t, i) };
+                 { std::invoke(f.onRemove, t) };
+             }
 void Deserializer::deserialize(std::string_view key, C& container, std::string_view itemKey,
                                deserializer::IndexFunctions<Funcs...> f) {
 
@@ -812,12 +813,12 @@ void Deserializer::deserialize(std::string_view key, C& container, std::string_v
 template <typename C, typename K, typename T, typename... Funcs>
     requires requires(const K& k, T& t, size_t i, std::string_view s,
                       deserializer::MapFunctions<Funcs...> f) {
-        { std::invoke(f.idTransform, s) } -> std::same_as<K>;
-        { std::invoke(f.makeNew) } -> std::same_as<T>;
-        { std::invoke(f.filter, k) } -> std::same_as<bool>;
-        { std::invoke(f.onNew, k, t) };
-        { std::invoke(f.onRemove, k) };
-    }
+                 { std::invoke(f.idTransform, s) } -> std::same_as<K>;
+                 { std::invoke(f.makeNew) } -> std::same_as<T>;
+                 { std::invoke(f.filter, k) } -> std::same_as<bool>;
+                 { std::invoke(f.onNew, k, t) };
+                 { std::invoke(f.onRemove, k) };
+             }
 void Deserializer::deserialize(std::string_view key, C& container, std::string_view itemKey,
                                deserializer::MapFunctions<Funcs...> f) {
 
@@ -1048,9 +1049,8 @@ void Deserializer::deserializeSmartPtr(std::string_view key, Ptr& data) {
                 // with the correct type
                 data.reset();
             } else {
-                LogWarn("Object with class Id: '" << data->getClassIdentifier()
-                                                  << "'  deserialized using type '" << *typeAttr
-                                                  << "'");
+                log::warn("Object with class Id: '{}' deserialized using type '{}'",
+                          data->getClassIdentifier(), *typeAttr);
             }
         }
     }
@@ -1158,8 +1158,8 @@ void Deserializer::deserializeAs(std::string_view key, std::unique_ptr<T>& data)
 template <typename T>
 void Deserializer::deserialize(std::string_view key, T& sObj)
     requires requires(T& t, Deserializer& d) {
-        { t.deserialize(d) };
-    }
+                 { t.deserialize(d) };
+             }
 {
     if (const NodeSwitch nodeSwitch{*this, key}) {
         sObj.deserialize(*this);

--- a/include/inviwo/core/io/serialization/deserializer.h
+++ b/include/inviwo/core/io/serialization/deserializer.h
@@ -65,11 +65,10 @@ class InviwoApplication;
 
 namespace detail {
 template <typename T>
-concept is_transparent = requires { typename T::key_compare::is_transparent; } ||
-                         requires {
-                             typename T::hasher::is_transparent;
-                             typename T::key_equal::is_transparent;
-                         };
+concept is_transparent = requires { typename T::key_compare::is_transparent; } || requires {
+    typename T::hasher::is_transparent;
+    typename T::key_equal::is_transparent;
+};
 }  // namespace detail
 
 namespace deserializer {
@@ -264,23 +263,23 @@ public:
     template <typename C, typename T = typename C::value_type, typename... Funcs>
         requires requires(T& t, size_t i, std::string_view s,
                           deserializer::IndexFunctions<Funcs...> f) {
-                     { std::invoke(f.makeNew) } -> std::same_as<T>;
-                     { std::invoke(f.onNew, t, i) };
-                     { std::invoke(f.onRemove, t) };
-                 }
+            { std::invoke(f.makeNew) } -> std::same_as<T>;
+            { std::invoke(f.onNew, t, i) };
+            { std::invoke(f.onRemove, t) };
+        }
     void deserialize(std::string_view key, C& container, std::string_view itemKey,
                      deserializer::IndexFunctions<Funcs...> f);
 
     template <typename C, typename T = typename C::value_type, typename... Funcs>
         requires requires(T& t, size_t i, std::string_view s,
                           deserializer::IdentifierFunctions<Funcs...> f) {
-                     { std::invoke(f.getID, t) } -> std::same_as<std::string_view>;
-                     { std::invoke(f.makeNew) } -> std::same_as<T>;
-                     { std::invoke(f.filter, s, i) } -> std::same_as<bool>;
-                     { std::invoke(f.onNew, t, i) };
-                     { std::invoke(f.onRemove, s) };
-                     { std::invoke(f.onMove, t, i) };
-                 }
+            { std::invoke(f.getID, t) } -> std::same_as<std::string_view>;
+            { std::invoke(f.makeNew) } -> std::same_as<T>;
+            { std::invoke(f.filter, s, i) } -> std::same_as<bool>;
+            { std::invoke(f.onNew, t, i) };
+            { std::invoke(f.onRemove, s) };
+            { std::invoke(f.onMove, t, i) };
+        }
     void deserialize(std::string_view key, C& container, std::string_view itemKey,
                      deserializer::IdentifierFunctions<Funcs...> f);
 
@@ -288,12 +287,12 @@ public:
               typename... Funcs>
         requires requires(const K& k, T& t, size_t i, std::string_view s,
                           deserializer::MapFunctions<Funcs...> f) {
-                     { std::invoke(f.idTransform, s) } -> std::same_as<K>;
-                     { std::invoke(f.makeNew) } -> std::same_as<T>;
-                     { std::invoke(f.filter, k) } -> std::same_as<bool>;
-                     { std::invoke(f.onNew, k, t) };
-                     { std::invoke(f.onRemove, k) };
-                 }
+            { std::invoke(f.idTransform, s) } -> std::same_as<K>;
+            { std::invoke(f.makeNew) } -> std::same_as<T>;
+            { std::invoke(f.filter, k) } -> std::same_as<bool>;
+            { std::invoke(f.onNew, k, t) };
+            { std::invoke(f.onRemove, k) };
+        }
     void deserialize(std::string_view key, C& container, std::string_view itemKey,
                      deserializer::MapFunctions<Funcs...> f);
 
@@ -357,8 +356,8 @@ public:
     template <class T>
     void deserialize(std::string_view key, T& sObj)
         requires requires(T& t, Deserializer& d) {
-                     { t.deserialize(d) };
-                 };
+            { t.deserialize(d) };
+        };
 
     std::optional<std::string_view> attribute(std::string_view key) const;
     std::optional<std::string_view> attribute(std::string_view child, std::string_view key) const;
@@ -720,13 +719,13 @@ void reorder(Functions& f, C& list, const std::pmr::vector<std::string_view>& or
 template <typename C, typename T, typename... Funcs>
     requires requires(T& t, size_t i, std::string_view s,
                       deserializer::IdentifierFunctions<Funcs...> f) {
-                 { std::invoke(f.getID, t) } -> std::same_as<std::string_view>;
-                 { std::invoke(f.makeNew) } -> std::same_as<T>;
-                 { std::invoke(f.filter, s, i) } -> std::same_as<bool>;
-                 { std::invoke(f.onNew, t, i) };
-                 { std::invoke(f.onRemove, s) };
-                 { std::invoke(f.onMove, t, i) };
-             }
+        { std::invoke(f.getID, t) } -> std::same_as<std::string_view>;
+        { std::invoke(f.makeNew) } -> std::same_as<T>;
+        { std::invoke(f.filter, s, i) } -> std::same_as<bool>;
+        { std::invoke(f.onNew, t, i) };
+        { std::invoke(f.onRemove, s) };
+        { std::invoke(f.onMove, t, i) };
+    }
 void Deserializer::deserialize(std::string_view key, C& container, std::string_view itemKey,
                                deserializer::IdentifierFunctions<Funcs...> f) {
 
@@ -772,10 +771,10 @@ void Deserializer::deserialize(std::string_view key, C& container, std::string_v
 template <typename C, typename T, typename... Funcs>
     requires requires(T& t, size_t i, std::string_view s,
                       deserializer::IndexFunctions<Funcs...> f) {
-                 { std::invoke(f.makeNew) } -> std::same_as<T>;
-                 { std::invoke(f.onNew, t, i) };
-                 { std::invoke(f.onRemove, t) };
-             }
+        { std::invoke(f.makeNew) } -> std::same_as<T>;
+        { std::invoke(f.onNew, t, i) };
+        { std::invoke(f.onRemove, t) };
+    }
 void Deserializer::deserialize(std::string_view key, C& container, std::string_view itemKey,
                                deserializer::IndexFunctions<Funcs...> f) {
 
@@ -813,12 +812,12 @@ void Deserializer::deserialize(std::string_view key, C& container, std::string_v
 template <typename C, typename K, typename T, typename... Funcs>
     requires requires(const K& k, T& t, size_t i, std::string_view s,
                       deserializer::MapFunctions<Funcs...> f) {
-                 { std::invoke(f.idTransform, s) } -> std::same_as<K>;
-                 { std::invoke(f.makeNew) } -> std::same_as<T>;
-                 { std::invoke(f.filter, k) } -> std::same_as<bool>;
-                 { std::invoke(f.onNew, k, t) };
-                 { std::invoke(f.onRemove, k) };
-             }
+        { std::invoke(f.idTransform, s) } -> std::same_as<K>;
+        { std::invoke(f.makeNew) } -> std::same_as<T>;
+        { std::invoke(f.filter, k) } -> std::same_as<bool>;
+        { std::invoke(f.onNew, k, t) };
+        { std::invoke(f.onRemove, k) };
+    }
 void Deserializer::deserialize(std::string_view key, C& container, std::string_view itemKey,
                                deserializer::MapFunctions<Funcs...> f) {
 
@@ -1158,8 +1157,8 @@ void Deserializer::deserializeAs(std::string_view key, std::unique_ptr<T>& data)
 template <typename T>
 void Deserializer::deserialize(std::string_view key, T& sObj)
     requires requires(T& t, Deserializer& d) {
-                 { t.deserialize(d) };
-             }
+        { t.deserialize(d) };
+    }
 {
     if (const NodeSwitch nodeSwitch{*this, key}) {
         sObj.deserialize(*this);

--- a/include/inviwo/core/processors/processorutils.h
+++ b/include/inviwo/core/processors/processorutils.h
@@ -168,9 +168,9 @@ T& trySetProperty(Processor* proc, std::string_view identifier, V&& val, bool re
  * @brief Find the module identifier of a registered processor
  * @param classIdentifier the class identifier of the processor to look for
  * @param app the InviwoApplication needed to get the modules
- * @return the identifer of the module that registered the processor or nullopt if not found
+ * @return the identifier of the module that registered the processor or nullopt if not found
  */
-IVW_CORE_API std::optional<std::string> getProcessorModuleIdentifier(
+IVW_CORE_API std::optional<std::string_view> getProcessorModuleIdentifier(
     std::string_view classIdentifier, InviwoApplication& app);
 
 }  // namespace util

--- a/include/inviwo/core/properties/optionproperty.h
+++ b/include/inviwo/core/properties/optionproperty.h
@@ -1017,9 +1017,11 @@ OptionProperty<T>& OptionProperty<T>::resetToDefaultState() {
     }
 
     if (defaultOptions_.empty()) {
-        LogWarn("Resetting option property: " + this->getIdentifier() +
-                " to an empty option list. Probably the default values have never been set, " +
-                "Remember to call setCurrentStateAsDefault() after adding all the options.")
+        log::warn(
+            "Resetting option property: {} to an empty option list. Probably the default values "
+            "have never been set, Remember to call setCurrentStateAsDefault() after adding all the "
+            "options.",
+            this->getIdentifier());
     }
 
     if (modified) this->propertyModified();

--- a/include/inviwo/core/properties/propertysemantics.h
+++ b/include/inviwo/core/properties/propertysemantics.h
@@ -87,4 +87,6 @@ private:
     std::string semantic_;
 };
 
+inline const auto& format_as(const PropertySemantics& semantics) { return semantics.getString(); }
+
 }  // namespace inviwo

--- a/include/inviwo/core/util/assertion.h
+++ b/include/inviwo/core/util/assertion.h
@@ -30,13 +30,14 @@
 #pragma once
 
 #include <inviwo/core/common/inviwocoredefine.h>
+#include <inviwo/core/util/sourcecontext.h>
 #include <sstream>
 #include <string_view>
 
 namespace inviwo {
 
-IVW_CORE_API void assertion(std::string_view fileName, std::string_view functionName,
-                            int lineNumber, std::string_view message);
+IVW_CORE_API void assertion(std::string_view message,
+                            SourceContext context = std::source_location::current());
 
 namespace util {
 
@@ -52,13 +53,13 @@ namespace inviwo::cfg {
 constexpr bool assertions = true;
 }
 
-#define IVW_ASSERT(condition, message)                                               \
-    {                                                                                \
-        if (!(bool(condition))) {                                                    \
-            std::ostringstream stream__;                                             \
-            stream__ << message;                                                     \
-            ::inviwo::assertion(__FILE__, __FUNCTION__, __LINE__, (stream__.str())); \
-        }                                                                            \
+#define IVW_ASSERT(condition, message)                    \
+    {                                                     \
+        if (!(bool(condition))) {                         \
+            std::ostringstream stream;                    \
+            stream << message;                            \
+            ::inviwo::assertion(std::move(stream).str()); \
+        }                                                 \
     }
 
 // Deprecated

--- a/include/inviwo/core/util/clock.h
+++ b/include/inviwo/core/util/clock.h
@@ -212,7 +212,7 @@ using ScopedClockCPU = ScopedClock<Clock, Callback>;
  */
 #if IVW_PROFILING
 #define IVW_CPU_PROFILING(message)                                                  \
-    const auto IVW_ADDLINE(inviwoScopedClock) = util::makeScopedClock<Clock>([]() { \
+    const auto IVW_ADDLINE(inviwoScopedClock) = util::makeScopedClock<Clock>([&]() { \
         std::ostringstream ss;                                                      \
         ss << message;                                                              \
         return std::move(ss).str();                                                 \
@@ -232,7 +232,7 @@ using ScopedClockCPU = ScopedClock<Clock, Callback>;
 #if IVW_PROFILING
 #define IVW_CPU_PROFILING_IF(time, message)                                   \
     const auto IVW_ADDLINE(inviwoScopedClock) = util::makeScopedClock<Clock>( \
-        []() {                                                                \
+        [&]() {                                                                \
             std::ostringstream ss;                                            \
             ss << message;                                                    \
             return std::move(ss).str();                                       \

--- a/include/inviwo/core/util/clock.h
+++ b/include/inviwo/core/util/clock.h
@@ -180,7 +180,7 @@ template <typename Clock, typename Callback>
 void ScopedClock<Clock, Callback>::print() const {
     if (Clock::getElapsedTime() > logIfAtLeast_) {
         ::inviwo::log::report(
-            logLevel_, LogAudience::Developer, context_, "{}: {}", message_(),
+            logLevel_, context_, "{}: {}", message_(),
             std::chrono::duration_cast<std::chrono::milliseconds>(Clock::getElapsedTime()));
     }
 }

--- a/include/inviwo/core/util/clock.h
+++ b/include/inviwo/core/util/clock.h
@@ -126,9 +126,13 @@ public:
     using Duration = Clock::duration;
     ScopedClock() = delete;
 
-    ScopedClock(Callback message, Duration logIfAtLeast = {}, LogLevel logLevel = LogLevel::Info,
-                SourceContext context = std::source_location::current());
-
+    explicit ScopedClock(Callback message, Duration logIfAtLeast = {},
+                         LogLevel logLevel = LogLevel::Info,
+                         SourceContext context = std::source_location::current());
+    ScopedClock(const ScopedClock&) = delete;
+    ScopedClock(ScopedClock&&) = delete;
+    ScopedClock& operator=(const ScopedClock&) = delete;
+    ScopedClock& operator=(ScopedClock&&) = delete;
     ~ScopedClock() { print(); }
 
     /**

--- a/include/inviwo/core/util/factory.h
+++ b/include/inviwo/core/util/factory.h
@@ -238,8 +238,8 @@ bool FactoryRegister<M, Key, K>::registerObject(M* obj) {
         this->notifyObserversOnRegister(obj);
         return true;
     } else {
-        LogWarn("Failed to register object \"" << detail::filter(obj->getClassIdentifier())
-                                               << "\", already registered");
+        log::warn("Failed to register object \"{}\", already registered",
+                  detail::filter(obj->getClassIdentifier()));
         return false;
     }
 }

--- a/include/inviwo/core/util/logcentral.h
+++ b/include/inviwo/core/util/logcentral.h
@@ -107,33 +107,31 @@ IVW_CORE_API std::ostream& operator<<(std::ostream& ss, MessageBreakLevel ll);
                            __FUNCTION__, __LINE__);                                       \
     }
 
-#define LogInfo(message) \
-    { LogSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Info, message) }
-#define LogWarn(message) \
-    { LogSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Warn, message) }
+#define LogInfo(message) {LogSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Info, message)}
+#define LogWarn(message) {LogSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Warn, message)}
 #define LogError(message) \
-    { LogSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Error, message) }
+    {LogSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Error, message)}
 
 #define LogInfoCustom(source, message) \
-    { LogCustomSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Info, source, message) }
+    {LogCustomSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Info, source, message)}
 #define LogWarnCustom(source, message) \
-    { LogCustomSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Warn, source, message) }
+    {LogCustomSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Warn, source, message)}
 #define LogErrorCustom(source, message) \
-    { LogCustomSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Error, source, message) }
+    {LogCustomSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Error, source, message)}
 
 #define LogProcessorInfo(message) \
-    { LogProcessorSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Info, message) }
+    {LogProcessorSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Info, message)}
 #define LogProcessorWarn(message) \
-    { LogProcessorSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Warn, message) }
+    {LogProcessorSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Warn, message)}
 #define LogProcessorError(message) \
-    { LogProcessorSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Error, message) }
+    {LogProcessorSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Error, message)}
 
 #define LogNetworkInfo(message) \
-    { LogNetworkSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Info, message) }
+    {LogNetworkSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Info, message)}
 #define LogNetworkWarn(message) \
-    { LogNetworkSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Warn, message) }
+    {LogNetworkSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Warn, message)}
 #define LogNetworkError(message) \
-    { LogNetworkSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Error, message) }
+    {LogNetworkSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Error, message)}
 
 class IVW_CORE_API Logger {
 public:
@@ -211,109 +209,74 @@ namespace log {
  * or automatically extracts one from the call site.
  * All functions that takes a fmt::format_string does compile time format checks
  *
- * ## Generic
- * report(LogLevel, LogAudience, SourceContext, fmt::format_string, Args&&...)
- * report(LogLevel, LogAudience, SourceContext, std::string_view)
- * report(LogLevel, LogAudience, std::string_view)
- * message(LogLevel level, LogAudience audience, fmt::format_string<Args...>, Args&&...)
-
- * ## LogAudience Developer
- * report(LogLevel, SourceContext, fmt::format_string, Args&&...)
- * report(LogLevel, SourceContext, std::string_view)
- * report(LogLevel, std::string_view)
- * exception(const Exception&)
- * info(fmt::format_string<Args...>, Args&&...)
- * warn(fmt::format_string<Args...>, Args&&...)
- * error(fmt::format_string<Args...>, Args&&...)
- *
- * ## LogAudience User
- * user::report(LogLevel, LogAudience, SourceContext, fmt::format_string, Args&&...)
- * user::report(LogLevel, SourceContext, std::string_view)
- * user::report(LogLevel, std::string_view)
- * user::exception(const Exception&)
- * user::info(fmt::format_string<Args...>, Args&&...)
- * user::warn(fmt::format_string<Args...>, Args&&...)
- * user::error(fmt::format_string<Args...>, Args&&...)
+ * * `report(LogLevel, SourceContext, fmt::format_string, Args&&...)
+ * * `report(LogLevel, SourceContext, std::string_view)
+ * * `report(LogLevel, std::string_view)
+ * * `exception(const Exception&)
+ * * `message(LogLevel level, fmt::format_string<Args...>, Args&&...)
+ * * `info(fmt::format_string<Args...>, Args&&...)
+ * * warn(fmt::format_string<Args...>, Args&&...)
+ * * error(fmt::format_string<Args...>, Args&&...)
  *
  */
 
-// Generic
-inline void report(LogLevel level, LogAudience audience, SourceContext context,
-                   std::string_view message) {
+inline void report(LogLevel level, SourceContext context, std::string_view message) {
     if (LogCentral::isInitialized()) {
-        LogCentral::getPtr()->log(context.source(), level, audience, context.file(),
+        LogCentral::getPtr()->log(context.source(), level, LogAudience::User, context.file(),
                                   context.function(), context.line(), message);
     } else {
         // TODO log directly to std::cout here?
     }
 }
 
-inline void report(LogLevel level, LogAudience audience, std::string_view message,
+inline void report(LogLevel level, std::string_view message,
                    SourceContext context = std::source_location::current()) {
-    ::inviwo::log::report(level, audience, context, message);
+    ::inviwo::log::report(level, context, message);
 }
 
-inline void implementation(LogLevel level, LogAudience audience, SourceContext context,
-                           fmt::string_view format, fmt::format_args&& args) {
-    ::inviwo::log::report(level, audience, context, fmt::vformat(format, std::move(args)));
+inline void implementation(LogLevel level, SourceContext context, fmt::string_view format,
+                           fmt::format_args&& args) {
+    ::inviwo::log::report(level, context, fmt::vformat(format, std::move(args)));
 }
 
 template <typename... Args>
-inline void report(LogLevel level, LogAudience audience, SourceContext context,
-                   fmt::format_string<Args...> format, Args&&... args) {
-    ::inviwo::log::implementation(level, audience, context, format, fmt::make_format_args(args...));
+inline void report(LogLevel level, SourceContext context, fmt::format_string<Args...> format,
+                   Args&&... args) {
+    ::inviwo::log::implementation(level, context, format, fmt::make_format_args(args...));
+}
+
+inline void exception(const Exception& e) {
+    ::inviwo::log::report(LogLevel::Error, e.getContext(), e.getFullMessage());
+}
+template <typename... Args>
+inline void exception(const Exception& e, fmt::format_string<Args...> format, Args&&... args) {
+    ::inviwo::log::implementation(LogLevel::Warn, e.getContext(), format,
+                                  fmt::make_format_args(args...));
+}
+inline void exception(const std::exception& e,
+                      SourceContext context = std::source_location::current()) {
+    ::inviwo::log::report(LogLevel::Error, context, e.what());
+}
+inline void exception(std::string_view message = "Unknown Exception",
+                      SourceContext context = std::source_location::current()) {
+    ::inviwo::log::report(LogLevel::Error, context, message);
 }
 
 template <typename... Args>
 struct message {
-    message(LogLevel level, LogAudience audience, fmt::format_string<Args...> format,
-            Args&&... args, SourceContext context = std::source_location::current()) {
-        ::inviwo::log::implementation(level, audience, context, format,
-                                      fmt::make_format_args(args...));
+    message(LogLevel level, fmt::format_string<Args...> format, Args&&... args,
+            SourceContext context = std::source_location::current()) {
+        ::inviwo::log::implementation(level, context, format, fmt::make_format_args(args...));
     }
 };
 template <typename... Args>
-message(LogLevel level, LogAudience audience, fmt::format_string<Args...>, Args&&...)
-    -> message<Args...>;
-
-// LogAudience Developer
-template <typename... Args>
-inline void report(LogLevel level, SourceContext context, fmt::format_string<Args...> format,
-                   Args&&... args) {
-    ::inviwo::log::implementation(level, LogAudience::Developer, context, format,
-                                  fmt::make_format_args(args...));
-}
-inline void report(LogLevel level, SourceContext context, std::string_view message) {
-    ::inviwo::log::report(level, LogAudience::Developer, context, message);
-}
-inline void report(LogLevel level, std::string_view message,
-                   SourceContext context = std::source_location::current()) {
-    ::inviwo::log::report(level, LogAudience::Developer, context, message);
-}
-
-inline void exception(const Exception& e) {
-    ::inviwo::log::report(LogLevel::Error, LogAudience::Developer, e.getContext(),
-                          e.getFullMessage());
-}
-template <typename... Args>
-inline void exception(const Exception& e, fmt::format_string<Args...> format, Args&&... args) {
-    ::inviwo::log::implementation(LogLevel::Warn, LogAudience::Developer, e.getContext(), format,
-                                  fmt::make_format_args(args...));
-}
-inline void exception(const std::exception& e,
-                      SourceContext context = std::source_location::current()) {
-    ::inviwo::log::report(LogLevel::Error, LogAudience::Developer, context, e.what());
-}
-inline void exception(std::string_view message = "Unknown Exception",
-                      SourceContext context = std::source_location::current()) {
-    ::inviwo::log::report(LogLevel::Error, LogAudience::Developer, context, message);
-}
+message(LogLevel level, fmt::format_string<Args...>, Args&&...) -> message<Args...>;
 
 template <typename... Args>
 struct info {
     info(fmt::format_string<Args...> format, Args&&... args,
          SourceContext context = std::source_location::current()) {
-        ::inviwo::log::implementation(LogLevel::Info, LogAudience::Developer, context, format,
+        ::inviwo::log::implementation(LogLevel::Info, context, format,
                                       fmt::make_format_args(args...));
     }
 };
@@ -324,7 +287,7 @@ template <typename... Args>
 struct warn {
     warn(fmt::format_string<Args...> format, Args&&... args,
          SourceContext context = std::source_location::current()) {
-        ::inviwo::log::implementation(LogLevel::Warn, LogAudience::Developer, context, format,
+        ::inviwo::log::implementation(LogLevel::Warn, context, format,
                                       fmt::make_format_args(args...));
     }
 };
@@ -335,81 +298,12 @@ template <typename... Args>
 struct error {
     error(fmt::format_string<Args...> format, Args&&... args,
           SourceContext context = std::source_location::current()) {
-        ::inviwo::log::implementation(LogLevel::Error, LogAudience::Developer, context, format,
+        ::inviwo::log::implementation(LogLevel::Error, context, format,
                                       fmt::make_format_args(args...));
     }
 };
 template <typename... Args>
 error(fmt::format_string<Args...>, Args&&...) -> error<Args...>;
-
-namespace user {
-// LogAudience User
-
-template <typename... Args>
-inline void report(LogLevel level, SourceContext context, fmt::format_string<Args...> format,
-                   Args&&... args) {
-    ::inviwo::log::implementation(level, LogAudience::User, context, format,
-                                  fmt::make_format_args(args...));
-}
-inline void report(LogLevel level, SourceContext context, std::string_view message) {
-    ::inviwo::log::report(level, LogAudience::User, context, message);
-}
-inline void report(LogLevel level, std::string_view message,
-                   SourceContext context = std::source_location::current()) {
-    ::inviwo::log::report(level, LogAudience::User, context, message);
-}
-
-inline void exception(const Exception& e) {
-    ::inviwo::log::report(LogLevel::Error, LogAudience::User, e.getContext(), e.getFullMessage());
-}
-template <typename... Args>
-inline void exception(const Exception& e, fmt::format_string<Args...> format, Args&&... args) {
-    ::inviwo::log::implementation(LogLevel::Warn, LogAudience::User, e.getContext(), format,
-                                  fmt::make_format_args(args...));
-}
-inline void exception(const std::exception& e,
-                      SourceContext context = std::source_location::current()) {
-    ::inviwo::log::report(LogLevel::Error, LogAudience::User, context, e.what());
-}
-inline void exception(std::string_view message = "Unknown Exception",
-                      SourceContext context = std::source_location::current()) {
-    ::inviwo::log::report(LogLevel::Error, LogAudience::User, context, message);
-}
-
-template <typename... Args>
-struct info {
-    info(fmt::format_string<Args...> format, Args&&... args,
-         SourceContext context = std::source_location::current()) {
-        ::inviwo::log::implementation(LogLevel::Info, LogAudience::User, context, format,
-                                      fmt::make_format_args(args...));
-    }
-};
-template <typename... Args>
-info(fmt::format_string<Args...>, Args&&...) -> info<Args...>;
-
-template <typename... Args>
-struct warn {
-    warn(fmt::format_string<Args...> format, Args&&... args,
-         SourceContext context = std::source_location::current()) {
-        ::inviwo::log::implementation(LogLevel::Warn, LogAudience::User, context, format,
-                                      fmt::make_format_args(args...));
-    }
-};
-template <typename... Args>
-warn(fmt::format_string<Args...>, Args&&...) -> warn<Args...>;
-
-template <typename... Args>
-struct error {
-    error(fmt::format_string<Args...> format, Args&&... args,
-          SourceContext context = std::source_location::current()) {
-        ::inviwo::log::implementation(LogLevel::Error, LogAudience::User, context, format,
-                                      fmt::make_format_args(args...));
-    }
-};
-template <typename... Args>
-error(fmt::format_string<Args...>, Args&&...) -> error<Args...>;
-
-}  // namespace user
 
 }  // namespace log
 

--- a/include/inviwo/core/util/logcentral.h
+++ b/include/inviwo/core/util/logcentral.h
@@ -156,20 +156,32 @@ private:
 namespace log {
 
 /**
- * All log function either take a explicit SourceContext argument,
- * or automatically extracts one from the call site.
- * All functions that takes a fmt::format_string does compile time format checks
+ * All log functions either take an explicit SourceContext argument,
+ * or automatically extract one from the call site.
+ * All functions that take a fmt::format_string do compile time format checks.
  *
- * * `report(LogLevel, SourceContext, fmt::format_string, Args&&...)`
- * * `report(LogLevel, SourceContext, std::string_view)`
- * * `report(LogLevel, std::string_view)`
- * * `exception(const Exception&)`
- * * `exception(const std::exception&)`
- * * `exception()`
- * * `message(LogLevel level, fmt::format_string<Args...>, Args&&...)`
+ * # Basic logging
  * * `info(fmt::format_string<Args...>, Args&&...)`
  * * `warn(fmt::format_string<Args...>, Args&&...)`
  * * `error(fmt::format_string<Args...>, Args&&...)`
+ *
+ * # Runtime Log Level
+ * * `report(LogLevel, SourceContext, fmt::format_string, Args&&...)`
+ * * `report(LogLevel, SourceContext, std::string_view)`
+ * * `report(LogLevel, std::string_view)`
+ * * `message(LogLevel level, fmt::format_string<Args...>, Args&&...)`
+
+ * # Log Exceptions
+ * * `exception(const Exception&)`
+ * * `exception(const std::exception&)`
+ * * `exception(std::string_view)`
+ * * `exception()`
+ *
+ * # Log to a custom logger
+ * * `report(Logger&, LogLevel, SourceContext, fmt::format_string, Args&&...)`
+ * * `report(Logger&, LogLevel, SourceContext, std::string_view)
+ * * `report(Logger&, LogLevel, std::string_view)`
+ * * `message(Logger&, LogLevel level, fmt::format_string<Args...>, Args&&...)`
  */
 
 namespace detail {
@@ -210,6 +222,11 @@ inline void report(Logger& logger, LogLevel level, SourceContext context, fmt::s
 }
 }  // namespace detail
 
+template <typename... Args>
+inline void report(Logger& logger, LogLevel level, SourceContext context,
+                   fmt::format_string<Args...> format, Args&&... args) {
+    ::inviwo::log::detail::report(logger, level, context, format, fmt::make_format_args(args...));
+}
 template <typename... Args>
 inline void report(LogLevel level, SourceContext context, fmt::format_string<Args...> format,
                    Args&&... args) {

--- a/include/inviwo/core/util/logcentral.h
+++ b/include/inviwo/core/util/logcentral.h
@@ -91,47 +91,19 @@ IVW_CORE_API std::ostream& operator<<(std::ostream& ss, MessageBreakLevel ll);
                     __LINE__, stream__.str());                                                \
     }
 
-#define LogProcessorSpecial(logger, logLevel, message)                                            \
-    {                                                                                             \
-        std::ostringstream stream__;                                                              \
-        stream__ << message;                                                                      \
-        logger->logProcessor(this, logLevel, inviwo::LogAudience::User, stream__.str(), __FILE__, \
-                             __FUNCTION__, __LINE__);                                             \
-    }
-
-#define LogNetworkSpecial(logger, logLevel, message)                                      \
-    {                                                                                     \
-        std::ostringstream stream__;                                                      \
-        stream__ << message;                                                              \
-        logger->logNetwork(logLevel, inviwo::LogAudience::User, stream__.str(), __FILE__, \
-                           __FUNCTION__, __LINE__);                                       \
-    }
-
-#define LogInfo(message) {LogSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Info, message)}
-#define LogWarn(message) {LogSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Warn, message)}
+#define LogInfo(message) \
+    { LogSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Info, message) }
+#define LogWarn(message) \
+    { LogSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Warn, message) }
 #define LogError(message) \
-    {LogSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Error, message)}
+    { LogSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Error, message) }
 
 #define LogInfoCustom(source, message) \
-    {LogCustomSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Info, source, message)}
+    { LogCustomSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Info, source, message) }
 #define LogWarnCustom(source, message) \
-    {LogCustomSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Warn, source, message)}
+    { LogCustomSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Warn, source, message) }
 #define LogErrorCustom(source, message) \
-    {LogCustomSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Error, source, message)}
-
-#define LogProcessorInfo(message) \
-    {LogProcessorSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Info, message)}
-#define LogProcessorWarn(message) \
-    {LogProcessorSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Warn, message)}
-#define LogProcessorError(message) \
-    {LogProcessorSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Error, message)}
-
-#define LogNetworkInfo(message) \
-    {LogNetworkSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Info, message)}
-#define LogNetworkWarn(message) \
-    {LogNetworkSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Warn, message)}
-#define LogNetworkError(message) \
-    {LogNetworkSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Error, message)}
+    { LogCustomSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Error, source, message) }
 
 class IVW_CORE_API Logger {
 public:
@@ -141,16 +113,6 @@ public:
     virtual void log(std::string_view logSource, LogLevel logLevel, LogAudience audience,
                      std::string_view file, std::string_view function, int line,
                      std::string_view msg) = 0;
-
-    virtual void logProcessor(Processor* processor, LogLevel level, LogAudience audience,
-                              std::string_view msg, std::string_view file,
-                              std::string_view function, int line);
-
-    virtual void logNetwork(LogLevel level, LogAudience audience, std::string_view msg,
-                            std::string_view file, std::string_view function, int line);
-
-    virtual void logAssertion(std::string_view file, std::string_view function, int line,
-                              std::string_view msg);
 };
 
 class IVW_CORE_API LogCentral : public Singleton<LogCentral>, public Logger {
@@ -171,17 +133,6 @@ public:
     virtual void log(std::string_view source, LogLevel level, LogAudience audience,
                      std::string_view file, std::string_view function, int line,
                      std::string_view msg) override;
-
-    virtual void logProcessor(Processor* processor, LogLevel level, LogAudience audience,
-                              std::string_view msg, std::string_view file = "",
-                              std::string_view function = "", int line = 0) override;
-
-    virtual void logNetwork(LogLevel level, LogAudience audience, std::string_view msg,
-                            std::string_view file = "", std::string_view function = "",
-                            int line = 0) override;
-
-    virtual void logAssertion(std::string_view file, std::string_view function, int line,
-                              std::string_view msg) override;
 
     void setLogStacktrace(const bool& logStacktrace = true);
     bool getLogStacktrace() const;
@@ -209,24 +160,35 @@ namespace log {
  * or automatically extracts one from the call site.
  * All functions that takes a fmt::format_string does compile time format checks
  *
- * * `report(LogLevel, SourceContext, fmt::format_string, Args&&...)
- * * `report(LogLevel, SourceContext, std::string_view)
- * * `report(LogLevel, std::string_view)
- * * `exception(const Exception&)
- * * `message(LogLevel level, fmt::format_string<Args...>, Args&&...)
- * * `info(fmt::format_string<Args...>, Args&&...)
- * * warn(fmt::format_string<Args...>, Args&&...)
- * * error(fmt::format_string<Args...>, Args&&...)
+ * * `report(LogLevel, SourceContext, fmt::format_string, Args&&...)`
+ * * `report(LogLevel, SourceContext, std::string_view)`
+ * * `report(LogLevel, std::string_view)`
+ * * `exception(const Exception&)`
+ * * `exception(const std::exception&)`
+ * * `exception()`
+ * * `message(LogLevel level, fmt::format_string<Args...>, Args&&...)`
+ * * `info(fmt::format_string<Args...>, Args&&...)`
+ * * `warn(fmt::format_string<Args...>, Args&&...)`
+ * * `error(fmt::format_string<Args...>, Args&&...)`
  *
  */
 
+inline void report(Logger& logger, LogLevel level, SourceContext context,
+                   std::string_view message) {
+    logger.log(context.source(), level, LogAudience::User, context.file(), context.function(),
+               context.line(), message);
+}
 inline void report(LogLevel level, SourceContext context, std::string_view message) {
     if (LogCentral::isInitialized()) {
-        LogCentral::getPtr()->log(context.source(), level, LogAudience::User, context.file(),
-                                  context.function(), context.line(), message);
+        ::inviwo::log::report(*LogCentral::getPtr(), level, context, message);
     } else {
         // TODO log directly to std::cout here?
     }
+}
+
+inline void report(Logger& logger, LogLevel level, std::string_view message,
+                   SourceContext context = std::source_location::current()) {
+    ::inviwo::log::report(logger, level, context, message);
 }
 
 inline void report(LogLevel level, std::string_view message,
@@ -268,9 +230,15 @@ struct message {
             SourceContext context = std::source_location::current()) {
         ::inviwo::log::implementation(level, context, format, fmt::make_format_args(args...));
     }
+    message(Logger& logger, LogLevel level, fmt::format_string<Args...> format, Args&&... args,
+            SourceContext context = std::source_location::current()) {
+        ::inviwo::log::implementation(level, context, format, fmt::make_format_args(args...));
+    }
 };
 template <typename... Args>
 message(LogLevel level, fmt::format_string<Args...>, Args&&...) -> message<Args...>;
+template <typename... Args>
+message(Logger& logger, LogLevel level, fmt::format_string<Args...>, Args&&...) -> message<Args...>;
 
 template <typename... Args>
 struct info {

--- a/include/inviwo/core/util/logcentral.h
+++ b/include/inviwo/core/util/logcentral.h
@@ -195,11 +195,11 @@ inline void report(LogLevel level, std::string_view message,
 
 inline void implementation(LogLevel level, SourceContext context, fmt::string_view format,
                            fmt::format_args&& args) {
-    ::inviwo::log::report(level, context, fmt::vformat(format, std::move(args)));
+    ::inviwo::log::report(level, context, fmt::vformat(format, args));
 }
 inline void implementation(Logger& logger, LogLevel level, SourceContext context,
                            fmt::string_view format, fmt::format_args&& args) {
-    ::inviwo::log::report(logger, level, context, fmt::vformat(format, std::move(args)));
+    ::inviwo::log::report(logger, level, context, fmt::vformat(format, args));
 }
 
 template <typename... Args>
@@ -247,8 +247,8 @@ message(Logger& logger, LogLevel level, fmt::format_string<Args...>, Args&&...) 
 
 template <typename... Args>
 struct info {
-    info(fmt::format_string<Args...> format, Args&&... args,
-         SourceContext context = std::source_location::current()) {
+    explicit info(fmt::format_string<Args...> format, Args&&... args,
+                  SourceContext context = std::source_location::current()) {
         ::inviwo::log::implementation(LogLevel::Info, context, format,
                                       fmt::make_format_args(args...));
     }
@@ -258,8 +258,8 @@ info(fmt::format_string<Args...>, Args&&...) -> info<Args...>;
 
 template <typename... Args>
 struct warn {
-    warn(fmt::format_string<Args...> format, Args&&... args,
-         SourceContext context = std::source_location::current()) {
+    explicit warn(fmt::format_string<Args...> format, Args&&... args,
+                  SourceContext context = std::source_location::current()) {
         ::inviwo::log::implementation(LogLevel::Warn, context, format,
                                       fmt::make_format_args(args...));
     }
@@ -269,8 +269,8 @@ warn(fmt::format_string<Args...>, Args&&...) -> warn<Args...>;
 
 template <typename... Args>
 struct error {
-    error(fmt::format_string<Args...> format, Args&&... args,
-          SourceContext context = std::source_location::current()) {
+    explicit error(fmt::format_string<Args...> format, Args&&... args,
+                   SourceContext context = std::source_location::current()) {
         ::inviwo::log::implementation(LogLevel::Error, context, format,
                                       fmt::make_format_args(args...));
     }

--- a/include/inviwo/core/util/logcentral.h
+++ b/include/inviwo/core/util/logcentral.h
@@ -91,19 +91,17 @@ IVW_CORE_API std::ostream& operator<<(std::ostream& ss, MessageBreakLevel ll);
                     __LINE__, stream__.str());                                                \
     }
 
-#define LogInfo(message) \
-    { LogSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Info, message) }
-#define LogWarn(message) \
-    { LogSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Warn, message) }
+#define LogInfo(message) {LogSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Info, message)}
+#define LogWarn(message) {LogSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Warn, message)}
 #define LogError(message) \
-    { LogSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Error, message) }
+    {LogSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Error, message)}
 
 #define LogInfoCustom(source, message) \
-    { LogCustomSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Info, source, message) }
+    {LogCustomSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Info, source, message)}
 #define LogWarnCustom(source, message) \
-    { LogCustomSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Warn, source, message) }
+    {LogCustomSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Warn, source, message)}
 #define LogErrorCustom(source, message) \
-    { LogCustomSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Error, source, message) }
+    {LogCustomSpecial(inviwo::LogCentral::getPtr(), inviwo::LogLevel::Error, source, message)}
 
 class IVW_CORE_API Logger {
 public:
@@ -170,7 +168,6 @@ namespace log {
  * * `info(fmt::format_string<Args...>, Args&&...)`
  * * `warn(fmt::format_string<Args...>, Args&&...)`
  * * `error(fmt::format_string<Args...>, Args&&...)`
- *
  */
 
 inline void report(Logger& logger, LogLevel level, SourceContext context,
@@ -200,6 +197,10 @@ inline void implementation(LogLevel level, SourceContext context, fmt::string_vi
                            fmt::format_args&& args) {
     ::inviwo::log::report(level, context, fmt::vformat(format, std::move(args)));
 }
+inline void implementation(Logger& logger, LogLevel level, SourceContext context,
+                           fmt::string_view format, fmt::format_args&& args) {
+    ::inviwo::log::report(logger, level, context, fmt::vformat(format, std::move(args)));
+}
 
 template <typename... Args>
 inline void report(LogLevel level, SourceContext context, fmt::format_string<Args...> format,
@@ -219,9 +220,12 @@ inline void exception(const std::exception& e,
                       SourceContext context = std::source_location::current()) {
     ::inviwo::log::report(LogLevel::Error, context, e.what());
 }
-inline void exception(std::string_view message = "Unknown Exception",
+inline void exception(std::string_view message,
                       SourceContext context = std::source_location::current()) {
     ::inviwo::log::report(LogLevel::Error, context, message);
+}
+inline void exception(SourceContext context = std::source_location::current()) {
+    ::inviwo::log::report(LogLevel::Error, context, "Unknown Exception");
 }
 
 template <typename... Args>
@@ -232,7 +236,8 @@ struct message {
     }
     message(Logger& logger, LogLevel level, fmt::format_string<Args...> format, Args&&... args,
             SourceContext context = std::source_location::current()) {
-        ::inviwo::log::implementation(level, context, format, fmt::make_format_args(args...));
+        ::inviwo::log::implementation(logger, level, context, format,
+                                      fmt::make_format_args(args...));
     }
 };
 template <typename... Args>

--- a/include/inviwo/core/util/logcentral.h
+++ b/include/inviwo/core/util/logcentral.h
@@ -204,6 +204,44 @@ private:
     MessageBreakLevel breakLevel_ = MessageBreakLevel::Off;
 };
 
+namespace log {
+
+struct IVW_CORE_API LogFormat {
+    consteval LogFormat(const char* format,
+                        std::source_location location = std::source_location::current())
+        : format(format), context{location} {}
+
+    std::string_view format;
+    SourceContext context;
+};
+
+inline void log(LogLevel level, LogAudience audience, SourceContext context,
+                std::string_view format, fmt::format_args&& args) {
+    LogCentral::getPtr()->log(context.source(), level, audience, context.file(), context.function(),
+                              context.line(), fmt::vformat(format, std::move(args)));
+}
+
+namespace user {
+template <typename... Args>
+void info(const LogFormat& format, Args&&... args) {
+    ::inviwo::log::log(LogLevel::Info, LogAudience::User, format.context, format.format,
+                       fmt::make_format_args(args...));
+}
+
+template <typename... Args>
+void warn(const LogFormat& format, Args&&... args) {
+    ::inviwo::log::log(LogLevel::Info, LogAudience::User, format.context, format.format,
+                       fmt::make_format_args(args...));
+}
+template <typename... Args>
+void error(const LogFormat& format, Args&&... args) {
+    ::inviwo::log::log(LogLevel::Info, LogAudience::User, format.context, format.format,
+                       fmt::make_format_args(args...));
+}
+}  // namespace user
+
+}  // namespace log
+
 namespace util {
 
 IVW_CORE_API void log(ExceptionContext context, std::string_view message,
@@ -217,27 +255,26 @@ IVW_CORE_API void log(Logger* logger, ExceptionContext context, std::string_view
 template <typename... Args>
 void log(SourceContext context, LogLevel level, LogAudience audience,
          fmt::format_string<Args...> format, Args&&... args) {
-    LogCentral::getPtr()->log(context.getCaller(), level, audience, context.getFile(),
-                              context.getFunction(), context.getLine(),
-                              fmt::format(format, std::forward<Args>(args)...));
+    LogCentral::getPtr()->log(context.source(), level, audience, context.file(), context.function(),
+                              context.line(), fmt::format(format, std::forward<Args>(args)...));
 }
 
 template <typename... Args>
 void logInfo(SourceContext context, fmt::format_string<Args...> format, Args&&... args) {
-    LogCentral::getPtr()->log(context.getCaller(), LogLevel::Info, LogAudience::Developer,
-                              context.getFile(), context.getFunction(), context.getLine(),
+    LogCentral::getPtr()->log(context.source(), LogLevel::Info, LogAudience::Developer,
+                              context.file(), context.function(), context.line(),
                               fmt::format(format, std::forward<Args>(args)...));
 }
 template <typename... Args>
 void logWarn(SourceContext context, fmt::format_string<Args...> format, Args&&... args) {
-    LogCentral::getPtr()->log(context.getCaller(), LogLevel::Warn, LogAudience::Developer,
-                              context.getFile(), context.getFunction(), context.getLine(),
+    LogCentral::getPtr()->log(context.source(), LogLevel::Warn, LogAudience::Developer,
+                              context.file(), context.function(), context.line(),
                               fmt::format(format, std::forward<Args>(args)...));
 }
 template <typename... Args>
 void logError(SourceContext context, fmt::format_string<Args...> format, Args&&... args) {
-    LogCentral::getPtr()->log(context.getCaller(), LogLevel::Error, LogAudience::Developer,
-                              context.getFile(), context.getFunction(), context.getLine(),
+    LogCentral::getPtr()->log(context.source(), LogLevel::Error, LogAudience::Developer,
+                              context.file(), context.function(), context.line(),
                               fmt::format(format, std::forward<Args>(args)...));
 }
 

--- a/include/inviwo/core/util/logfilter.h
+++ b/include/inviwo/core/util/logfilter.h
@@ -63,13 +63,6 @@ public:
                      std::string_view file, std::string_view function, int line,
                      std::string_view msg) override;
 
-    virtual void logProcessor(Processor* processor, LogLevel level, LogAudience audience,
-                              std::string_view msg, std::string_view file,
-                              std::string_view function, int line) override;
-
-    virtual void logNetwork(LogLevel level, LogAudience audience, std::string_view msg,
-                            std::string_view file, std::string_view function, int line) override;
-
 private:
     LogVerbosity logVerbosity_;
     Logger* logger_;

--- a/include/inviwo/core/util/networkdebugobserver.h
+++ b/include/inviwo/core/util/networkdebugobserver.h
@@ -52,15 +52,15 @@ struct IVW_CORE_API NetworkDebugObserver : ProcessorNetworkObserver,
                                            ProcessorNetworkEvaluationObserver,
                                            ProcessorObserver {
 
-    void log(std::source_location location = std::source_location::current()) {
+    static void log(std::source_location location = std::source_location::current()) {
         log::info("{:33}", location.function_name());
     }
-    void log(std::string_view msg,
-             std::source_location location = std::source_location::current()) {
+    static void log(std::string_view msg,
+                    std::source_location location = std::source_location::current()) {
         log::info("{:33} {}", location.function_name(), msg);
     }
-    void log(std::string_view msg1, std::string_view msg2,
-             std::source_location location = std::source_location::current()) {
+    static void log(std::string_view msg1, std::string_view msg2,
+                    std::source_location location = std::source_location::current()) {
         log::info("{:33} {} - {}", location.function_name(), msg1, msg2);
     }
 

--- a/include/inviwo/core/util/networkdebugobserver.h
+++ b/include/inviwo/core/util/networkdebugobserver.h
@@ -53,15 +53,15 @@ struct IVW_CORE_API NetworkDebugObserver : ProcessorNetworkObserver,
                                            ProcessorObserver {
 
     void log(std::source_location location = std::source_location::current()) {
-        LogInfo(fmt::format("{:33}", location.function_name()));
+        log::user::info("{:33}", location.function_name());
     }
     void log(std::string_view msg,
              std::source_location location = std::source_location::current()) {
-        LogInfo(fmt::format("{:33} {}", location.function_name(), msg));
+        log::user::info("{:33} {}", location.function_name(), msg);
     }
     void log(std::string_view msg1, std::string_view msg2,
              std::source_location location = std::source_location::current()) {
-        LogInfo(fmt::format("{:33} {} - {}", location.function_name(), msg1, msg2));
+        log::user::info("{:33} {} - {}", location.function_name(), msg1, msg2);
     }
 
     // Network
@@ -116,10 +116,10 @@ struct IVW_CORE_API NetworkDebugObserver : ProcessorNetworkObserver,
 
     // Evaluator
     virtual void onProcessorNetworkEvaluationBegin() override {
-        LogWarn("ProcessorNetworkEvaluationBegin");
+        log::warn("ProcessorNetworkEvaluationBegin");
     };
     virtual void onProcessorNetworkEvaluationEnd() override {
-        LogWarn("ProcessorNetworkEvaluationEnd");
+        log::warn("ProcessorNetworkEvaluationEnd");
     };
 
     // Processor

--- a/include/inviwo/core/util/networkdebugobserver.h
+++ b/include/inviwo/core/util/networkdebugobserver.h
@@ -52,14 +52,16 @@ struct IVW_CORE_API NetworkDebugObserver : ProcessorNetworkObserver,
                                            ProcessorNetworkEvaluationObserver,
                                            ProcessorObserver {
 
-    void log(const SourceLocation& loc) {
-        LogInfo(fmt::format("{:33}", loc.getFunction().substr(2)));
+    void log(std::source_location location = std::source_location::current()) {
+        LogInfo(fmt::format("{:33}", location.function_name()));
     }
-    void log(const SourceLocation& loc, std::string_view msg) {
-        LogInfo(fmt::format("{:33} {}", loc.getFunction().substr(2), msg));
+    void log(std::string_view msg,
+             std::source_location location = std::source_location::current()) {
+        LogInfo(fmt::format("{:33} {}", location.function_name(), msg));
     }
-    void log(const SourceLocation& loc, std::string_view msg1, std::string_view msg2) {
-        LogInfo(fmt::format("{:33} {} - {}", loc.getFunction().substr(2), msg1, msg2));
+    void log(std::string_view msg1, std::string_view msg2,
+             std::source_location location = std::source_location::current()) {
+        LogInfo(fmt::format("{:33} {} - {}", location.function_name(), msg1, msg2));
     }
 
     // Network
@@ -68,52 +70,48 @@ struct IVW_CORE_API NetworkDebugObserver : ProcessorNetworkObserver,
     virtual void onProcessorNetworkUnlocked() override {}
 
     virtual void onProcessorNetworkWillAddProcessor(Processor* p) override {
-        log(IVW_SOURCE_LOCATION, p->getIdentifier());
+        log(p->getIdentifier());
     }
     virtual void onProcessorNetworkDidAddProcessor(Processor* p) override {
         p->ProcessorObservable::addObserver(this);
-        log(IVW_SOURCE_LOCATION, p->getIdentifier());
+        log(p->getIdentifier());
     }
     virtual void onProcessorNetworkWillRemoveProcessor(Processor* p) override {
-        log(IVW_SOURCE_LOCATION, p->getIdentifier());
+        log(p->getIdentifier());
     }
     virtual void onProcessorNetworkDidRemoveProcessor(Processor* p) override {
-        log(IVW_SOURCE_LOCATION, p->getIdentifier());
+        log(p->getIdentifier());
     }
 
     virtual void onProcessorNetworkWillAddConnection(const PortConnection& p) override {
-        log(IVW_SOURCE_LOCATION, p.getInport()->getIdentifier(), p.getOutport()->getIdentifier());
+        log(p.getInport()->getIdentifier(), p.getOutport()->getIdentifier());
     }
     virtual void onProcessorNetworkDidAddConnection(const PortConnection& p) override {
-        log(IVW_SOURCE_LOCATION, p.getInport()->getIdentifier(), p.getOutport()->getIdentifier());
+        log(p.getInport()->getIdentifier(), p.getOutport()->getIdentifier());
     }
     virtual void onProcessorNetworkWillRemoveConnection(const PortConnection& p) override {
-        log(IVW_SOURCE_LOCATION, p.getInport()->getIdentifier(), p.getOutport()->getIdentifier());
+        log(p.getInport()->getIdentifier(), p.getOutport()->getIdentifier());
     }
     virtual void onProcessorNetworkDidRemoveConnection(const PortConnection& p) override {
-        log(IVW_SOURCE_LOCATION, p.getInport()->getIdentifier(), p.getOutport()->getIdentifier());
+        log(p.getInport()->getIdentifier(), p.getOutport()->getIdentifier());
     }
 
     virtual void onProcessorNetworkWillAddLink(const PropertyLink& l) override {
-        log(IVW_SOURCE_LOCATION, l.getSource()->getIdentifier(),
-            l.getDestination()->getIdentifier());
+        log(l.getSource()->getIdentifier(), l.getDestination()->getIdentifier());
     }
     virtual void onProcessorNetworkDidAddLink(const PropertyLink& l) override {
-        log(IVW_SOURCE_LOCATION, l.getSource()->getIdentifier(),
-            l.getDestination()->getIdentifier());
+        log(l.getSource()->getIdentifier(), l.getDestination()->getIdentifier());
     }
     virtual void onProcessorNetworkWillRemoveLink(const PropertyLink& l) override {
-        log(IVW_SOURCE_LOCATION, l.getSource()->getIdentifier(),
-            l.getDestination()->getIdentifier());
+        log(l.getSource()->getIdentifier(), l.getDestination()->getIdentifier());
     }
     virtual void onProcessorNetworkDidRemoveLink(const PropertyLink& l) override {
-        log(IVW_SOURCE_LOCATION, l.getSource()->getIdentifier(),
-            l.getDestination()->getIdentifier());
+        log(l.getSource()->getIdentifier(), l.getDestination()->getIdentifier());
     }
 
     virtual void onProcessorBackgroundJobsChanged(Processor* p, [[maybe_unused]] int diff,
                                                   [[maybe_unused]] int total) override {
-        log(IVW_SOURCE_LOCATION, p->getIdentifier());
+        log(p->getIdentifier());
     }
 
     // Evaluator
@@ -125,46 +123,30 @@ struct IVW_CORE_API NetworkDebugObserver : ProcessorNetworkObserver,
     };
 
     // Processor
-    virtual void onAboutPropertyChange(Property* p) override {
-        log(IVW_SOURCE_LOCATION, p ? p->getPath() : "null");
-    };
-    virtual void onProcessorInvalidationBegin(Processor* p) override {
-        log(IVW_SOURCE_LOCATION, p->getIdentifier());
-    };
-    virtual void onProcessorInvalidationEnd(Processor* p) override {
-        log(IVW_SOURCE_LOCATION, p->getIdentifier());
-    };
+    virtual void onAboutPropertyChange(Property* p) override { log(p ? p->getPath() : "null"); };
+    virtual void onProcessorInvalidationBegin(Processor* p) override { log(p->getIdentifier()); };
+    virtual void onProcessorInvalidationEnd(Processor* p) override { log(p->getIdentifier()); };
     virtual void onProcessorPortAdded(Processor* p, [[maybe_unused]] Port* port) override {
-        log(IVW_SOURCE_LOCATION, p->getIdentifier());
+        log(p->getIdentifier());
     };
     virtual void onProcessorPortRemoved(Processor* p, [[maybe_unused]] Port* port) override {
-        log(IVW_SOURCE_LOCATION, p->getIdentifier());
+        log(p->getIdentifier());
     };
-    virtual void onProcessorAboutToProcess(Processor* p) override {
-        log(IVW_SOURCE_LOCATION, p->getIdentifier());
-    };
-    virtual void onProcessorFinishedProcess(Processor* p) override {
-        log(IVW_SOURCE_LOCATION, p->getIdentifier());
-    };
-    virtual void onProcessorSourceChanged(Processor* p) override {
-        log(IVW_SOURCE_LOCATION, p->getIdentifier());
-    };
-    virtual void onProcessorSinkChanged(Processor* p) override {
-        log(IVW_SOURCE_LOCATION, p->getIdentifier());
-    };
-    virtual void onProcessorReadyChanged(Processor* p) override {
-        log(IVW_SOURCE_LOCATION, p->getIdentifier());
-    };
+    virtual void onProcessorAboutToProcess(Processor* p) override { log(p->getIdentifier()); };
+    virtual void onProcessorFinishedProcess(Processor* p) override { log(p->getIdentifier()); };
+    virtual void onProcessorSourceChanged(Processor* p) override { log(p->getIdentifier()); };
+    virtual void onProcessorSinkChanged(Processor* p) override { log(p->getIdentifier()); };
+    virtual void onProcessorReadyChanged(Processor* p) override { log(p->getIdentifier()); };
     virtual void onProcessorActiveConnectionsChanged(Processor* p) override {
-        log(IVW_SOURCE_LOCATION, p->getIdentifier());
+        log(p->getIdentifier());
     };
     virtual void onProcessorStartBackgroundWork(Processor* p,
                                                 [[maybe_unused]] size_t jobs) override {
-        log(IVW_SOURCE_LOCATION, p->getIdentifier());
+        log(p->getIdentifier());
     };
     virtual void onProcessorFinishBackgroundWork(Processor* p,
                                                  [[maybe_unused]] size_t jobs) override {
-        log(IVW_SOURCE_LOCATION, p->getIdentifier());
+        log(p->getIdentifier());
     };
 };
 

--- a/include/inviwo/core/util/networkdebugobserver.h
+++ b/include/inviwo/core/util/networkdebugobserver.h
@@ -53,15 +53,15 @@ struct IVW_CORE_API NetworkDebugObserver : ProcessorNetworkObserver,
                                            ProcessorObserver {
 
     void log(std::source_location location = std::source_location::current()) {
-        log::user::info("{:33}", location.function_name());
+        log::info("{:33}", location.function_name());
     }
     void log(std::string_view msg,
              std::source_location location = std::source_location::current()) {
-        log::user::info("{:33} {}", location.function_name(), msg);
+        log::info("{:33} {}", location.function_name(), msg);
     }
     void log(std::string_view msg1, std::string_view msg2,
              std::source_location location = std::source_location::current()) {
-        log::user::info("{:33} {} - {}", location.function_name(), msg1, msg2);
+        log::info("{:33} {} - {}", location.function_name(), msg1, msg2);
     }
 
     // Network

--- a/include/inviwo/core/util/sourcecontext.h
+++ b/include/inviwo/core/util/sourcecontext.h
@@ -79,7 +79,7 @@ public:
         : SourceContext{source.view(), location.file_name(), location.function_name(),
                         location.line(), location.column()} {}
 
-    explicit consteval SourceContext(
+    consteval SourceContext(
         std::source_location location = std::source_location::current())
         : SourceContext{extractName(location.function_name()), location.file_name(),
                         location.function_name(), location.line(), location.column()} {}

--- a/include/inviwo/core/util/sourcecontext.h
+++ b/include/inviwo/core/util/sourcecontext.h
@@ -30,16 +30,11 @@
 #pragma once
 
 #include <inviwo/core/common/inviwocoredefine.h>
-#include <inviwo/core/util/demangle.h>
 #include <inviwo/core/util/hashcombine.h>
 
 #include <string_view>
-#include <string>
-#include <cstring>
 #include <iosfwd>
-#include <iterator>
 #include <source_location>
-
 #include <fmt/format.h>
 
 namespace inviwo {
@@ -79,8 +74,7 @@ public:
         : SourceContext{source.view(), location.file_name(), location.function_name(),
                         location.line(), location.column()} {}
 
-    consteval SourceContext(
-        std::source_location location = std::source_location::current())
+    consteval SourceContext(std::source_location location = std::source_location::current())
         : SourceContext{extractName(location.function_name()), location.file_name(),
                         location.function_name(), location.line(), location.column()} {}
 

--- a/include/inviwo/core/util/sourcecontext.h
+++ b/include/inviwo/core/util/sourcecontext.h
@@ -75,7 +75,7 @@ public:
         : SourceContext{source.view(), location.file_name(), location.function_name(),
                         location.line(), location.column()} {}
 
-    constexpr SourceContext(std::source_location location = std::source_location::current())
+    explicit(false) constexpr SourceContext(std::source_location location = std::source_location::current())
         : SourceContext{extractName(location.function_name()), location.file_name(),
                         location.function_name(), location.line(), location.column()} {}
 
@@ -87,7 +87,7 @@ public:
 
 private:
     static constexpr std::string_view extractName(std::string_view name) noexcept {
-        const std::size_t end = name.find("(");
+        const std::size_t end = name.find('(');
         name = name.substr(0, end);
         name = name.substr(name.rfind(' ') + 1);
         return name;

--- a/include/inviwo/core/util/sourcecontext.h
+++ b/include/inviwo/core/util/sourcecontext.h
@@ -35,6 +35,7 @@
 #include <string_view>
 #include <iosfwd>
 #include <source_location>
+#include <iterator>
 #include <fmt/format.h>
 
 namespace inviwo {
@@ -61,8 +62,8 @@ constexpr Literal operator""_sl(const char* str, size_t len) { return Literal{st
  */
 class IVW_CORE_API SourceContext {
 public:
-    constexpr SourceContext(const char*) = delete;
-    constexpr SourceContext(std::string_view) = delete;
+    explicit constexpr SourceContext(const char*) = delete;
+    explicit constexpr SourceContext(std::string_view) = delete;
 
     explicit constexpr SourceContext(Literal source, std::string_view file,
                                      std::string_view function, std::uint32_t line = 0,
@@ -74,7 +75,7 @@ public:
         : SourceContext{source.view(), location.file_name(), location.function_name(),
                         location.line(), location.column()} {}
 
-    consteval SourceContext(std::source_location location = std::source_location::current())
+    constexpr SourceContext(std::source_location location = std::source_location::current())
         : SourceContext{extractName(location.function_name()), location.file_name(),
                         location.function_name(), location.line(), location.column()} {}
 

--- a/include/inviwo/core/util/sourcecontext.h
+++ b/include/inviwo/core/util/sourcecontext.h
@@ -75,7 +75,8 @@ public:
         : SourceContext{source.view(), location.file_name(), location.function_name(),
                         location.line(), location.column()} {}
 
-    explicit(false) constexpr SourceContext(std::source_location location = std::source_location::current())
+    explicit(false) constexpr SourceContext(
+        std::source_location location = std::source_location::current())
         : SourceContext{extractName(location.function_name()), location.file_name(),
                         location.function_name(), location.line(), location.column()} {}
 

--- a/include/inviwo/qt/applicationbase/qtapptools.h
+++ b/include/inviwo/qt/applicationbase/qtapptools.h
@@ -79,6 +79,12 @@ IVW_QTAPPLICATIONBASE_API void configureFileSystemObserver(InviwoApplication& ap
 IVW_QTAPPLICATIONBASE_API void configurePostEnqueueFront(InviwoApplication& app);
 
 /**
+ * Set a AssertionHandler to display a Qt dialog when asserts happen.
+ */
+IVW_QTAPPLICATIONBASE_API void configureAssertionHandler(InviwoApplication& app);
+
+
+/**
  * Configure the inviwo pool resize to work with the qt event system
  */
 IVW_QTAPPLICATIONBASE_API void configurePoolResizeWait(InviwoApplication& app, QWidget* window);

--- a/include/inviwo/qt/applicationbase/qtapptools.h
+++ b/include/inviwo/qt/applicationbase/qtapptools.h
@@ -83,7 +83,6 @@ IVW_QTAPPLICATIONBASE_API void configurePostEnqueueFront(InviwoApplication& app)
  */
 IVW_QTAPPLICATIONBASE_API void configureAssertionHandler(InviwoApplication& app);
 
-
 /**
  * Configure the inviwo pool resize to work with the qt event system
  */

--- a/include/inviwo/qt/editor/consolewidget.h
+++ b/include/inviwo/qt/editor/consolewidget.h
@@ -154,16 +154,6 @@ public:
                      std::string_view file, std::string_view function, int line,
                      std::string_view) override;
 
-    virtual void logProcessor(Processor* processor, LogLevel level, LogAudience audience,
-                              std::string_view msg, std::string_view file,
-                              std::string_view function, int line) override;
-
-    virtual void logNetwork(LogLevel level, LogAudience audience, std::string_view msg,
-                            std::string_view file, std::string_view function, int line) override;
-
-    virtual void logAssertion(std::string_view file, std::string_view function, int line,
-                              std::string_view msg) override;
-
     QAction* getClearAction();
     QTableView* view() { return tableView_; }
 

--- a/modules/animation/include/modules/animation/datastructures/easing.h
+++ b/modules/animation/include/modules/animation/datastructures/easing.h
@@ -286,7 +286,7 @@ inline double inOutBounce(const double t) {
 /// Some functions overshoot, which means you get also values outside of [0,1].
 /// Most interpolations should be fine with that. Linear Interpolation is fine with that.
 inline double ease(const double t, easing::EasingType howToEase) {
-    ivwAssert(t >= 0 && t <= 1, "Normalized time required as easing input.");
+    IVW_ASSERT(t >= 0 && t <= 1, "Normalized time required as easing input.");
 
     switch (howToEase) {
         default:

--- a/modules/animation/src/animationcontroller.cpp
+++ b/modules/animation/src/animationcontroller.cpp
@@ -56,7 +56,6 @@
 #include <inviwo/core/properties/propertysemantics.h>   // for PropertySemantics, Prop...
 #include <inviwo/core/properties/stringproperty.h>      // for StringProperty
 #include <inviwo/core/properties/valuewrapper.h>        // for PropertySerializationMode
-#include <inviwo/core/util/assertion.h>                 // for ivwAssert
 #include <inviwo/core/util/fileextension.h>             // for FileExtension, operator<<
 #include <inviwo/core/util/glmvec.h>                    // for ivec2, dvec2
 #include <inviwo/core/util/staticstring.h>              // for operator+

--- a/modules/animation/src/animationcontroller.cpp
+++ b/modules/animation/src/animationcontroller.cpp
@@ -448,8 +448,7 @@ void AnimationController::render() {
         });
 
         if (recordingFunctors.empty()) {
-            util::log(IVW_CONTEXT, "No applicable exporters selected for rendering",
-                      LogLevel::Warn);
+            log::warn("No applicable exporters selected for rendering");
             return;
         }
 
@@ -482,17 +481,18 @@ void AnimationController::render() {
                            std::chrono::high_resolution_clock::now() - start)
                            .count();
 
-        util::logInfo(IVW_CONTEXT, "Rendered {} frames in {:.3f} seconds, {:.3f} per frame",
-                      numFrames, seconds, seconds / numFrames);
+        log::user::info("Rendered {} frames in {:.3f} seconds, {:.3f} per frame", numFrames,
+                        seconds, seconds / numFrames);
 
     } catch (const Exception& e) {
-        util::log(IVW_CONTEXT, "Rendering aborted", LogLevel::Error);
-        util::log(e.getContext(), e.getMessage(), LogLevel::Error);
+        log::user::report(LogLevel::Error, "Rendering aborted");
+        log::user::exception(e);
     } catch (const std::exception& e) {
-        util::log(IVW_CONTEXT, "Rendering aborted", LogLevel::Error);
-        util::log(IVW_CONTEXT, e.what(), LogLevel::Error);
+        log::user::report(LogLevel::Error, "Rendering aborted");
+        log::user::exception(e);
     } catch (...) {
-        util::log(IVW_CONTEXT, "Rendering aborted", LogLevel::Error);
+        log::user::report(LogLevel::Error, "Rendering aborted");
+        log::user::exception();
     }
 }
 

--- a/modules/animation/src/animationcontroller.cpp
+++ b/modules/animation/src/animationcontroller.cpp
@@ -481,18 +481,18 @@ void AnimationController::render() {
                            std::chrono::high_resolution_clock::now() - start)
                            .count();
 
-        log::user::info("Rendered {} frames in {:.3f} seconds, {:.3f} per frame", numFrames,
-                        seconds, seconds / numFrames);
+        log::info("Rendered {} frames in {:.3f} seconds, {:.3f} per frame", numFrames, seconds,
+                  seconds / numFrames);
 
     } catch (const Exception& e) {
-        log::user::report(LogLevel::Error, "Rendering aborted");
-        log::user::exception(e);
+        log::report(LogLevel::Error, "Rendering aborted");
+        log::exception(e);
     } catch (const std::exception& e) {
-        log::user::report(LogLevel::Error, "Rendering aborted");
-        log::user::exception(e);
+        log::report(LogLevel::Error, "Rendering aborted");
+        log::exception(e);
     } catch (...) {
-        log::user::report(LogLevel::Error, "Rendering aborted");
-        log::user::exception();
+        log::report(LogLevel::Error, "Rendering aborted");
+        log::exception();
     }
 }
 

--- a/modules/animation/src/datastructures/animation.cpp
+++ b/modules/animation/src/datastructures/animation.cpp
@@ -36,7 +36,7 @@
 #include <inviwo/core/properties/propertyownerobserver.h>        // for PropertyOwnerObserver
 #include <inviwo/core/util/exception.h>                          // for Exception
 #include <inviwo/core/util/indirectiterator.h>                   // for makeIndirectIterator
-#include <inviwo/core/util/logcentral.h>                         // for LogCentral, LogWarn, Log...
+#include <inviwo/core/util/logcentral.h>                         // for LogCentral
 #include <inviwo/core/util/sourcecontext.h>                      // for IVW_CONTEXT
 #include <inviwo/core/util/stdextensions.h>                      // for erase_remove
 #include <inviwo/core/util/typetraits.h>                         // for alwaysTrue, identity
@@ -134,10 +134,10 @@ Keyframe* Animation::addKeyframe(Property* property, Seconds time) {
         } else if (auto basePropertyTrack = add(property)) {
             return basePropertyTrack->addKeyFrameUsingPropertyValue(time);
         } else {
-            LogWarn("No matching Track found for property \"" << property->getIdentifier() << "\"");
+            log::warn("No matching Track found for property \"{}\"", property->getIdentifier());
         }
-    } catch (const Exception& ex) {
-        LogError(ex.getMessage());
+    } catch (const Exception& e) {
+        log::exception(e);
     }
     return nullptr;
 }
@@ -152,10 +152,10 @@ KeyframeSequence* Animation::addKeyframeSequence(Property* property, Seconds tim
             basePropertyTrack->addKeyFrameUsingPropertyValue(time);
             return &basePropertyTrack->toTrack()->getFirst();
         } else {
-            LogWarn("No matching Track found for property \"" << property->getIdentifier() << "\"");
+            log::warn("No matching Track found for property \"{}\"", property->getIdentifier());
         }
     } catch (const Exception& ex) {
-        LogError(ex.getMessage());
+        log::exception(ex);
     }
     return nullptr;
 }
@@ -180,7 +180,7 @@ BasePropertyTrack* Animation::add(Property* property) {
                 try {
                     basePropertyTrack->setProperty(property);
                 } catch (const Exception& e) {
-                    LogWarn(e.getMessage() << " Invalid property class identified?");
+                    log::warn("{} Invalid property class identified?", e.getMessage());
                     return nullptr;
                 }
                 add(std::move(track));

--- a/modules/animation/src/datastructures/invalidationtrack.cpp
+++ b/modules/animation/src/datastructures/invalidationtrack.cpp
@@ -88,11 +88,11 @@ AnimationTimeState InvalidationTrack::operator()(Seconds, Seconds to, AnimationS
                 } else if (auto property = processor->getPropertyByPath(propertyPath)) {
                     property->propertyModified();
                 } else {
-                    util::logWarn(IVW_CONTEXT, "Unable to find property '{}' of processor '{}'",
-                                  propertyPath, processorId);
+                    log::user::warn("Unable to find property '{}' of processor '{}'", propertyPath,
+                                    processorId);
                 }
             } else {
-                util::logWarn(IVW_CONTEXT, "Unable to find processor '{}'", processorId);
+                log::user::warn("Unable to find processor '{}'", processorId);
             }
         }
     }

--- a/modules/animation/src/datastructures/invalidationtrack.cpp
+++ b/modules/animation/src/datastructures/invalidationtrack.cpp
@@ -88,11 +88,11 @@ AnimationTimeState InvalidationTrack::operator()(Seconds, Seconds to, AnimationS
                 } else if (auto property = processor->getPropertyByPath(propertyPath)) {
                     property->propertyModified();
                 } else {
-                    log::user::warn("Unable to find property '{}' of processor '{}'", propertyPath,
-                                    processorId);
+                    log::warn("Unable to find property '{}' of processor '{}'", propertyPath,
+                              processorId);
                 }
             } else {
-                log::user::warn("Unable to find processor '{}'", processorId);
+                log::warn("Unable to find processor '{}'", processorId);
             }
         }
     }

--- a/modules/animation/src/demo/democontroller.cpp
+++ b/modules/animation/src/demo/democontroller.cpp
@@ -142,12 +142,12 @@ void DemoController::loadWorkspaceApp(const std::filesystem::path& fileName) {
             try {
                 throw;
             } catch (const IgnoreException& e) {
-                log::user::exception(e, "Incomplete network loading {} due to {}", fileName,
-                                     e.getMessage());
+                log::exception(e, "Incomplete network loading {} due to {}", fileName,
+                               e.getMessage());
             }
         });
     } catch (const Exception& e) {
-        log::user::exception(e, "Unable to load network {} due to {}", fileName, e.getMessage());
+        log::exception(e, "Unable to load network {} due to {}", fileName, e.getMessage());
         app_->getWorkspaceManager()->clear();
     }
 }

--- a/modules/animation/src/demo/democontroller.cpp
+++ b/modules/animation/src/demo/democontroller.cpp
@@ -142,16 +142,12 @@ void DemoController::loadWorkspaceApp(const std::filesystem::path& fileName) {
             try {
                 throw;
             } catch (const IgnoreException& e) {
-                util::log(e.getContext(),
-                          fmt::format("Incomplete network loading {} due to {}", fileName,
-                                      e.getMessage()),
-                          LogLevel::Error);
+                log::user::exception(e, "Incomplete network loading {} due to {}", fileName,
+                                     e.getMessage());
             }
         });
     } catch (const Exception& e) {
-        util::log(e.getContext(),
-                  fmt::format("Unable to load network {} due to {}", fileName, e.getMessage()),
-                  LogLevel::Error);
+        log::user::exception(e, "Unable to load network {} due to {}", fileName, e.getMessage());
         app_->getWorkspaceManager()->clear();
     }
 }

--- a/modules/animation/src/factories/imagerecorderfactory.cpp
+++ b/modules/animation/src/factories/imagerecorderfactory.cpp
@@ -52,11 +52,11 @@ class ExceptionPropagator {
             try {
                 throwOnError();
             } catch (const Exception& e) {
-                util::log(e.getContext(), e.getMessage());
+                log::user::exception(e);
             } catch (const std::exception& e) {
-                util::log(IVW_CONTEXT, e.what());
+                log::user::exception(e);
             } catch (...) {
-                util::log(IVW_CONTEXT, "unknown error");
+                log::user::exception();
             }
         }
         void setException() {

--- a/modules/animation/src/factories/imagerecorderfactory.cpp
+++ b/modules/animation/src/factories/imagerecorderfactory.cpp
@@ -52,11 +52,11 @@ class ExceptionPropagator {
             try {
                 throwOnError();
             } catch (const Exception& e) {
-                log::user::exception(e);
+                log::exception(e);
             } catch (const std::exception& e) {
-                log::user::exception(e);
+                log::exception(e);
             } catch (...) {
-                log::user::exception();
+                log::exception();
             }
         }
         void setException() {

--- a/modules/animation/src/factories/trackfactory.cpp
+++ b/modules/animation/src/factories/trackfactory.cpp
@@ -31,7 +31,7 @@
 
 #include <inviwo/core/properties/property.h>                 // for Property
 #include <inviwo/core/util/exception.h>                      // for Exception
-#include <inviwo/core/util/logcentral.h>                     // for LogCentral, LogWarn
+#include <inviwo/core/util/logcentral.h>                     // for LogCentral
 #include <modules/animation/datastructures/propertytrack.h>  // for BasePropertyTrack
 #include <modules/animation/datastructures/track.h>          // for Track
 #include <modules/animation/factories/trackfactoryobject.h>  // for TrackFactoryObject
@@ -58,7 +58,8 @@ std::unique_ptr<Track> TrackFactory::create(Property* property) const {
                 try {
                     basePropertyTrack->setProperty(property);
                 } catch (const Exception& e) {
-                    LogWarn(e.getMessage() << " Invalid property class identified?") return nullptr;
+                    log::warn("{} Invalid property class identified?", e.getMessage());
+                    return nullptr;
                 }
 
                 return track;

--- a/modules/animationqt/src/animationeditordockwidgetqt.cpp
+++ b/modules/animationqt/src/animationeditordockwidgetqt.cpp
@@ -34,7 +34,7 @@
 #include <inviwo/core/properties/propertywidgetfactory.h>            // for PropertyWidgetFactory
 #include <inviwo/core/util/filedialogstate.h>                        // for FileMode, FileMode::...
 #include <inviwo/core/util/filesystem.h>                             // for cleanupPath, fileExists
-#include <inviwo/core/util/logcentral.h>                             // for LogCentral, LogError
+#include <inviwo/core/util/logcentral.h>                             // for LogCentral
 #include <inviwo/core/util/pathtype.h>                               // for PathType, PathType::...
 #include <inviwo/core/util/raiiutils.h>                              // for KeepTrueWhileInScope
 #include <modules/animation/animationcontroller.h>                   // for AnimationController
@@ -438,7 +438,7 @@ void AnimationEditorDockWidgetQt::importAnimation() {
         const QString path = openFileDialog.selectedFiles().at(0);
         const std::filesystem::path fileName{utilqt::toPath(path)};
         if (!std::filesystem::is_regular_file(fileName)) {
-            LogError("Could not find file: " << fileName);
+            log::error("Could not find file: {}", fileName);
             return;
         }
         try {
@@ -452,7 +452,7 @@ void AnimationEditorDockWidgetQt::importAnimation() {
                 animations_.add(std::move(animation));
             }
         } catch (const std::exception& ex) {
-            LogError(ex.what());
+            log::exception(ex);
         }
     }
 }

--- a/modules/animationqt/src/trackcontrolswidgetqt.cpp
+++ b/modules/animationqt/src/trackcontrolswidgetqt.cpp
@@ -29,7 +29,7 @@
 
 #include <modules/animationqt/trackcontrolswidgetqt.h>
 
-#include <inviwo/core/util/logcentral.h>                     // for LogCentral, LogWarn
+#include <inviwo/core/util/logcentral.h>                     // for LogCentral
 #include <modules/animation/animationcontroller.h>           // for AnimationController
 #include <modules/animation/datastructures/animationtime.h>  // for Seconds
 #include <modules/animation/datastructures/track.h>          // for Track
@@ -99,7 +99,7 @@ TrackControlsWidgetQt::TrackControlsWidgetQt(QStandardItem*, Track& track,
             iconSize, QIcon::Normal, QIcon::Off);
         QAction* lock = new QAction(lockTrackIcon, "Lock/Unlock Track", this);
         connect(lock, &QAction::triggered, this,
-                [=]() { LogWarn("Locking tracks is not implemented yet."); });
+                [=]() { log::warn("Locking tracks is not implemented yet."); });
         lock->setCheckable(true);
         lock->setChecked(false);
         btnLock_ = new QToolButton(this);

--- a/modules/base/include/modules/base/algorithm/image/layerramdistancetransform.h
+++ b/modules/base/include/modules/base/algorithm/image/layerramdistancetransform.h
@@ -37,7 +37,7 @@
 #include <inviwo/core/util/glmutils.h>                  // for Vector, Matrix
 #include <inviwo/core/util/glmvec.h>                    // for i64vec2, size2_t
 #include <inviwo/core/util/indexmapper.h>               // for IndexMapper
-#include <inviwo/core/util/logcentral.h>                // for LogCentral, LogWarnCustom
+#include <inviwo/core/util/logcentral.h>                // for LogCentral
 #include <inviwo/core/util/sourcecontext.h>             // for IVW_CONTEXT_CUSTOM
 #include <inviwo/core/util/stringconversion.h>          // for toString
 
@@ -149,8 +149,7 @@ void util::layerRAMDistanceTransform(const LayerRAMPrecision<T>* inLayer,
             }
         }
         if (!orthogonal) {
-            LogWarnCustom(
-                "layerRAMDistanceTransform",
+            log::warn(
                 "Calculating the distance transform on a non-orthogonal layer will not give "
                 "correct values");
         }

--- a/modules/base/include/modules/base/algorithm/volume/volumeramdistancetransform.h
+++ b/modules/base/include/modules/base/algorithm/volume/volumeramdistancetransform.h
@@ -37,7 +37,7 @@
 #include <inviwo/core/util/glmutils.h>           // for Vector, Matrix
 #include <inviwo/core/util/glmvec.h>             // for i64vec3, size3_t
 #include <inviwo/core/util/indexmapper.h>        // for IndexMapper
-#include <inviwo/core/util/logcentral.h>         // for LogCentral, LogWarnCustom
+#include <inviwo/core/util/logcentral.h>         // for LogCentral
 #include <inviwo/core/util/sourcecontext.h>      // for IVW_CONTEXT_CUSTOM
 #include <inviwo/core/util/stringconversion.h>   // for toString
 
@@ -153,8 +153,7 @@ void util::volumeRAMDistanceTransform(const VolumeRAMPrecision<T>* inVolume,
             }
         }
         if (!orthogonal) {
-            LogWarnCustom(
-                "volumeRAMDistanceTransform",
+            log::warn(
                 "Calculating the distance transform on a non-orthogonal volume will not give "
                 "correct values");
         }

--- a/modules/base/include/modules/base/processors/dataexport.h
+++ b/modules/base/include/modules/base/processors/dataexport.h
@@ -135,7 +135,7 @@ void DataExport<DataType, PortType>::exportData() {
 
     writer->setOverwrite(overwrite_ ? Overwrite::Yes : Overwrite::No);
     writer->writeData(data, file_.get());
-    log::user::info("Data exported to disk: {}", file_.get().string());
+    log::info("Data exported to disk: {}", file_.get().string());
 
     // update widgets as the file might now exist
     file_.clearInitiatingWidget();

--- a/modules/base/include/modules/base/processors/dataexport.h
+++ b/modules/base/include/modules/base/processors/dataexport.h
@@ -119,35 +119,27 @@ template <typename DataType, typename PortType>
 void DataExport<DataType, PortType>::exportData() {
     auto data = getData();
 
-    if (data && !file_.get().empty()) {
-
-        auto writer = wf_->template getWriterForTypeAndExtension<DataType>(
-            file_.getSelectedExtension(), file_.get());
-
-        if (!writer) {
-            LogProcessorError(
-                "Error: Could not find a writer for the specified extension and data type");
-            return;
-        }
-
-        try {
-            writer->setOverwrite(overwrite_ ? Overwrite::Yes : Overwrite::No);
-            writer->writeData(data, file_.get());
-            util::log(IVW_CONTEXT, "Data exported to disk: {}" + file_.get().string(),
-                      LogLevel::Info, LogAudience::User);
-
-            // update widgets as the file might now exist
-            file_.clearInitiatingWidget();
-            file_.updateWidgets();
-        } catch (DataWriterException const& e) {
-            util::log(e.getContext(), e.getMessage(), LogLevel::Error, LogAudience::User);
-        }
-
-    } else if (file_.get().empty()) {
-        LogProcessorWarn("Error: Please specify a file to write to");
-    } else if (!data) {
-        LogProcessorWarn("Error: Please connect a port to export");
+    if (file_.get().empty()) {
+        throw Exception("Please specify a file to write to");
     }
+    if (!data) {
+        throw Exception("Please connect a port to export");
+    }
+
+    auto writer = wf_->template getWriterForTypeAndExtension<DataType>(file_.getSelectedExtension(),
+                                                                       file_.get());
+
+    if (!writer) {
+        throw Exception("Could not find a writer for the specified extension and data type");
+    }
+
+    writer->setOverwrite(overwrite_ ? Overwrite::Yes : Overwrite::No);
+    writer->writeData(data, file_.get());
+    log::user::info("Data exported to disk: {}", file_.get().string());
+
+    // update widgets as the file might now exist
+    file_.clearInitiatingWidget();
+    file_.updateWidgets();
 }
 
 template <typename DataType, typename PortType>

--- a/modules/base/include/modules/base/processors/datasource.h
+++ b/modules/base/include/modules/base/processors/datasource.h
@@ -158,9 +158,9 @@ protected:
     virtual std::shared_ptr<DataType> transform(std::shared_ptr<ReaderType> data);
 
     // Called when we load new data.
-    virtual void dataLoaded(std::shared_ptr<DataType> data){};
+    virtual void dataLoaded(std::shared_ptr<DataType> data) {};
     // Called when we deserialized old data.
-    virtual void dataDeserialized(std::shared_ptr<DataType> data){};
+    virtual void dataDeserialized(std::shared_ptr<DataType> data) {};
 
     DataReaderFactory* rf_;
     PortType port_;
@@ -231,7 +231,7 @@ void DataSource<DataType, PortType, ReaderType>::handleError(std::string_view er
     error_ = error;
     port_.clear();
     isReady_.update();
-    log::user::report(LogLevel::Error, error_);
+    log::report(LogLevel::Error, error_);
 }
 
 template <typename DataType, typename PortType, typename ReaderType>

--- a/modules/base/include/modules/base/processors/datasource.h
+++ b/modules/base/include/modules/base/processors/datasource.h
@@ -231,7 +231,7 @@ void DataSource<DataType, PortType, ReaderType>::handleError(std::string_view er
     error_ = error;
     port_.clear();
     isReady_.update();
-    LogProcessorError(error_);
+    log::user::report(LogLevel::Error, error_);
 }
 
 template <typename DataType, typename PortType, typename ReaderType>

--- a/modules/base/src/algorithm/mesh/meshclipping.cpp
+++ b/modules/base/src/algorithm/mesh/meshclipping.cpp
@@ -222,9 +222,9 @@ std::vector<std::vector<std::uint32_t>> gatherLoops(std::vector<glm::u32vec2>& e
                     edges.erase(it);
                 }
             } else {
-                LogWarnCustom("MeshClipping",
-                              "Found edge that is not connected to any other edge. This could mean "
-                              "the clipped mesh was not a manifold.");
+                log::warn(
+                    "Found edge that is not connected to any other edge. This could mean "
+                    "the clipped mesh was not a manifold.");
                 break;
             }
         }

--- a/modules/base/src/algorithm/volume/marchingcubes.cpp
+++ b/modules/base/src/algorithm/volume/marchingcubes.cpp
@@ -36,7 +36,7 @@
 #include <inviwo/core/datastructures/representationconverterfactory.h>  // for RepresentationCon...
 #include <inviwo/core/datastructures/volume/volume.h>                   // IWYU pragma: keep
 #include <inviwo/core/datastructures/volume/volumeram.h>                // for VolumeRAM
-#include <inviwo/core/util/assertion.h>                                 // for ivwAssert
+#include <inviwo/core/util/assertion.h>                                 // for IVW_ASSERT
 #include <inviwo/core/util/exception.h>                                 // for Exception
 #include <inviwo/core/util/formatdispatching.h>                         // for PrecisionValueType
 #include <inviwo/core/util/glmvec.h>                                    // for size3_t, vec3, vec4
@@ -666,7 +666,7 @@ std::shared_ptr<Mesh> marchingcubes(std::shared_ptr<const Volume> volume, double
                                     dx, dy, dz);
         }
 
-        ivwAssert(positions.size() == normals.size(), "positions_ and normals_ must be equal");
+        IVW_ASSERT(positions.size() == normals.size(), "positions_ and normals_ must be equal");
         std::vector<BasicMesh::Vertex> vertices;
         vertices.reserve(positions.size());
 

--- a/modules/base/src/algorithm/volume/marchingcubesopt.cpp
+++ b/modules/base/src/algorithm/volume/marchingcubesopt.cpp
@@ -37,7 +37,7 @@
 #include <inviwo/core/datastructures/representationconverterfactory.h>  // for RepresentationCon...
 #include <inviwo/core/datastructures/volume/volume.h>                   // IWYU pragma: keep
 #include <inviwo/core/datastructures/volume/volumeram.h>                // for VolumeRAM
-#include <inviwo/core/util/assertion.h>                                 // for ivwAssert
+#include <inviwo/core/util/assertion.h>                                 // for IVW_ASSERT
 #include <inviwo/core/util/formatdispatching.h>                         // for PrecisionValueType
 #include <inviwo/core/util/glmconvert.h>                                // for glm_convert
 #include <inviwo/core/util/glmvec.h>                                    // for vec3, size3_t, vec4
@@ -586,7 +586,7 @@ std::shared_ptr<Mesh> marchingCubesOpt(std::shared_ptr<const Volume> volume, dou
             });
     }
 
-    ivwAssert(positions.size() == normals.size(), "positions and normals must be equal size");
+    IVW_ASSERT(positions.size() == normals.size(), "positions and normals must be equal size");
 
     std::transform(normals.begin(), normals.end(), normals.begin(),
                    [](const vec3& n) { return glm::normalize(n); });

--- a/modules/base/src/algorithm/volume/marchingtetrahedron.cpp
+++ b/modules/base/src/algorithm/volume/marchingtetrahedron.cpp
@@ -64,8 +64,7 @@ std::shared_ptr<Mesh> MarchingTetrahedron::apply(
     std::shared_ptr<const Volume> volume, double iso, const vec4& color, bool invert, bool enclose,
     std::function<void(float)> progressCallback,
     std::function<bool(const size3_t&)> maskingCallback) {
-    LogWarnCustom("MarchingTetrahedron::apply",
-                  "Deprecated: Use util::marchingtetrahedron(...) instead");
+    log::warn("Deprecated: Use util::marchingtetrahedron(...) instead");
     return util::marchingtetrahedron(volume, iso, color, invert, enclose, progressCallback,
                                      maskingCallback);
 }

--- a/modules/base/src/algorithm/volume/marchingtetrahedron.cpp
+++ b/modules/base/src/algorithm/volume/marchingtetrahedron.cpp
@@ -65,8 +65,8 @@ std::shared_ptr<Mesh> MarchingTetrahedron::apply(
     std::function<void(float)> progressCallback,
     std::function<bool(const size3_t&)> maskingCallback) {
     log::warn("Deprecated: Use util::marchingtetrahedron(...) instead");
-    return util::marchingtetrahedron(volume, iso, color, invert, enclose, progressCallback,
-                                     maskingCallback);
+    return util::marchingtetrahedron(std::move(volume), iso, color, invert, enclose,
+                                     std::move(progressCallback), maskingCallback);
 }
 
 namespace marchingtetrahedron {

--- a/modules/base/src/algorithm/volume/marchingtetrahedron.cpp
+++ b/modules/base/src/algorithm/volume/marchingtetrahedron.cpp
@@ -36,7 +36,7 @@
 #include <inviwo/core/datastructures/representationconverterfactory.h>  // for RepresentationCon...
 #include <inviwo/core/datastructures/volume/volume.h>                   // IWYU pragma: keep
 #include <inviwo/core/datastructures/volume/volumeram.h>                // for VolumeRAM
-#include <inviwo/core/util/assertion.h>                                 // for ivwAssert
+#include <inviwo/core/util/assertion.h>                                 // for IVW_ASSERT
 #include <inviwo/core/util/exception.h>                                 // for Exception
 #include <inviwo/core/util/formatdispatching.h>                         // for PrecisionValueType
 #include <inviwo/core/util/glmvec.h>                                    // for size3_t, vec3, vec4
@@ -254,7 +254,7 @@ std::shared_ptr<Mesh> marchingtetrahedron(std::shared_ptr<const Volume> volume, 
                                     dx, dy, dz);
         }
 
-        ivwAssert(positions.size() == normals.size(), "positions_ and normals_ must be equal");
+        IVW_ASSERT(positions.size() == normals.size(), "positions_ and normals_ must be equal");
         std::vector<BasicMesh::Vertex> vertices;
         vertices.reserve(positions.size());
 

--- a/modules/base/src/io/binarystlwriter.cpp
+++ b/modules/base/src/io/binarystlwriter.cpp
@@ -167,7 +167,7 @@ void BinarySTLWriter::writeData(const Mesh* data, std::ostream& f) const {
 
     for (const auto& inds : data->getIndexBuffers()) {
         if (inds.first.dt != DrawType::Triangles) {
-            log::user::error("Draw type: {} not supported", inds.first.dt);
+            log::error("Draw type: {} not supported", inds.first.dt);
             continue;
         }
 

--- a/modules/base/src/io/binarystlwriter.cpp
+++ b/modules/base/src/io/binarystlwriter.cpp
@@ -167,9 +167,7 @@ void BinarySTLWriter::writeData(const Mesh* data, std::ostream& f) const {
 
     for (const auto& inds : data->getIndexBuffers()) {
         if (inds.first.dt != DrawType::Triangles) {
-            std::stringstream err;
-            err << "Draw type: \n" << inds.first.dt << "\" not supported";
-            util::log(IVW_CONTEXT, err.str(), LogLevel::Warn, LogAudience::User);
+            log::user::error("Draw type: {} not supported", inds.first.dt);
             continue;
         }
 

--- a/modules/base/src/io/datvolumesequencereader.cpp
+++ b/modules/base/src/io/datvolumesequencereader.cpp
@@ -318,8 +318,7 @@ std::shared_ptr<VolumeSequence> DatVolumeSequenceReader::readData(
             std::copy(v->begin(), v->end(), std::back_inserter(*volumes));
         }
         if (enableLogOutput_) {
-            log::user::info("Loaded multiple volumes: {} volumes: ", filePath,
-                            state.datFiles.size());
+            log::info("Loaded multiple volumes: {} volumes: ", filePath, state.datFiles.size());
         }
 
     } else {
@@ -432,7 +431,7 @@ std::shared_ptr<VolumeSequence> DatVolumeSequenceReader::readData(
                 }
                 // Performance warning for larger volumes (rougly > 2MB)
                 if (bytes < 128 * 128 * 128 || state.sequences > 1) {
-                    log::user::warn(
+                    log::warn(
                         "Performance warning: Using min/max of data since DataRange was not "
                         "specified. Data range refer to the range of the data type, i.e. [0 4095] "
                         "for 12-bit unsigned integer data. It is important that the data range is "
@@ -446,7 +445,7 @@ std::shared_ptr<VolumeSequence> DatVolumeSequenceReader::readData(
                         filePath);
                 }
                 if (state.sequences > 1) {
-                    log::user::warn(
+                    log::warn(
                         "Multiple volumes in file but we only computed DataRange of the first "
                         "volume sequence due to performance consideration. \nWe strongly recommend "
                         "setting the DataRange, for example to min(Volume sequence), max(Volume "
@@ -457,7 +456,7 @@ std::shared_ptr<VolumeSequence> DatVolumeSequenceReader::readData(
 
         if (enableLogOutput_) {
             const auto size = util::formatBytesToString(bytes * state.sequences);
-            log::user::info("Loaded volume sequence: {} size: {}", filePath, size);
+            log::info("Loaded volume sequence: {} size: {}", filePath, size);
         }
     }
     return volumes;

--- a/modules/base/src/io/datvolumesequencereader.cpp
+++ b/modules/base/src/io/datvolumesequencereader.cpp
@@ -46,7 +46,7 @@
 #include <inviwo/core/util/formats.h>                 // for DataFormatBase, DataFormat
 #include <inviwo/core/util/glmmat.h>                  // for mat3
 #include <inviwo/core/util/glmvec.h>                  // for dvec2, vec3, size3_t
-#include <inviwo/core/util/logcentral.h>              // for LogCentral, LogInfo, LogWarn
+#include <inviwo/core/util/logcentral.h>              // for LogCentral
 #include <inviwo/core/util/sourcecontext.h>           // for IVW_CONTEXT
 #include <inviwo/core/util/stringconversion.h>        // for toLower, trim, splitByFirst
 #include <modules/base/algorithm/algorithmoptions.h>  // for IgnoreSpecialValues, IgnoreSpe...
@@ -242,7 +242,7 @@ std::shared_ptr<VolumeSequence> DatVolumeSequenceReader::readData(
         {"axis1name", [](State& state, std::stringstream& ss) { ss >> state.axes[0].name; }},
         {"axis2name", [](State& state, std::stringstream& ss) { ss >> state.axes[1].name; }},
         {"axis3name", [](State& state, std::stringstream& ss) { ss >> state.axes[2].name; }},
-        
+
         {"axisunits",
          [](State& state, std::stringstream& ss) {
              std::string unit;
@@ -318,8 +318,8 @@ std::shared_ptr<VolumeSequence> DatVolumeSequenceReader::readData(
             std::copy(v->begin(), v->end(), std::back_inserter(*volumes));
         }
         if (enableLogOutput_) {
-            LogInfo("Loaded multiple volumes: " << filePath
-                                                << " volumes: " << state.datFiles.size());
+            log::user::info("Loaded multiple volumes: {} volumes: ", filePath,
+                            state.datFiles.size());
         }
 
     } else {
@@ -432,7 +432,7 @@ std::shared_ptr<VolumeSequence> DatVolumeSequenceReader::readData(
                 }
                 // Performance warning for larger volumes (rougly > 2MB)
                 if (bytes < 128 * 128 * 128 || state.sequences > 1) {
-                    LogWarn(
+                    log::user::warn(
                         "Performance warning: Using min/max of data since DataRange was not "
                         "specified. Data range refer to the range of the data type, i.e. [0 4095] "
                         "for 12-bit unsigned integer data. It is important that the data range is "
@@ -441,13 +441,12 @@ std::shared_ptr<VolumeSequence> DatVolumeSequenceReader::readData(
                         "example performing color mapping, i.e. applying a transfer function. "
                         "\nValue range refer to the physical meaning of the value, i.e. Hounsfield "
                         "value range is from [-1000 3000]. Improve volume read performance by "
-                        "adding for example: \n"
-                        << "DataRange: " << computedRange[0] << " " << computedRange[1]
-                        << "\nValueRange: " << computedRange[0] << " " << computedRange[1]
-                        << "\nin file: " << filePath);
+                        "adding for example: \nDataRange: {} {}\nValueRange: {} {}\nin file: ",
+                        computedRange[0], computedRange[1], computedRange[0], computedRange[1],
+                        filePath);
                 }
                 if (state.sequences > 1) {
-                    LogWarn(
+                    log::user::warn(
                         "Multiple volumes in file but we only computed DataRange of the first "
                         "volume sequence due to performance consideration. \nWe strongly recommend "
                         "setting the DataRange, for example to min(Volume sequence), max(Volume "
@@ -458,7 +457,7 @@ std::shared_ptr<VolumeSequence> DatVolumeSequenceReader::readData(
 
         if (enableLogOutput_) {
             const auto size = util::formatBytesToString(bytes * state.sequences);
-            LogInfo("Loaded volume sequence: " << filePath << " size: " << size);
+            log::user::info("Loaded volume sequence: {} size: {}", filePath, size);
         }
     }
     return volumes;

--- a/modules/base/src/io/stlwriter.cpp
+++ b/modules/base/src/io/stlwriter.cpp
@@ -169,7 +169,7 @@ void StlWriter::writeData(const Mesh* data, std::ostream& f) const {
 
     for (const auto& inds : data->getIndexBuffers()) {
         if (inds.first.dt != DrawType::Triangles) {
-            log::user::warn("Draw type: {} not supported", inds.first.dt);
+            log::warn("Draw type: {} not supported", inds.first.dt);
             continue;
         }
 

--- a/modules/base/src/io/stlwriter.cpp
+++ b/modules/base/src/io/stlwriter.cpp
@@ -169,9 +169,7 @@ void StlWriter::writeData(const Mesh* data, std::ostream& f) const {
 
     for (const auto& inds : data->getIndexBuffers()) {
         if (inds.first.dt != DrawType::Triangles) {
-            std::stringstream err;
-            err << "Draw type: \n" << inds.first.dt << "\" not supported";
-            util::log(IVW_CONTEXT, err.str(), LogLevel::Warn, LogAudience::User);
+            log::user::warn("Draw type: {} not supported", inds.first.dt);
             continue;
         }
 

--- a/modules/base/src/processors/convexhull2dprocessor.cpp
+++ b/modules/base/src/processors/convexhull2dprocessor.cpp
@@ -132,7 +132,7 @@ void ConvexHull2DProcessor::process() {
     std::vector<vec2> hull;
     hull = util::convexHull(points);
     if (!util::isConvex(hull)) {
-        log::user::warn("Hull returned by Monotone Chain algorithm (convexHull) is _not_ convex");
+        log::warn("Hull returned by Monotone Chain algorithm (convexHull) is _not_ convex");
     }
 
     // convert hull into a line strip mesh

--- a/modules/base/src/processors/convexhull2dprocessor.cpp
+++ b/modules/base/src/processors/convexhull2dprocessor.cpp
@@ -45,7 +45,7 @@
 #include <inviwo/core/properties/ordinalproperty.h>                     // for FloatVec3Property
 #include <inviwo/core/util/glmmat.h>                                    // for mat3
 #include <inviwo/core/util/glmvec.h>                                    // for vec2, vec3
-#include <inviwo/core/util/logcentral.h>                                // for LogCentral, LogWarn
+#include <inviwo/core/util/logcentral.h>                                // for LogCentral
 #include <modules/base/algorithm/convexhull.h>                          // for convexHull, isConvex
 #include <modules/base/algorithm/convexhullmesh.h>                      // for convertHullToMesh
 
@@ -132,7 +132,7 @@ void ConvexHull2DProcessor::process() {
     std::vector<vec2> hull;
     hull = util::convexHull(points);
     if (!util::isConvex(hull)) {
-        LogWarn("Hull returned by Monotone Chain algorithm (convexHull) is _not_ convex");
+        log::user::warn("Hull returned by Monotone Chain algorithm (convexHull) is _not_ convex");
     }
 
     // convert hull into a line strip mesh

--- a/modules/base/src/processors/heightfieldmapper.cpp
+++ b/modules/base/src/processors/heightfieldmapper.cpp
@@ -46,7 +46,7 @@
 #include <inviwo/core/properties/ordinalproperty.h>                     // for FloatProperty
 #include <inviwo/core/util/formats.h>                                   // for DataFormatBase
 #include <inviwo/core/util/glmvec.h>                                    // for size2_t, dvec2
-#include <inviwo/core/util/logcentral.h>                                // for LogCentral, LogWarn
+#include <inviwo/core/util/logcentral.h>                                // for LogCentral
 
 #include <algorithm>      // for copy, max, max_el...
 #include <cmath>          // for abs
@@ -125,7 +125,7 @@ void HeightFieldMapper::process() {
 
     auto srcImg = inport_.getData();
     if (!srcImg) {
-        LogWarn("No valid input image given");
+        log::warn("No valid input image given");
         return;
     }
 

--- a/modules/base/src/processors/imagesource.cpp
+++ b/modules/base/src/processors/imagesource.cpp
@@ -48,7 +48,7 @@
 #include <inviwo/core/util/filesystem.h>               // for fileExists
 #include <inviwo/core/util/formats.h>                  // for DataFormat, DataVec4UInt8
 #include <inviwo/core/util/glmvec.h>                   // for size2_t
-#include <inviwo/core/util/logcentral.h>               // for log, LogCentral, LogError, LogLevel
+#include <inviwo/core/util/logcentral.h>               // for log, LogCentral
 #include <inviwo/core/util/statecoordinator.h>         // for StateCoordinator
 #include <modules/base/processors/datasource.h>        // for updateFilenameFilters, updateReade...
 

--- a/modules/base/src/processors/imagesourceseries.cpp
+++ b/modules/base/src/processors/imagesourceseries.cpp
@@ -43,7 +43,7 @@
 #include <inviwo/core/properties/filepatternproperty.h>  // for FilePatternProperty
 #include <inviwo/core/properties/ordinalproperty.h>      // for IntProperty
 #include <inviwo/core/properties/stringproperty.h>       // for StringProperty
-#include <inviwo/core/util/assertion.h>                  // for ivwAssert
+#include <inviwo/core/util/assertion.h>                  // for IVW_ASSERT
 #include <inviwo/core/util/fileextension.h>              // for FileExtension
 #include <inviwo/core/util/filesystem.h>                 // for getPath
 #include <inviwo/core/util/formats.h>                    // for DataFormat, DataVec4UInt8

--- a/modules/base/src/processors/imagesourceseries.cpp
+++ b/modules/base/src/processors/imagesourceseries.cpp
@@ -47,7 +47,7 @@
 #include <inviwo/core/util/fileextension.h>              // for FileExtension
 #include <inviwo/core/util/filesystem.h>                 // for getPath
 #include <inviwo/core/util/formats.h>                    // for DataFormat, DataVec4UInt8
-#include <inviwo/core/util/logcentral.h>                 // for LogCentral, LogError
+#include <inviwo/core/util/logcentral.h>                 // for LogCentral
 #include <inviwo/core/util/pathtype.h>                   // for PathType, PathType::Images
 #include <inviwo/core/util/statecoordinator.h>           // for StateCoordinator
 #include <inviwo/core/util/stdextensions.h>              // for contains_if, erase_remove_if
@@ -128,8 +128,7 @@ void ImageSourceSeries::process() {
     // sanity check for valid index
     const auto index = currentImageIndex_.get() - 1;
     if ((index < 0) || (index >= static_cast<int>(fileList_.size()))) {
-        LogError("Invalid image index. Exceeded number of files.");
-        return;
+        throw Exception(IVW_CONTEXT, "Invalid image index. Exceeded number of files.");
     }
 
     const auto currentFileName = fileList_[index];
@@ -139,14 +138,10 @@ void ImageSourceSeries::process() {
     auto reader = factory->getReaderForTypeAndExtension<Layer>(sext, currentFileName);
 
     // there should always be a reader since we asked the reader for valid extensions
-    ivwAssert(reader != nullptr, "Could not find reader for \"" << currentFileName << "\"");
+    IVW_ASSERT(reader != nullptr, "Could not find reader for \"" << currentFileName << "\"");
 
-    try {
-        auto layer = reader->readData(currentFileName);
-        outport_.setData(std::make_shared<Image>(layer));
-    } catch (DataReaderException const& e) {
-        LogError(e.getMessage());
-    }
+    auto layer = reader->readData(currentFileName);
+    outport_.setData(std::make_shared<Image>(layer));
 }
 
 void ImageSourceSeries::onFindFiles() {
@@ -154,14 +149,12 @@ void ImageSourceSeries::onFindFiles() {
     fileList_ = imageFilePattern_.getFileList();
     if (fileList_.empty() && !imageFilePattern_.getFilePattern().empty()) {
         if (imageFilePattern_.hasOutOfRangeMatches()) {
-            LogError("All matching files are outside the specified range (\""
-                     << imageFilePattern_.getFilePattern() << "\", "
-                     << imageFilePattern_.getMinRange() << " - " << imageFilePattern_.getMaxRange()
-                     << ").");
+            log::error("All matching files are outside the specified range (\"{}\", {} - {}).",
+                       imageFilePattern_.getFilePattern(), imageFilePattern_.getMinRange(),
+                       imageFilePattern_.getMaxRange());
         } else {
-            LogError("No images found matching \"" << imageFilePattern_.getFilePattern() << "\" in "
-                                                   << imageFilePattern_.getFilePatternPath()
-                                                   << ".");
+            log::error("No images found matching \"{}\" in {}.", imageFilePattern_.getFilePattern(),
+                       imageFilePattern_.getFilePatternPath());
         }
     }
     updateProperties();

--- a/modules/base/src/processors/imagestackvolumesource.cpp
+++ b/modules/base/src/processors/imagestackvolumesource.cpp
@@ -226,8 +226,8 @@ std::shared_ptr<Volume> ImageStackVolumeSource::load() {
             const auto read = [&](const auto& file, auto* reader) -> std::shared_ptr<Layer> {
                 try {
                     return reader->readData(file);
-                } catch (DataReaderException const& e) {
-                    log::user::warn("Could not load image: {}, {}", file, e.getMessage());
+                } catch (const DataReaderException& e) {
+                    log::warn("Could not load image: {}, {}", file, e.getMessage());
                     return nullptr;
                 }
             };
@@ -251,15 +251,15 @@ std::shared_ptr<Volume> ImageStackVolumeSource::load() {
                 const auto* format = layerRAM->getDataFormat();
                 if ((format->getNumericType() != NumericType::Float) &&
                     (format->getPrecision() > 32)) {
-                    log::user::warn("Unsupported integer bit depth: {}, for image: {}",
-                                    format->getPrecision(), file);
+                    log::warn("Unsupported integer bit depth: {}, for image: {}",
+                              format->getPrecision(), file);
                     fill(slice);
                     continue;
                 }
 
                 if (layerRAM->getDimensions() != layerDims) {
-                    log::user::warn("Unexpected dimensions: {}, expected: {}, for image: {}",
-                                    layer->getDimensions(), layerDims, file);
+                    log::warn("Unexpected dimensions: {}, expected: {}, for image: {}",
+                              layer->getDimensions(), layerDims, file);
                     fill(slice);
                     continue;
                 }

--- a/modules/base/src/processors/imagestackvolumesource.cpp
+++ b/modules/base/src/processors/imagestackvolumesource.cpp
@@ -185,9 +185,8 @@ std::shared_ptr<Volume> ImageStackVolumeSource::load() {
     const auto first = std::find_if(slices.begin(), slices.end(),
                                     [](auto& item) { return item.second != nullptr; });
     if (first == slices.end()) {  // could not find any suitable data reader for the images
-        throw Exception(
-            fmt::format("No supported images found in '{}'", filePattern_.getFilePatternPath()),
-            IVW_CONTEXT);
+        throw Exception(IVW_CONTEXT, "No supported images found in '{}'",
+                        filePattern_.getFilePatternPath());
     }
 
     const auto referenceLayer = first->second->readData(first->first);
@@ -197,16 +196,14 @@ std::shared_ptr<Volume> ImageStackVolumeSource::load() {
     // does not provide meta data for all image formats.
     const auto* referenceRAM = referenceLayer->getRepresentation<LayerRAM>();
     if (glm::compMul(referenceRAM->getDimensions()) == 0) {
-        throw Exception(
-            fmt::format("Could not extract valid image dimensions from {}", first->first),
-            IVW_CONTEXT);
+        throw Exception(IVW_CONTEXT, "Could not extract valid image dimensions from {}",
+                        first->first);
     }
 
     const auto* refFormat = referenceRAM->getDataFormat();
     if ((refFormat->getNumericType() != NumericType::Float) && (refFormat->getPrecision() > 32)) {
-        throw DataReaderException(
-            fmt::format("Unsupported integer bit depth ({})", refFormat->getPrecision()),
-            IVW_CONTEXT);
+        throw DataReaderException(IVW_CONTEXT, "Unsupported integer bit depth ({})",
+                                  refFormat->getPrecision());
     }
 
     return referenceRAM->dispatch<std::shared_ptr<Volume>, FloatOrIntMax32>(
@@ -230,8 +227,7 @@ std::shared_ptr<Volume> ImageStackVolumeSource::load() {
                 try {
                     return reader->readData(file);
                 } catch (DataReaderException const& e) {
-                    LogProcessorWarn(
-                        fmt::format("Could not load image: {}, {}", file, e.getMessage()));
+                    log::user::warn("Could not load image: {}, {}", file, e.getMessage());
                     return nullptr;
                 }
             };
@@ -255,16 +251,15 @@ std::shared_ptr<Volume> ImageStackVolumeSource::load() {
                 const auto* format = layerRAM->getDataFormat();
                 if ((format->getNumericType() != NumericType::Float) &&
                     (format->getPrecision() > 32)) {
-                    LogProcessorWarn(fmt::format("Unsupported integer bit depth: {}, for image: {}",
-                                                 format->getPrecision(), file));
+                    log::user::warn("Unsupported integer bit depth: {}, for image: {}",
+                                    format->getPrecision(), file);
                     fill(slice);
                     continue;
                 }
 
                 if (layerRAM->getDimensions() != layerDims) {
-                    LogProcessorWarn(
-                        fmt::format("Unexpected dimensions: {}, expected: {}, for image: {}",
-                                    layer->getDimensions(), layerDims, file));
+                    log::user::warn("Unexpected dimensions: {}, expected: {}, for image: {}",
+                                    layer->getDimensions(), layerDims, file);
                     fill(slice);
                     continue;
                 }

--- a/modules/base/src/processors/layersequencesource.cpp
+++ b/modules/base/src/processors/layersequencesource.cpp
@@ -173,13 +173,13 @@ void LayerSequenceSource::loadFile(bool deserialize) {
         try {
             layers_ = reader->readData(file_.get(), this);
         } catch (const DataReaderException& e) {
-            LogProcessorError(e.getMessage());
+            log::user::exception(e);
             layers_.reset();
             loadingFailed_ = true;
             isReady_.update();
         }
     } else {
-        LogProcessorError("Could not find a data reader for file: " << file_.get());
+        log::user::error("Could not find a data reader for file: {}", file_.get());
         layers_.reset();
         loadingFailed_ = true;
         isReady_.update();
@@ -212,13 +212,13 @@ void LayerSequenceSource::loadFolder(bool deserialize) {
                         layers_->push_back(layer);
                     }
                 } else {
-                    LogProcessorError("Could not find a data reader for file: " << file);
+                    log::user::error("Could not find a data reader for file: {}", file);
                     layers_.reset();
                     loadingFailed_ = true;
                     isReady_.update();
                 }
             } catch (const DataReaderException& e) {
-                LogProcessorError(e.getMessage());
+                log::user::exception(e);
                 layers_.reset();
                 loadingFailed_ = true;
                 isReady_.update();

--- a/modules/base/src/processors/layersequencesource.cpp
+++ b/modules/base/src/processors/layersequencesource.cpp
@@ -173,13 +173,13 @@ void LayerSequenceSource::loadFile(bool deserialize) {
         try {
             layers_ = reader->readData(file_.get(), this);
         } catch (const DataReaderException& e) {
-            log::user::exception(e);
+            log::exception(e);
             layers_.reset();
             loadingFailed_ = true;
             isReady_.update();
         }
     } else {
-        log::user::error("Could not find a data reader for file: {}", file_.get());
+        log::error("Could not find a data reader for file: {}", file_.get());
         layers_.reset();
         loadingFailed_ = true;
         isReady_.update();
@@ -212,13 +212,13 @@ void LayerSequenceSource::loadFolder(bool deserialize) {
                         layers_->push_back(layer);
                     }
                 } else {
-                    log::user::error("Could not find a data reader for file: {}", file);
+                    log::error("Could not find a data reader for file: {}", file);
                     layers_.reset();
                     loadingFailed_ = true;
                     isReady_.update();
                 }
             } catch (const DataReaderException& e) {
-                log::user::exception(e);
+                log::exception(e);
                 layers_.reset();
                 loadingFailed_ = true;
                 isReady_.update();

--- a/modules/base/src/processors/layerseriessource.cpp
+++ b/modules/base/src/processors/layerseriessource.cpp
@@ -102,8 +102,7 @@ void LayerSeriesSource::process() {
     // sanity check for valid index
     const auto index = currentIndex_.get() - 1;
     if ((index < 0) || (index >= static_cast<int>(fileList_.size()))) {
-        LogError("Invalid image index. Exceeded number of files.");
-        return;
+        throw Exception("Invalid image index. Exceeded number of files.");
     }
 
     const auto fileName = fileList_[index];
@@ -119,7 +118,7 @@ void LayerSeriesSource::process() {
         auto layer = reader->readData(fileName);
         outport_.setData(layer);
     } catch (const DataReaderException& e) {
-        LogError(e.getMessage());
+        log::user::exception(e);
     }
 }
 
@@ -128,12 +127,12 @@ void LayerSeriesSource::onFindFiles() {
     fileList_ = filePattern_.getFileList();
     if (fileList_.empty() && !filePattern_.getFilePattern().empty()) {
         if (filePattern_.hasOutOfRangeMatches()) {
-            LogError("All matching files are outside the specified range (\""
-                     << filePattern_.getFilePattern() << "\", " << filePattern_.getMinRange()
-                     << " - " << filePattern_.getMaxRange() << ").");
+            log::error("All matching files are outside the specified range (\"{}\", {} - {}).",
+                       filePattern_.getFilePattern(), filePattern_.getMinRange(),
+                       filePattern_.getMaxRange());
         } else {
-            LogError("No images found matching \"" << filePattern_.getFilePattern() << "\" in "
-                                                   << filePattern_.getFilePatternPath() << ".");
+            log::error("No images found matching \"{}\n in {}", filePattern_.getFilePattern(),
+                       filePattern_.getFilePatternPath());
         }
     }
     updateProperties();

--- a/modules/base/src/processors/layerseriessource.cpp
+++ b/modules/base/src/processors/layerseriessource.cpp
@@ -118,7 +118,7 @@ void LayerSeriesSource::process() {
         auto layer = reader->readData(fileName);
         outport_.setData(layer);
     } catch (const DataReaderException& e) {
-        log::user::exception(e);
+        log::exception(e);
     }
 }
 

--- a/modules/base/src/processors/meshclipping.cpp
+++ b/modules/base/src/processors/meshclipping.cpp
@@ -52,7 +52,7 @@
 #include <inviwo/core/util/formatdispatching.h>                         // for Float3s
 #include <inviwo/core/util/formats.h>                                   // for DataFormatBase
 #include <inviwo/core/util/glmvec.h>                                    // for vec3, vec4
-#include <inviwo/core/util/logcentral.h>                                // for LogCentral, LogError
+#include <inviwo/core/util/logcentral.h>                                // for LogCentral
 #include <inviwo/core/util/stdextensions.h>                             // for find_if
 #include <modules/base/algorithm/mesh/meshclipping.h>                   // for clipMeshAgainstPlane
 
@@ -203,7 +203,7 @@ void MeshClipping::onAlignPlaneNormalToCameraNormalPressed() {
         return buf.first.type == BufferType::PositionAttrib;
     });
     if (it == geom->getBuffers().end()) {
-        LogError("Unsupported mesh, no buffers with the Position Attribute found");
+        log::error("Unsupported mesh, no buffers with the Position Attribute found");
         return;
     }
 
@@ -250,7 +250,7 @@ void MeshClipping::onAlignPlaneNormalToCameraNormalPressed() {
         });
 
     } else {
-        LogError("Unsupported mesh, only 3D meshes supported");
+        log::error("Unsupported mesh, only 3D meshes supported");
     }
 }
 

--- a/modules/base/src/processors/noisegenerator2d.cpp
+++ b/modules/base/src/processors/noisegenerator2d.cpp
@@ -133,7 +133,7 @@ NoiseGenerator2D::NoiseGenerator2D()
     size_.onChange([&]() {
         auto s = std::max(size_.get().x, size_.get().y);
         s = std::bit_ceil(s);
-        auto l2 = log(s) / log(2.0f);
+        auto l2 = std::log(s) / std::log(2.0f);
         levels_.setRangeMax(static_cast<int>(std::round(l2)));
     });
 

--- a/modules/base/src/processors/volumesequencesingletimestepsampler.cpp
+++ b/modules/base/src/processors/volumesequencesingletimestepsampler.cpp
@@ -38,7 +38,7 @@
 #include <inviwo/core/processors/processortags.h>    // for Tags, Tags::None
 #include <inviwo/core/properties/ordinalproperty.h>  // for DoubleProperty
 #include <inviwo/core/properties/valuewrapper.h>     // for PropertySerializationMode, PropertyS...
-#include <inviwo/core/util/logcentral.h>             // for LogCentral, LogWarn
+#include <inviwo/core/util/logcentral.h>             // for LogCentral
 #include <inviwo/core/util/spatialsampler.h>         // for SpatialSampler
 #include <inviwo/core/util/volumesequenceutils.h>    // for getTimestamp, hasTimestamp, getTimes...
 
@@ -110,7 +110,8 @@ VolumeSequenceSingleTimestepSamplerProcessor::VolumeSequenceSingleTimestepSample
         if (!sampler_.hasData()) return;
         auto seq = volumeSequence_.getData();
         if (!util::hasTimestamps(*seq, false)) {
-            LogWarn("Input volume Sequence does not have timestamps, behavior is undefined");
+            log::user::warn(
+                "Input volume Sequence does not have timestamps, behavior is undefined");
         }
 
         auto newRange = util::getTimestampRange(*seq);

--- a/modules/base/src/processors/volumesequencesingletimestepsampler.cpp
+++ b/modules/base/src/processors/volumesequencesingletimestepsampler.cpp
@@ -110,8 +110,7 @@ VolumeSequenceSingleTimestepSamplerProcessor::VolumeSequenceSingleTimestepSample
         if (!sampler_.hasData()) return;
         auto seq = volumeSequence_.getData();
         if (!util::hasTimestamps(*seq, false)) {
-            log::user::warn(
-                "Input volume Sequence does not have timestamps, behavior is undefined");
+            log::warn("Input volume Sequence does not have timestamps, behavior is undefined");
         }
 
         auto newRange = util::getTimestampRange(*seq);

--- a/modules/base/src/processors/volumesequencesource.cpp
+++ b/modules/base/src/processors/volumesequencesource.cpp
@@ -181,13 +181,13 @@ void VolumeSequenceSource::loadFile(bool deserialize) {
         try {
             volumes_ = reader->readData(file_.get(), this);
         } catch (const DataReaderException& e) {
-            log::user::exception(e);
+            log::exception(e);
             volumes_.reset();
             loadingFailed_ = true;
             isReady_.update();
         }
     } else {
-        log::user::error("Could not find a data reader for file: {}", file_.get());
+        log::error("Could not find a data reader for file: {}", file_.get());
         volumes_.reset();
         loadingFailed_ = true;
         isReady_.update();
@@ -222,13 +222,13 @@ void VolumeSequenceSource::loadFolder(bool deserialize) {
                         volumes_->push_back(volume);
                     }
                 } else {
-                    log::user::error("Could not find a data reader for file: {}", file);
+                    log::error("Could not find a data reader for file: {}", file);
                     volumes_.reset();
                     loadingFailed_ = true;
                     isReady_.update();
                 }
             } catch (const DataReaderException& e) {
-                log::user::exception(e);
+                log::exception(e);
                 volumes_.reset();
                 loadingFailed_ = true;
                 isReady_.update();

--- a/modules/base/src/processors/volumesequencesource.cpp
+++ b/modules/base/src/processors/volumesequencesource.cpp
@@ -180,14 +180,14 @@ void VolumeSequenceSource::loadFile(bool deserialize) {
     if (auto reader = rf_->getReaderForTypeAndExtension<VolumeSequence>(sext, file_.get())) {
         try {
             volumes_ = reader->readData(file_.get(), this);
-        } catch (DataReaderException const& e) {
-            LogProcessorError(e.getMessage());
+        } catch (const DataReaderException& e) {
+            log::user::exception(e);
             volumes_.reset();
             loadingFailed_ = true;
             isReady_.update();
         }
     } else {
-        LogProcessorError("Could not find a data reader for file: " << file_.get());
+        log::user::error("Could not find a data reader for file: {}", file_.get());
         volumes_.reset();
         loadingFailed_ = true;
         isReady_.update();
@@ -222,13 +222,13 @@ void VolumeSequenceSource::loadFolder(bool deserialize) {
                         volumes_->push_back(volume);
                     }
                 } else {
-                    LogProcessorError("Could not find a data reader for file: " << file);
+                    log::user::error("Could not find a data reader for file: {}", file);
                     volumes_.reset();
                     loadingFailed_ = true;
                     isReady_.update();
                 }
-            } catch (DataReaderException const& e) {
-                LogProcessorError(e.getMessage());
+            } catch (const DataReaderException& e) {
+                log::user::exception(e);
                 volumes_.reset();
                 loadingFailed_ = true;
                 isReady_.update();

--- a/modules/base/src/processors/volumesource.cpp
+++ b/modules/base/src/processors/volumesource.cpp
@@ -155,13 +155,13 @@ void VolumeSource::load(bool deserialize) {
             volumes_.reset();
             error_ = fmt::format("Could not find a data reader for file: {}", file_.get());
             isReady_.update();
-            LogProcessorError(error_);
+            log::user::report(LogLevel::Error, error_);
         }
     } catch (const DataReaderException& e) {
         volumes_.reset();
         error_ = e.getMessage();
         isReady_.update();
-        LogProcessorError(e.getMessage());
+        log::user::report(LogLevel::Error, error_);
     }
 
     if (volumes_ && !volumes_->empty() && (*volumes_)[0]) {

--- a/modules/base/src/processors/volumesource.cpp
+++ b/modules/base/src/processors/volumesource.cpp
@@ -155,13 +155,13 @@ void VolumeSource::load(bool deserialize) {
             volumes_.reset();
             error_ = fmt::format("Could not find a data reader for file: {}", file_.get());
             isReady_.update();
-            log::user::report(LogLevel::Error, error_);
+            log::report(LogLevel::Error, error_);
         }
     } catch (const DataReaderException& e) {
         volumes_.reset();
         error_ = e.getMessage();
         isReady_.update();
-        log::user::report(LogLevel::Error, error_);
+        log::report(LogLevel::Error, error_);
     }
 
     if (volumes_ && !volumes_->empty() && (*volumes_)[0]) {

--- a/modules/basegl/src/processors/imageprocessing/imagenormalizationprocessor.cpp
+++ b/modules/basegl/src/processors/imageprocessing/imagenormalizationprocessor.cpp
@@ -42,7 +42,7 @@
 #include <inviwo/core/properties/stringproperty.h>                       // for StringProperty
 #include <inviwo/core/util/formats.h>                                    // for DataFormatBase
 #include <inviwo/core/util/glmvec.h>                                     // for dvec3, dvec4, vec4
-#include <inviwo/core/util/logcentral.h>                                 // for LogCentral, LogWarn
+#include <inviwo/core/util/logcentral.h>                                 // for LogCentral
 #include <modules/base/algorithm/algorithmoptions.h>                     // for IgnoreSpecialValues
 #include <modules/base/algorithm/dataminmax.h>                           // for layerMinMax
 #include <modules/basegl/processors/imageprocessing/imageglprocessor.h>  // for ImageGLProcessor

--- a/modules/basegl/src/processors/lightvolumegl.cpp
+++ b/modules/basegl/src/processors/lightvolumegl.cpp
@@ -51,7 +51,7 @@
 #include <inviwo/core/properties/transferfunctionproperty.h>            // for TransferFunctionP...
 #include <inviwo/core/util/formats.h>                                   // for DataFormatBase
 #include <inviwo/core/util/glmvec.h>                                    // for vec3, size3_t, vec4
-#include <inviwo/core/util/logcentral.h>                                // for LogCentral, LogWarn
+#include <inviwo/core/util/logcentral.h>                                // for LogCentral
 #include <modules/opengl/buffer/framebufferobject.h>                    // for FrameBufferObject
 #include <modules/opengl/geometry/meshgl.h>                             // for MeshGL
 #include <modules/opengl/image/layergl.h>                               // for LayerGL

--- a/modules/basegl/src/processors/volumeprocessing/volumelowpass.cpp
+++ b/modules/basegl/src/processors/volumeprocessing/volumelowpass.cpp
@@ -101,8 +101,8 @@ VolumeLowPass::VolumeLowPass()
         int kernelSize95 = static_cast<int>(sigma_.get() * 2 * 1.960f);
         int kernelSize99 = static_cast<int>(sigma_.get() * 2 * 2.576f);
         // https://de.wikipedia.org/wiki/Normalverteilung
-        log::user::info("Optimal kernelSize for sigma {} is:\n\t90%: {}\n\t95%: {}\n\t99%: {}",
-                        sigma_.get(), kernelSize95, kernelSize90, kernelSize99);
+        log::info("Optimal kernelSize for sigma {} is:\n\t90%: {}\n\t95%: {}\n\t99%: {}",
+                  sigma_.get(), kernelSize95, kernelSize90, kernelSize99);
     });
 
     setAllPropertiesCurrentStateAsDefault();

--- a/modules/basegl/src/processors/volumeprocessing/volumelowpass.cpp
+++ b/modules/basegl/src/processors/volumeprocessing/volumelowpass.cpp
@@ -101,9 +101,8 @@ VolumeLowPass::VolumeLowPass()
         int kernelSize95 = static_cast<int>(sigma_.get() * 2 * 1.960f);
         int kernelSize99 = static_cast<int>(sigma_.get() * 2 * 2.576f);
         // https://de.wikipedia.org/wiki/Normalverteilung
-        LogInfo("Optimizal kernelSize for sigma " << sigma_.get() << " is: "
-                                                  << "\n\t90%: " << kernelSize90 << "\n\t95%: "
-                                                  << kernelSize95 << "\n\t99%: " << kernelSize99);
+        log::user::info("Optimal kernelSize for sigma {} is:\n\t90%: {}\n\t95%: {}\n\t99%: {}",
+                        sigma_.get(), kernelSize95, kernelSize90, kernelSize99);
     });
 
     setAllPropertiesCurrentStateAsDefault();

--- a/modules/brushingandlinking/src/processors/brushingandlinkingprocessor.cpp
+++ b/modules/brushingandlinking/src/processors/brushingandlinkingprocessor.cpp
@@ -119,9 +119,8 @@ BrushingAndLinkingProcessor::BrushingAndLinkingProcessor()
                       std::next(indices.begin(), std::min(indices.size(), maxIndices)), ", "),
             indices.size() > maxIndices ? "..." : "");
 
-        log::user::info("{:<20} action: {:<13} target: {}\n  source: {}\n  indices: [{}] ({})",
-                        getDisplayName(), action, target.getString(), source, str,
-                        indices.cardinality());
+        log::info("{:<20} action: {:<13} target: {}\n  source: {}\n  indices: [{}] ({})",
+                  getDisplayName(), action, target.getString(), source, str, indices.cardinality());
     });
 }
 

--- a/modules/brushingandlinking/src/processors/brushingandlinkingprocessor.cpp
+++ b/modules/brushingandlinking/src/processors/brushingandlinkingprocessor.cpp
@@ -64,7 +64,9 @@ const ProcessorInfo BrushingAndLinkingProcessor::processorInfo_{
     CodeState::Stable,                         // Code state
     "Brushing, Linking",                       // Tags
 };
-const ProcessorInfo& BrushingAndLinkingProcessor::getProcessorInfo() const { return processorInfo_; }
+const ProcessorInfo& BrushingAndLinkingProcessor::getProcessorInfo() const {
+    return processorInfo_;
+}
 
 BrushingAndLinkingProcessor::BrushingAndLinkingProcessor()
     : Processor()
@@ -117,9 +119,9 @@ BrushingAndLinkingProcessor::BrushingAndLinkingProcessor()
                       std::next(indices.begin(), std::min(indices.size(), maxIndices)), ", "),
             indices.size() > maxIndices ? "..." : "");
 
-        LogProcessorInfo(fmt::format(
-            "{:<20} action: {:<13} target: {}\n  source: {}\n  indices: [{}] ({})",
-            getDisplayName(), action, target.getString(), source, str, indices.cardinality()));
+        log::user::info("{:<20} action: {:<13} target: {}\n  source: {}\n  indices: [{}] ({})",
+                        getDisplayName(), action, target.getString(), source, str,
+                        indices.cardinality());
     });
 }
 

--- a/modules/cimg/src/cimgmodule.cpp
+++ b/modules/cimg/src/cimgmodule.cpp
@@ -68,8 +68,8 @@ CImgModule::CImgModule(InviwoApplication* app)
         app_->setLayerRamResizer(resizer_.get());
     }
 
-    LogInfo("Using LibJPG Version " << cimgutil::getLibJPGVersion());
-    LogInfo("Using OpenEXR Version " << cimgutil::getOpenEXRVersion());
+    log::info("Using LibJPG Version {}", cimgutil::getLibJPGVersion());
+    log::info("Using OpenEXR Version {}", cimgutil::getOpenEXRVersion());
 }
 
 CImgModule::~CImgModule() {

--- a/modules/cimg/src/cimgmodule.cpp
+++ b/modules/cimg/src/cimgmodule.cpp
@@ -34,7 +34,7 @@
 #include <inviwo/core/datastructures/image/layerram.h>  // for LayerRamResizer
 #include <inviwo/core/io/datareader.h>                  // for DataReader
 #include <inviwo/core/io/datawriter.h>                  // for DataWriter
-#include <inviwo/core/util/logcentral.h>                // for LogCentral, LogInfo
+#include <inviwo/core/util/logcentral.h>                // for LogCentral
 #include <modules/cimg/cimglayerreader.h>               // for CImgLayerReader
 #include <modules/cimg/cimglayerwriter.h>               // for CImgLayerWriter
 #include <modules/cimg/cimgutils.h>                     // for getLibJPGVersion, getOpenEXRVersion

--- a/modules/cimg/src/cimgvolumereader.cpp
+++ b/modules/cimg/src/cimgvolumereader.cpp
@@ -71,7 +71,7 @@ void CImgVolumeReader::printMetaInfo(const MetaDataOwner& metaDataOwner,
     if (auto metaData = metaDataOwner.getMetaData<StringMetaData>(key)) {
         std::string metaStr = metaData->get();
         replaceInString(metaStr, "\n", ", ");
-        log::user::info("{}: {}", key, metaStr);
+        log::info("{}: {}", key, metaStr);
     }
 }
 

--- a/modules/cimg/src/cimgvolumereader.cpp
+++ b/modules/cimg/src/cimgvolumereader.cpp
@@ -41,12 +41,11 @@
 #include <inviwo/core/util/filesystem.h>                             // for fileExists, addBasePath
 #include <inviwo/core/util/formats.h>                                // for DataFormatId, DataFo...
 #include <inviwo/core/util/glmvec.h>                                 // for size3_t
-#include <inviwo/core/util/logcentral.h>                             // for LogCentral, LogInfo
+#include <inviwo/core/util/logcentral.h>                             // for LogCentral
 #include <inviwo/core/util/sourcecontext.h>                          // for IVW_CONTEXT
 #include <inviwo/core/util/stringconversion.h>                       // for replaceInString
 #include <modules/cimg/cimgutils.h>                                  // for loadVolumeData
 
-#include <ostream>      // for operator<<, basic_os...
 #include <type_traits>  // for remove_extent_t
 
 #include <fmt/std.h>
@@ -72,7 +71,7 @@ void CImgVolumeReader::printMetaInfo(const MetaDataOwner& metaDataOwner,
     if (auto metaData = metaDataOwner.getMetaData<StringMetaData>(key)) {
         std::string metaStr = metaData->get();
         replaceInString(metaStr, "\n", ", ");
-        LogInfo(key << ": " << metaStr);
+        log::user::info("{}: {}", key, metaStr);
     }
 }
 

--- a/modules/dataframe/src/io/csvreader.cpp
+++ b/modules/dataframe/src/io/csvreader.cpp
@@ -462,7 +462,7 @@ std::vector<CSVReader::TypeCounts> CSVReader::findCellTypes(
         }
     }
     if (sampledRows != sampleRows) {
-        log::user::warn(
+        log::warn(
             "Could not find any data for some columns, sampled more rows to determine column "
             "types {}",
             sampledRows);

--- a/modules/dataframe/src/io/csvreader.cpp
+++ b/modules/dataframe/src/io/csvreader.cpp
@@ -38,7 +38,7 @@
 #include <inviwo/core/util/detected.h>                                  // for alwaysFalse
 #include <inviwo/core/util/fileextension.h>                             // for FileExtension
 #include <inviwo/core/util/filesystem.h>                                // for skipByteOrderMark
-#include <inviwo/core/util/logcentral.h>                                // for LogCentral, LogWarn
+#include <inviwo/core/util/logcentral.h>                                // for LogCentral
 #include <inviwo/core/util/raiiutils.h>                                 // for OnScopeExit, OnSc...
 #include <inviwo/core/util/safecstr.h>                                  // for SafeCStr
 #include <inviwo/core/util/sourcecontext.h>                             // for IVW_CONTEXT_CUSTOM
@@ -462,10 +462,10 @@ std::vector<CSVReader::TypeCounts> CSVReader::findCellTypes(
         }
     }
     if (sampledRows != sampleRows) {
-        LogWarn(
+        log::user::warn(
             "Could not find any data for some columns, sampled more rows to determine column "
-            "types "
-            << sampledRows);
+            "types {}",
+            sampledRows);
     }
 
     return counts;
@@ -648,7 +648,7 @@ std::shared_ptr<DataFrame> CSVReader::readData(std::istream& stream) const {
         auto prevLocale = std::setlocale(LC_ALL, nullptr);
         std::string prev{prevLocale ? prevLocale : ""};
         if (!std::setlocale(LC_ALL, locale_.c_str())) {
-            LogWarn("Failed to set locale " << locale_);
+            log::warn("Failed to set locale {}", locale_);
         }
         cleanup.setAction([prev]() { std::setlocale(LC_ALL, prev.c_str()); });
     }

--- a/modules/dataframe/src/processors/csvsource.cpp
+++ b/modules/dataframe/src/processors/csvsource.cpp
@@ -188,7 +188,7 @@ void CSVSource::process() {
         error_ = e.getMessage();
         data_.clear();
         isReady_.update();
-        LogProcessorError(error_);
+        log::user::report(LogLevel::Error, error_);
     }
 }
 

--- a/modules/dataframe/src/processors/csvsource.cpp
+++ b/modules/dataframe/src/processors/csvsource.cpp
@@ -188,7 +188,7 @@ void CSVSource::process() {
         error_ = e.getMessage();
         data_.clear();
         isReady_.update();
-        log::user::report(LogLevel::Error, error_);
+        log::report(LogLevel::Error, error_);
     }
 }
 

--- a/modules/dataframe/src/processors/dataframeexporter.cpp
+++ b/modules/dataframe/src/processors/dataframeexporter.cpp
@@ -44,7 +44,7 @@
 #include <inviwo/core/util/filedialogstate.h>         // for AcceptMode, AcceptMode::Save
 #include <inviwo/core/util/fileextension.h>           // for FileExtension, operator==
 #include <inviwo/core/util/glmvec.h>                  // for uvec3
-#include <inviwo/core/util/logcentral.h>              // for LogCentral, LogInfo, LogWarn
+#include <inviwo/core/util/logcentral.h>              // for LogCentral
 #include <inviwo/dataframe/datastructures/dataframe.h>  // IWYU pragma: keep
 #include <inviwo/dataframe/io/csvwriter.h>              // for CSVWriter
 #include <inviwo/dataframe/io/xmlwriter.h>              // for XMLWriter
@@ -129,8 +129,10 @@ void DataFrameExporter::exportData() {
         exportAsCSV();
     } else {
         // use CSV format as fallback
-        LogWarn("Could not determine export format from file "
-                << exportFile_ << ", exporting as comma-separated values (csv).");
+        log::user::warn(
+            "Could not determine export format from file {}, exporting as comma-separated values "
+            "(csv).",
+            exportFile_.get());
         exportAsCSV();
     }
 
@@ -149,7 +151,7 @@ void DataFrameExporter::exportAsCSV() {
 
     writer.writeData(dataFrame_.getData().get(), exportFile_.get());
 
-    LogInfo("CSV file exported to " << exportFile_);
+    log::user::info("CSV file exported to {}", exportFile_.get());
 }
 
 void DataFrameExporter::exportAsXML() {
@@ -158,7 +160,7 @@ void DataFrameExporter::exportAsXML() {
     writer.exportIndexCol = exportIndexCol_.get();
 
     writer.writeData(dataFrame_.getData().get(), exportFile_.get());
-    LogInfo("XML file exported to " << exportFile_);
+    log::user::info("XML file exported to {}", exportFile_.get());
 }
 
 }  // namespace inviwo

--- a/modules/dataframe/src/processors/dataframeexporter.cpp
+++ b/modules/dataframe/src/processors/dataframeexporter.cpp
@@ -129,7 +129,7 @@ void DataFrameExporter::exportData() {
         exportAsCSV();
     } else {
         // use CSV format as fallback
-        log::user::warn(
+        log::warn(
             "Could not determine export format from file {}, exporting as comma-separated values "
             "(csv).",
             exportFile_.get());
@@ -151,7 +151,7 @@ void DataFrameExporter::exportAsCSV() {
 
     writer.writeData(dataFrame_.getData().get(), exportFile_.get());
 
-    log::user::info("CSV file exported to {}", exportFile_.get());
+    log::info("CSV file exported to {}", exportFile_.get());
 }
 
 void DataFrameExporter::exportAsXML() {
@@ -160,7 +160,7 @@ void DataFrameExporter::exportAsXML() {
     writer.exportIndexCol = exportIndexCol_.get();
 
     writer.writeData(dataFrame_.getData().get(), exportFile_.get());
-    log::user::info("XML file exported to {}", exportFile_.get());
+    log::info("XML file exported to {}", exportFile_.get());
 }
 
 }  // namespace inviwo

--- a/modules/dataframe/src/processors/volumesequencetodataframe.cpp
+++ b/modules/dataframe/src/processors/volumesequencetodataframe.cpp
@@ -151,7 +151,7 @@ void VolumeSequenceToDataFrame::recomputeReduceBuffer() {
         for (auto vol : volumeSequence) {
             if (vol->getDataFormat()->getNumericType() != NumericType::Float) continue;
             if (vol->getDataFormat()->getComponents() != 1)
-                log::user::warn("This volume is omitted because it has more than one channel.");
+                log::warn("This volume is omitted because it has more than one channel.");
             volumeData.push_back(
                 static_cast<const glm::f32*>(vol->getRepresentation<VolumeRAM>()->getData()));
         }

--- a/modules/dataframe/src/processors/volumesequencetodataframe.cpp
+++ b/modules/dataframe/src/processors/volumesequencetodataframe.cpp
@@ -50,7 +50,7 @@
 #include <inviwo/core/util/formats.h>                                   // for DataFormatBase
 #include <inviwo/core/util/glmvec.h>                                    // for vec2, size3_t, uvec3
 #include <inviwo/core/util/indexmapper.h>                               // for IndexMapper3D
-#include <inviwo/core/util/logcentral.h>                                // for LogCentral, LogWarn
+#include <inviwo/core/util/logcentral.h>                                // for LogCentral
 #include <inviwo/core/util/sourcecontext.h>                             // for IVW_CONTEXT
 #include <inviwo/core/util/volumeramutils.h>                            // for forEachVoxelParallel
 #include <inviwo/dataframe/datastructures/column.h>                     // for TemplateColumn
@@ -151,7 +151,7 @@ void VolumeSequenceToDataFrame::recomputeReduceBuffer() {
         for (auto vol : volumeSequence) {
             if (vol->getDataFormat()->getNumericType() != NumericType::Float) continue;
             if (vol->getDataFormat()->getComponents() != 1)
-                LogWarn("This volume is omitted because it has more than one channel.");
+                log::user::warn("This volume is omitted because it has more than one channel.");
             volumeData.push_back(
                 static_cast<const glm::f32*>(vol->getRepresentation<VolumeRAM>()->getData()));
         }

--- a/modules/dataframe/src/properties/colormapproperty.cpp
+++ b/modules/dataframe/src/properties/colormapproperty.cpp
@@ -43,7 +43,7 @@
 #include <inviwo/core/properties/templateproperty.h>                    // for TemplateProperty
 #include <inviwo/core/util/colorbrewer.h>                               // for getTransferFunction
 #include <inviwo/core/util/formatdispatching.h>                         // for Scalars
-#include <inviwo/core/util/logcentral.h>                                // for LogCentral, LogWarn
+#include <inviwo/core/util/logcentral.h>                                // for LogCentral
 #include <inviwo/core/util/staticstring.h>                              // for operator+
 #include <inviwo/dataframe/datastructures/column.h>                     // for CategoricalColumn
 #include <modules/base/algorithm/algorithmoptions.h>                    // for IgnoreSpecialValues
@@ -173,10 +173,10 @@ void ColormapProperty::setupForColumn(const Column& col, double minVal, double m
         auto maxColors = getMaxNumberOfColorsForFamily(colormap);
         auto numCategories = catCol->getCategories().size();
         if (maxColors < numCategories) {
-            LogWarn(fmt::format(
+            log::warn(
                 "Categories exceed maximum classes in colormap. {} will be used but {} classes are "
                 "needed. Override colormap to provide your own colormap with more classes.",
-                maxColors, numCategories));
+                maxColors, numCategories);
         }
         nColors = numCategories;
         discrete = true;

--- a/modules/dataframe/src/util/dataframeutil.cpp
+++ b/modules/dataframe/src/util/dataframeutil.cpp
@@ -187,16 +187,16 @@ namespace detail {
 
 void columnCheck(const DataFrame& left, const DataFrame& right,
                  const std::vector<std::pair<std::string, std::string>>& keyColumns,
-                 const std::string& context) {
+                 Literal context) {
     for (const auto& [leftCol, rightCol] : keyColumns) {
         auto indexCol1 = left.getColumn(leftCol);
         auto indexCol2 = right.getColumn(rightCol);
         if (!indexCol1) {
-            throw Exception(IVW_CONTEXT_CUSTOM(context),
+            throw Exception(SourceContext(context),
                             "key column '{}' missing in the left data frame", leftCol);
         }
         if (!indexCol2) {
-            throw Exception(IVW_CONTEXT_CUSTOM(context),
+            throw Exception(SourceContext(context),
                             "key column '{}' missing in the right data frame", rightCol);
         }
 
@@ -205,14 +205,14 @@ void columnCheck(const DataFrame& left, const DataFrame& right,
         // check only for categorical types and do not compare column types directly.
         // This enables combining a regular column with an index column, e.g. for indexing.
         if (catcol1 != catcol2) {
-            throw Exception(IVW_CONTEXT_CUSTOM(context),
+            throw Exception(SourceContext(context),
                             "column type mismatch in key columns '{}' = {}, '{}' = {}", leftCol,
                             indexCol1->getColumnType(), rightCol, indexCol2->getColumnType());
         }
 
         if (indexCol1->getBuffer()->getDataFormat()->getId() !=
             indexCol2->getBuffer()->getDataFormat()->getId()) {
-            throw Exception(IVW_CONTEXT_CUSTOM(context),
+            throw Exception(SourceContext(context),
                             "format mismatch in key columns '{}' = {}, '{}' = {}", leftCol,
                             indexCol1->getBuffer()->getDataFormat()->getString(), rightCol,
                             indexCol2->getBuffer()->getDataFormat()->getString());
@@ -364,7 +364,7 @@ void addColumns(std::shared_ptr<DataFrame> dst, const DataFrame& srcDataFrame,
 
 std::shared_ptr<DataFrame> innerJoin(const DataFrame& left, const DataFrame& right,
                                      const std::pair<std::string, std::string>& keyColumn) {
-    detail::columnCheck(left, right, {keyColumn}, "dataframe::innerJoin");
+    detail::columnCheck(left, right, {keyColumn}, "dataframe::innerJoin"_sl);
 
     auto indexCol1 = left.getColumn(keyColumn.first);
     auto indexCol2 = right.getColumn(keyColumn.second);
@@ -398,7 +398,7 @@ std::shared_ptr<DataFrame> innerJoin(
         throw Exception("no key columns given", IVW_CONTEXT_CUSTOM("dataframe::innerJoin"));
     }
 
-    detail::columnCheck(left, right, keyColumns, "dataframe::innerJoin");
+    detail::columnCheck(left, right, keyColumns, "dataframe::innerJoin"_sl);
 
     std::vector<std::uint32_t> rowsLeft;
     std::vector<std::uint32_t> rowsRight;
@@ -430,7 +430,7 @@ std::shared_ptr<DataFrame> innerJoin(
 
 std::shared_ptr<DataFrame> leftJoin(const DataFrame& left, const DataFrame& right,
                                     const std::pair<std::string, std::string>& keyColumn) {
-    detail::columnCheck(left, right, {keyColumn}, "dataframe::leftJoin");
+    detail::columnCheck(left, right, {keyColumn}, "dataframe::leftJoin"_sl);
 
     auto indexCol1 = left.getColumn(keyColumn.first);
     auto indexCol2 = right.getColumn(keyColumn.second);
@@ -464,7 +464,7 @@ std::shared_ptr<DataFrame> leftJoin(
         throw Exception("no key columns given", IVW_CONTEXT_CUSTOM("dataframe::leftJoin"));
     }
 
-    detail::columnCheck(left, right, keyColumns, "dataframe::leftJoin");
+    detail::columnCheck(left, right, keyColumns, "dataframe::leftJoin"_sl);
 
     auto rows = util::transform(
         detail::getMatchingRows(left, right, keyColumns),

--- a/modules/ffmpeg/src/ffmpeganimationrecorder.cpp
+++ b/modules/ffmpeg/src/ffmpeganimationrecorder.cpp
@@ -49,9 +49,9 @@ public:
         : recorder{std::make_unique<ffmpeg::Recorder>(filename, format,
                                                       ffmpeg::Recorder::Mode::Evaluation, opts)} {
 
-        log::user::info("Recording to: {}", filename);
-        log::user::info("  - Format:   {}", recorder->getFormat().outputFormat().desc());
-        log::user::info("  - Codec:    {}", recorder->getStream().codec.codecID());
+        log::info("Recording to: {}", filename);
+        log::info("  - Format:   {}", recorder->getFormat().outputFormat().desc());
+        log::info("  - Codec:    {}", recorder->getStream().codec.codecID());
     }
     virtual ~FFmpegRecorder() = default;
 
@@ -66,13 +66,13 @@ void FFmpegRecorder::record(const Layer& layer) {
         try {
             recorder->queueFrame(*layer.getRepresentation<LayerRAM>());
         } catch (const Exception& e) {
-            log::user::exception(e);
+            log::exception(e);
             recorder.reset();
         } catch (const std::exception& e) {
-            log::user::exception(e);
+            log::exception(e);
             recorder.reset();
         } catch (...) {
-            log::user::exception();
+            log::exception();
             recorder.reset();
         }
     }

--- a/modules/ffmpeg/src/ffmpeganimationrecorder.cpp
+++ b/modules/ffmpeg/src/ffmpeganimationrecorder.cpp
@@ -49,9 +49,9 @@ public:
         : recorder{std::make_unique<ffmpeg::Recorder>(filename, format,
                                                       ffmpeg::Recorder::Mode::Evaluation, opts)} {
 
-        util::logInfo(IVW_CONTEXT, "Recording to: {}", filename);
-        util::logInfo(IVW_CONTEXT, "  - Format:   {}", recorder->getFormat().outputFormat().desc());
-        util::logInfo(IVW_CONTEXT, "  - Codec:    {}", recorder->getStream().codec.codecID());
+        log::user::info("Recording to: {}", filename);
+        log::user::info("  - Format:   {}", recorder->getFormat().outputFormat().desc());
+        log::user::info("  - Codec:    {}", recorder->getStream().codec.codecID());
     }
     virtual ~FFmpegRecorder() = default;
 
@@ -66,13 +66,13 @@ void FFmpegRecorder::record(const Layer& layer) {
         try {
             recorder->queueFrame(*layer.getRepresentation<LayerRAM>());
         } catch (const Exception& e) {
-            util::log(e.getContext(), e.getMessage(), LogLevel::Error);
+            log::user::exception(e);
             recorder.reset();
         } catch (const std::exception& e) {
-            util::log(IVW_CONTEXT, e.what(), LogLevel::Error);
+            log::user::exception(e);
             recorder.reset();
         } catch (...) {
-            util::log(IVW_CONTEXT, "unknown error", LogLevel::Error);
+            log::user::exception();
             recorder.reset();
         }
     }

--- a/modules/ffmpeg/src/ffmpegmodule.cpp
+++ b/modules/ffmpeg/src/ffmpegmodule.cpp
@@ -50,8 +50,7 @@ void ffmpeg_log_callback(void* ptr, int level, const char* fmt, va_list vl) {
     if (auto needSize = av_log_format_line2(ptr, level, fmt, vl, line.data(),
                                             static_cast<int>(line.size()), &print_prefix);
         needSize < 0) {
-        log::user::report(LogLevel::Error, SourceContext{"ffmpeg"_sl},
-                          "Error formatting log message");
+        log::report(LogLevel::Error, SourceContext{"ffmpeg"_sl}, "Error formatting log message");
     } else if (needSize >= static_cast<int>(line.size())) {
         dynamicLine.resize(needSize + 1);
         if (av_log_format_line2(ptr, level, fmt, vl, dynamicLine.data(),
@@ -75,7 +74,7 @@ void ffmpeg_log_callback(void* ptr, int level, const char* fmt, va_list vl) {
         }
     }();
 
-    log::user::report(logLevel, SourceContext{"ffmpeg"_sl}, message);
+    log::report(logLevel, SourceContext{"ffmpeg"_sl}, message);
 }
 
 }  // namespace

--- a/modules/ffmpeg/src/processors/movieexport.cpp
+++ b/modules/ffmpeg/src/processors/movieexport.cpp
@@ -170,22 +170,22 @@ void MovieExport::process() {
 
         notifyObserversStartBackgroundWork(this, 1);
 
-        util::logInfo(IVW_CONTEXT, "Recording to: {}", file_.get());
-        util::logInfo(IVW_CONTEXT, "  - Format:   {}", recorder->getFormat().outputFormat().desc());
-        util::logInfo(IVW_CONTEXT, "  - Codec:    {}", recorder->getStream().codec.codecID());
+        log::user::info("Recording to: {}", file_.get());
+        log::user::info("  - Format:   {}", recorder->getFormat().outputFormat().desc());
+        log::user::info("  - Codec:    {}", recorder->getStream().codec.codecID());
     }
 
     if (recorder) {
         try {
             recorder->queueFrame(*img->getColorLayer()->getRepresentation<LayerRAM>());
         } catch (const Exception& e) {
-            util::log(e.getContext(), e.getMessage(), LogLevel::Error);
+            log::user::exception(e);
             recorder.reset();
         } catch (const std::exception& e) {
-            util::log(IVW_CONTEXT, e.what(), LogLevel::Error);
+            log::user::exception(e);
             recorder.reset();
         } catch (...) {
-            util::log(IVW_CONTEXT, "unknown error", LogLevel::Error);
+            log::user::exception();
             recorder.reset();
         }
     }

--- a/modules/ffmpeg/src/processors/movieexport.cpp
+++ b/modules/ffmpeg/src/processors/movieexport.cpp
@@ -170,22 +170,22 @@ void MovieExport::process() {
 
         notifyObserversStartBackgroundWork(this, 1);
 
-        log::user::info("Recording to: {}", file_.get());
-        log::user::info("  - Format:   {}", recorder->getFormat().outputFormat().desc());
-        log::user::info("  - Codec:    {}", recorder->getStream().codec.codecID());
+        log::info("Recording to: {}", file_.get());
+        log::info("  - Format:   {}", recorder->getFormat().outputFormat().desc());
+        log::info("  - Codec:    {}", recorder->getStream().codec.codecID());
     }
 
     if (recorder) {
         try {
             recorder->queueFrame(*img->getColorLayer()->getRepresentation<LayerRAM>());
         } catch (const Exception& e) {
-            log::user::exception(e);
+            log::exception(e);
             recorder.reset();
         } catch (const std::exception& e) {
-            log::user::exception(e);
+            log::exception(e);
             recorder.reset();
         } catch (...) {
-            log::user::exception();
+            log::exception();
             recorder.reset();
         }
     }

--- a/modules/ffmpeg/src/recorder.cpp
+++ b/modules/ffmpeg/src/recorder.cpp
@@ -120,7 +120,7 @@ void Recorder::queueFrame(const LayerRAM& layer) {
             frame.emplace(stream.codec.ctx->pix_fmt, stream.codec.ctx->width,
                           stream.codec.ctx->height);
         } else {
-            log::user::info("Queue saturated");
+            log::info("Queue saturated");
         }
     }
 
@@ -243,8 +243,8 @@ void Recorder::run() {
 
         const auto end = clock::now();
         const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-        log::user::info("Exported frames: {} time: {}ms, fps: {}", frameCount, ms.count(),
-                        static_cast<double>(frameCount) / ms.count() * 1000);
+        log::info("Exported frames: {} time: {}ms, fps: {}", frameCount, ms.count(),
+                  static_cast<double>(frameCount) / ms.count() * 1000);
 
     } catch (...) {
         std::unique_lock<std::mutex> lock(mutex_);

--- a/modules/ffmpeg/src/recorder.cpp
+++ b/modules/ffmpeg/src/recorder.cpp
@@ -120,7 +120,7 @@ void Recorder::queueFrame(const LayerRAM& layer) {
             frame.emplace(stream.codec.ctx->pix_fmt, stream.codec.ctx->width,
                           stream.codec.ctx->height);
         } else {
-            util::log(IVW_CONTEXT, "Queue saturated");
+            log::user::info("Queue saturated");
         }
     }
 
@@ -243,9 +243,8 @@ void Recorder::run() {
 
         const auto end = clock::now();
         const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-        LogInfo("Exported frames: " << frameCount << " "
-                                    << "time:" << ms.count() << " ms, fps: "
-                                    << static_cast<double>(frameCount) / ms.count() * 1000);
+        log::user::info("Exported frames: {} time: {}ms, fps: {}", frameCount, ms.count(),
+                        static_cast<double>(frameCount) / ms.count() * 1000);
 
     } catch (...) {
         std::unique_lock<std::mutex> lock(mutex_);

--- a/modules/fontrendering/src/processors/textoverlaygl.cpp
+++ b/modules/fontrendering/src/processors/textoverlaygl.cpp
@@ -44,7 +44,7 @@
 #include <inviwo/core/properties/propertysemantics.h>                 // for PropertySemantics
 #include <inviwo/core/properties/stringproperty.h>                    // for StringProperty
 #include <inviwo/core/util/glmvec.h>                                  // for vec2, ivec2, vec4
-#include <inviwo/core/util/logcentral.h>                              // for LogCentral, LogWarn
+#include <inviwo/core/util/logcentral.h>                              // for LogCentral
 #include <inviwo/core/util/rendercontext.h>                           // for RenderContext
 #include <inviwo/core/util/stdextensions.h>                           // for any_of
 #include <inviwo/core/util/zip.h>                                     // for zip, zipIterator
@@ -200,10 +200,10 @@ void TextOverlayGL::updateCache() {
             try {
                 text = fmt::vformat(tp->text.get(), store);
             } catch (const fmt::format_error&) {
-                LogWarn(
-                    fmt::format("Invalid formatting string {}:'{}'\nFormat uses fmt syntax, args "
-                                "can be named by index {{0}} or by name {{arg0}}",
-                                tp->getPath(), tp->text.get()));
+                log::warn(
+                    "Invalid formatting string {}:'{}'\nFormat uses fmt syntax, args "
+                    "can be named by index {{0}} or by name {{arg0}}",
+                    tp->getPath(), tp->text.get());
                 text = "<Invalid Format!>";
             }
             tex = util::createTextTextureObject(textRenderer_, text, color_.get(), tex.texture);

--- a/modules/fontrendering/src/textrenderer.cpp
+++ b/modules/fontrendering/src/textrenderer.cpp
@@ -33,7 +33,7 @@
 #include <inviwo/core/datastructures/camera/camera.h>  // for mat4
 #include <inviwo/core/util/exception.h>                // for Exception, FileException
 #include <inviwo/core/util/glmvec.h>                   // for ivec2, vec2, size2_t
-#include <inviwo/core/util/logcentral.h>               // for LogCentral, LogWarn
+#include <inviwo/core/util/logcentral.h>               // for LogCentral
 #include <inviwo/core/util/sourcecontext.h>            // for IVW_CONTEXT
 #include <inviwo/core/util/stdextensions.h>            // for hash
 #include <inviwo/core/util/zip.h>                      // for get, zip, zipIterator
@@ -155,8 +155,8 @@ std::string_view::const_iterator TextRenderer::validateString(std::string_view s
     // check input string for invalid utf8 encoding, process only valid part
     auto end = utf8::find_invalid(str.begin(), str.end());
     if (end != str.end()) {
-        LogWarn("Invalid UTF-8 encoding detected. This part is fine: " << std::string(str.begin(),
-                                                                                      end));
+        log::warn("Invalid UTF-8 encoding detected. This part is fine: {}",
+                  std::string(str.begin(), end));
     }
     return end;
 }
@@ -487,8 +487,7 @@ std::pair<bool, TextRenderer::GlyphEntry> TextRenderer::requestGlyph(FontCache& 
 std::pair<bool, TextRenderer::GlyphEntry> TextRenderer::addGlyph(FontCache& fc,
                                                                  unsigned int glyph) {
     if (FT_Load_Char(fontface_, glyph, FT_LOAD_RENDER)) {
-        LogWarn("FreeType: could not load char: '" << static_cast<char>(glyph) << "' (0x"
-                                                   << std::hex << glyph << ")");
+        log::warn("FreeType: could not load char: '{}' ({:#X})", static_cast<char>(glyph), glyph);
         return std::make_pair(false, GlyphEntry());
     }
 
@@ -522,8 +521,8 @@ std::pair<bool, TextRenderer::GlyphEntry> TextRenderer::addGlyph(FontCache& fc,
     // check remaining vertical space inside atlas texture
     if (line == fc.lineLengths.size()) {
         if (fc.lineHeights.back() + glyphExtent.y > texDims.y) {
-            LogWarn("Could not cache char '" << static_cast<char>(glyph) << "' (0x" << std::hex
-                                             << glyph << ") (max size for texture atlas exceeded)");
+            log::warn("Could not cache char '{}' ({:#X}) (max size for texture atlas exceeded)",
+                      static_cast<char>(glyph), glyph);
             return std::make_pair(false, glyphEntry);
         }
         // create a new, empty line in the texture and store the glyph there
@@ -583,8 +582,7 @@ void TextRenderer::createDefaultGlyphAtlas() {
     // create glyphs for all ascii characters between 32 and 128
     for (unsigned int c = 32u; c < 128u; ++c) {
         if (FT_Load_Char(fontface_, c, FT_LOAD_RENDER)) {
-            LogWarn("FreeType: could not load char: '" << static_cast<char>(c) << "' (0x"
-                                                       << std::hex << c << ")");
+            log::warn("FreeType: could not load char: '{}' ({:#X})", static_cast<char>(c), c);
             continue;
         }
 

--- a/modules/glfw/src/canvasglfw.cpp
+++ b/modules/glfw/src/canvasglfw.cpp
@@ -316,10 +316,10 @@ ivec2 CanvasGLFW::movePointOntoDesktop(ivec2 pos, ivec2 size) {
             return pos;
         }
     } catch (const Exception& e) {
-        log::user::exception(e);
+        log::exception(e);
         return pos;
     } catch (...) {
-        log::user::exception("MovePointOntoDestop unknown exception");
+        log::exception("MovePointOntoDestop unknown exception");
         return pos;
     }
 }

--- a/modules/glfw/src/canvasglfw.cpp
+++ b/modules/glfw/src/canvasglfw.cpp
@@ -37,7 +37,7 @@
 #include <inviwo/core/util/canvas.h>                         // for Canvas::ContextID, Canvas
 #include <inviwo/core/util/exception.h>                      // for Exception
 #include <inviwo/core/util/glmvec.h>                         // for ivec2, uvec2, size2_t, dvec2
-#include <inviwo/core/util/logcentral.h>                     // for LogCentral, LogErrorCustom
+#include <inviwo/core/util/logcentral.h>                     // for LogCentral
 #include <inviwo/core/util/rendercontext.h>                  // for CanvasContextHolder, RenderC...
 #include <inviwo/core/util/sourcecontext.h>                  // for IVW_CONTEXT_CUSTOM
 #include <modules/glfw/glfwexception.h>                      // for GLFWException
@@ -316,10 +316,10 @@ ivec2 CanvasGLFW::movePointOntoDesktop(ivec2 pos, ivec2 size) {
             return pos;
         }
     } catch (const Exception& e) {
-        LogErrorCustom("CanvasGLFW", e.getMessage());
+        log::user::exception(e);
         return pos;
     } catch (...) {
-        LogErrorCustom("CanvasGLFW", "MovePointOntoDestop unknown exception");
+        log::user::exception("MovePointOntoDestop unknown exception");
         return pos;
     }
 }

--- a/modules/glfw/src/filewatcher.cpp
+++ b/modules/glfw/src/filewatcher.cpp
@@ -30,7 +30,7 @@
 #include <modules/glfw/filewatcher.h>
 
 #include <inviwo/core/util/assertion.h>      // for IVW_ASSERT
-#include <inviwo/core/util/logcentral.h>     // for LogCentral, LogWarn
+#include <inviwo/core/util/logcentral.h>     // for LogCentral
 #include <inviwo/core/util/stdextensions.h>  // for erase_remove
 
 #include <algorithm>  // for find
@@ -102,7 +102,7 @@ private:
             const auto handle = FindFirstChangeNotification(path.c_str(), TRUE, filter);
 
             if (handle == INVALID_HANDLE_VALUE || handle == nullptr) {
-                LogError("FindFirstChangeNotification function failed.");
+                log::error("FindFirstChangeNotification function failed.");
                 continue;
             }
 
@@ -269,7 +269,7 @@ void FileWatcher::startFileObservation(const std::filesystem::path& fileName) {
     if (it == observed_.end()) {
         observed_[dir].insert(fileName);
         if (!watcher_->addObservation(dir)) {
-            LogError("Can't watch more files");
+            log::error("Can't watch more files");
         }
     } else {
         it->second.insert(fileName);
@@ -305,7 +305,7 @@ public:
 
 FileWatcher::FileWatcher(InviwoApplication* app) : app_{app} {
     (void)app_;
-    LogWarn("FileObserver are currently not supported using GLFW on this platform");
+    log::warn("FileObserver are currently not supported using GLFW on this platform");
 }
 
 FileWatcher::~FileWatcher() = default;

--- a/modules/glfw/src/glfwmodule.cpp
+++ b/modules/glfw/src/glfwmodule.cpp
@@ -36,7 +36,7 @@
 #include <inviwo/core/util/canvas.h>                        // for Canvas, Canvas::ContextID
 #include <inviwo/core/util/exception.h>                     // for ModuleInitException
 #include <inviwo/core/util/glmvec.h>                        // for uvec2
-#include <inviwo/core/util/logcentral.h>                    // for LogCentral, LogError
+#include <inviwo/core/util/logcentral.h>                    // for LogCentral
 #include <inviwo/core/util/rendercontext.h>                 // for RenderContext, ContextHolder
 #include <inviwo/core/util/sourcecontext.h>                 // for IVW_CONTEXT
 #include <modules/glfw/canvasglfw.h>                        // for CanvasGLFW
@@ -140,7 +140,7 @@ void GLFWModule::onProcessorNetworkEvaluationEnd() {
         case GL_TIMEOUT_EXPIRED:  // Handled above
             break;
         case GL_WAIT_FAILED:
-            LogError("Error syncing with opengl 'GL_WAIT_FAILED'");
+            log::error("Error syncing with opengl 'GL_WAIT_FAILED'");
             break;
         case GL_CONDITION_SATISFIED:  // Queue done.
             break;

--- a/modules/hdf5/src/datastructures/hdf5handle.cpp
+++ b/modules/hdf5/src/datastructures/hdf5handle.cpp
@@ -181,10 +181,9 @@ std::shared_ptr<Volume> Handle::getVolumeAtPathAsType(const Path& path,
 
     hsize_t selectionSize = memorySpace.getSelectNpoints();
 
-    LogInfo("Data rank: " << rank << " dims " << joinString(dataDimensions, " x ") << " size "
-                          << dataSize << " selection " << dataSpace.getSelectNpoints()
-                          << " memory size " << memorySpace.getSelectNpoints() << " memory dim "
-                          << volumeDimensions);
+    log::user::info("Data rank: {} dims {} size {} selection {} memory size {} memory dim {}", rank,
+                    joinString(dataDimensions, " x "), dataSize, dataSpace.getSelectNpoints(),
+                    memorySpace.getSelectNpoints(), volumeDimensions);
 
     const DataFormatBase* format = type ? type : util::getDataFormatFromDataSet(dataset);
 
@@ -206,9 +205,9 @@ std::shared_ptr<Volume> Handle::getVolumeAtPathAsType(const Path& path,
 
             auto res = ::inviwo::util::dataMinMax(data, selectionSize);
 
-            LogInfo("Read HDF volume type: " << DataFormat<ValueType>::str()
-                                             << " data range: " << res.first << ", " << res.second
-                                             << " file: " << dataset.getFileName());
+            log::user::info("Read HDF volume type: {} data range: {}, {} file: {}",
+                            DataFormat<ValueType>::str(), res.first, res.second,
+                            dataset.getFileName());
 
             return res;
         });

--- a/modules/hdf5/src/datastructures/hdf5handle.cpp
+++ b/modules/hdf5/src/datastructures/hdf5handle.cpp
@@ -181,9 +181,9 @@ std::shared_ptr<Volume> Handle::getVolumeAtPathAsType(const Path& path,
 
     hsize_t selectionSize = memorySpace.getSelectNpoints();
 
-    log::user::info("Data rank: {} dims {} size {} selection {} memory size {} memory dim {}", rank,
-                    joinString(dataDimensions, " x "), dataSize, dataSpace.getSelectNpoints(),
-                    memorySpace.getSelectNpoints(), volumeDimensions);
+    log::info("Data rank: {} dims {} size {} selection {} memory size {} memory dim {}", rank,
+              joinString(dataDimensions, " x "), dataSize, dataSpace.getSelectNpoints(),
+              memorySpace.getSelectNpoints(), volumeDimensions);
 
     const DataFormatBase* format = type ? type : util::getDataFormatFromDataSet(dataset);
 
@@ -205,9 +205,8 @@ std::shared_ptr<Volume> Handle::getVolumeAtPathAsType(const Path& path,
 
             auto res = ::inviwo::util::dataMinMax(data, selectionSize);
 
-            log::user::info("Read HDF volume type: {} data range: {}, {} file: {}",
-                            DataFormat<ValueType>::str(), res.first, res.second,
-                            dataset.getFileName());
+            log::info("Read HDF volume type: {} data range: {}, {} file: {}",
+                      DataFormat<ValueType>::str(), res.first, res.second, dataset.getFileName());
 
             return res;
         });

--- a/modules/hdf5/src/hdf5types.cpp
+++ b/modules/hdf5/src/hdf5types.cpp
@@ -58,7 +58,7 @@ IVW_MODULE_HDF5_API const DataFormatBase* util::getDataFormatFromDataSet(
                     break;
                 }
                 default: {
-                    LogWarnCustom("HDFType", "HDF type not supported");
+                    log::warn("HDF type not supported");
                     return nullptr;
                 }
             }
@@ -73,11 +73,11 @@ IVW_MODULE_HDF5_API const DataFormatBase* util::getDataFormatFromDataSet(
         }
         case H5T_ARRAY: {
             H5::ArrayType type = dataset.getArrayType();
-            LogWarnCustom("HDFType", "HDF type not supported");
+            log::warn("HDF type not supported");
             return nullptr;
         }
         default: {
-            LogWarnCustom("HDFType", "HDF type not supported");
+            log::warn("HDF type not supported");
             return nullptr;
         }
     }

--- a/modules/hdf5/src/processors/hdf5source.cpp
+++ b/modules/hdf5/src/processors/hdf5source.cpp
@@ -58,9 +58,9 @@ void Source::process() {
         auto data = std::make_shared<Handle>(file_.get());
         port_.setData(data);
     } catch (H5::Exception& e) {
-        LogWarn("Could not load file: " << file_ << ": " << e.getCDetailMsg());
+        log::warn("Could not load file: {}: {}", file_.get(), e.getCDetailMsg());
     } catch (...) {
-        LogWarn("Could not load file: " << file_);
+        log::warn("Could not load file: {}", file_.get());
     }
 }
 

--- a/modules/hdf5/src/processors/hdf5volumesource.cpp
+++ b/modules/hdf5/src/processors/hdf5volumesource.cpp
@@ -343,7 +343,7 @@ void HDF5ToVolume::makeVolume() {
             outport_.setData(volume_);
 
         } catch (const H5::GroupIException& e) {
-            LogInfo(e.getDetailMsg());
+            log::user::report(LogLevel::Error, e.getDetailMsg());
         }
     }
 }

--- a/modules/hdf5/src/processors/hdf5volumesource.cpp
+++ b/modules/hdf5/src/processors/hdf5volumesource.cpp
@@ -343,7 +343,7 @@ void HDF5ToVolume::makeVolume() {
             outport_.setData(volume_);
 
         } catch (const H5::GroupIException& e) {
-            log::user::report(LogLevel::Error, e.getDetailMsg());
+            log::report(LogLevel::Error, e.getDetailMsg());
         }
     }
 }

--- a/modules/oit/src/processors/meshrasterizer.cpp
+++ b/modules/oit/src/processors/meshrasterizer.cpp
@@ -456,7 +456,7 @@ void MeshRasterizer::rasterize(const ivec2& imageSize, const mat4& worldMatrixTr
 
     if (!faceSettings_[0].show_ && !faceSettings_[1].show_) {
         outport_.setData(nullptr);
-        LogWarn("Both sides are disabled, not rendering anything.");
+        log::warn("Both sides are disabled, not rendering anything.");
         return;  // everything is culled
     }
 

--- a/modules/oit/src/processors/meshvolumerenderer.cpp
+++ b/modules/oit/src/processors/meshvolumerenderer.cpp
@@ -84,7 +84,7 @@ MeshVolumeRenderer::MeshVolumeRenderer()
     }()} {
 
     if (!VolumeFragmentListRenderer::supportsFragmentLists()) {
-        LogProcessorWarn(
+        log::user::warn(
             "Fragment lists are not supported by the hardware -> volume rasterization disabled, "
             "regular meshes rendered without sorting.");
     }
@@ -133,10 +133,10 @@ void MeshVolumeRenderer::process() {
     }
     const int numVolumes = volumeId;
     if (volumeId > maxSupportedVolumeRasterizers) {
-        LogWarn(
-            fmt::format("More than {} Volume Rasterizers connected to {} ({}). Omitting "
-                        "surplus rasterizers.",
-                        maxSupportedVolumeRasterizers, getDisplayName(), getIdentifier()));
+        log::warn(
+            "More than {} Volume Rasterizers connected to {} ({}). Omitting "
+            "surplus rasterizers.",
+            maxSupportedVolumeRasterizers, getDisplayName(), getIdentifier());
     }
 
     if (intermediateImage_.getDimensions() != outport_.getDimensions()) {

--- a/modules/oit/src/processors/meshvolumerenderer.cpp
+++ b/modules/oit/src/processors/meshvolumerenderer.cpp
@@ -84,7 +84,7 @@ MeshVolumeRenderer::MeshVolumeRenderer()
     }()} {
 
     if (!VolumeFragmentListRenderer::supportsFragmentLists()) {
-        log::user::warn(
+        log::warn(
             "Fragment lists are not supported by the hardware -> volume rasterization disabled, "
             "regular meshes rendered without sorting.");
     }

--- a/modules/oit/src/processors/rasterizationrenderer.cpp
+++ b/modules/oit/src/processors/rasterizationrenderer.cpp
@@ -107,12 +107,12 @@ RasterizationRenderer::RasterizationRenderer()
     }()} {
 
     if (!FragmentListRenderer::supportsFragmentLists()) {
-        LogProcessorWarn(
+        log::user::warn(
             "Fragment lists are not supported by the hardware -> use blending without sorting, "
             "may lead to errors");
     }
     if (!FragmentListRenderer::supportsIllustration()) {
-        LogProcessorWarn(
+        log::user::warn(
             "Illustration Buffer not supported by the hardware, screen-space silhouettes not "
             "available");
     }

--- a/modules/oit/src/processors/rasterizationrenderer.cpp
+++ b/modules/oit/src/processors/rasterizationrenderer.cpp
@@ -107,12 +107,12 @@ RasterizationRenderer::RasterizationRenderer()
     }()} {
 
     if (!FragmentListRenderer::supportsFragmentLists()) {
-        log::user::warn(
+        log::warn(
             "Fragment lists are not supported by the hardware -> use blending without sorting, "
             "may lead to errors");
     }
     if (!FragmentListRenderer::supportsIllustration()) {
-        log::user::warn(
+        log::warn(
             "Illustration Buffer not supported by the hardware, screen-space silhouettes not "
             "available");
     }

--- a/modules/opengl/include/modules/opengl/clockgl.h
+++ b/modules/opengl/include/modules/opengl/clockgl.h
@@ -165,7 +165,8 @@ protected:
  * \see IVW_OPENGL_PROFILING(message), IVW_OPENGL_PROFILING_CUSTOM(src, message)
  * \see IVW_OPENGL_PROFILING_IF(time, message), IVW_OPENGL_PROFILING_IF(time, src, message)
  */
-using ScopedClockGL = ScopedClock<ClockGL>;
+template <typename Callback>
+using ScopedClockGL = ScopedClock<ClockGL, Callback>;
 
 /**
  * \def IVW_OPENGL_PROFILING(message)
@@ -173,71 +174,36 @@ using ScopedClockGL = ScopedClock<ClockGL>;
  *
  * @param message  log message
  */
-
-/**
- * \def IVW_OPENGL_PROFILING_CUSTOM(src, message)
- * creates a scoped ClockGL clock with the given source and message.
- * Does nothing unless IVW_PROFILING is defined.
- *
- * @param src      source of the log message
- * @param message  log message
- */
+#if IVW_PROFILING
+#define IVW_OPENGL_PROFILING(message)                                                 \
+    const auto IVW_ADDLINE(inviwoScopedClock) = util::makeScopedClock<ClockGL>([]() { \
+        std::ostringstream ss;                                                        \
+        ss << message;                                                                \
+        return std::move(ss).str();                                                   \
+    })
+#else
+#define IVW_OPENGL_PROFILING(message)
+#endif
 
 /**
  * \def IVW_OPENGL_PROFILING_IF(time, message)
  * creates a scoped ClockGL clock with the given message and minimum duration.
  * Does nothing unless IVW_PROFILING is defined.
  *
- * @param time     either a std::chrono::duration or a double value (milliseconds)
+ * @param time     a double value (milliseconds)
  * @param message  log message
  */
-
-/**
- * \def IVW_OPENGL_PROFILING_IF_CUSTOM(time, src, message)
- * creates a scoped ClockGL clock with the given source, message, and minimum duration.
- * Does nothing unless IVW_PROFILING is defined.
- *
- * @param time     either a std::chrono::duration or a double value (milliseconds)
- * @param src      source of the log message
- * @param message  log message
- */
-
 #if IVW_PROFILING
-#define IVW_OPENGL_PROFILING(message)                                              \
-    std::ostringstream IVW_ADDLINE(__stream);                                      \
-    IVW_ADDLINE(__stream) << message;                                              \
-    ScopedClockGL IVW_ADDLINE(__clock)(util::parseTypeIdName(typeid(this).name()), \
-                                       IVW_ADDLINE(__stream).str());
-#else
-#define IVW_OPENGL_PROFILING(message)
-#endif
-
-#if IVW_PROFILING
-#define IVW_OPENGL_PROFILING_CUSTOM(src, message) \
-    std::ostringstream IVW_ADDLINE(__stream);     \
-    IVW_ADDLINE(__stream) << message;             \
-    ScopedClockGL IVW_ADDLINE(__clock)(src, IVW_ADDLINE(__stream).str());
-#else
-#define IVW_OPENGL_PROFILING_CUSTOM(src, message)
-#endif
-
-#if IVW_PROFILING
-#define IVW_OPENGL_PROFILING_IF(time, message)                                     \
-    std::ostringstream IVW_ADDLINE(__stream);                                      \
-    IVW_ADDLINE(__stream) << message;                                              \
-    ScopedClockGL IVW_ADDLINE(__clock)(util::parseTypeIdName(typeid(this).name()), \
-                                       IVW_ADDLINE(__stream).str(), time);
+#define IVW_OPENGL_PROFILING_IF(time, message)                                  \
+    const auto IVW_ADDLINE(inviwoScopedClock) = util::makeScopedClock<ClockGL>( \
+        []() {                                                                  \
+            std::ostringstream ss;                                              \
+            ss << message;                                                      \
+            return std::move(ss).str();                                         \
+        },                                                                      \
+        std::chrono::milliseconds(time))
 #else
 #define IVW_OPENGL_PROFILING_IF(time, message)
-#endif
-
-#if IVW_PROFILING
-#define IVW_OPENGL_PROFILING_IF_CUSTOM(time, src, message) \
-    std::ostringstream IVW_ADDLINE(__stream);              \
-    IVW_ADDLINE(__stream) << message;                      \
-    ScopedClockGL IVW_ADDLINE(__clock)(src, IVW_ADDLINE(__stream).str(), time);
-#else
-#define IVW_OPENGL_PROFILING_IF_CUSTOM(time, src, message)
 #endif
 
 }  // namespace inviwo

--- a/modules/opengl/include/modules/opengl/clockgl.h
+++ b/modules/opengl/include/modules/opengl/clockgl.h
@@ -176,7 +176,7 @@ using ScopedClockGL = ScopedClock<ClockGL, Callback>;
  */
 #if IVW_PROFILING
 #define IVW_OPENGL_PROFILING(message)                                                 \
-    const auto IVW_ADDLINE(inviwoScopedClock) = util::makeScopedClock<ClockGL>([]() { \
+    const auto IVW_ADDLINE(inviwoScopedClock) = util::makeScopedClock<ClockGL>([&]() { \
         std::ostringstream ss;                                                        \
         ss << message;                                                                \
         return std::move(ss).str();                                                   \
@@ -196,7 +196,7 @@ using ScopedClockGL = ScopedClock<ClockGL, Callback>;
 #if IVW_PROFILING
 #define IVW_OPENGL_PROFILING_IF(time, message)                                  \
     const auto IVW_ADDLINE(inviwoScopedClock) = util::makeScopedClock<ClockGL>( \
-        []() {                                                                  \
+        [&]() {                                                                  \
             std::ostringstream ss;                                              \
             ss << message;                                                      \
             return std::move(ss).str();                                         \

--- a/modules/opengl/include/modules/opengl/debugmessages.h
+++ b/modules/opengl/include/modules/opengl/debugmessages.h
@@ -34,6 +34,7 @@
 #include <inviwo/core/util/canvas.h>
 #include <inviwo/core/util/logcentral.h>
 #include <modules/opengl/inviwoopengl.h>
+#include <inviwo/core/util/fmtutils.h>
 
 #include <iosfwd>
 
@@ -97,10 +98,6 @@ inline LogLevel toLogLevel(Severity s) {
     }
 }
 
-IVW_MODULE_OPENGL_API std::ostream& operator<<(std::ostream& ss, Mode m);
-
-IVW_MODULE_OPENGL_API std::ostream& operator<<(std::ostream& ss, BreakLevel b);
-
 namespace detail {
 
 inline int toInt(Severity s) {
@@ -160,6 +157,14 @@ inline bool operator<=(const BreakLevel& b, const Severity& s) { return s >= b; 
 inline bool operator>(const BreakLevel& b, const Severity& s) { return s < b; }
 inline bool operator>=(const BreakLevel& b, const Severity& s) { return s <= b; }
 
+IVW_MODULE_OPENGL_API std::string_view enumToStr(Mode s);
+IVW_MODULE_OPENGL_API std::string_view enumToStr(BreakLevel t);
+IVW_MODULE_OPENGL_API std::string_view enumToStr(Source s);
+IVW_MODULE_OPENGL_API std::string_view enumToStr(Type t);
+IVW_MODULE_OPENGL_API std::string_view enumToStr(Severity s);
+
+IVW_MODULE_OPENGL_API std::ostream& operator<<(std::ostream& ss, Mode m);
+IVW_MODULE_OPENGL_API std::ostream& operator<<(std::ostream& ss, BreakLevel b);
 IVW_MODULE_OPENGL_API std::ostream& operator<<(std::ostream& ss, Source s);
 
 IVW_MODULE_OPENGL_API std::ostream& operator<<(std::ostream& ss, Type t);
@@ -176,3 +181,23 @@ IVW_MODULE_OPENGL_API bool configureOpenGLDebugMessages(utilgl::debug::Severity 
 }  // namespace utilgl
 
 }  // namespace inviwo
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+template <>
+struct fmt::formatter<inviwo::utilgl::debug::Mode>
+    : inviwo::FlagFormatter<inviwo::utilgl::debug::Mode> {};
+template <>
+struct fmt::formatter<inviwo::utilgl::debug::BreakLevel>
+    : inviwo::FlagFormatter<inviwo::utilgl::debug::BreakLevel> {};
+
+template <>
+struct fmt::formatter<inviwo::utilgl::debug::Source>
+    : inviwo::FlagFormatter<inviwo::utilgl::debug::Source> {};
+template <>
+struct fmt::formatter<inviwo::utilgl::debug::Type>
+    : inviwo::FlagFormatter<inviwo::utilgl::debug::Type> {};
+
+template <>
+struct fmt::formatter<inviwo::utilgl::debug::Severity>
+    : inviwo::FlagFormatter<inviwo::utilgl::debug::Severity> {};
+#endif

--- a/modules/opengl/include/modules/opengl/openglcapabilities.h
+++ b/modules/opengl/include/modules/opengl/openglcapabilities.h
@@ -137,24 +137,6 @@ protected:
     static int parseAndRetrieveVersion(std::string);
 
 private:
-    template <typename T, typename... Ts>
-    void printHelper(std::stringstream& ss, T& message, const Ts&... messages) const {
-        ss << message;
-        printHelper(ss, messages...);
-    }
-    template <typename T>
-    void printHelper(std::stringstream& ss, const T& message) const {
-        ss << message;
-    }
-
-    template <typename... Ts>
-    void print(const Ts&... messages) const {
-        std::stringstream ss;
-        printHelper(ss, messages...);
-        LogCentral::getPtr()->log("OpenGLInfo", LogLevel::Info, LogAudience::User, "", "", 0,
-                                  ss.str());
-    }
-
     static bool glewInitialized_;
     static int glVersion_;
     static std::string glVersionStr_;

--- a/modules/opengl/src/buffer/bufferobject.cpp
+++ b/modules/opengl/src/buffer/bufferobject.cpp
@@ -31,7 +31,7 @@
 
 #include <inviwo/core/datastructures/geometry/geometrytype.h>  // for BufferTarget, BufferUsage
 #include <inviwo/core/util/formats.h>                          // for DataFormatBase, NumericType
-#include <inviwo/core/util/logcentral.h>                       // for LogCentral, LogError
+#include <inviwo/core/util/logcentral.h>                       // for LogCentral
 #include <inviwo/core/util/observer.h>                         // for Observable
 #include <inviwo/core/util/sourcecontext.h>                    // for IVW_CONTEXT
 #include <modules/opengl/buffer/bufferobjectobserver.h>        // for BufferObjectObserver
@@ -297,7 +297,7 @@ void BufferObject::download(void* data) const {
         // Unmap buffer after using it
         glUnmapBufferARB(target_);
     } else {
-        LogError("Unable to map data");
+        log::error("Unable to map data");
     }
 }
 

--- a/modules/opengl/src/buffer/bufferobjectarray.cpp
+++ b/modules/opengl/src/buffer/bufferobjectarray.cpp
@@ -46,7 +46,8 @@ namespace inviwo {
 
 using namespace std::literals;
 
-inline void checkContext(std::string_view error, Canvas::ContextID org, SourceLocation loc) {
+inline void checkContext(std::string_view error, Canvas::ContextID org,
+                         std::source_location location = std::source_location::current()) {
     if constexpr (cfg::assertions) {
         auto rc = RenderContext::getPtr();
         Canvas::ContextID curr = rc->activeContext();
@@ -55,7 +56,7 @@ inline void checkContext(std::string_view error, Canvas::ContextID org, SourceLo
                 fmt::format("{}: '{}' ({}) than it was created: '{}' ({})", error,
                             rc->getContextName(curr), curr, rc->getContextName(org), org);
 
-            assertion(loc.getFile(), loc.getFunction(), loc.getLine(), message);
+            assertion(location.file_name(), location.function_name(), location.line(), message);
         }
     }
 }
@@ -116,7 +117,7 @@ BufferObjectArray& BufferObjectArray::operator=(const BufferObjectArray& that) {
 
 BufferObjectArray::~BufferObjectArray() {
     if (id_ != 0) {
-        checkContext("VAO deleted in a different context"sv, creationContext_, IVW_SOURCE_LOCATION);
+        checkContext("VAO deleted in a different context"sv, creationContext_);
         glDeleteVertexArrays(1, &id_);
     }
 }
@@ -133,14 +134,14 @@ void BufferObjectArray::clear() {
 }
 
 void BufferObjectArray::bind() const {
-    checkContext("VAO bound in a different context"sv, creationContext_, IVW_SOURCE_LOCATION);
+    checkContext("VAO bound in a different context"sv, creationContext_);
     glBindVertexArray(id_);
 }
 
 void BufferObjectArray::unbind() const { glBindVertexArray(0); }
 
 bool BufferObjectArray::isActive() const {
-    checkContext("VAO used in a different context"sv, creationContext_, IVW_SOURCE_LOCATION);
+    checkContext("VAO used in a different context"sv, creationContext_);
     return glIsVertexArray(id_);
 }
 

--- a/modules/opengl/src/buffer/bufferobjectarray.cpp
+++ b/modules/opengl/src/buffer/bufferobjectarray.cpp
@@ -47,16 +47,16 @@ namespace inviwo {
 using namespace std::literals;
 
 inline void checkContext(std::string_view error, Canvas::ContextID org,
-                         std::source_location location = std::source_location::current()) {
+                         SourceContext context = std::source_location::current()) {
     if constexpr (cfg::assertions) {
-        auto rc = RenderContext::getPtr();
-        Canvas::ContextID curr = rc->activeContext();
+        auto* rc = RenderContext::getPtr();
+        const auto curr = rc->activeContext();
         if (org != curr) {
             const auto message =
                 fmt::format("{}: '{}' ({}) than it was created: '{}' ({})", error,
                             rc->getContextName(curr), curr, rc->getContextName(org), org);
 
-            assertion(location.file_name(), location.function_name(), location.line(), message);
+            assertion(message, context);
         }
     }
 }

--- a/modules/opengl/src/buffer/bufferobjectarray.cpp
+++ b/modules/opengl/src/buffer/bufferobjectarray.cpp
@@ -50,7 +50,7 @@ inline void checkContext(std::string_view error, Canvas::ContextID org,
                          SourceContext context = std::source_location::current()) {
     if constexpr (cfg::assertions) {
         auto* rc = RenderContext::getPtr();
-        const auto curr = rc->activeContext();
+        const auto* const curr = rc->activeContext();
         if (org != curr) {
             const auto message =
                 fmt::format("{}: '{}' ({}) than it was created: '{}' ({})", error,

--- a/modules/opengl/src/buffer/framebufferobject.cpp
+++ b/modules/opengl/src/buffer/framebufferobject.cpp
@@ -53,17 +53,16 @@ namespace inviwo {
 using namespace std::literals;
 
 inline void checkContext(std::string_view error, Canvas::ContextID org,
-                         std::source_location location = std::source_location::current()) {
+                         SourceContext context = std::source_location::current()) {
     if constexpr (cfg::assertions) {
-        auto rc = RenderContext::getPtr();
-        Canvas::ContextID curr = rc->activeContext();
+        auto* rc = RenderContext::getPtr();
+        const auto curr = rc->activeContext();
         if (org != curr) {
-
             const auto message =
                 fmt::format("{}: '{}' ({}) than it was created: '{}' ({})", error,
                             rc->getContextName(curr), curr, rc->getContextName(org), org);
 
-            assertion(location.file_name(), location.function_name(), location.line(), message);
+            assertion(message, context);
         }
     }
 }

--- a/modules/opengl/src/buffer/framebufferobject.cpp
+++ b/modules/opengl/src/buffer/framebufferobject.cpp
@@ -52,7 +52,8 @@ namespace inviwo {
 
 using namespace std::literals;
 
-inline void checkContext(std::string_view error, Canvas::ContextID org, SourceLocation loc) {
+inline void checkContext(std::string_view error, Canvas::ContextID org,
+                         std::source_location location = std::source_location::current()) {
     if constexpr (cfg::assertions) {
         auto rc = RenderContext::getPtr();
         Canvas::ContextID curr = rc->activeContext();
@@ -62,7 +63,7 @@ inline void checkContext(std::string_view error, Canvas::ContextID org, SourceLo
                 fmt::format("{}: '{}' ({}) than it was created: '{}' ({})", error,
                             rc->getContextName(curr), curr, rc->getContextName(org), org);
 
-            assertion(loc.getFile(), loc.getFunction(), loc.getLine(), message);
+            assertion(location.file_name(), location.function_name(), location.line(), message);
         }
     }
 }
@@ -99,8 +100,7 @@ FrameBufferObject::FrameBufferObject(FrameBufferObject&& rhs) noexcept
 FrameBufferObject& FrameBufferObject::operator=(FrameBufferObject&& rhs) noexcept {
     if (this != &rhs) {
         if (id_ != 0) {
-            checkContext("FBO deleted in a different context"sv, creationContext_,
-                         IVW_SOURCE_LOCATION);
+            checkContext("FBO deleted in a different context"sv, creationContext_);
             glDeleteFramebuffers(1, &id_);
         }
 
@@ -117,13 +117,13 @@ FrameBufferObject& FrameBufferObject::operator=(FrameBufferObject&& rhs) noexcep
 
 FrameBufferObject::~FrameBufferObject() {
     if (id_ != 0) {
-        checkContext("FBO deleted in a different context"sv, creationContext_, IVW_SOURCE_LOCATION);
+        checkContext("FBO deleted in a different context"sv, creationContext_);
         glDeleteFramebuffers(1, &id_);
     }
 }
 
 void FrameBufferObject::activate() {
-    checkContext("FBO activated in a different context"sv, creationContext_, IVW_SOURCE_LOCATION);
+    checkContext("FBO activated in a different context"sv, creationContext_);
     glBindFramebuffer(GL_FRAMEBUFFER, id_);
 }
 
@@ -132,7 +132,7 @@ void FrameBufferObject::deactivate() { deactivateFBO(); }
 void FrameBufferObject::deactivateFBO() { glBindFramebuffer(GL_FRAMEBUFFER, 0); }
 
 bool FrameBufferObject::isActive() const {
-    checkContext("FBO used in a different context"sv, creationContext_, IVW_SOURCE_LOCATION);
+    checkContext("FBO used in a different context"sv, creationContext_);
     GLint currentFbo = 0;
     glGetIntegerv(GL_FRAMEBUFFER_BINDING, &currentFbo);
     return (static_cast<GLint>(id_) == currentFbo);
@@ -329,8 +329,7 @@ bool FrameBufferObject::hasStencilAttachment() const { return attachedStencilId_
 
 void FrameBufferObject::setReadBlit(bool set) const {
     if (set) {  // store currently bound draw FBO
-        checkContext("FBO activated in a different context"sv, creationContext_,
-                     IVW_SOURCE_LOCATION);
+        checkContext("FBO activated in a different context"sv, creationContext_);
         glBindFramebuffer(GL_READ_FRAMEBUFFER, id_);
     } else {
         glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
@@ -339,8 +338,7 @@ void FrameBufferObject::setReadBlit(bool set) const {
 
 void FrameBufferObject::setDrawBlit(bool set) {
     if (set) {  // store currently bound draw FBO
-        checkContext("FBO activated in a different context"sv, creationContext_,
-                     IVW_SOURCE_LOCATION);
+        checkContext("FBO activated in a different context"sv, creationContext_);
         glBindFramebuffer(GL_DRAW_FRAMEBUFFER, id_);
     } else {
         glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);

--- a/modules/opengl/src/buffer/framebufferobject.cpp
+++ b/modules/opengl/src/buffer/framebufferobject.cpp
@@ -56,7 +56,7 @@ inline void checkContext(std::string_view error, Canvas::ContextID org,
                          SourceContext context = std::source_location::current()) {
     if constexpr (cfg::assertions) {
         auto* rc = RenderContext::getPtr();
-        const auto curr = rc->activeContext();
+        const auto* const curr = rc->activeContext();
         if (org != curr) {
             const auto message =
                 fmt::format("{}: '{}' ({}) than it was created: '{}' ({})", error,

--- a/modules/opengl/src/debugmessages.cpp
+++ b/modules/opengl/src/debugmessages.cpp
@@ -51,19 +51,18 @@ void logDebugMode(debug::Mode mode, debug::Severity severity, Canvas::ContextID 
     const auto rc = RenderContext::getPtr();
     switch (mode) {
         case debug::Mode::Off:
-            log::user::report(LogLevel::Info, SourceContext("OpenGL Debug"_sl),
-                              "Debugging off for context: {} ({})", rc->getContextName(context),
-                              context);
+            log::report(LogLevel::Info, SourceContext("OpenGL Debug"_sl),
+                        "Debugging off for context: {} ({})", rc->getContextName(context), context);
             break;
         case debug::Mode::Debug:
-            log::user::report(LogLevel::Info, SourceContext("OpenGL Debug"_sl),
-                              "Debugging active for context: {} ({}) at level: {}",
-                              rc->getContextName(context), context, severity);
+            log::report(LogLevel::Info, SourceContext("OpenGL Debug"_sl),
+                        "Debugging active for context: {} ({}) at level: {}",
+                        rc->getContextName(context), context, severity);
             break;
         case debug::Mode::DebugSynchronous:
-            log::user::report(LogLevel::Info, SourceContext("OpenGL Debug"_sl),
-                              "Synchronous debugging active for context: {} ({}) at level: {}",
-                              rc->getContextName(context), context, severity);
+            log::report(LogLevel::Info, SourceContext("OpenGL Debug"_sl),
+                        "Synchronous debugging active for context: {} ({}) at level: {}",
+                        rc->getContextName(context), context, severity);
             break;
     }
 }
@@ -115,8 +114,8 @@ void handleOpenGLDebugModeChange(debug::Mode mode, debug::Severity severity) {
                     if (setOpenGLDebugMode(mode, severity)) {
                         logDebugMode(mode, severity, id);
                     } else {
-                        log::user::report(LogLevel::Info, SourceContext("OpenGL Debug"_sl),
-                                          "Debug messages not supported");
+                        log::report(LogLevel::Info, SourceContext("OpenGL Debug"_sl),
+                                    "Debug messages not supported");
                     }
                 }
             });
@@ -161,12 +160,12 @@ void handleOpenGLDebugMessagesChange(utilgl::debug::Severity severity) {
                     const auto rc = RenderContext::getPtr();
                     canvas->activate();
                     if (configureOpenGLDebugMessages(severity)) {
-                        log::user::report(LogLevel::Info, SourceContext("OpenGL Debug"_sl),
-                                          "Debug messages for level: {} for context: {} ({})",
-                                          severity, rc->getContextName(id), id);
+                        log::report(LogLevel::Info, SourceContext("OpenGL Debug"_sl),
+                                    "Debug messages for level: {} for context: {} ({})", severity,
+                                    rc->getContextName(id), id);
                     } else {
-                        log::user::report(LogLevel::Info, SourceContext("OpenGL Debug"_sl),
-                                          "Debug messages not supported");
+                        log::report(LogLevel::Info, SourceContext("OpenGL Debug"_sl),
+                                    "Debug messages not supported");
                     }
                 }
             });

--- a/modules/opengl/src/debugmessages.cpp
+++ b/modules/opengl/src/debugmessages.cpp
@@ -33,7 +33,7 @@
 #include <inviwo/core/properties/optionproperty.h>  // for OptionProperty
 #include <inviwo/core/util/assertion.h>             // for debugBreak
 #include <inviwo/core/util/canvas.h>                // for Canvas, Canvas::ContextID
-#include <inviwo/core/util/logcentral.h>            // for LogCentral, LogInfoCustom, LogAudience
+#include <inviwo/core/util/logcentral.h>            // for LogCentral, LogAudience
 #include <inviwo/core/util/rendercontext.h>         // for RenderContext, ContextHolder
 #include <modules/opengl/openglsettings.h>          // for OpenGLSettings
 
@@ -51,19 +51,19 @@ void logDebugMode(debug::Mode mode, debug::Severity severity, Canvas::ContextID 
     const auto rc = RenderContext::getPtr();
     switch (mode) {
         case debug::Mode::Off:
-            LogInfoCustom("OpenGL Debug",
-                          "Debugging off for context: " << rc->getContextName(context) << " ("
-                                                        << context << ")");
+            log::user::report(LogLevel::Info, SourceContext("OpenGL Debug"_sl),
+                              "Debugging off for context: {} ({})", rc->getContextName(context),
+                              context);
             break;
         case debug::Mode::Debug:
-            LogInfoCustom("OpenGL Debug", "Debugging active for context: "
-                                              << rc->getContextName(context) << " (" << context
-                                              << ")  at level: " << severity);
+            log::user::report(LogLevel::Info, SourceContext("OpenGL Debug"_sl),
+                              "Debugging active for context: {} ({}) at level: {}",
+                              rc->getContextName(context), context, severity);
             break;
         case debug::Mode::DebugSynchronous:
-            LogInfoCustom("OpenGL Debug", "Synchronous debugging active for context: "
-                                              << rc->getContextName(context) << " (" << context
-                                              << ") at level: " << severity);
+            log::user::report(LogLevel::Info, SourceContext("OpenGL Debug"_sl),
+                              "Synchronous debugging active for context: {} ({}) at level: {}",
+                              rc->getContextName(context), context, severity);
             break;
     }
 }
@@ -115,7 +115,8 @@ void handleOpenGLDebugModeChange(debug::Mode mode, debug::Severity severity) {
                     if (setOpenGLDebugMode(mode, severity)) {
                         logDebugMode(mode, severity, id);
                     } else {
-                        LogInfoCustom("OpenGL Debug", "Debug messages not supported");
+                        log::user::report(LogLevel::Info, SourceContext("OpenGL Debug"_sl),
+                                          "Debug messages not supported");
                     }
                 }
             });
@@ -160,12 +161,12 @@ void handleOpenGLDebugMessagesChange(utilgl::debug::Severity severity) {
                     const auto rc = RenderContext::getPtr();
                     canvas->activate();
                     if (configureOpenGLDebugMessages(severity)) {
-                        LogInfoCustom("OpenGL Debug",
-                                      "Debug messages for level: " << severity << " for context: "
-                                                                   << rc->getContextName(id) << " ("
-                                                                   << id << ")");
+                        log::user::report(LogLevel::Info, SourceContext("OpenGL Debug"_sl),
+                                          "Debug messages for level: {} for context: {} ({})",
+                                          severity, rc->getContextName(id), id);
                     } else {
-                        LogInfoCustom("OpenGL Debug", "Debug messages not supported");
+                        log::user::report(LogLevel::Info, SourceContext("OpenGL Debug"_sl),
+                                          "Debug messages not supported");
                     }
                 }
             });
@@ -222,131 +223,102 @@ void handleOpenGLDebugMode(Canvas::ContextID context) {
 
 namespace debug {
 
-std::ostream& operator<<(std::ostream& ss, Mode m) {
+std::string_view enumToStr(Mode m) {
     switch (m) {
         case Mode::Off:
-            ss << "Off";
-            break;
+            return "Off";
         case Mode::Debug:
-            ss << "Debug";
-            break;
+            return "Debug";
         case Mode::DebugSynchronous:
-            ss << "DebugSynchronous";
-            break;
+            return "DebugSynchronous";
         default:
-            break;
+            return "";
     }
-    return ss;
 }
-std::ostream& operator<<(std::ostream& ss, BreakLevel b) {
+std::string_view enumToStr(BreakLevel b) {
     switch (b) {
         case BreakLevel::Off:
-            ss << "Off";
-            break;
+            return "Off";
         case BreakLevel::High:
-            ss << "High";
-            break;
+            return "High";
         case BreakLevel::Medium:
-            ss << "Medium";
-            break;
+            return "Medium";
         case BreakLevel::Low:
-            ss << "Low";
-            break;
+            return "Low";
         case BreakLevel::Notification:
-            ss << "Notification";
-            break;
+            return "Notification";
         default:
-            break;
+            return "";
     }
-    return ss;
 }
-std::ostream& operator<<(std::ostream& ss, Source s) {
+std::string_view enumToStr(Source s) {
     switch (s) {
         case Source::Api:
-            ss << "Api";
-            break;
+            return "Api";
         case Source::WindowSystem:
-            ss << "WindowSystem";
-            break;
+            return "WindowSystem";
         case Source::ShaderCompiler:
-            ss << "ShaderCompiler";
-            break;
+            return "ShaderCompiler";
         case Source::ThirdParty:
-            ss << "ThirdParty";
-            break;
+            return "ThirdParty";
         case Source::Application:
-            ss << "Application";
-            break;
+            return "Application";
         case Source::Other:
-            ss << "Other";
-            break;
+            return "Other";
         case Source::DontCare:
-            ss << "DontCare";
-            break;
+            return "DontCare";
         default:
-            break;
+            return "";
     }
-    return ss;
 }
-std::ostream& operator<<(std::ostream& ss, Type t) {
+std::string_view enumToStr(Type t) {
     switch (t) {
         case Type::Error:
-            ss << "Error";
-            break;
+            return "Error";
         case Type::DeprecatedBehavior:
-            ss << "DeprecatedBehavior";
-            break;
+            return "DeprecatedBehavior";
         case Type::UndefinedBehavior:
-            ss << "UndefinedBehavior";
-            break;
+            return "UndefinedBehavior";
         case Type::Portability:
-            ss << "Portability";
-            break;
+            return "Portability";
         case Type::Performance:
-            ss << "Performance";
-            break;
+            return "Performance";
         case Type::Marker:
-            ss << "Marker";
-            break;
+            return "Marker";
         case Type::PushGroup:
-            ss << "PushGroup";
-            break;
+            return "PushGroup";
         case Type::PopGroup:
-            ss << "PopGroup";
-            break;
+            return "PopGroup";
         case Type::Other:
-            ss << "Other";
-            break;
+            return "Other";
         case Type::DontCare:
-            ss << "DontCare";
-            break;
+            return "DontCare";
         default:
-            break;
+            return "";
     }
-    return ss;
 }
-std::ostream& operator<<(std::ostream& ss, Severity s) {
+std::string_view enumToStr(Severity s) {
     switch (s) {
         case Severity::Low:
-            ss << "Low";
-            break;
+            return "Low";
         case Severity::Medium:
-            ss << "Medium";
-            break;
+            return "Medium";
         case Severity::High:
-            ss << "High";
-            break;
+            return "High";
         case Severity::Notification:
-            ss << "Notification";
-            break;
+            return "Notification";
         case Severity::DontCare:
-            ss << "DontCare";
-            break;
+            return "DontCare";
         default:
-            break;
+            return "";
     }
-    return ss;
 }
+
+std::ostream& operator<<(std::ostream& ss, Mode m) { return ss << enumToStr(m); }
+std::ostream& operator<<(std::ostream& ss, BreakLevel b) { return ss << enumToStr(b); }
+std::ostream& operator<<(std::ostream& ss, Source s) { return ss << enumToStr(s); }
+std::ostream& operator<<(std::ostream& ss, Type t) { return ss << enumToStr(t); }
+std::ostream& operator<<(std::ostream& ss, Severity s) { return ss << enumToStr(s); }
 
 }  // namespace debug
 

--- a/modules/opengl/src/geometry/meshgl.cpp
+++ b/modules/opengl/src/geometry/meshgl.cpp
@@ -78,7 +78,7 @@ const BufferGL* MeshGL::getBufferGL(size_t idx) const {
 
 const Mesh::MeshInfo& MeshGL::getMeshInfoForIndexBuffer(size_t idx) const {
     IVW_ASSERT(idx < indexBuffers_.size(),
-              "MeshGL::getMeshInfoForIndexBuffer(): index out of bounds");
+               "MeshGL::getMeshInfoForIndexBuffer(): index out of bounds");
     return indexBuffers_[idx].first;
 }
 const Mesh::MeshInfo& MeshGL::getDefaultMeshInfo() const { return defaultMeshInfo_; }

--- a/modules/opengl/src/geometry/meshgl.cpp
+++ b/modules/opengl/src/geometry/meshgl.cpp
@@ -31,7 +31,7 @@
 #include <inviwo/core/datastructures/geometry/meshrepresentation.h>     // for MeshRepresentation
 #include <inviwo/core/datastructures/representationconverter.h>         // for RepresentationCon...
 #include <inviwo/core/datastructures/representationconverterfactory.h>  // for RepresentationCon...
-#include <inviwo/core/util/assertion.h>                                 // for ivwAssert
+#include <inviwo/core/util/assertion.h>                                 // for IVW_ASSERT
 #include <inviwo/core/util/stdextensions.h>                             // for all_of
 #include <modules/opengl/buffer/buffergl.h>                             // for BufferGL
 #include <modules/opengl/buffer/bufferobjectarray.h>                    // for BufferObjectArray
@@ -72,19 +72,19 @@ size_t MeshGL::size() const { return bufferGLs_.size(); }
 bool MeshGL::empty() const { return bufferGLs_.empty(); }
 
 const BufferGL* MeshGL::getBufferGL(size_t idx) const {
-    ivwAssert(idx < bufferGLs_.size(), "MeshGL::getBufferGL(): index out of bounds");
+    IVW_ASSERT(idx < bufferGLs_.size(), "MeshGL::getBufferGL(): index out of bounds");
     return bufferGLs_[idx];
 }
 
 const Mesh::MeshInfo& MeshGL::getMeshInfoForIndexBuffer(size_t idx) const {
-    ivwAssert(idx < indexBuffers_.size(),
+    IVW_ASSERT(idx < indexBuffers_.size(),
               "MeshGL::getMeshInfoForIndexBuffer(): index out of bounds");
     return indexBuffers_[idx].first;
 }
 const Mesh::MeshInfo& MeshGL::getDefaultMeshInfo() const { return defaultMeshInfo_; }
 
 const BufferGL* MeshGL::getIndexBuffer(size_t idx) const {
-    ivwAssert(idx < indexBuffers_.size(), "MeshGL::getIndexBuffer(): index out of bounds");
+    IVW_ASSERT(idx < indexBuffers_.size(), "MeshGL::getIndexBuffer(): index out of bounds");
     return indexBuffers_[idx].second;
 }
 

--- a/modules/opengl/src/image/layergl.cpp
+++ b/modules/opengl/src/image/layergl.cpp
@@ -112,7 +112,7 @@ bool LayerGL::copyRepresentationsTo(LayerRepresentation* /*targetLayerGL*/) cons
     LayerGL* target = dynamic_cast<LayerGL*>(targetLayerGL);
     if(!target){
         return false;
-        LogError("Target representation missing.");
+        log::error("Target representation missing.");
     }
 
     const Texture2D* sTex = source->getTexture().get();

--- a/modules/opengl/src/image/layerglconverter.cpp
+++ b/modules/opengl/src/image/layerglconverter.cpp
@@ -31,7 +31,7 @@
 
 #include <inviwo/core/datastructures/image/layerram.h>  // for LayerRAM (ptr only), createLayerRAM
 #include <inviwo/core/util/formats.h>                   // for DataFormatBase
-#include <inviwo/core/util/logcentral.h>                // for LogCentral, LogError
+#include <inviwo/core/util/logcentral.h>                // for LogCentral
 #include <modules/opengl/image/layergl.h>               // for LayerGL
 #include <modules/opengl/texture/texture2d.h>           // IWYU pragma: keep
 

--- a/modules/opengl/src/openglcapabilities.cpp
+++ b/modules/opengl/src/openglcapabilities.cpp
@@ -32,7 +32,7 @@
 #include <inviwo/core/properties/buttonproperty.h>  // for ButtonProperty
 #include <inviwo/core/util/exception.h>             // for Exception
 #include <inviwo/core/util/formatconversion.h>      // for formatBytesToString, kilobytes_to_bytes
-#include <inviwo/core/util/logcentral.h>            // for LogCentral, LogWarn, LogError
+#include <inviwo/core/util/logcentral.h>            // for LogCentral
 #include <inviwo/core/util/sourcecontext.h>         // for IVW_CONTEXT_CUSTOM
 #include <inviwo/core/util/staticstring.h>          // for StaticString
 #include <inviwo/core/util/stringconversion.h>      // for stringTo, splitStringView, toString
@@ -303,7 +303,7 @@ size_t OpenGLCapabilities::getCurrentAvailableTextureMem() {
         currentAvailableTexMeminBytes =
             util::kilobytes_to_bytes(static_cast<size_t>(nCurAvailMemoryInKB[0]));
     } catch (const Exception& e) {
-        LogWarn("Failed to fetch current available texture memory: " << e.what());
+        log::warn("Failed to fetch current available texture memory: {}", e.what());
     }
 
     return currentAvailableTexMeminBytes;
@@ -342,7 +342,7 @@ size_t OpenGLCapabilities::getTotalAvailableTextureMem() {
 #endif
         }
     } catch (const Exception& e) {
-        LogWarn("Failed to fetch total available texture memory: " << e.what());
+        log::warn("Failed to fetch total available texture memory: {}", e.what());
     }
 
     return totalAvailableTexMemInBytes;
@@ -386,8 +386,7 @@ void OpenGLCapabilities::retrieveStaticInfo() {
             glRenderStr:  {}
             contextMask:  {}
         )");
-        LogError(
-            fmt::format(err, glVersionStr_, glVersion_, glVendorStr_, glRenderStr_, contextMask));
+        log::error(err, glVersionStr_, glVersion_, glVendorStr_, glRenderStr_, contextMask);
         glProfileStr_ = "core";
     }
     // GLSL

--- a/modules/opengl/src/openglcapabilities.cpp
+++ b/modules/opengl/src/openglcapabilities.cpp
@@ -119,76 +119,78 @@ OpenGLCapabilities::~OpenGLCapabilities() {
 
 void OpenGLCapabilities::printInfo() {
     // OpenGL General Info
-    print("GPU Vendor: ", glVendorStr_);
-    print("GPU Renderer: ", glRenderStr_);
+    log::info("GPU Vendor: {}", glVendorStr_);
+    log::info("GPU Renderer: {}", glRenderStr_);
     if (isTexturesSupported()) {
         auto totalMem = getTotalAvailableTextureMem();
-        print("Dedicated video memory: ",
-              (totalMem > 0 ? util::formatBytesToString(totalMem) : "UNKNOWN"));
+        log::info("Dedicated video memory: {}",
+                  (totalMem > 0 ? util::formatBytesToString(totalMem) : "UNKNOWN"));
     }
-    print("OpenGL Version: ", glVersionStr_);
+    log::info("OpenGL Version: {}", glVersionStr_);
     std::string profile = getProfileString();
     profile[0] = static_cast<char>(toupper(profile[0]));
-    print("OpenGL Profile: ", profile);
+    log::info("OpenGL Profile: {}", profile);
 
     if (isShadersSupported()) {
-        print("GLSL version: ", glslVersionStr_);
+        log::info("GLSL version: {}", glslVersionStr_);
     }
 }
 
 void OpenGLCapabilities::printDetailedInfo() {
     // OpenGL General Info
-    print("GPU Vendor: " + glVendorStr_);
-    print("GPU Renderer: " + glRenderStr_);
-    print("OpenGL Version: " + glVersionStr_);
+    log::info("GPU Vendor: {}", glVendorStr_);
+    log::info("GPU Renderer: {}", glRenderStr_);
+    log::info("OpenGL Version: {}", glVersionStr_);
     std::string profile = getProfileString();
     profile[0] = static_cast<char>(toupper(profile[0]));
-    print("OpenGL Profile: " + profile);
+    log::info("OpenGL Profile: {}", profile);
 
     // GLSL
     if (isShadersSupported()) {
-        print("GLSL version: ", glslVersionStr_);
-        print("Current set global GLSL version: ",
-              getCurrentShaderVersion().getVersionAndProfileAsString());
-        print("Shaders supported: YES");
+        log::info("GLSL version: {}", glslVersionStr_);
+        log::info("Current set global GLSL version: {}",
+                  getCurrentShaderVersion().getVersionAndProfileAsString());
+        log::info("Shaders supported: YES");
     } else if (isShadersSupportedARB()) {
-        print("GLSL version: ", glslVersionStr_);
-        print("Current set global GLSL version: ",
-              getCurrentShaderVersion().getVersionAndProfileAsString());
-        print("Shaders supported: YES(ARB)");
+        log::info("GLSL version: {}", glslVersionStr_);
+        log::info("Current set global GLSL version: {}",
+                  getCurrentShaderVersion().getVersionAndProfileAsString());
+        log::info("Shaders supported: YES(ARB)");
     } else {
-        print("Shaders supported: NO");
+        log::info("Shaders supported: NO");
     }
 
     if (isGeometryShadersSupported()) {
-        print("Geometry shaders supported: YES");
-        print("Geometry shaders: Max output vertices : ", geometryShadersMaxVertices_);
-        print("Geometry shaders: Max output components: ", geometryShadersMaxOutputComponents_);
-        print("Geometry shaders: Max total output components: ",
-              geometryShadersMaxTotalOutputComponents_);
+        log::info("Geometry shaders supported: YES");
+        log::info("Geometry shaders: Max output vertices: {}", geometryShadersMaxVertices_);
+        log::info("Geometry shaders: Max output components: {}",
+                  geometryShadersMaxOutputComponents_);
+        log::info("Geometry shaders: Max total output components: {}",
+                  geometryShadersMaxTotalOutputComponents_);
     } else {
-        print("Geometry shaders supported: NO");
+        log::info("Geometry shaders supported: NO");
     }
 
-    print("Framebuffer objects supported: ", (isFboSupported() ? "YES" : "NO "));
-    // Texturing
-    print("1D/2D textures supported: ", (isTexturesSupported() ? "YES" : "NO "));
-    print("3D textures supported: ", (is3DTexturesSupported() ? "YES" : "NO "));
-    print("Array textures supported: ", (isTextureArraysSupported() ? "YES" : "NO "));
+    log::info("Framebuffer objects supported: {}", (isFboSupported() ? "YES" : "NO "));
 
-    if (isTexturesSupported()) print("Max 1D/2D texture size: ", getMaxTexSize());
-    if (is3DTexturesSupported()) print("Max 3D texture size: ", getMax3DTexSize());
-    if (isTextureArraysSupported()) print("Max array texture size: ", getMaxArrayTexSize());
-    if (isFboSupported()) print("Max color attachments: ", getMaxColorAttachments());
+    // Texturing
+    log::info("1D/2D textures supported: {}", (isTexturesSupported() ? "YES" : "NO "));
+    log::info("3D textures supported: {}", (is3DTexturesSupported() ? "YES" : "NO "));
+    log::info("Array textures supported: {}", (isTextureArraysSupported() ? "YES" : "NO "));
+
+    if (isTexturesSupported()) log::info("Max 1D/2D texture size: {}", getMaxTexSize());
+    if (is3DTexturesSupported()) log::info("Max 3D texture size: {}", getMax3DTexSize());
+    if (isTextureArraysSupported()) log::info("Max array texture size: {}", getMaxArrayTexSize());
+    if (isFboSupported()) log::info("Max color attachments: {}", getMaxColorAttachments());
 
     if (isTexturesSupported()) {
-        print("Max number of texture units: ", getNumTexUnits());
+        log::info("Max number of texture units: {}", getNumTexUnits());
         auto totalMem = getTotalAvailableTextureMem();
-        print("Total available texture memory: ",
-              (totalMem > 0 ? util::formatBytesToString(totalMem) : "UNKNOWN"));
+        log::info("Total available texture memory: {}",
+                  (totalMem > 0 ? util::formatBytesToString(totalMem) : "UNKNOWN"));
         auto curMem = getCurrentAvailableTextureMem();
-        print("Current available texture memory: ",
-              (curMem > 0 ? util::formatBytesToString(curMem) : "UNKNOWN"));
+        log::info("Current available texture memory: {}",
+                  (curMem > 0 ? util::formatBytesToString(curMem) : "UNKNOWN"));
     }
 }
 

--- a/modules/opengl/src/shader/shader.cpp
+++ b/modules/opengl/src/shader/shader.cpp
@@ -404,10 +404,8 @@ GLint Shader::findUniformLocation(std::string_view name) const {
             throw OpenGLException(IVW_CONTEXT, "Unable to set uniform {} in shader id: {}, {}",
                                   name, program_.id, shaderNames());
         } else if (warningLevel_ == UniformWarning::Warn && location == -1) {
-            util::log(IVW_CONTEXT,
-                      fmt::format("Unable to set uniform {} in shader id {}, {}: ", name,
-                                  program_.id, shaderNames()),
-                      LogLevel::Warn, LogAudience::User);
+            log::user::warn("Unable to set uniform {} in shader id {}, {}: ", name, program_.id,
+                            shaderNames());
         }
 
         return location;

--- a/modules/opengl/src/shader/shader.cpp
+++ b/modules/opengl/src/shader/shader.cpp
@@ -404,8 +404,8 @@ GLint Shader::findUniformLocation(std::string_view name) const {
             throw OpenGLException(IVW_CONTEXT, "Unable to set uniform {} in shader id: {}, {}",
                                   name, program_.id, shaderNames());
         } else if (warningLevel_ == UniformWarning::Warn && location == -1) {
-            log::user::warn("Unable to set uniform {} in shader id {}, {}: ", name, program_.id,
-                            shaderNames());
+            log::warn("Unable to set uniform {} in shader id {}, {}: ", name, program_.id,
+                      shaderNames());
         }
 
         return location;

--- a/modules/opengl/src/shader/shadermanager.cpp
+++ b/modules/opengl/src/shader/shadermanager.cpp
@@ -176,7 +176,7 @@ void ShaderManager::rebuildAllShaders() {
     for (auto& shader : shaders_) {
         shader->build();
     }
-    log::user::info("Rebuild of all shaders completed");
+    log::info("Rebuild of all shaders completed");
 }
 
 bool ShaderManager::addShaderSearchPathImpl(const std::filesystem::path& shaderSearchPath) {

--- a/modules/opengl/src/shader/shadermanager.cpp
+++ b/modules/opengl/src/shader/shadermanager.cpp
@@ -33,7 +33,7 @@
 #include <inviwo/core/properties/optionproperty.h>  // for OptionProperty
 #include <inviwo/core/util/dispatcher.h>            // for Dispatcher
 #include <inviwo/core/util/filesystem.h>            // for fileExists, directoryExists
-#include <inviwo/core/util/logcentral.h>            // for LogCentral, LogInfo, LogWarn
+#include <inviwo/core/util/logcentral.h>            // for LogCentral
 #include <inviwo/core/util/stdextensions.h>         // for erase_remove, find_if
 #include <inviwo/core/util/stringconversion.h>      // for replaceInString
 #include <inviwo/core/util/vectoroperations.h>      // for getTypeFromVector
@@ -100,7 +100,7 @@ const std::vector<std::filesystem::path>& ShaderManager::getShaderSearchPaths() 
 
 void ShaderManager::addShaderSearchPath(const std::filesystem::path& shaderSearchPath) {
     if (!addShaderSearchPathImpl(shaderSearchPath)) {
-        LogWarn("Failed to add shader search path: " << shaderSearchPath);
+        log::warn("Failed to add shader search path: {}", shaderSearchPath);
     }
 }
 
@@ -176,7 +176,7 @@ void ShaderManager::rebuildAllShaders() {
     for (auto& shader : shaders_) {
         shader->build();
     }
-    LogInfo("Rebuild of all shaders completed");
+    log::user::info("Rebuild of all shaders completed");
 }
 
 bool ShaderManager::addShaderSearchPathImpl(const std::filesystem::path& shaderSearchPath) {

--- a/modules/opengl/src/shader/shaderobject.cpp
+++ b/modules/opengl/src/shader/shaderobject.cpp
@@ -611,7 +611,7 @@ void ShaderObject::compile() {
 
     const auto log = utilgl::getShaderInfoLog(id_);
     if (!log.empty()) {
-        log::user::info("{} {}", resource_->key(), resolveLog(log));
+        log::info("{} {}", resource_->key(), resolveLog(log));
     }
 }
 

--- a/modules/opengl/src/shader/shaderobject.cpp
+++ b/modules/opengl/src/shader/shaderobject.cpp
@@ -138,17 +138,15 @@ struct Psm {
             auto pathBegin = std::find(c.curr, c.end, '"');
             if (pathBegin == c.end) {
                 throw OpenGLException{
-                    fmt::format("Invalid include found at {}({})", s.key, s.lines + 1),
-                    SourceContext(std::string{s.key}, std::string{s.key}, "",
-                                  static_cast<int>(s.lines + 1))};
+                    SourceContext{"ShaderObject"_sl, s.key, "", static_cast<uint32_t>(s.lines + 1)},
+                    "Invalid include found at {}({})", s.key, s.lines + 1};
             }
 
             auto pathEnd = std::find(pathBegin + 1, c.end, '"');
             if (pathEnd == c.end) {
                 throw OpenGLException{
-                    fmt::format("Invalid include found at {}({})", s.key, s.lines + 1),
-                    SourceContext(std::string{s.key}, std::string{s.key}, "",
-                                  static_cast<int>(s.lines + 1))};
+                    SourceContext{"ShaderObject"_sl, s.key, "", static_cast<uint32_t>(s.lines + 1)},
+                    "Invalid include found at {}({})", s.key, s.lines + 1};
             }
 
             const auto path =
@@ -164,8 +162,8 @@ struct Psm {
                 }
             } catch (const OpenGLException& e) {
                 throw OpenGLException(e.getMessage(),
-                                      SourceContext(std::string{s.key}, std::string{s.key}, "",
-                                                    static_cast<int>(s.lines + 1)));
+                                      SourceContext{"ShaderObject"_sl, s.key, "",
+                                                    static_cast<uint32_t>(s.lines + 1)});
             }
         };
 

--- a/modules/opengl/src/shader/shaderobject.cpp
+++ b/modules/opengl/src/shader/shaderobject.cpp
@@ -303,8 +303,8 @@ ShaderObject::ShaderObject(ShaderType shaderType, std::shared_ptr<const ShaderRe
     // Help developer to spot errors
     auto resourceType = ShaderType::typeFromString(resource_->key());
     if (resourceType != shaderType_) {
-        LogWarn("File extension does not match shader type: "
-                << resource_->key() << "\n    expected extension: " << shaderType_.extension());
+        log::warn("File extension does not match shader type: {}\n    expected extension: {}",
+                  resource_->key(), shaderType_.extension());
     }
 
     if (shaderType_ == ShaderType::Fragment) {
@@ -611,8 +611,7 @@ void ShaderObject::compile() {
 
     const auto log = utilgl::getShaderInfoLog(id_);
     if (!log.empty()) {
-        util::log(IVW_CONTEXT, resource_->key() + " " + resolveLog(log), LogLevel::Info,
-                  LogAudience::User);
+        log::user::info("{} {}", resource_->key(), resolveLog(log));
     }
 }
 

--- a/modules/opengl/src/texture/textureunit.cpp
+++ b/modules/opengl/src/texture/textureunit.cpp
@@ -29,7 +29,7 @@
 
 #include <modules/opengl/texture/textureunit.h>
 
-#include <inviwo/core/util/assertion.h>      // for ivwAssert
+#include <inviwo/core/util/assertion.h>      // for IVW_ASSERT
 #include <inviwo/core/util/sourcecontext.h>  // for IVW_CONTEXT
 #include <modules/opengl/openglexception.h>  // for OpenGLException
 
@@ -42,7 +42,7 @@ namespace inviwo {
 std::vector<bool> TextureUnit::textureUnits_{};
 
 TextureUnit::TextureUnit() : unitEnum_(0), unitNumber_(0) {
-    ivwAssert(!textureUnits_.empty(), "Texture unit handler not initialized.");
+    IVW_ASSERT(!textureUnits_.empty(), "Texture unit handler not initialized.");
 
     // check which texture unit is available
     for (size_t i = 1; i < textureUnits_.size(); i++) {

--- a/modules/opengl/src/texture/textureutils.cpp
+++ b/modules/opengl/src/texture/textureutils.cpp
@@ -122,9 +122,8 @@ void activateTargetAndCopySource(Image& targetImage, const ImageInport& sourceIn
     if (auto inImage = sourceInport.getData()) {
         inImage->getRepresentation<ImageGL>()->copyRepresentationsTo(outImageGL);
     } else {
-        LogWarnCustom("TextureUtils", "Trying to copy empty image inport: \""
-                                          << sourceInport.getIdentifier() << "\" in processor: \""
-                                          << sourceInport.getProcessor()->getIdentifier() << "\"");
+        log::warn("Trying to copy empty image inport: \"{}\" in processor: \"{}\"",
+                  sourceInport.getIdentifier(), sourceInport.getProcessor()->getIdentifier());
     }
     outImageGL->activateBuffer(type);
 }
@@ -539,7 +538,7 @@ void bindTexture(const Volume& volume, const TextureUnit& texUnit) {
     if (const auto* volumeGL = volume.getRepresentation<VolumeGL>()) {
         volumeGL->bindTexture(texUnit.getEnum());
     } else {
-        LogErrorCustom("TextureUtils", "Could not get a GL representation from volume");
+        log::error("Could not get a GL representation from volume");
     }
 }
 

--- a/modules/opengl/src/texture/textureutils.cpp
+++ b/modules/opengl/src/texture/textureutils.cpp
@@ -122,7 +122,7 @@ void activateTargetAndCopySource(Image& targetImage, const ImageInport& sourceIn
     if (auto inImage = sourceInport.getData()) {
         inImage->getRepresentation<ImageGL>()->copyRepresentationsTo(outImageGL);
     } else {
-        log::warn("Trying to copy empty image inport: \"{}\" in processor: \"{}\"",
+        log::warn(R"(Trying to copy empty image inport: "{}" in processor: "{}")",
                   sourceInport.getIdentifier(), sourceInport.getProcessor()->getIdentifier());
     }
     outImageGL->activateBuffer(type);

--- a/modules/opengl/src/volume/volumeglconverter.cpp
+++ b/modules/opengl/src/volume/volumeglconverter.cpp
@@ -31,7 +31,7 @@
 
 #include <inviwo/core/datastructures/volume/volumeram.h>  // for VolumeRAM (ptr only), createVol...
 #include <inviwo/core/util/formats.h>                     // for DataFormatBase
-#include <inviwo/core/util/logcentral.h>                  // for LogCentral, LogError
+#include <inviwo/core/util/logcentral.h>                  // for LogCentral
 #include <modules/opengl/volume/volumegl.h>               // for VolumeGL
 #include <modules/opengl/texture/texture3d.h>             // IWYU pragma: keep
 

--- a/modules/openglqt/src/openglqtmodule.cpp
+++ b/modules/openglqt/src/openglqtmodule.cpp
@@ -153,7 +153,7 @@ void OpenGLQtModule::onProcessorNetworkEvaluationEnd() {
         case GL_TIMEOUT_EXPIRED:  // Handled above
             break;
         case GL_WAIT_FAILED:
-            LogError("Error syncing with opengl 'GL_WAIT_FAILED'");
+            log::error("Error syncing with opengl 'GL_WAIT_FAILED'");
             break;
         case GL_CONDITION_SATISFIED:  // Queue done.
             break;

--- a/modules/openglqt/src/processors/canvaswithpropertiesprocessorwidgetqt.cpp
+++ b/modules/openglqt/src/processors/canvaswithpropertiesprocessorwidgetqt.cpp
@@ -37,7 +37,7 @@
 #include <inviwo/core/processors/canvasprocessorwidget.h>  // for CanvasProcessorWidget
 #include <inviwo/core/processors/processor.h>              // for Processor
 #include <inviwo/core/util/glmvec.h>                       // for ivec2, size2_t
-#include <inviwo/core/util/logcentral.h>                   // for LogCentral, LogWarn
+#include <inviwo/core/util/logcentral.h>                   // for LogCentral
 #include <inviwo/core/util/rendercontext.h>                // for RenderContext
 #include <inviwo/core/util/stringconversion.h>             // for forEachStringPart, splitByFirst
 #include <modules/openglqt/canvasqopenglwidget.h>          // for CanvasQOpenGLWidget
@@ -176,10 +176,10 @@ void CanvasWithPropertiesProcessorWidgetQt::setProperties(std::string_view paths
                     frame_->add(property);
                     addedPaths_.emplace_back(path);
                 } else {
-                    LogWarn("Property: " << prop << " not found in processor " << proc);
+                    log::warn("Property: {} not found in processor ", prop, proc);
                 }
             } else {
-                LogWarn("Processor: " << proc << " not found");
+                log::warn("Processor: {} not found", proc);
             }
         });
     }

--- a/modules/openglqt/src/shaderwidget.cpp
+++ b/modules/openglqt/src/shaderwidget.cpp
@@ -224,7 +224,7 @@ void ShaderWidget::save() {
         resource->setSource(utilqt::fromQString(shadercode_->toPlainText()));
         shadercode_->document()->setModified(false);
     } else {
-        log::user::warn(
+        log::warn(
             "Could not save. The ShaderResource \"{}\" was not found in the ShaderManager. It "
             "needs to be registered with the ShaderManager for saving to work.",
             obj_->getResource()->key());

--- a/modules/openglqt/src/shaderwidget.cpp
+++ b/modules/openglqt/src/shaderwidget.cpp
@@ -32,7 +32,7 @@
 #include <inviwo/core/common/inviwoapplication.h>  // for InviwoApplication
 #include <inviwo/core/util/colorconversion.h>      // for hsv2rgb, rgb2hsv
 #include <inviwo/core/util/glmvec.h>               // for vec4, vec3
-#include <inviwo/core/util/logcentral.h>           // for LogCentral, LogWarn
+#include <inviwo/core/util/logcentral.h>           // for LogCentral
 #include <inviwo/core/util/raiiutils.h>            // for KeepTrueWhileInScope
 #include <modules/opengl/shader/shadermanager.h>   // for ShaderManager
 #include <modules/opengl/shader/shaderobject.h>    // for ShaderObject
@@ -224,10 +224,10 @@ void ShaderWidget::save() {
         resource->setSource(utilqt::fromQString(shadercode_->toPlainText()));
         shadercode_->document()->setModified(false);
     } else {
-        LogWarn(fmt::format(
+        log::user::warn(
             "Could not save. The ShaderResource \"{}\" was not found in the ShaderManager. It "
             "needs to be registered with the ShaderManager for saving to work.",
-            obj_->getResource()->key()));
+            obj_->getResource()->key());
     }
 }
 

--- a/modules/png/src/pngmodule.cpp
+++ b/modules/png/src/pngmodule.cpp
@@ -32,7 +32,7 @@
 #include <inviwo/core/common/inviwomodule.h>  // for InviwoModule
 #include <inviwo/core/io/datareader.h>        // for DataReader
 #include <inviwo/core/io/datawriter.h>        // for DataWriter
-#include <inviwo/core/util/logcentral.h>      // for LogCentral, LogInfo
+#include <inviwo/core/util/logcentral.h>      // for LogCentral
 #include <inviwo/png/pngreader.h>             // for PNGLayerReader
 #include <inviwo/png/pngutils.h>              // for getLibPNGVesrion
 #include <inviwo/png/pngwriter.h>             // for PNGLayerWriter

--- a/modules/png/src/pngmodule.cpp
+++ b/modules/png/src/pngmodule.cpp
@@ -45,7 +45,7 @@ class InviwoApplication;
 
 pngModule::pngModule(InviwoApplication* app) : InviwoModule(app, "png") {
 
-    log::user::info("Using LibPNG Version {}", pngutil::getLibPNGVesrion());
+    log::info("Using LibPNG Version {}", pngutil::getLibPNGVesrion());
 
     registerDataReader(std::make_unique<PNGLayerReader>());
     registerDataWriter(std::make_unique<PNGLayerWriter>());

--- a/modules/png/src/pngmodule.cpp
+++ b/modules/png/src/pngmodule.cpp
@@ -45,7 +45,7 @@ class InviwoApplication;
 
 pngModule::pngModule(InviwoApplication* app) : InviwoModule(app, "png") {
 
-    LogInfo("Using LibPNG Version " << pngutil::getLibPNGVesrion());
+    log::user::info("Using LibPNG Version {}", pngutil::getLibPNGVesrion());
 
     registerDataReader(std::make_unique<PNGLayerReader>());
     registerDataWriter(std::make_unique<PNGLayerWriter>());

--- a/modules/png/src/pngreader.cpp
+++ b/modules/png/src/pngreader.cpp
@@ -95,7 +95,7 @@ std::shared_ptr<inviwo::Layer> PNGLayerReader::readData(FILE* fp, std::string_vi
             throw DataReaderException(IVW_CONTEXT_CUSTOM("PNGLayerReader::readData"),
                                       "Error reading PNG: {}", message);
         },
-        [](png_structp, png_const_charp message) { log::user::report(LogLevel::Warn, message); });
+        [](png_structp, png_const_charp message) { log::report(LogLevel::Warn, message); });
 
     auto info_ptr = png_create_info_struct(png_ptr);
     if (!info_ptr) {

--- a/modules/png/src/pngreader.cpp
+++ b/modules/png/src/pngreader.cpp
@@ -95,7 +95,7 @@ std::shared_ptr<inviwo::Layer> PNGLayerReader::readData(FILE* fp, std::string_vi
             throw DataReaderException(IVW_CONTEXT_CUSTOM("PNGLayerReader::readData"),
                                       "Error reading PNG: {}", message);
         },
-        [](png_structp, png_const_charp message) { LogWarnCustom("PNGReader", message); });
+        [](png_structp, png_const_charp message) { log::user::report(LogLevel::Warn, message); });
 
     auto info_ptr = png_create_info_struct(png_ptr);
     if (!info_ptr) {

--- a/modules/png/src/pngwriter.cpp
+++ b/modules/png/src/pngwriter.cpp
@@ -120,7 +120,7 @@ void write(const LayerRAMPrecision<T>* ram, png_voidp ioPtr, png_rw_ptr writeFun
             throw DataWriterException(IVW_CONTEXT_CUSTOM("PNGLayerWriter"), "Error writing PNG: {}",
                                       message);
         },
-        [](png_structp, png_const_charp message) { LogWarnCustom("PNGWriter", message); });
+        [](png_structp, png_const_charp message) { log::user::report(LogLevel::Warn, message); });
 
     auto info_ptr = png_create_info_struct(png_ptr);
     if (!info_ptr) {

--- a/modules/png/src/pngwriter.cpp
+++ b/modules/png/src/pngwriter.cpp
@@ -120,7 +120,7 @@ void write(const LayerRAMPrecision<T>* ram, png_voidp ioPtr, png_rw_ptr writeFun
             throw DataWriterException(IVW_CONTEXT_CUSTOM("PNGLayerWriter"), "Error writing PNG: {}",
                                       message);
         },
-        [](png_structp, png_const_charp message) { log::user::report(LogLevel::Warn, message); });
+        [](png_structp, png_const_charp message) { log::report(LogLevel::Warn, message); });
 
     auto info_ptr = png_create_info_struct(png_ptr);
     if (!info_ptr) {

--- a/modules/postprocessing/src/processors/depthoffield.cpp
+++ b/modules/postprocessing/src/processors/depthoffield.cpp
@@ -61,7 +61,7 @@
 #include <inviwo/core/properties/ordinalproperty.h>                     // for IntSizeTProperty
 #include <inviwo/core/util/formats.h>                                   // for DataFormat
 #include <inviwo/core/util/glmvec.h>                                    // for vec2, size2_t, vec3
-#include <inviwo/core/util/logcentral.h>                                // for LogCentral, LogWarn
+#include <inviwo/core/util/logcentral.h>                                // for LogCentral
 #include <modules/base/algorithm/randomutils.h>                         // for haltonSequence
 #include <modules/opengl/image/imagegl.h>                               // for ImageGL
 #include <modules/opengl/inviwoopengl.h>                                // for GLuint, GL_FALSE
@@ -151,8 +151,9 @@ DepthOfField::DepthOfField()
     approximate_.onChange([this]() {
         if (approximate_ && !useComputeShaders_) {
             // Using CPU version of approximative algorithm.
-            LogWarn("Compute shaders are not supported. Approximative depth of field "
-                    << "post-processing may be slow.");
+            log::user::warn(
+                "Compute shaders are not supported. Approximative depth of field "
+                "post-processing may be slow.");
         }
     });
 
@@ -244,7 +245,7 @@ void DepthOfField::setupRecursion(size2_t dim, size_t maxEvalCount,
                                   std::shared_ptr<const Image> img) {
     ogCamera_.reset(camera_.get().clone());
     if (camera_.get().getClassIdentifier() != PerspectiveCamera::classIdentifier) {
-        LogWarn("Intended for use with Perspective Camera. Unexpected behavior may follow.");
+        log::warn("Intended for use with Perspective Camera. Unexpected behavior may follow.");
     }
 
     if (approximate_) {

--- a/modules/postprocessing/src/processors/depthoffield.cpp
+++ b/modules/postprocessing/src/processors/depthoffield.cpp
@@ -151,7 +151,7 @@ DepthOfField::DepthOfField()
     approximate_.onChange([this]() {
         if (approximate_ && !useComputeShaders_) {
             // Using CPU version of approximative algorithm.
-            log::user::warn(
+            log::warn(
                 "Compute shaders are not supported. Approximative depth of field "
                 "post-processing may be slow.");
         }

--- a/modules/pvm/src/mpvmvolumereader.cpp
+++ b/modules/pvm/src/mpvmvolumereader.cpp
@@ -99,7 +99,7 @@ std::shared_ptr<Volume> MPVMVolumeReader::readData(const std::filesystem::path& 
         if (newVol) {
             volumes.push_back(newVol);
         } else {
-            log::user::warn("Could not load {}", fileDirectory / files[i]);
+            log::warn("Could not load {}", fileDirectory / files[i]);
         }
     }
 
@@ -117,7 +117,7 @@ std::shared_ptr<Volume> MPVMVolumeReader::readData(const std::filesystem::path& 
     size3_t mdim = volumes[0]->getDimensions();
     for (size_t i = 1; i < volumes.size(); i++) {
         if (format != volumes[i]->getDataFormat() || mdim != volumes[i]->getDimensions()) {
-            log::user::warn(
+            log::warn(
                 "PVM volumes did not have the same format or dimensions, using first volume.");
             printPVMMeta(*volumes[0], fileDirectory / files[0]);
             return volumes[0];
@@ -178,7 +178,7 @@ void MPVMVolumeReader::printPVMMeta(const Volume& volume,
     size3_t dim = volume.getDimensions();
     size_t bytes = dim.x * dim.y * dim.z * (volume.getDataFormat()->getSizeInBytes());
     std::string size = util::formatBytesToString(bytes);
-    log::user::info("Loaded volume: '{}' size: {}", fileName, size);
+    log::info("Loaded volume: '{}' size: {}", fileName, size);
     printMetaInfo(volume, "description");
     printMetaInfo(volume, "courtesy");
     printMetaInfo(volume, "parameter");
@@ -190,7 +190,7 @@ void MPVMVolumeReader::printMetaInfo(const MetaDataOwner& metaDataOwner,
     if (auto metaData = metaDataOwner.getMetaData<StringMetaData>(key)) {
         std::string metaStr = metaData->get();
         replaceInString(metaStr, "\n", ", ");
-        log::user::info("{}: {}", key, metaStr);
+        log::info("{}: {}", key, metaStr);
     }
 }
 

--- a/modules/pvm/src/mpvmvolumereader.cpp
+++ b/modules/pvm/src/mpvmvolumereader.cpp
@@ -42,7 +42,7 @@
 #include <inviwo/core/util/formatconversion.h>                          // for formatBytesToString
 #include <inviwo/core/util/formats.h>                                   // for DataFormatBase
 #include <inviwo/core/util/glmvec.h>                                    // for size3_t
-#include <inviwo/core/util/logcentral.h>                                // for LogCentral, LogInfo
+#include <inviwo/core/util/logcentral.h>                                // for LogCentral
 #include <inviwo/core/util/sourcecontext.h>                             // for IVW_CONTEXT
 #include <inviwo/core/util/stringconversion.h>                          // for replaceInString
 #include <modules/pvm/pvmvolumereader.h>                                // for PVMVolumeReader
@@ -99,7 +99,7 @@ std::shared_ptr<Volume> MPVMVolumeReader::readData(const std::filesystem::path& 
         if (newVol) {
             volumes.push_back(newVol);
         } else {
-            LogWarn("Could not load " << fileDirectory << "/" << files[i]);
+            log::user::warn("Could not load {}", fileDirectory / files[i]);
         }
     }
 
@@ -117,7 +117,8 @@ std::shared_ptr<Volume> MPVMVolumeReader::readData(const std::filesystem::path& 
     size3_t mdim = volumes[0]->getDimensions();
     for (size_t i = 1; i < volumes.size(); i++) {
         if (format != volumes[i]->getDataFormat() || mdim != volumes[i]->getDimensions()) {
-            LogWarn("PVM volumes did not have the same format or dimensions, using first volume.");
+            log::user::warn(
+                "PVM volumes did not have the same format or dimensions, using first volume.");
             printPVMMeta(*volumes[0], fileDirectory / files[0]);
             return volumes[0];
         }
@@ -177,7 +178,7 @@ void MPVMVolumeReader::printPVMMeta(const Volume& volume,
     size3_t dim = volume.getDimensions();
     size_t bytes = dim.x * dim.y * dim.z * (volume.getDataFormat()->getSizeInBytes());
     std::string size = util::formatBytesToString(bytes);
-    LogInfo("Loaded volume: " << fileName << " size: " << size);
+    log::user::info("Loaded volume: '{}' size: {}", fileName, size);
     printMetaInfo(volume, "description");
     printMetaInfo(volume, "courtesy");
     printMetaInfo(volume, "parameter");
@@ -189,7 +190,7 @@ void MPVMVolumeReader::printMetaInfo(const MetaDataOwner& metaDataOwner,
     if (auto metaData = metaDataOwner.getMetaData<StringMetaData>(key)) {
         std::string metaStr = metaData->get();
         replaceInString(metaStr, "\n", ", ");
-        LogInfo(key << ": " << metaStr);
+        log::user::info("{}: {}", key, metaStr);
     }
 }
 

--- a/modules/pvm/src/pvmvolumereader.cpp
+++ b/modules/pvm/src/pvmvolumereader.cpp
@@ -79,7 +79,7 @@ std::shared_ptr<Volume> PVMVolumeReader::readData(const std::filesystem::path& f
     size3_t dim = volume->getDimensions();
     size_t bytes = dim.x * dim.y * dim.z * (volume->getDataFormat()->getSizeInBytes());
     std::string size = util::formatBytesToString(bytes);
-    log::user::info("Loaded volume: {} size: {}", filePath, size);
+    log::info("Loaded volume: {} size: {}", filePath, size);
     printMetaInfo(*volume, "description");
     printMetaInfo(*volume, "courtesy");
     printMetaInfo(*volume, "parameter");
@@ -177,7 +177,7 @@ void PVMVolumeReader::printMetaInfo(const MetaDataOwner& metaDataOwner,
     if (auto metaData = metaDataOwner.getMetaData<StringMetaData>(key)) {
         std::string metaStr = metaData->get();
         replaceInString(metaStr, "\n", ", ");
-        log::user::info("{}: {}", key, metaStr);
+        log::info("{}: {}", key, metaStr);
     }
 }
 

--- a/modules/pvm/src/pvmvolumereader.cpp
+++ b/modules/pvm/src/pvmvolumereader.cpp
@@ -40,7 +40,7 @@
 #include <inviwo/core/util/formats.h>                     // for DataFormat, DataFormatBase, Dat...
 #include <inviwo/core/util/glmmat.h>                      // for mat3
 #include <inviwo/core/util/glmvec.h>                      // for uvec3, vec3, size3_t
-#include <inviwo/core/util/logcentral.h>                  // for LogCentral, LogInfo
+#include <inviwo/core/util/logcentral.h>                  // for LogCentral
 #include <inviwo/core/util/raiiutils.h>                   // for OnScopeExit, OnScopeExit::ExitA...
 #include <inviwo/core/util/safecstr.h>                    // for SafeCStr
 #include <inviwo/core/util/sourcecontext.h>               // for IVW_CONTEXT_CUSTOM
@@ -79,7 +79,7 @@ std::shared_ptr<Volume> PVMVolumeReader::readData(const std::filesystem::path& f
     size3_t dim = volume->getDimensions();
     size_t bytes = dim.x * dim.y * dim.z * (volume->getDataFormat()->getSizeInBytes());
     std::string size = util::formatBytesToString(bytes);
-    LogInfo("Loaded volume: " << filePath << " size: " << size);
+    log::user::info("Loaded volume: {} size: {}", filePath, size);
     printMetaInfo(*volume, "description");
     printMetaInfo(*volume, "courtesy");
     printMetaInfo(*volume, "parameter");
@@ -177,7 +177,7 @@ void PVMVolumeReader::printMetaInfo(const MetaDataOwner& metaDataOwner,
     if (auto metaData = metaDataOwner.getMetaData<StringMetaData>(key)) {
         std::string metaStr = metaData->get();
         replaceInString(metaStr, "\n", ", ");
-        LogInfo(key << ": " << metaStr);
+        log::user::info("{}: {}", key, metaStr);
     }
 }
 

--- a/modules/python3/bindings/src/pyglmtypes.cpp
+++ b/modules/python3/bindings/src/pyglmtypes.cpp
@@ -249,7 +249,7 @@ void vecx(py::module& m, const std::string& prefix, const std::string& name,
             PYBIND11_NUMPY_DTYPE(Vec, x, y, z, w);
         }
     } catch (const std::exception& e) {
-        util::log(IVW_CONTEXT_CUSTOM("pyglmtypes"), e.what());
+        log::user::exception(e);
     }
 
     switch (Dim) {

--- a/modules/python3/bindings/src/pyglmtypes.cpp
+++ b/modules/python3/bindings/src/pyglmtypes.cpp
@@ -249,39 +249,27 @@ void vecx(py::module& m, const std::string& prefix, const std::string& name,
             PYBIND11_NUMPY_DTYPE(Vec, x, y, z, w);
         }
     } catch (const std::exception& e) {
-        log::user::exception(e);
+        log::exception(e);
     }
 
     switch (Dim) {
         case 4:
-            pyv.def_property(
-                "w", [](Vec& b) { return b[3]; }, [](Vec& b, T t) { b[3] = t; });
-            pyv.def_property(
-                "a", [](Vec& b) { return b[3]; }, [](Vec& b, T t) { b[3] = t; });
-            pyv.def_property(
-                "q", [](Vec& b) { return b[3]; }, [](Vec& b, T t) { b[3] = t; });
+            pyv.def_property("w", [](Vec& b) { return b[3]; }, [](Vec& b, T t) { b[3] = t; });
+            pyv.def_property("a", [](Vec& b) { return b[3]; }, [](Vec& b, T t) { b[3] = t; });
+            pyv.def_property("q", [](Vec& b) { return b[3]; }, [](Vec& b, T t) { b[3] = t; });
             [[fallthrough]];
         case 3:
-            pyv.def_property(
-                "z", [](Vec& b) { return b[2]; }, [](Vec& b, T t) { b[2] = t; });
-            pyv.def_property(
-                "b", [](Vec& b) { return b[2]; }, [](Vec& b, T t) { b[2] = t; });
-            pyv.def_property(
-                "p", [](Vec& b) { return b[2]; }, [](Vec& b, T t) { b[2] = t; });
+            pyv.def_property("z", [](Vec& b) { return b[2]; }, [](Vec& b, T t) { b[2] = t; });
+            pyv.def_property("b", [](Vec& b) { return b[2]; }, [](Vec& b, T t) { b[2] = t; });
+            pyv.def_property("p", [](Vec& b) { return b[2]; }, [](Vec& b, T t) { b[2] = t; });
             [[fallthrough]];
         case 2:
-            pyv.def_property(
-                "y", [](Vec& b) { return b[1]; }, [](Vec& b, T t) { b[1] = t; });
-            pyv.def_property(
-                "g", [](Vec& b) { return b[1]; }, [](Vec& b, T t) { b[1] = t; });
-            pyv.def_property(
-                "t", [](Vec& b) { return b[1]; }, [](Vec& b, T t) { b[1] = t; });
-            pyv.def_property(
-                "x", [](Vec& b) { return b[0]; }, [](Vec& b, T t) { b[0] = t; });
-            pyv.def_property(
-                "r", [](Vec& b) { return b[0]; }, [](Vec& b, T t) { b[0] = t; });
-            pyv.def_property(
-                "s", [](Vec& b) { return b[0]; }, [](Vec& b, T t) { b[0] = t; });
+            pyv.def_property("y", [](Vec& b) { return b[1]; }, [](Vec& b, T t) { b[1] = t; });
+            pyv.def_property("g", [](Vec& b) { return b[1]; }, [](Vec& b, T t) { b[1] = t; });
+            pyv.def_property("t", [](Vec& b) { return b[1]; }, [](Vec& b, T t) { b[1] = t; });
+            pyv.def_property("x", [](Vec& b) { return b[0]; }, [](Vec& b, T t) { b[0] = t; });
+            pyv.def_property("r", [](Vec& b) { return b[0]; }, [](Vec& b, T t) { b[0] = t; });
+            pyv.def_property("s", [](Vec& b) { return b[0]; }, [](Vec& b, T t) { b[0] = t; });
             [[fallthrough]];
         default:
             break;

--- a/modules/python3/bindings/src/pylogging.cpp
+++ b/modules/python3/bindings/src/pylogging.cpp
@@ -122,13 +122,13 @@ void exposeLogging(pybind11::module& m) {
         py::arg("function") = "", py::arg("line") = 0, py::arg("msg") = "");
 
     m.def("logInfo", [](const std::string& msg) {
-        log::user::report(LogLevel::Info, SourceContext{"inviwopy"_sl}, msg);
+        log::report(LogLevel::Info, SourceContext{"inviwopy"_sl}, msg);
     });
     m.def("logWarn", [](const std::string& msg) {
-        log::user::report(LogLevel::Warn, SourceContext{"inviwopy"_sl}, msg);
+        log::report(LogLevel::Warn, SourceContext{"inviwopy"_sl}, msg);
     });
     m.def("logError", [](const std::string& msg) {
-        log::user::report(LogLevel::Error, SourceContext{"inviwopy"_sl}, msg);
+        log::report(LogLevel::Error, SourceContext{"inviwopy"_sl}, msg);
     });
 }
 

--- a/modules/python3/bindings/src/pylogging.cpp
+++ b/modules/python3/bindings/src/pylogging.cpp
@@ -121,9 +121,15 @@ void exposeLogging(pybind11::module& m) {
         py::arg("audience") = LogAudience::Developer, py::arg("file") = "",
         py::arg("function") = "", py::arg("line") = 0, py::arg("msg") = "");
 
-    m.def("logInfo", [](const std::string& msg) { LogInfoCustom("inviwopy", msg); });
-    m.def("logWarn", [](const std::string& msg) { LogWarnCustom("inviwopy", msg); });
-    m.def("logError", [](const std::string& msg) { LogErrorCustom("inviwopy", msg); });
+    m.def("logInfo", [](const std::string& msg) {
+        log::user::report(LogLevel::Info, SourceContext{"inviwopy"_sl}, msg);
+    });
+    m.def("logWarn", [](const std::string& msg) {
+        log::user::report(LogLevel::Warn, SourceContext{"inviwopy"_sl}, msg);
+    });
+    m.def("logError", [](const std::string& msg) {
+        log::user::report(LogLevel::Error, SourceContext{"inviwopy"_sl}, msg);
+    });
 }
 
 }  // namespace inviwo

--- a/modules/python3/bindings/src/pylogging.cpp
+++ b/modules/python3/bindings/src/pylogging.cpp
@@ -67,11 +67,7 @@ void exposeLogging(pybind11::module& m) {
         .value("Warn", MessageBreakLevel::Warn)
         .value("Info", MessageBreakLevel::Info);
 
-    py::class_<Logger>(m, "Logger")
-        .def("log", &Logger::log)
-        .def("logProcessor", &Logger::logProcessor)
-        .def("logNetwork", &Logger::logNetwork)
-        .def("logAssertion", &Logger::logAssertion);
+    py::class_<Logger>(m, "Logger").def("log", &Logger::log);
 
     py::class_<LogCentral, Logger>(m, "LogCentral")
         .def(py::init([]() {
@@ -90,15 +86,6 @@ void exposeLogging(pybind11::module& m) {
         .def_static("get", &LogCentral::getPtr, py::return_value_policy::reference)
         .def("log", &LogCentral::log, py::arg("source") = "", py::arg("level") = LogLevel::Info,
              py::arg("audience") = LogAudience::Developer, py::arg("file") = "",
-             py::arg("function") = "", py::arg("line") = 0, py::arg("msg") = "")
-        .def("logProcessor", &LogCentral::logProcessor, py::arg("processor"),
-             py::arg("level") = LogLevel::Info, py::arg("audience") = LogAudience::Developer,
-             py::arg("msg") = "", py::arg("file") = "", py::arg("function") = "",
-             py::arg("line") = 0)
-        .def("logNetwork", &LogCentral::logNetwork, py::arg("level") = LogLevel::Info,
-             py::arg("audience") = LogAudience::Developer, py::arg("msg") = "",
-             py::arg("file") = "", py::arg("function") = "", py::arg("line") = 0)
-        .def("logAssertion", &LogCentral::logAssertion, py::arg("file") = "",
              py::arg("function") = "", py::arg("line") = 0, py::arg("msg") = "");
 
     py::class_<ConsoleLogger, Logger>(m, "ConsoleLogger")

--- a/modules/python3/bindings/src/pymesh.cpp
+++ b/modules/python3/bindings/src/pymesh.cpp
@@ -126,8 +126,7 @@ void exposeMesh(pybind11::module& m) {
                               std::shared_ptr<IndexBuffer> ind) { m->addIndices(info, ind); })
         .def("addIndicies",
              [](Mesh* m, Mesh::MeshInfo info, std::shared_ptr<IndexBuffer> ind) {
-                 LogInfoCustom("inviwopy.data.Mesh",
-                               "Mesh::addIndicies is deprecated, use addIndices");
+                 log::user::info("Mesh::addIndicies is deprecated, use addIndices");
                  m->addIndices(info, ind);
              })
         .def("removeIndexBuffer", [](Mesh* m, size_t idx) { m->removeIndexBuffer(idx); })

--- a/modules/python3/bindings/src/pymesh.cpp
+++ b/modules/python3/bindings/src/pymesh.cpp
@@ -127,7 +127,7 @@ void exposeMesh(pybind11::module& m) {
         .def("addIndicies",
              [](Mesh* m, Mesh::MeshInfo info, std::shared_ptr<IndexBuffer> ind) {
                  log::info("Mesh::addIndicies is deprecated, use addIndices");
-                 m->addIndices(info, ind);
+                 m->addIndices(info, std::move(ind));
              })
         .def("removeIndexBuffer", [](Mesh* m, size_t idx) { m->removeIndexBuffer(idx); })
 

--- a/modules/python3/bindings/src/pymesh.cpp
+++ b/modules/python3/bindings/src/pymesh.cpp
@@ -126,7 +126,7 @@ void exposeMesh(pybind11::module& m) {
                               std::shared_ptr<IndexBuffer> ind) { m->addIndices(info, ind); })
         .def("addIndicies",
              [](Mesh* m, Mesh::MeshInfo info, std::shared_ptr<IndexBuffer> ind) {
-                 log::user::info("Mesh::addIndicies is deprecated, use addIndices");
+                 log::info("Mesh::addIndicies is deprecated, use addIndices");
                  m->addIndices(info, ind);
              })
         .def("removeIndexBuffer", [](Mesh* m, size_t idx) { m->removeIndexBuffer(idx); })

--- a/modules/python3/bindings/src/pypickingmapper.cpp
+++ b/modules/python3/bindings/src/pypickingmapper.cpp
@@ -129,7 +129,7 @@ void exposePickingMapper(pybind11::module& m) {
                 try {
                     callback(py::cast(e));
                 } catch (const py::error_already_set& e) {
-                    LogErrorCustom("pybind11", e.what());
+                    log::user::exception(e);
                 }
             });
         }))

--- a/modules/python3/bindings/src/pypickingmapper.cpp
+++ b/modules/python3/bindings/src/pypickingmapper.cpp
@@ -129,7 +129,7 @@ void exposePickingMapper(pybind11::module& m) {
                 try {
                     callback(py::cast(e));
                 } catch (const py::error_already_set& e) {
-                    log::user::exception(e);
+                    log::exception(e);
                 }
             });
         }))

--- a/modules/python3/src/python3module.cpp
+++ b/modules/python3/src/python3module.cpp
@@ -43,7 +43,7 @@
 #include <inviwo/core/util/commandlineparser.h>  // for CommandLineParser
 #include <inviwo/core/util/exception.h>          // for ModuleInitException
 #include <inviwo/core/util/filesystem.h>         // for fileExists
-#include <inviwo/core/util/logcentral.h>         // for LogCentral, LogWarn
+#include <inviwo/core/util/logcentral.h>         // for LogCentral
 #include <inviwo/core/util/pathtype.h>           // for PathType, PathType::...
 #include <inviwo/core/util/sourcecontext.h>      // for IVW_CONTEXT
 #include <modules/python3/pythonscript.h>
@@ -111,7 +111,7 @@ Python3Module::Python3Module(InviwoApplication* app)
                        [this]() {
                            auto filename = std::filesystem::path{scriptArg_.getValue()};
                            if (!std::filesystem::is_regular_file(filename)) {
-                               LogWarn("Could not run script, file does not exist: " << filename);
+                               log::warn("Could not run script, file does not exist: {}", filename);
                                return;
                            }
                            auto code = PythonScript::fromFile(filename);
@@ -131,8 +131,7 @@ Python3Module::Python3Module(InviwoApplication* app)
                                         auto code = PythonScript(*script, key);
                                         runScript(code, app_);
                                     } else {
-                                        LogError("Python workspace script: '" << key
-                                                                              << "' not found");
+                                        log::error("Python workspace script: '{}' not found", key);
                                     }
                                 }}
     , pythonLogger_{}

--- a/modules/python3/src/pythoninterpreter.cpp
+++ b/modules/python3/src/pythoninterpreter.cpp
@@ -72,7 +72,7 @@ PythonInterpreter::PythonInterpreter() : embedded_{false}, isInit_(false) {
 
     if (!Py_IsInitialized()) {
 
-        log::user::info("Python version: {}", Py_GetVersion());
+        log::info("Python version: {}", Py_GetVersion());
 
         try {
             py::initialize_interpreter(false);

--- a/modules/python3/src/pythoninterpreter.cpp
+++ b/modules/python3/src/pythoninterpreter.cpp
@@ -72,7 +72,7 @@ PythonInterpreter::PythonInterpreter() : embedded_{false}, isInit_(false) {
 
     if (!Py_IsInitialized()) {
 
-        LogInfo("Python version: " + toString(Py_GetVersion()));
+        log::user::info("Python version: {}", Py_GetVersion());
 
         try {
             py::initialize_interpreter(false);

--- a/modules/python3/src/pythoninterpreter.cpp
+++ b/modules/python3/src/pythoninterpreter.cpp
@@ -43,7 +43,7 @@
 
 #include <inviwo/core/util/exception.h>         // for ModuleInitException
 #include <inviwo/core/util/filesystem.h>        // for getExecutablePath, getFileDirectory
-#include <inviwo/core/util/logcentral.h>        // for LogCentral, LogInfo
+#include <inviwo/core/util/logcentral.h>        // for LogCentral
 #include <inviwo/core/util/sourcecontext.h>     // for IVW_CONTEXT
 #include <inviwo/core/util/stringconversion.h>  // for toString
 #include <inviwo/core/util/safecstr.h>

--- a/modules/python3/src/pythonlogger.cpp
+++ b/modules/python3/src/pythonlogger.cpp
@@ -29,7 +29,7 @@
 
 #include <modules/python3/pythonlogger.h>
 
-#include <inviwo/core/util/logcentral.h>                      // for LogCentral, LogError, LogInfo
+#include <inviwo/core/util/logcentral.h>                      // for LogCentral
 #include <modules/python3/pythonexecutionoutputobservable.h>  // for PythonOutputType, PythonOut...
 
 namespace inviwo {

--- a/modules/python3/src/pythonlogger.cpp
+++ b/modules/python3/src/pythonlogger.cpp
@@ -38,7 +38,7 @@ void PythonLogger::onPythonExecutionOutput(const std::string& msg, PythonOutputT
     const LogLevel level =
         PythonOutputType::sysstderr == outputType ? LogLevel::Error : LogLevel::Info;
 
-    log::report(level, LogAudience::User, msg);
+    log::report(level, msg);
 }
 
 }  // namespace inviwo

--- a/modules/python3/src/pythonlogger.cpp
+++ b/modules/python3/src/pythonlogger.cpp
@@ -35,14 +35,10 @@
 namespace inviwo {
 
 void PythonLogger::onPythonExecutionOutput(const std::string& msg, PythonOutputType outputType) {
-    switch (outputType) {
-        case PythonOutputType::sysstderr:
-            LogError(msg);
-            break;
-        case PythonOutputType::sysstdout:
-        default:
-            LogInfo(msg);
-    }
+    const LogLevel level =
+        PythonOutputType::sysstderr == outputType ? LogLevel::Error : LogLevel::Info;
+
+    log::report(level, LogAudience::User, msg);
 }
 
 }  // namespace inviwo

--- a/modules/python3/src/pythonprocessorfactoryobject.cpp
+++ b/modules/python3/src/pythonprocessorfactoryobject.cpp
@@ -90,14 +90,14 @@ void PythonProcessorFactoryObject::fileChanged(const std::filesystem::path&) {
     try {
         auto data = load(file_);
         name_ = data.name;
-        log::user::info("Reloaded python processor: '{}' file: {}", name_, file_);
+        log::info("Reloaded python processor: '{}' file: {}", name_, file_);
         if (getProcessorInfo() != data.info) {
-            log::user::error("ProcessorInfo changes in '{}' will not be reflected", name_);
+            log::error("ProcessorInfo changes in '{}' will not be reflected", name_);
         }
         reloadProcessors();
 
     } catch (const std::exception& e) {
-        log::user::error("Error reloading file: '{}' Message:\n{}", file_, e.what());
+        log::error("Error reloading file: '{}' Message:\n{}", file_, e.what());
     }
 }
 
@@ -107,8 +107,7 @@ void PythonProcessorFactoryObject::reloadProcessors() {
                                              // modifying the list below by replacing them
     for (auto p : processors) {
         if (p->getClassIdentifier() == getProcessorInfo().classIdentifier) {
-            log::user::info("Updating python processor: \"{}\" id: \"{}\"", name_,
-                            p->getIdentifier());
+            log::info("Updating python processor: \"{}\" id: \"{}\"", name_, p->getIdentifier());
             if (auto replacement = std::shared_ptr<Processor>(create(app_))) {
                 util::replaceProcessor(net, replacement, p);
             }

--- a/modules/python3/src/pythonprocessorfactoryobject.cpp
+++ b/modules/python3/src/pythonprocessorfactoryobject.cpp
@@ -107,8 +107,8 @@ void PythonProcessorFactoryObject::reloadProcessors() {
                                              // modifying the list below by replacing them
     for (auto p : processors) {
         if (p->getClassIdentifier() == getProcessorInfo().classIdentifier) {
-            log::info("Updating python processor: \"{}\" id: \"{}\"", name_, p->getIdentifier());
-            if (auto replacement = std::shared_ptr<Processor>(create(app_))) {
+            log::info(R"(Updating python processor: "{}" id: "{}")", name_, p->getIdentifier());
+            if (auto replacement = static_cast<std::shared_ptr<Processor>>(create(app_))) {
                 util::replaceProcessor(net, replacement, p);
             }
         }

--- a/modules/python3/src/pythonprocessorfactoryobject.cpp
+++ b/modules/python3/src/pythonprocessorfactoryobject.cpp
@@ -47,7 +47,7 @@
 #include <inviwo/core/util/exception.h>                     // for Exception
 #include <inviwo/core/util/fileobserver.h>                  // for FileObserver
 #include <inviwo/core/util/filesystem.h>                    // for getFileNameWithoutExtension
-#include <inviwo/core/util/logcentral.h>                    // for LogCentral, LogError, LogInfo
+#include <inviwo/core/util/logcentral.h>                    // for LogCentral
 #include <inviwo/core/util/sourcecontext.h>                 // for IVW_CONTEXT_CUSTOM
 #include <inviwo/core/util/stringconversion.h>              // for trim
 #include <inviwo/core/util/utilities.h>                     // for stripIdentifier
@@ -90,14 +90,14 @@ void PythonProcessorFactoryObject::fileChanged(const std::filesystem::path&) {
     try {
         auto data = load(file_);
         name_ = data.name;
-        LogInfo("Reloaded python processor: \"" << name_ << "\" file: " << file_);
+        log::user::info("Reloaded python processor: '{}' file: {}", name_, file_);
         if (getProcessorInfo() != data.info) {
-            LogError("ProcessorInfo changes in \"" + name_ + "\" will not be reflected");
+            log::user::error("ProcessorInfo changes in '{}' will not be reflected", name_);
         }
         reloadProcessors();
 
     } catch (const std::exception& e) {
-        LogError("Error reloading file: " << file_ << " Message:\n" << e.what());
+        log::user::error("Error reloading file: '{}' Message:\n{}", file_, e.what());
     }
 }
 
@@ -107,8 +107,8 @@ void PythonProcessorFactoryObject::reloadProcessors() {
                                              // modifying the list below by replacing them
     for (auto p : processors) {
         if (p->getClassIdentifier() == getProcessorInfo().classIdentifier) {
-            LogInfo("Updating python processor: \"" << name_ << "\" id: \"" << p->getIdentifier()
-                                                    << "\"");
+            log::user::info("Updating python processor: \"{}\" id: \"{}\"", name_,
+                            p->getIdentifier());
             if (auto replacement = std::shared_ptr<Processor>(create(app_))) {
                 util::replaceProcessor(net, replacement, p);
             }

--- a/modules/python3/src/pythonprocessorfolderobserver.cpp
+++ b/modules/python3/src/pythonprocessorfolderobserver.cpp
@@ -34,7 +34,7 @@
 #include <inviwo/core/util/exception.h>                     // for Exception
 #include <inviwo/core/util/fileobserver.h>                  // for FileObserver
 #include <inviwo/core/util/filesystem.h>                    // for getFileExtension, directoryEx...
-#include <inviwo/core/util/logcentral.h>                    // for LogCentral, log, LogInfo, Log...
+#include <inviwo/core/util/logcentral.h>                    // for LogCentral
 #include <modules/python3/pythonprocessorfactoryobject.h>   // for PythonProcessorFactoryObject
 
 #include <algorithm>  // for count
@@ -81,9 +81,9 @@ bool PythonProcessorFolderObserver::registerFile(const std::filesystem::path& fi
             registeredFiles_.push_back(filename);
             return true;
         } catch (const Exception& e) {
-            util::log(e.getContext(), e.getMessage(), LogLevel::Warn);
+            log::user::exception(e);
         } catch (const std::exception& e) {
-            LogWarn(e.what());
+            log::user::exception(e);
         }
     }
     return false;
@@ -98,7 +98,7 @@ void PythonProcessorFolderObserver::fileChanged(const std::filesystem::path& cha
                 if (file.extension() != ".py") continue;
 
                 if (registerFile(directory_ / file)) {
-                    LogInfo("Loaded python processor: " << directory_ / file);
+                    log::user::info("Loaded python processor: {}", directory_ / file);
                     stopFileObservation(directory_ / file);
                 } else {
                     startFileObservation(directory_ / file);
@@ -108,7 +108,7 @@ void PythonProcessorFolderObserver::fileChanged(const std::filesystem::path& cha
     } else {
         if (changed.extension() == ".py") {
             if (registerFile(changed)) {
-                LogInfo("Loaded python processor: " << changed);
+                log::user::info("Loaded python processor: {}", changed);
                 stopFileObservation(changed);
             }
         }

--- a/modules/python3/src/pythonprocessorfolderobserver.cpp
+++ b/modules/python3/src/pythonprocessorfolderobserver.cpp
@@ -81,9 +81,9 @@ bool PythonProcessorFolderObserver::registerFile(const std::filesystem::path& fi
             registeredFiles_.push_back(filename);
             return true;
         } catch (const Exception& e) {
-            log::user::exception(e);
+            log::exception(e);
         } catch (const std::exception& e) {
-            log::user::exception(e);
+            log::exception(e);
         }
     }
     return false;
@@ -98,7 +98,7 @@ void PythonProcessorFolderObserver::fileChanged(const std::filesystem::path& cha
                 if (file.extension() != ".py") continue;
 
                 if (registerFile(directory_ / file)) {
-                    log::user::info("Loaded python processor: {}", directory_ / file);
+                    log::info("Loaded python processor: {}", directory_ / file);
                     stopFileObservation(directory_ / file);
                 } else {
                     startFileObservation(directory_ / file);
@@ -108,7 +108,7 @@ void PythonProcessorFolderObserver::fileChanged(const std::filesystem::path& cha
     } else {
         if (changed.extension() == ".py") {
             if (registerFile(changed)) {
-                log::user::info("Loaded python processor: {}", changed);
+                log::info("Loaded python processor: {}", changed);
                 stopFileObservation(changed);
             }
         }

--- a/modules/python3/src/pythonscript.cpp
+++ b/modules/python3/src/pythonscript.cpp
@@ -36,7 +36,7 @@
 
 #include <inviwo/core/common/inviwoapplication.h>             // for InviwoApplication
 #include <inviwo/core/common/inviwoapplicationutil.h>         // for getInviwoApplication
-#include <inviwo/core/util/assertion.h>                       // for ivwAssert
+#include <inviwo/core/util/assertion.h>                       // for IVW_ASSERT
 #include <inviwo/core/util/callback.h>                        // for CallBackList, BaseCallBack
 #include <inviwo/core/util/fileobserver.h>                    // for FileObserver
 #include <inviwo/core/util/filesystem.h>                      // for ifstream

--- a/modules/python3qt/src/python3qtmodule.cpp
+++ b/modules/python3qt/src/python3qtmodule.cpp
@@ -134,7 +134,7 @@ Python3QtModule::Python3QtModule(InviwoApplication* app)
                          try {
                              py::exec("lambda x: 1");
                          } catch (...) {
-                             log::user::info("Aborted Qt event loop");
+                             log::info("Aborted Qt event loop");
                              qApp->quit();
                          }
                      });

--- a/modules/python3qt/src/python3qtmodule.cpp
+++ b/modules/python3qt/src/python3qtmodule.cpp
@@ -134,7 +134,7 @@ Python3QtModule::Python3QtModule(InviwoApplication* app)
                          try {
                              py::exec("lambda x: 1");
                          } catch (...) {
-                             LogInfoCustom("InviwoPyApp", "Aborted Qt event loop");
+                             log::user::info("Aborted Qt event loop");
                              qApp->quit();
                          }
                      });

--- a/modules/python3qt/src/python3qtmodule.cpp
+++ b/modules/python3qt/src/python3qtmodule.cpp
@@ -125,6 +125,7 @@ Python3QtModule::Python3QtModule(InviwoApplication* app)
                  })
             .def("configureFileSystemObserver", &utilqt::configureFileSystemObserver)
             .def("configurePostEnqueueFront", &utilqt::configurePostEnqueueFront)
+            .def("configureAssertionHandler", &utilqt::configureAssertionHandler)
             .def("configurePoolResizeWait", &utilqt::configurePoolResizeWait)
             .def("setStyleSheetFile", &utilqt::setStyleSheetFile)
             .def("execWithTimer",

--- a/modules/python3qt/src/pythonmenu.cpp
+++ b/modules/python3qt/src/pythonmenu.cpp
@@ -124,7 +124,7 @@ PythonMenu::PythonMenu(const std::filesystem::path& modulePath, InviwoApplicatio
                 QDesktopServices::openUrl(QUrl("file:///" + qpath, QUrl::TolerantMode));
             }
         } catch (const std::exception& e) {
-            LogError(e.what());
+            log::user::exception(e);
         }
     });
 

--- a/modules/python3qt/src/pythonmenu.cpp
+++ b/modules/python3qt/src/pythonmenu.cpp
@@ -124,7 +124,7 @@ PythonMenu::PythonMenu(const std::filesystem::path& modulePath, InviwoApplicatio
                 QDesktopServices::openUrl(QUrl("file:///" + qpath, QUrl::TolerantMode));
             }
         } catch (const std::exception& e) {
-            log::user::exception(e);
+            log::exception(e);
         }
     });
 

--- a/modules/qtwidgets/include/modules/qtwidgets/properties/propertysettingswidgetqt.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/properties/propertysettingswidgetqt.h
@@ -39,7 +39,7 @@
 #include <inviwo/core/util/glmcomp.h>               // for glmcomp
 #include <inviwo/core/util/glmutils.h>              // for value_type
 #include <inviwo/core/util/glmvec.h>                // for uvec2
-#include <inviwo/core/util/logcentral.h>            // for LogCentral, LogError
+#include <inviwo/core/util/logcentral.h>            // for LogCentral
 #include <modules/qtwidgets/inviwoqtutils.h>        // for refSpacePx, toQString
 #include <modules/qtwidgets/qstringhelper.h>        // for QStringHelper
 
@@ -278,9 +278,8 @@ void OrdinalLikePropertySettingsWidgetQt<Prop>::apply() {
     for (size_t i = 0; i < settings_.size(); i++) {
         if (util::glmcomp(vals[0], i) > util::glmcomp(vals[1], i) ||
             util::glmcomp(vals[1], i) > util::glmcomp(vals[2], i)) {
-            LogError(fmt::format("Invalid range found elem {}: {} <= {} <= {}", i,
-                                 util::glmcomp(vals[0], i), util::glmcomp(vals[1], i),
-                                 util::glmcomp(vals[1], i)));
+            log::error("Invalid range found elem {}: {} <= {} <= {}", i, util::glmcomp(vals[0], i),
+                       util::glmcomp(vals[1], i), util::glmcomp(vals[1], i));
             return;
         }
     }

--- a/modules/qtwidgets/src/inviwofiledialog.cpp
+++ b/modules/qtwidgets/src/inviwofiledialog.cpp
@@ -32,7 +32,7 @@
 #include <inviwo/core/util/filedialogstate.h>  // for FileMode, AcceptMode, AcceptMode::Open
 #include <inviwo/core/util/fileextension.h>    // for FileExtension
 #include <inviwo/core/util/filesystem.h>       // for fileExists, directoryExists, findBasePath
-#include <inviwo/core/util/logcentral.h>       // for LogCentral, LogError
+#include <inviwo/core/util/logcentral.h>       // for LogCentral
 #include <inviwo/core/util/pathtype.h>         // for PathType
 #include <modules/qtwidgets/inviwoqtutils.h>   // for toQString, fromQString
 
@@ -225,7 +225,7 @@ void InviwoFileDialog::addExtension(const FileExtension& fileExt) {
     if (retval.second) {  // insert successful
         extensions_ << utilqt::toQString(str);
     } else {
-        LogError("Extension already registered: " << str);
+        log::error("Extension already registered: {}", str);
     }
 }
 

--- a/modules/qtwidgets/src/inviwoqtutils.cpp
+++ b/modules/qtwidgets/src/inviwoqtutils.cpp
@@ -47,7 +47,7 @@
 #include <inviwo/core/properties/isotfproperty.h>
 #include <inviwo/core/util/exception.h>          // for Exception
 #include <inviwo/core/util/glmvec.h>             // for ivec2, vec4, dvec2
-#include <inviwo/core/util/logcentral.h>         // for LogCentral, LogWarnCustom
+#include <inviwo/core/util/logcentral.h>         // for LogCentral
 #include <inviwo/core/util/safecstr.h>           // for SafeCStr
 #include <inviwo/core/util/sourcecontext.h>      // for IVW_CONTEXT_CUSTOM
 #include <inviwo/core/util/stringconversion.h>   // for replaceInString, toString

--- a/modules/qtwidgets/src/properties/buttongrouppropertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/buttongrouppropertywidgetqt.cpp
@@ -75,7 +75,7 @@ ButtonGroupPropertyWidgetQt::ButtonGroupPropertyWidgetQt(ButtonGroupProperty* pr
                 try {
                     property_->pressButton(i);
                 } catch (const Exception& e) {
-                    log::user::exception(e);
+                    log::exception(e);
                 }
             }
         });

--- a/modules/qtwidgets/src/properties/buttongrouppropertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/buttongrouppropertywidgetqt.cpp
@@ -75,7 +75,7 @@ ButtonGroupPropertyWidgetQt::ButtonGroupPropertyWidgetQt(ButtonGroupProperty* pr
                 try {
                     property_->pressButton(i);
                 } catch (const Exception& e) {
-                    util::log(e.getContext(), e.getMessage(), LogLevel::Warn);
+                    log::user::exception(e);
                 }
             }
         });

--- a/modules/qtwidgets/src/properties/buttonpropertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/buttonpropertywidgetqt.cpp
@@ -60,7 +60,7 @@ ButtonPropertyWidgetQt::ButtonPropertyWidgetQt(ButtonProperty* property)
             try {
                 property_->pressButton();
             } catch (const Exception& e) {
-                util::log(e.getContext(), e.getMessage(), LogLevel::Warn);
+                log::user::exception(e);
             }
         }
     });

--- a/modules/qtwidgets/src/properties/buttonpropertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/buttonpropertywidgetqt.cpp
@@ -60,7 +60,7 @@ ButtonPropertyWidgetQt::ButtonPropertyWidgetQt(ButtonProperty* property)
             try {
                 property_->pressButton();
             } catch (const Exception& e) {
-                log::user::exception(e);
+                log::exception(e);
             }
         }
     });

--- a/modules/qtwidgets/src/properties/collapsiblegroupboxwidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/collapsiblegroupboxwidgetqt.cpp
@@ -44,7 +44,7 @@
 #include <inviwo/core/properties/propertypresetmanager.h>   // for PropertyPresetManager
 #include <inviwo/core/properties/propertywidgetfactory.h>   // for PropertyWidgetFactory
 #include <inviwo/core/util/exception.h>                     // for Exception
-#include <inviwo/core/util/logcentral.h>                    // for LogCentral, LogWarn, LogError
+#include <inviwo/core/util/logcentral.h>                    // for LogCentral
 #include <inviwo/core/util/raiiutils.h>                     // for OnScopeExit, OnScopeExit::Exi...
 #include <inviwo/core/util/rendercontext.h>                 // for RenderContext
 #include <inviwo/core/util/settings/settings.h>             // for Settings
@@ -287,7 +287,7 @@ std::unique_ptr<QMenu> CollapsibleGroupBoxWidgetQt::getContextMenu() {
                     }
                 }
             } catch (Exception& e) {
-                LogError(e.getMessage());
+                log::exception(e);
             }
         });
 
@@ -532,7 +532,7 @@ void CollapsibleGroupBoxWidgetQt::onSetSemantics(Property* prop, const PropertyS
                 setTabOrder((*(it - 1)), (*it));
             }
         } else {
-            LogWarn("Could not change semantic for property: " << prop->getClassIdentifier());
+            log::warn("Could not change semantic for property: {}", prop->getClassIdentifier());
         }
     }
 }
@@ -703,7 +703,7 @@ void CollapsibleGroupBoxWidgetQt::insertProperty(Property* prop, size_t index) {
             setTabOrder(*(wit - 1), *wit);
         }
     } else {
-        LogWarn("Could not find a widget for property: " << prop->getClassIdentifier());
+        log::warn("Could not find a widget for property: {}", prop->getClassIdentifier());
 
         // insert empty element to keep property widget vector in sync with property vector
         propertyWidgets_.insert(widgetInsertPoint, nullptr);

--- a/modules/qtwidgets/src/properties/colorlineedit.cpp
+++ b/modules/qtwidgets/src/properties/colorlineedit.cpp
@@ -29,7 +29,7 @@
 
 #include <modules/qtwidgets/properties/colorlineedit.h>
 
-#include <inviwo/core/util/assertion.h>        // for ivwAssert
+#include <inviwo/core/util/assertion.h>        // for IVW_ASSERT
 #include <inviwo/core/util/colorconversion.h>  // for hex2rgba, rgb2hex, rgba2hex
 #include <inviwo/core/util/glmconvert.h>       // for glm_convert
 #include <inviwo/core/util/glmvec.h>           // for ivec4, dvec4, ivec3, dvec3, vec3, vec4
@@ -210,9 +210,9 @@ void ColorLineEdit::updateText() {
 void ColorLineEdit::updateColor() {
     QStringList tokens = text().trimmed().split(QRegularExpression("\\s+"));
 
-    ivwAssert((tokens.size() == 1) || (tokens.size() == 3) || (tokens.size() == 4),
+    IVW_ASSERT((tokens.size() == 1) || (tokens.size() == 3) || (tokens.size() == 4),
               "Invalid number of color components");
-    ivwAssert((tokens.size() > 1) || ((tokens.size() == 1) && tokens.front().startsWith("#")),
+    IVW_ASSERT((tokens.size() > 1) || ((tokens.size() == 1) && tokens.front().startsWith("#")),
               "Invalid single component (expected hex color code starting with '#')");
 
     if (tokens.size() == 1) {

--- a/modules/qtwidgets/src/properties/colorlineedit.cpp
+++ b/modules/qtwidgets/src/properties/colorlineedit.cpp
@@ -211,9 +211,9 @@ void ColorLineEdit::updateColor() {
     QStringList tokens = text().trimmed().split(QRegularExpression("\\s+"));
 
     IVW_ASSERT((tokens.size() == 1) || (tokens.size() == 3) || (tokens.size() == 4),
-              "Invalid number of color components");
+               "Invalid number of color components");
     IVW_ASSERT((tokens.size() > 1) || ((tokens.size() == 1) && tokens.front().startsWith("#")),
-              "Invalid single component (expected hex color code starting with '#')");
+               "Invalid single component (expected hex color code starting with '#')");
 
     if (tokens.size() == 1) {
         // it is a hex color code

--- a/modules/qtwidgets/src/properties/lightpropertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/lightpropertywidgetqt.cpp
@@ -131,10 +131,12 @@ LightPropertyWidgetQt::LightPropertyWidgetQt(FloatVec3Property* property)
 
     // Assuming that minimum value is negative and maximum value is positive
     if (glm::any(glm::greaterThan(property_->getMinValue(), vec3(0.0f)))) {
-        log::warn("Minimum value is assumed to be negative. Widget may produce values out of range.");
+        log::warn(
+            "Minimum value is assumed to be negative. Widget may produce values out of range.");
     }
     if (glm::any(glm::lessThan(property_->getMaxValue(), vec3(0.0f)))) {
-        log::warn("Maximum value is assumed to be positive. Widget may produce values out of range.");
+        log::warn(
+            "Maximum value is assumed to be positive. Widget may produce values out of range.");
     }
 
     radius_->setMinValue(0, ConstraintBehavior::Immutable);

--- a/modules/qtwidgets/src/properties/lightpropertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/lightpropertywidgetqt.cpp
@@ -32,7 +32,7 @@
 #include <inviwo/core/properties/constraintbehavior.h>              // for ConstraintBehavior
 #include <inviwo/core/properties/ordinalproperty.h>                 // for FloatVec3Property
 #include <inviwo/core/util/glmvec.h>                                // for vec3, dvec3
-#include <inviwo/core/util/logcentral.h>                            // for LogCentral, LogWarn
+#include <inviwo/core/util/logcentral.h>                            // for LogCentral
 #include <inviwo/core/util/zip.h>                                   // for enumerate, zipIterator
 #include <modules/qtwidgets/editablelabelqt.h>                      // for EditableLabelQt
 #include <modules/qtwidgets/lightpositionwidgetqt.h>                // for LightPositionWidgetQt
@@ -131,10 +131,10 @@ LightPropertyWidgetQt::LightPropertyWidgetQt(FloatVec3Property* property)
 
     // Assuming that minimum value is negative and maximum value is positive
     if (glm::any(glm::greaterThan(property_->getMinValue(), vec3(0.0f)))) {
-        LogWarn("Minimum value is assumed to be negative. Widget may produce values out of range.")
+        log::warn("Minimum value is assumed to be negative. Widget may produce values out of range.");
     }
     if (glm::any(glm::lessThan(property_->getMaxValue(), vec3(0.0f)))) {
-        LogWarn("Maximum value is assumed to be positive. Widget may produce values out of range.")
+        log::warn("Maximum value is assumed to be positive. Widget may produce values out of range.");
     }
 
     radius_->setMinValue(0, ConstraintBehavior::Immutable);

--- a/modules/qtwidgets/src/properties/propertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/propertywidgetqt.cpp
@@ -199,11 +199,11 @@ std::unique_ptr<QMenu> PropertyWidgetQt::getContextMenu() {
                     }
                 } catch (const AbortException&) {
                 } catch (const Exception& e) {
-                    log::user::exception(e);
+                    log::exception(e);
                 } catch (const std::exception& e) {
-                    log::user::exception(e);
+                    log::exception(e);
                 } catch (...) {
-                    log::user::exception();
+                    log::exception();
                 }
             });
 
@@ -405,10 +405,8 @@ void PropertyWidgetQt::addPresetMenuActions(QMenu* menu, InviwoApplication* app)
             ss << "Save preset in " << type << ". " << type << " presets are local to this "
                << type;
             saveAction->setToolTip(utilqt::toQString(ss.str()));
-            connect(saveAction, &QAction::triggered, [=]() {
-                while (!savePreset(saveMenu, type))
-                    ;
-            });
+            connect(saveAction, &QAction::triggered,
+                    [=]() { while (!savePreset(saveMenu, type)); });
         }
 
         auto clearMenu = presetMenu->addMenu("Clear");
@@ -453,7 +451,7 @@ bool PropertyWidgetQt::event(QEvent* event) {
         try {
             html.append("body").append(property_->getDescription());
         } catch (const Exception& e) {
-           log::user::exception(e);
+            log::exception(e);
         }
 
         QToolTip::showText(helpEvent->globalPos(), utilqt::toQString(desc));

--- a/modules/qtwidgets/src/properties/propertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/propertywidgetqt.cpp
@@ -199,11 +199,11 @@ std::unique_ptr<QMenu> PropertyWidgetQt::getContextMenu() {
                     }
                 } catch (const AbortException&) {
                 } catch (const Exception& e) {
-                    util::log(e.getContext(), e.getMessage());
+                    log::user::exception(e);
                 } catch (const std::exception& e) {
-                    util::log(IVW_CONTEXT, e.what());
+                    log::user::exception(e);
                 } catch (...) {
-                    util::log(IVW_CONTEXT, "unknown error");
+                    log::user::exception();
                 }
             });
 
@@ -453,7 +453,7 @@ bool PropertyWidgetQt::event(QEvent* event) {
         try {
             html.append("body").append(property_->getDescription());
         } catch (const Exception& e) {
-            util::log(e.getContext(), e.getFullMessage());
+           log::user::exception(e);
         }
 
         QToolTip::showText(helpEvent->globalPos(), utilqt::toQString(desc));

--- a/modules/qtwidgets/src/properties/tfprimitivesetwidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/tfprimitivesetwidgetqt.cpp
@@ -218,7 +218,7 @@ std::vector<TFPrimitiveData> TFPrimitiveSetWidgetQt::extractPrimitiveData(
         }
     }
     if (!errorMsg.empty()) {
-        log::user::error("Parse error(s): {}", errorMsg);
+        log::error("Parse error(s): {}", errorMsg);
     }
     return primitives;
 }

--- a/modules/qtwidgets/src/properties/tfprimitivesetwidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/tfprimitivesetwidgetqt.cpp
@@ -218,7 +218,7 @@ std::vector<TFPrimitiveData> TFPrimitiveSetWidgetQt::extractPrimitiveData(
         }
     }
     if (!errorMsg.empty()) {
-        LogError("Parse error(s):" << errorMsg);
+        log::user::error("Parse error(s): {}", errorMsg);
     }
     return primitives;
 }

--- a/modules/qtwidgets/src/tf/tfutils.cpp
+++ b/modules/qtwidgets/src/tf/tfutils.cpp
@@ -199,7 +199,7 @@ void exportIsoValueCollectionDialog(const IsoValueCollection& iso, QWidget* pare
                     factory->getWriterForTypeAndExtension<IsoValueCollection>(fileExt, filename)) {
                 writer->writeData(&iso, filename);
 
-                log::user::info("Data exported to disk: {}", filename);
+                log::info("Data exported to disk: {}", filename);
             } else {
                 throw DataWriterException(IVW_CONTEXT_CUSTOM("exportTransferFunctionDialog"),
                                           "Unable to find a Iso Value Collection writer for {}",

--- a/modules/qtwidgets/src/tf/tfutils.cpp
+++ b/modules/qtwidgets/src/tf/tfutils.cpp
@@ -39,7 +39,7 @@
 #include <inviwo/core/datastructures/tfprimitiveset.h>    // for TFPrimitiveSet
 #include <inviwo/core/datastructures/transferfunction.h>  // for TransferFunction
 #include <inviwo/core/datastructures/isovaluecollection.h>
-#include <inviwo/core/io/datareaderexception.h>           // for DataReaderException
+#include <inviwo/core/io/datareaderexception.h>  // for DataReaderException
 #include <inviwo/core/io/datareaderfactory.h>
 #include <inviwo/core/io/datareader.h>
 #include <inviwo/core/io/datawriterfactory.h>
@@ -199,8 +199,7 @@ void exportIsoValueCollectionDialog(const IsoValueCollection& iso, QWidget* pare
                     factory->getWriterForTypeAndExtension<IsoValueCollection>(fileExt, filename)) {
                 writer->writeData(&iso, filename);
 
-                util::log(IVW_CONTEXT_CUSTOM("util::exportToFile"),
-                          "Data exported to disk: " + filename, LogLevel::Info, LogAudience::User);
+                log::user::info("Data exported to disk: {}", filename);
             } else {
                 throw DataWriterException(IVW_CONTEXT_CUSTOM("exportTransferFunctionDialog"),
                                           "Unable to find a Iso Value Collection writer for {}",

--- a/modules/userinterfacegl/src/glui/widgets/checkbox.cpp
+++ b/modules/userinterfacegl/src/glui/widgets/checkbox.cpp
@@ -59,7 +59,7 @@ CheckBox::CheckBox(const std::string& label, Processor& processor, Renderer& uiR
                    const ivec2& extent)
     : Element(label, processor, uiRenderer) {
     widgetExtent_ = extent;
-    action_ = [&]() { log::user::info("UI checkbox {} toggled: {}", getLabel(), getValue()); };
+    action_ = [&]() { log::info("UI checkbox {} toggled: {}", getLabel(), getValue()); };
 
     std::vector<std::filesystem::path> textureFiles = {
         "checkbox-fill.png", "checkbox-unchecked.png", "checkbox-checked.png",

--- a/modules/userinterfacegl/src/glui/widgets/checkbox.cpp
+++ b/modules/userinterfacegl/src/glui/widgets/checkbox.cpp
@@ -32,7 +32,7 @@
 #include <inviwo/core/common/inviwomodule.h>        // for ModulePath, ModulePath::Images
 #include <inviwo/core/interaction/pickingmapper.h>  // for PickingMapper
 #include <inviwo/core/util/glmvec.h>                // for ivec2, vec2, size2_t
-#include <inviwo/core/util/logcentral.h>            // for LogCentral, LogInfo
+#include <inviwo/core/util/logcentral.h>            // for LogCentral
 #include <inviwo/core/util/moduleutils.h>           // for getModulePath
 #include <modules/opengl/rendering/meshdrawergl.h>  // for MeshDrawerGL
 #include <modules/opengl/shader/shader.h>           // for Shader
@@ -59,7 +59,7 @@ CheckBox::CheckBox(const std::string& label, Processor& processor, Renderer& uiR
                    const ivec2& extent)
     : Element(label, processor, uiRenderer) {
     widgetExtent_ = extent;
-    action_ = [&]() { LogInfo("UI checkbox " << getLabel() << " toggled: " << getValue()); };
+    action_ = [&]() { log::user::info("UI checkbox {} toggled: {}", getLabel(), getValue()); };
 
     std::vector<std::filesystem::path> textureFiles = {
         "checkbox-fill.png", "checkbox-unchecked.png", "checkbox-checked.png",

--- a/modules/userinterfacegl/src/glui/widgets/toolbutton.cpp
+++ b/modules/userinterfacegl/src/glui/widgets/toolbutton.cpp
@@ -142,14 +142,13 @@ std::shared_ptr<Texture2D> ToolButton::loadImage(const std::filesystem::path& fi
             // try to load texture data from current file
             auto layer = reader->readData(filename);
             return layer->getRepresentation<LayerGL>()->getTexture();
-        } catch (DataReaderException const& e) {
-            util::logError(e.getContext(), "Could not load texture data: {}, {}", filename,
-                           e.getMessage());
+        } catch (const DataReaderException& e) {
+            log::user::exception(e, "Could not load texture data: {}, {}", filename,
+                                 e.getMessage());
             return nullptr;
         }
     } else {
-        LogErrorCustom("ToolButton::loadImage",
-                       "Could not find a data reader for texture data (" << filename << ").");
+        log::error("Could not find a data reader for texture data ({}).", filename);
         return nullptr;
     }
 }

--- a/modules/userinterfacegl/src/glui/widgets/toolbutton.cpp
+++ b/modules/userinterfacegl/src/glui/widgets/toolbutton.cpp
@@ -143,8 +143,7 @@ std::shared_ptr<Texture2D> ToolButton::loadImage(const std::filesystem::path& fi
             auto layer = reader->readData(filename);
             return layer->getRepresentation<LayerGL>()->getTexture();
         } catch (const DataReaderException& e) {
-            log::user::exception(e, "Could not load texture data: {}, {}", filename,
-                                 e.getMessage());
+            log::exception(e, "Could not load texture data: {}, {}", filename, e.getMessage());
             return nullptr;
         }
     } else {

--- a/modules/userinterfacegl/src/processors/cropwidget.cpp
+++ b/modules/userinterfacegl/src/processors/cropwidget.cpp
@@ -505,7 +505,7 @@ void CropWidget::updateBoundingCube() {
 void CropWidget::objectPicked(PickingEvent* e) {
     const auto axisID = e->getPickedId() / static_cast<size_t>(numInteractionWidgets);
     if (axisID >= cropAxes_.size()) {
-        LogWarn("invalid picking ID");
+        log::warn("invalid picking ID");
         return;
     }
     if (e->getPressState() != PickingPressState::None) {

--- a/modules/userinterfacegl/src/processors/gluitestprocessor.cpp
+++ b/modules/userinterfacegl/src/processors/gluitestprocessor.cpp
@@ -157,7 +157,7 @@ GLUITestProcessor::GLUITestProcessor()
     uiSettings_.addProperty(layoutMargins_);
 
     // regular properties
-    buttonProperty_.onChange([&]() { log::user::info("Property button pressed"); });
+    buttonProperty_.onChange([&]() { log::info("Property button pressed"); });
 
     addProperty(boolProperty_);
     addProperty(intProperty_);
@@ -201,18 +201,17 @@ GLUITestProcessor::GLUITestProcessor()
     // create a slider
     auto slider =
         std::make_unique<glui::Slider>("slider", 0, 0, 100, *this, uiRenderer_, ivec2(100, 24));
-    slider->setAction(
-        [&, p = slider.get()]() { log::user::info("UI slider changed: {}", p->get()); });
+    slider->setAction([&, p = slider.get()]() { log::info("UI slider changed: {}", p->get()); });
     widgets_.emplace_back(std::move(slider));
     // create a range slider
     auto rangeslider = std::make_unique<glui::RangeSlider>("rangeslider", ivec2(10, 70), 0, 100, 40,
                                                            *this, uiRenderer_, ivec2(100, 24));
     rangeslider->setAction(
-        [&, p = rangeslider.get()]() { log::user::info("UI range slider changed: {}", p->get()); });
+        [&, p = rangeslider.get()]() { log::info("UI range slider changed: {}", p->get()); });
     widgets_.emplace_back(std::move(rangeslider));
     // create a wide button
     auto button = std::make_unique<glui::Button>("button 1", *this, uiRenderer_, ivec2(100, 28));
-    button->setAction([&]() { log::user::info("UI button pressed"); });
+    button->setAction([&]() { log::info("UI button pressed"); });
     widgets_.emplace_back(std::move(button));
     // create a large button
     widgets_.emplace_back(

--- a/modules/userinterfacegl/src/processors/gluitestprocessor.cpp
+++ b/modules/userinterfacegl/src/processors/gluitestprocessor.cpp
@@ -157,7 +157,7 @@ GLUITestProcessor::GLUITestProcessor()
     uiSettings_.addProperty(layoutMargins_);
 
     // regular properties
-    buttonProperty_.onChange([&]() { LogInfo("Property button pressed"); });
+    buttonProperty_.onChange([&]() { log::user::info("Property button pressed"); });
 
     addProperty(boolProperty_);
     addProperty(intProperty_);
@@ -201,17 +201,18 @@ GLUITestProcessor::GLUITestProcessor()
     // create a slider
     auto slider =
         std::make_unique<glui::Slider>("slider", 0, 0, 100, *this, uiRenderer_, ivec2(100, 24));
-    slider->setAction([&, p = slider.get()]() { LogInfo("UI slider changed: " << p->get()); });
+    slider->setAction(
+        [&, p = slider.get()]() { log::user::info("UI slider changed: {}", p->get()); });
     widgets_.emplace_back(std::move(slider));
     // create a range slider
     auto rangeslider = std::make_unique<glui::RangeSlider>("rangeslider", ivec2(10, 70), 0, 100, 40,
                                                            *this, uiRenderer_, ivec2(100, 24));
     rangeslider->setAction(
-        [&, p = rangeslider.get()]() { LogInfo("UI range slider changed: " << p->get()); });
+        [&, p = rangeslider.get()]() { log::user::info("UI range slider changed: {}", p->get()); });
     widgets_.emplace_back(std::move(rangeslider));
     // create a wide button
     auto button = std::make_unique<glui::Button>("button 1", *this, uiRenderer_, ivec2(100, 28));
-    button->setAction([&]() { LogInfo("UI button pressed"); });
+    button->setAction([&]() { log::user::info("UI button pressed"); });
     widgets_.emplace_back(std::move(button));
     // create a large button
     widgets_.emplace_back(

--- a/modules/userinterfacegl/src/processors/presentationprocessor.cpp
+++ b/modules/userinterfacegl/src/processors/presentationprocessor.cpp
@@ -53,7 +53,7 @@
 #include <inviwo/core/util/assertion.h>                   // for ivwAssert
 #include <inviwo/core/util/fileextension.h>               // for FileExtension
 #include <inviwo/core/util/filesystem.h>                  // for getPath
-#include <inviwo/core/util/logcentral.h>                  // for LogCentral, LogError
+#include <inviwo/core/util/logcentral.h>                  // for LogCentral
 #include <inviwo/core/util/pathtype.h>                    // for PathType, PathType::Images
 #include <inviwo/core/util/statecoordinator.h>            // for StateCoordinator
 #include <inviwo/core/util/stdextensions.h>               // for contains_if, erase_remove_if
@@ -198,7 +198,7 @@ void PresentationProcessor::updateSlideImage() {
     // sanity check for valid index
     const auto index = slideIndex_.get() - 1;
     if ((index < 0) || (index >= static_cast<int>(fileList_.size()))) {
-        LogError("Invalid image index. Exceeded number of files.");
+        log::error("Invalid image index. Exceeded number of files.");
         currentSlide_ = nullptr;
         return;
     }
@@ -215,8 +215,8 @@ void PresentationProcessor::updateSlideImage() {
         auto layer = reader->readData(currentFileName);
 
         currentSlide_ = std::make_shared<Image>(layer);
-    } catch (DataReaderException const& e) {
-        LogError(e.getMessage());
+    } catch (const DataReaderException& e) {
+        log::user::exception(e.getMessage());
     }
 }
 
@@ -225,14 +225,12 @@ void PresentationProcessor::onFindFiles() {
     fileList_ = imageFilePattern_.getFileList();
     if (fileList_.empty() && !imageFilePattern_.getFilePattern().empty()) {
         if (imageFilePattern_.hasOutOfRangeMatches()) {
-            LogError("All matching files are outside the specified range (\""
-                     << imageFilePattern_.getFilePattern() << "\", "
-                     << imageFilePattern_.getMinRange() << " - " << imageFilePattern_.getMaxRange()
-                     << ").");
+            log::error("All matching files are outside the specified range (\"{}\", {} - {}).",
+                       imageFilePattern_.getFilePattern(), imageFilePattern_.getMinRange(),
+                       imageFilePattern_.getMaxRange());
         } else {
-            LogError("No images found matching \"" << imageFilePattern_.getFilePattern() << "\" in "
-                                                   << imageFilePattern_.getFilePatternPath()
-                                                   << ".");
+            log::error("No images found matching \"{}\n in {}", imageFilePattern_.getFilePattern(),
+                       imageFilePattern_.getFilePatternPath());
         }
     }
     updateProperties();

--- a/modules/userinterfacegl/src/processors/presentationprocessor.cpp
+++ b/modules/userinterfacegl/src/processors/presentationprocessor.cpp
@@ -50,7 +50,7 @@
 #include <inviwo/core/properties/filepatternproperty.h>   // for FilePatternProperty
 #include <inviwo/core/properties/ordinalproperty.h>       // for IntProperty
 #include <inviwo/core/properties/stringproperty.h>        // for StringProperty
-#include <inviwo/core/util/assertion.h>                   // for ivwAssert
+#include <inviwo/core/util/assertion.h>                   // for IVW_ASSERT
 #include <inviwo/core/util/fileextension.h>               // for FileExtension
 #include <inviwo/core/util/filesystem.h>                  // for getPath
 #include <inviwo/core/util/logcentral.h>                  // for LogCentral

--- a/modules/userinterfacegl/src/processors/presentationprocessor.cpp
+++ b/modules/userinterfacegl/src/processors/presentationprocessor.cpp
@@ -216,7 +216,7 @@ void PresentationProcessor::updateSlideImage() {
 
         currentSlide_ = std::make_shared<Image>(layer);
     } catch (const DataReaderException& e) {
-        log::user::exception(e.getMessage());
+        log::exception(e.getMessage());
     }
 }
 

--- a/modules/vectorfieldvisualization/src/algorithms/integrallineoperations.cpp
+++ b/modules/vectorfieldvisualization/src/algorithms/integrallineoperations.cpp
@@ -102,7 +102,7 @@ void curvature(IntegralLine& line, dmat4 toWorld) {
             auto l2 = glm::length(t2);
             if (l1 == 0 || l2 == 0) {
                 K.emplace_back(0);
-                LogWarnCustom("util::curvature", "Got zero offset");
+                log::warn("Got zero offset");
                 continue;
             }
             const auto nt1 = t1 / l1;  // normalize t1

--- a/modules/vectorfieldvisualization/src/processors/3d/pathlines.cpp
+++ b/modules/vectorfieldvisualization/src/processors/3d/pathlines.cpp
@@ -154,7 +154,7 @@ PathLinesDeprecated::PathLinesDeprecated()
     addProperty(maxVelocity_);
     addProperty(allowLooping_);
 
-    LogWarn(
+    log::warn(
         "This Path Lines Processor is Deprecated, use the new Path Lines processor together "
         "with the IntegralLineToMesh processor.");
 }
@@ -230,7 +230,7 @@ void PathLinesDeprecated::process() {
             if (line.getIndex() >= colors_.getData()->size()) {
                 if (warnOnce2) {
                     warnOnce2 = false;
-                    LogWarn("The vector of colors is smaller then the vector of seed points");
+                    log::warn("The vector of colors is smaller then the vector of seed points");
                 }
             } else {
                 c = colors_.getData()->at(line.getIndex());
@@ -256,7 +256,7 @@ void PathLinesDeprecated::process() {
                     } else {
                         if (warnOnce) {
                             warnOnce = false;
-                            LogWarn(
+                            log::warn(
                                 "No colors in the color port, using velocity for coloring "
                                 "instead ");
                         }

--- a/modules/vectorfieldvisualization/src/processors/3d/streamlines.cpp
+++ b/modules/vectorfieldvisualization/src/processors/3d/streamlines.cpp
@@ -141,7 +141,7 @@ StreamLinesDeprecated::StreamLinesDeprecated()
 
     setAllPropertiesCurrentStateAsDefault();
 
-    LogWarn(
+    log::warn(
         "This Stream Lines Processor is Deprecated, use the new Stream Lines processor together "
         "with the IntegralLineToMesh processor.");
 }

--- a/modules/vectorfieldvisualization/src/processors/3d/streamribbons.cpp
+++ b/modules/vectorfieldvisualization/src/processors/3d/streamribbons.cpp
@@ -149,7 +149,7 @@ StreamRibbonsDeprecated::StreamRibbonsDeprecated()
     addProperty(maxVelocity_);
     addProperty(maxVorticity_);
 
-    LogWarn(
+    log::warn(
         "This Stream Ribbons Processor is Deprecated, use the new Stream Lines processor together "
         "with the IntegralLineToMesh processor.");
 }
@@ -204,7 +204,7 @@ void StreamRibbonsDeprecated::process() {
             vec4 c{0};
             if (hasColors) {
                 if (lineId >= colors_.getData()->size()) {
-                    LogWarn("The vector of colors is smaller then the vector of seed points");
+                    log::warn("The vector of colors is smaller then the vector of seed points");
                 } else {
                     c = colors_.getData()->at(lineId);
                 }
@@ -236,7 +236,7 @@ void StreamRibbonsDeprecated::process() {
                         if (hasColors) {
                             break;
                         } else {
-                            LogWarn(
+                            log::warn(
                                 "No colors in the color port, using velocity for coloring "
                                 "instead ");
                             [[fallthrough]];

--- a/modules/vectorfieldvisualization/src/processors/datageneration/seedpointgenerator.cpp
+++ b/modules/vectorfieldvisualization/src/processors/datageneration/seedpointgenerator.cpp
@@ -39,7 +39,7 @@
 #include <inviwo/core/properties/optionproperty.h>                  // for OptionPropertyInt
 #include <inviwo/core/properties/ordinalproperty.h>                 // for FloatVec3Property
 #include <inviwo/core/util/glmvec.h>                                // for vec3, vec2
-#include <inviwo/core/util/logcentral.h>                            // for LogCentral, LogWarn
+#include <inviwo/core/util/logcentral.h>                            // for LogCentral
 #include <modules/base/algorithm/randomutils.h>                     // for randomNumber
 #include <modules/vectorfieldvisualization/ports/seedpointsport.h>  // for SeedPoints3DOutport
 
@@ -149,7 +149,7 @@ void SeedPointGenerator::process() {
             spherePoints();
             break;
         default:
-            LogWarn("No points generated since given type is not yet implemented");
+            log::warn("No points generated since given type is not yet implemented");
             break;
     }
 }

--- a/modules/vectorfieldvisualization/src/processors/integrallinevectortomesh.cpp
+++ b/modules/vectorfieldvisualization/src/processors/integrallinevectortomesh.cpp
@@ -364,12 +364,12 @@ void IntegralLineVectorToMesh::process() {
         if (!mdProp) {  // Fallback
             auto props = getPropertiesByType<ColorByProperty>();
             if (props.size() == 0) {
-                throw Exception("Couldn't get ColorByProperty for meta data " + metaDataKey,
-                                IVW_CONTEXT);
+                throw Exception(IVW_CONTEXT, "Couldn't get ColorByProperty for meta data {}",
+                                metaDataKey);
             }
             mdProp = props.front();
-            LogWarn("Couldn't get ColorByProperty for meta data "
-                    << metaDataKey << ", using " << mdProp->getDisplayName() << " instead");
+            log::warn("Couldn't get ColorByProperty for meta data {}, using {} instead",
+                      metaDataKey, mdProp->getDisplayName());
         }
     }
 
@@ -418,7 +418,7 @@ void IntegralLineVectorToMesh::process() {
                 if (index >= colors->size()) {
                     if (colorWarningOnce) {
                         colorWarningOnce = false;
-                        LogWarn("Line index for color is out of range");
+                        log::warn("Line index for color is out of range");
                     }
                     index %= colors->size();
                 }

--- a/modules/vectorfieldvisualizationgl/src/processors/3d/streamparticles.cpp
+++ b/modules/vectorfieldvisualizationgl/src/processors/3d/streamparticles.cpp
@@ -212,7 +212,7 @@ void StreamParticles::update() {
             invalidate(InvalidationLevel::InvalidOutput);
         }
     } catch (const Exception& e) {
-        util::log(e.getContext(), e.getMessage(), LogLevel::Error);
+        log::user::exception(e);
     }
 }
 

--- a/modules/vectorfieldvisualizationgl/src/processors/3d/streamparticles.cpp
+++ b/modules/vectorfieldvisualizationgl/src/processors/3d/streamparticles.cpp
@@ -212,7 +212,7 @@ void StreamParticles::update() {
             invalidate(InvalidationLevel::InvalidOutput);
         }
     } catch (const Exception& e) {
-        log::user::exception(e);
+        log::exception(e);
     }
 }
 

--- a/resources/changelog.html
+++ b/resources/changelog.html
@@ -33,6 +33,67 @@
 </style>
 </head>
 <body>
+<h2>2025-01-19 New Logging functions</h2>
+<p>The existing macro based logging functions <code class="notranslate">LogInfo</code>, <code class="notranslate">LogWarn</code>, <code class="notranslate">LogError</code> and there <code class="notranslate">_Custom</code> versions are superseded a new<br>
+API that takes advantage of <code class="notranslate">std::source_location</code>, meaning, we no longer need any macros.</p>
+<p>The new log functions all live in the <code class="notranslate">inviwo::log</code> namespace. They either take an explicit <code class="notranslate">SourceContext</code> argument, or automatically extract one from the call site. All functions that take a <code class="notranslate">fmt::format_string</code> do compile time format checks.</p>
+<h4>Basic logging</h4>
+<ul>
+<li>
+<div class="highlight highlight-source-c++"><pre class="notranslate"><span class="pl-en">log::info</span>(fmt::format_string&lt;Args...&gt;, Args&amp;&amp;...)</pre></div>
+</li>
+<li>
+<div class="highlight highlight-source-c++"><pre class="notranslate"><span class="pl-en">log::warn</span>(fmt::format_string&lt;Args...&gt;, Args&amp;&amp;...)</pre></div>
+</li>
+<li>
+<div class="highlight highlight-source-c++"><pre class="notranslate"><span class="pl-en">log::error</span>(fmt::format_string&lt;Args...&gt;, Args&amp;&amp;...)</pre></div>
+</li>
+</ul>
+<h4>Runtime Log Level</h4>
+<ul>
+<li>
+<div class="highlight highlight-source-c++"><pre class="notranslate"><span class="pl-en">log::report</span>(LogLevel, SourceContext, fmt::format_string, Args&amp;&amp;...)</pre></div>
+</li>
+<li>
+<div class="highlight highlight-source-c++"><pre class="notranslate"><span class="pl-en">log::report</span>(LogLevel, SourceContext, std::string_view)</pre></div>
+</li>
+<li>
+<div class="highlight highlight-source-c++"><pre class="notranslate"><span class="pl-en">log::report</span>(LogLevel, std::string_view)</pre></div>
+</li>
+<li>
+<div class="highlight highlight-source-c++"><pre class="notranslate"><span class="pl-en">log::message</span>(LogLevel level, fmt::format_string&lt;Args...&gt;, Args&amp;&amp;...)</pre></div>
+</li>
+</ul>
+<h4>Log Exceptions</h4>
+<ul>
+<li>
+<div class="highlight highlight-source-c++"><pre class="notranslate"><span class="pl-en">log::exception</span>(<span class="pl-k">const</span> Exception&amp;)</pre></div>
+</li>
+<li>
+<div class="highlight highlight-source-c++"><pre class="notranslate"><span class="pl-en">log::exception</span>(<span class="pl-k">const</span> std::<span class="pl-c1">exception</span>&amp;)</pre></div>
+</li>
+<li>
+<div class="highlight highlight-source-c++"><pre class="notranslate"><span class="pl-en">log::exception</span>(std::string_view)</pre></div>
+</li>
+<li>
+<div class="highlight highlight-source-c++"><pre class="notranslate"><span class="pl-en">log::exception</span>()</pre></div>
+</li>
+</ul>
+<h4>Log to a custom logger</h4>
+<ul>
+<li>
+<div class="highlight highlight-source-c++"><pre class="notranslate"><span class="pl-en">log::report</span>(Logger&amp;, LogLevel, SourceContext, fmt::format_string, Args&amp;&amp;...)</pre></div>
+</li>
+<li>
+<div class="highlight highlight-source-c++"><pre class="notranslate"><span class="pl-en">log::report</span>(Logger&amp;, LogLevel, SourceContext, std::string_view)</pre></div>
+</li>
+<li>
+<div class="highlight highlight-source-c++"><pre class="notranslate"><span class="pl-en">log::report</span>(Logger&amp;, LogLevel, std::string_view)</pre></div>
+</li>
+<li>
+<div class="highlight highlight-source-c++"><pre class="notranslate"><span class="pl-en">log::message</span>(Logger&amp;, LogLevel level, fmt::format_string&lt;Args...&gt;, Args&amp;&amp;...)</pre></div>
+</li>
+</ul>
 <h2>2024-12-09 <strong>Breaking</strong> change: string_view class identifiers</h2>
 <p>All base classes that have a <code class="notranslate">virtual std::string getClassIdentifier() const</code> were refactored into <code class="notranslate">virtual std::string_view getClassIdentifier() const</code>. This is done to avoid string allocations.<br>
 If you have a class that derives from <code class="notranslate">Inport</code>, <code class="notranslate">Outport</code>, <code class="notranslate">Property</code>, <code class="notranslate">Metadata</code>, <code class="notranslate">Camera</code>, <code class="notranslate">animation::Track</code> or <code class="notranslate">animation::Interpolation</code> and with a override of</p>
@@ -151,7 +212,7 @@ Since the extra quotes inserted while formatting will make the path ill formed.<
 <p>This change potentially breaks existing Python processors handling either image layers and/or volumes. To fix these, ensure that the shape of Numpy arrays is in the form of <code class="notranslate">(z, y, x)</code> or <code class="notranslate">(z, y, x, c)</code> for volumes and <code class="notranslate">(y, x)</code>/<code class="notranslate">(y, x, c)</code> for layers, respectively. Reordering of axes should no longer be necessary.</p>
 <p><em>Note:</em> Numpy arrays must be C-contiguous in order to be used by Inviwo. If they are not, the conversion from Numpy to Inviwo will fail and throw an exception (<code class="notranslate">Buffer</code>, <code class="notranslate">LayerPy</code>, <code class="notranslate">VolumePy</code>, etc.). Bear in mind that in Python the right-most index is the fastest.</p>
 <div class="highlight highlight-source-python"><pre class="notranslate"><span class="pl-s1">l</span> <span class="pl-c1">=</span> [ [ <span class="pl-c1">0</span>, <span class="pl-c1">1</span>, <span class="pl-c1">2</span> ], [ <span class="pl-c1">3</span>, <span class="pl-c1">4</span>, <span class="pl-c1">5</span> ] ]
-<span class="pl-en">print</span>(<span class="pl-s1">l</span>[<span class="pl-c1">0</span>][<span class="pl-c1">2</span>]) <span class="pl-c"># [2] refers to the fastest running index</span>
+<span class="pl-s1">const</span> <span class="pl-v">ProcessorInfo</span><span class="pl-c1">&amp;</span> ::<span class="pl-en">getProcessorInfo</span>() <span class="pl-s1">const</span> { <span class="pl-s1">return</span> <span class="pl-s1">processorInfo_</span>; }<span class="pl-s1">l</span>[<span class="pl-c1">0</span>][<span class="pl-c1">2</span>]) <span class="pl-c"># [2] refers to the fastest running index</span>
 
 <span class="pl-s1">n</span> <span class="pl-c1">=</span> <span class="pl-s1">numpy</span>.<span class="pl-c1">array</span>(<span class="pl-s1">l</span>)
 <span class="pl-en">print</span>(<span class="pl-s1">n</span>.<span class="pl-c1">flatten</span>()) <span class="pl-c"># -&gt; [ 0, 1, 2, 3, 4, 5 ]</span>

--- a/src/core/algorithm/camerautils.cpp
+++ b/src/core/algorithm/camerautils.cpp
@@ -139,8 +139,7 @@ void setCameraView(CameraProperty& cam, const mat4& boundingBox, vec3 inViewDir,
             *skewedPerspectiveCamera, boundingBox, inViewDir, inLookUp, fitRatio);
         cam.setLook(lookFrom, lookTo, lookUp);
     } else {
-        LogWarnCustom("camerautil::setCameraView",
-                      "setCameraView does not support " << cam.get().getClassIdentifier());
+        log::warn("setCameraView does not support {}", cam.get().getClassIdentifier());
     }
 }
 

--- a/src/core/algorithm/markdown.cpp
+++ b/src/core/algorithm/markdown.cpp
@@ -248,7 +248,7 @@ Document util::md2doc(std::string_view markdown) {
         return 0;
     };
     auto debug_log_callback = [](const char* msg, void*) -> void {
-        LogInfoCustom("Markdown", "Error: " << msg);
+        log::user::error("Markdown Error: {}", msg);
     };
 
     MD_PARSER parser = {

--- a/src/core/algorithm/markdown.cpp
+++ b/src/core/algorithm/markdown.cpp
@@ -248,7 +248,7 @@ Document util::md2doc(std::string_view markdown) {
         return 0;
     };
     auto debug_log_callback = [](const char* msg, void*) -> void {
-        log::user::error("Markdown Error: {}", msg);
+        log::error("Markdown Error: {}", msg);
     };
 
     MD_PARSER parser = {

--- a/src/core/common/inviwoapplication.cpp
+++ b/src/core/common/inviwoapplication.cpp
@@ -370,7 +370,7 @@ void InviwoApplication::setLayerRamResizer(LayerRamResizer* obj) { layerRamResiz
 
 void InviwoApplication::setAssertionHandler(
     std::function<void(std::string_view message, SourceContext context)> assertionHandler) {
-    assertionHandler_ = assertionHandler;
+    assertionHandler_ = std::move(assertionHandler);
 }
 
 const std::function<void(std::string_view message, SourceContext context)>&
@@ -417,8 +417,7 @@ ThreadPool& InviwoApplication::getThreadPool() { return pool_; }
 void InviwoApplication::waitForPool() {
     size_t old_size = pool_.getSize();
     resizePool(0);  // This will wait until all tasks are done;
-    while (processFront())
-        ;
+    while (processFront()) {}
     resizePool(old_size);
 }
 

--- a/src/core/common/inviwoapplication.cpp
+++ b/src/core/common/inviwoapplication.cpp
@@ -258,18 +258,18 @@ const CommandLineParser& InviwoApplication::getCommandLineParser() const {
 CommandLineParser& InviwoApplication::getCommandLineParser() { return *commandLineParser_; }
 
 void InviwoApplication::printApplicationInfo() {
-    log::user::info("Inviwo Version: {}", build::version);
+    log::info("Inviwo Version: {}", build::version);
     if (auto buildInfo = util::getBuildInfo()) {
-        log::user::info("Build Date: {}", buildInfo->getDate());
+        log::info("Build Date: {}", buildInfo->getDate());
         for (auto [name, hash] : buildInfo->githashes) {
-            log::user::info("Git {}  hash: {}", name, hash);
+            log::info("Git {}  hash: {}", name, hash);
         }
     }
-    log::user::info("Base Path: {}", getBasePath());
-    log::user::info("ThreadPool Worker Threads: {}", pool_.getSize());
+    log::info("Base Path: {}", getBasePath());
+    log::info("ThreadPool Worker Threads: {}", pool_.getSize());
 
-    log::user::info("Config: {} [{}] {} ({})", build::generator, build::configuration,
-                    build::compiler, build::compilerVersion);
+    log::info("Config: {} [{}] {} ({})", build::generator, build::configuration, build::compiler,
+              build::compilerVersion);
 }
 
 void InviwoApplication::postProgress(std::string_view progress) const {
@@ -353,8 +353,7 @@ void InviwoApplication::resizePool(size_t newSize) {
     while (size != newSize) {
         if (timeout()) {
             const auto left = size - newSize;
-            log::user::info("Waiting for {} background thread{} to finish", left,
-                            (left > 1 ? "s" : ""));
+            log::info("Waiting for {} background thread{} to finish", left, (left > 1 ? "s" : ""));
             timeLimit += std::chrono::milliseconds(1000);
         }
 

--- a/src/core/common/inviwoapplication.cpp
+++ b/src/core/common/inviwoapplication.cpp
@@ -368,6 +368,16 @@ void InviwoApplication::resizePool(size_t newSize) {
 LayerRamResizer* InviwoApplication::getLayerRamResizer() const { return layerRamResizer_; }
 void InviwoApplication::setLayerRamResizer(LayerRamResizer* obj) { layerRamResizer_ = obj; }
 
+void InviwoApplication::setAssertionHandler(
+    std::function<void(std::string_view message, SourceContext context)> assertionHandler) {
+    assertionHandler_ = assertionHandler;
+}
+
+const std::function<void(std::string_view message, SourceContext context)>&
+InviwoApplication::getAssertionHandler() const {
+    return assertionHandler_;
+}
+
 std::locale InviwoApplication::getUILocale() const { return uiLocale_; }
 void InviwoApplication::setUILocale(const std::locale& locale) { uiLocale_ = locale; }
 
@@ -407,7 +417,8 @@ ThreadPool& InviwoApplication::getThreadPool() { return pool_; }
 void InviwoApplication::waitForPool() {
     size_t old_size = pool_.getSize();
     resizePool(0);  // This will wait until all tasks are done;
-    while (processFront());
+    while (processFront())
+        ;
     resizePool(old_size);
 }
 

--- a/src/core/common/inviwoapplication.cpp
+++ b/src/core/common/inviwoapplication.cpp
@@ -258,18 +258,18 @@ const CommandLineParser& InviwoApplication::getCommandLineParser() const {
 CommandLineParser& InviwoApplication::getCommandLineParser() { return *commandLineParser_; }
 
 void InviwoApplication::printApplicationInfo() {
-    LogInfoCustom("InviwoInfo", "Inviwo Version: " << build::version);
+    log::user::info("Inviwo Version: {}", build::version);
     if (auto buildInfo = util::getBuildInfo()) {
-        LogInfoCustom("InviwoInfo", "Build Date: " << buildInfo->getDate());
+        log::user::info("Build Date: {}", buildInfo->getDate());
         for (auto [name, hash] : buildInfo->githashes) {
-            LogInfoCustom("InviwoInfo", "Git " << name << " hash: " << hash);
+            log::user::info("Git {}  hash: {}", name, hash);
         }
     }
-    LogInfoCustom("InviwoInfo", "Base Path: " << getBasePath());
-    LogInfoCustom("InviwoInfo", "ThreadPool Worker Threads: " << pool_.getSize());
+    log::user::info("Base Path: {}", getBasePath());
+    log::user::info("ThreadPool Worker Threads: {}", pool_.getSize());
 
-    util::logInfo(IVW_CONTEXT_CUSTOM("InviwoInfo"), "Config: {} [{}] {} ({})", build::generator,
-                  build::configuration, build::compiler, build::compilerVersion);
+    log::user::info("Config: {} [{}] {} ({})", build::generator, build::configuration,
+                    build::compiler, build::compilerVersion);
 }
 
 void InviwoApplication::postProgress(std::string_view progress) const {
@@ -352,9 +352,9 @@ void InviwoApplication::resizePool(size_t newSize) {
 
     while (size != newSize) {
         if (timeout()) {
-            auto left = size - newSize;
-            LogInfo("Waiting for " << left << " background thread" << (left > 1 ? "s" : "")
-                                   << " to finish");
+            const auto left = size - newSize;
+            log::user::info("Waiting for {} background thread{} to finish", left,
+                            (left > 1 ? "s" : ""));
             timeLimit += std::chrono::milliseconds(1000);
         }
 

--- a/src/core/common/inviwomodulelibraryobserver.cpp
+++ b/src/core/common/inviwomodulelibraryobserver.cpp
@@ -72,7 +72,7 @@ void InviwoModuleLibraryObserver::fileChanged(const std::filesystem::path& dir) 
             if (time > it->second) {
                 it->second = time;
                 reload = true;
-                LogInfo("Detected change in: " << file);
+                log::user::info("Detected change in: {}", file);
             }
         }
     }

--- a/src/core/common/inviwomodulelibraryobserver.cpp
+++ b/src/core/common/inviwomodulelibraryobserver.cpp
@@ -72,7 +72,7 @@ void InviwoModuleLibraryObserver::fileChanged(const std::filesystem::path& dir) 
             if (time > it->second) {
                 it->second = time;
                 reload = true;
-                log::user::info("Detected change in: {}", file);
+                log::info("Detected change in: {}", file);
             }
         }
     }

--- a/src/core/common/modulemanager.cpp
+++ b/src/core/common/modulemanager.cpp
@@ -197,15 +197,14 @@ void ModuleManager::reloadModules() {
     // 5. Load module libraries and register them
     // 6. De-serialize network
 
-    log::user::info("Reloading modules");
+    log::info("Reloading modules");
 
     // Serialize network
     std::stringstream stream;
     try {
         app_->getWorkspaceManager()->save(stream, app_->getBasePath());
-    } catch (SerializationException& exception) {
-        log::report(LogLevel::Error, LogAudience::User, exception.getContext(),
-                    "Unable to save network due to {}", exception.getMessage());
+    } catch (SerializationException& e) {
+        log::exception(e, "Unable to save network due to {}", e.getMessage());
         return;
     }
 
@@ -242,14 +241,13 @@ void ModuleManager::reloadModules() {
                 const auto err = dereg.empty() ? ""
                                                : fmt::format("\nUnregistered dependent modules: {}",
                                                              fmt::join(dereg, ", "));
-                log::user::exception(e, "Failed to register module: {}. Reason:\n {}{}",
-                                     cont.name(), e.getMessage(), err);
+                log::exception(e, "Failed to register module: {}. Reason:\n {}{}", cont.name(),
+                               e.getMessage(), err);
             } catch (const Exception& e) {
-                log::user::exception(e, "Failed to register module: {}. Reason:\n{}", cont.name(),
-                                     e.getMessage());
+                log::exception(e, "Failed to register module: {}. Reason:\n{}", cont.name(),
+                               e.getMessage());
             } catch (const std::exception& e) {
-                log::user::error("Failed to register module: {}. Reason:\n{}", cont.name(),
-                                 e.what());
+                log::error("Failed to register module: {}. Reason:\n{}", cont.name(), e.what());
             }
         }
     }
@@ -274,7 +272,7 @@ void ModuleManager::reloadModules() {
         // Lock the network that so no evaluations are triggered during the de-serialization
         app_->getWorkspaceManager()->load(stream, app_->getBasePath());
     } catch (SerializationException& e) {
-        log::user::exception(e, "Unable to load network due to {}", e.getMessage());
+        log::exception(e, "Unable to load network due to {}", e.getMessage());
         return;
     }
 }
@@ -319,8 +317,8 @@ std::vector<ModuleContainer> ModuleManager::findRuntimeModules(
             try {
                 modules.emplace_back(file, runtimeReloading);
             } catch (const Exception& e) {
-                log::user::warn("Could not load library: {}", file.path());
-                log::user::exception(e);
+                log::warn("Could not load library: {}", file.path());
+                log::exception(e);
             }
         }
     }

--- a/src/core/datastructures/geometry/mesh.cpp
+++ b/src/core/datastructures/geometry/mesh.cpp
@@ -189,7 +189,6 @@ auto Mesh::replaceBuffer(BufferBase* oldbuffer, BufferInfo info, std::shared_ptr
 }
 
 void Mesh::setBuffer(size_t idx, BufferInfo info, std::shared_ptr<BufferBase> buffer) {
-    LogWarn("Deprecated: Mesh::setBuffer() has been renamed to Mesh::replaceBuffer()");
     replaceBuffer(idx, info, buffer);
 }
 

--- a/src/core/datastructures/image/image.cpp
+++ b/src/core/datastructures/image/image.cpp
@@ -274,7 +274,7 @@ std::unique_ptr<std::vector<unsigned char>> Image::getLayerAsCodedBuffer(
     if (auto layer = this->getLayer(layerType, idx)) {
         return layer->getAsCodedBuffer(fileExtension);
     } else {
-        LogError("Requested layer does not exist");
+        log::error("Requested layer does not exist");
     }
     return nullptr;
 }
@@ -316,7 +316,7 @@ void Image::copyRepresentationsTo(Image* targetImage) const {
                 if (sourceRepr->copyRepresentationsTo(targetRepr)) {
                     return;
                 } else {
-                    LogError("Copy representation failed!")
+                    log::error("Copy representation failed!");
                 }
             }
         }

--- a/src/core/datastructures/image/layer.cpp
+++ b/src/core/datastructures/image/layer.cpp
@@ -155,7 +155,7 @@ std::unique_ptr<std::vector<unsigned char>> Layer::getAsCodedBuffer(
         try {
             return writer->writeDataToBuffer(this, fileExtension);
         } catch (const DataWriterException& e) {
-            log::user::exception(e);
+            log::exception(e);
         }
     } else {
         log::error("Could not find a writer for the specified file extension (\"{}\")",

--- a/src/core/datastructures/image/layer.cpp
+++ b/src/core/datastructures/image/layer.cpp
@@ -155,11 +155,11 @@ std::unique_ptr<std::vector<unsigned char>> Layer::getAsCodedBuffer(
         try {
             return writer->writeDataToBuffer(this, fileExtension);
         } catch (const DataWriterException& e) {
-            LogError(e.getMessage());
+            log::user::exception(e);
         }
     } else {
-        LogError("Could not find a writer for the specified file extension (\"" << fileExtension
-                                                                                << "\")");
+        log::error("Could not find a writer for the specified file extension (\"{}\")",
+                   fileExtension);
     }
 
     return {};

--- a/src/core/interaction/pickingmanager.cpp
+++ b/src/core/interaction/pickingmanager.cpp
@@ -61,8 +61,8 @@ PickingAction* PickingManager::registerPickingAction(Processor* processor,
         // we can only differentiate up to 2^24-1 picking IDs due to the use of u8vec3 for picking
         // colors
         if (lastIndex_ >= (1 << 24)) {
-            LogWarn("More than " << (1 << 24)
-                                 << " picking IDs in use. Unreliable picking behavior expected.");
+            log::warn("More than {} picking IDs in use. Unreliable picking behavior expected.",
+                      (1 << 24));
         }
         pickObj = pickingActions_.back().get();
     }

--- a/src/core/io/datareaderfactory.cpp
+++ b/src/core/io/datareaderfactory.cpp
@@ -38,7 +38,7 @@ bool DataReaderFactory::registerObject(DataReader* reader) {
         if (util::insert_unique(map_, ext, reader)) {
             ++added;
         } else {
-            LogWarn("Failed to register DataReader for \"" << ext << "\", already registered");
+            log::warn("Failed to register DataReader for \"{}\", already registered", ext);
         }
     }
     if (added > 0) {

--- a/src/core/io/datawriterfactory.cpp
+++ b/src/core/io/datawriterfactory.cpp
@@ -41,7 +41,7 @@ bool DataWriterFactory::registerObject(DataWriter* writer) {
         if (util::insert_unique(map_, ext, writer)) {
             ++added;
         } else {
-            LogWarn("Failed to register DataWriter for \"" << ext << "\", already registered");
+            log::warn("Failed to register DataWriter for \"{}\", already registered", ext);
         }
     }
     if (added > 0) {

--- a/src/core/io/imagewriterutil.cpp
+++ b/src/core/io/imagewriterutil.cpp
@@ -44,9 +44,9 @@ void saveLayer(const Layer& layer, const std::filesystem::path& path,
                const FileExtension& extension) {
     try {
         util::saveData<Layer>(layer, path, extension, Overwrite::Yes);
-        LogInfoCustom("ImageWriterUtil", "Canvas layer exported to disk: " << path);
-    } catch (DataWriterException const& e) {
-        LogErrorCustom("ImageWriterUtil", e.getMessage());
+        log::user::info("Canvas layer exported to disk: {}", path);
+    } catch (const DataWriterException& e) {
+        log::user::exception(e);
     }
 }
 

--- a/src/core/io/imagewriterutil.cpp
+++ b/src/core/io/imagewriterutil.cpp
@@ -44,9 +44,9 @@ void saveLayer(const Layer& layer, const std::filesystem::path& path,
                const FileExtension& extension) {
     try {
         util::saveData<Layer>(layer, path, extension, Overwrite::Yes);
-        log::user::info("Canvas layer exported to disk: {}", path);
+        log::info("Canvas layer exported to disk: {}", path);
     } catch (const DataWriterException& e) {
-        log::user::exception(e);
+        log::exception(e);
     }
 }
 

--- a/src/core/io/rawvolumereader.cpp
+++ b/src/core/io/rawvolumereader.cpp
@@ -187,7 +187,7 @@ std::shared_ptr<Volume> RawVolumeReader::readData(const std::filesystem::path& f
         volume->dataMap = dataMapper_;
         std::string size = util::formatBytesToString(dimensions_.x * dimensions_.y * dimensions_.z *
                                                      (format_->getSizeInBytes()));
-        LogInfo("Loaded volume: " << filePath << " size: " << size);
+        log::user::info("Loaded volume: {}  size: {}", filePath, size);
         return volume;
     } else {
         throw DataReaderException("Raw data import could not determine format", IVW_CONTEXT);

--- a/src/core/io/rawvolumereader.cpp
+++ b/src/core/io/rawvolumereader.cpp
@@ -187,7 +187,7 @@ std::shared_ptr<Volume> RawVolumeReader::readData(const std::filesystem::path& f
         volume->dataMap = dataMapper_;
         std::string size = util::formatBytesToString(dimensions_.x * dimensions_.y * dimensions_.z *
                                                      (format_->getSizeInBytes()));
-        log::user::info("Loaded volume: {}  size: {}", filePath, size);
+        log::info("Loaded volume: {}  size: {}", filePath, size);
         return volume;
     } else {
         throw DataReaderException("Raw data import could not determine format", IVW_CONTEXT);

--- a/src/core/io/serialization/deserializer.cpp
+++ b/src/core/io/serialization/deserializer.cpp
@@ -57,9 +57,8 @@ TiXmlElement* getRootElement(TiXmlDocument& doc, std::string_view rootElement) {
 
     root = doc.FirstChildElement();
     if (root) {
-        LogInfoCustom("Deserializer", "Expected to find root element of type: '"
-                                          << rootElement << "' but found '" << root->Value()
-                                          << "'");
+        log::user::warn("Deserializer expected to find root element of type: '{}' but found '{}'",
+                        rootElement, root->Value());
         return root;
     }
 

--- a/src/core/io/serialization/deserializer.cpp
+++ b/src/core/io/serialization/deserializer.cpp
@@ -57,8 +57,8 @@ TiXmlElement* getRootElement(TiXmlDocument& doc, std::string_view rootElement) {
 
     root = doc.FirstChildElement();
     if (root) {
-        log::user::warn("Deserializer expected to find root element of type: '{}' but found '{}'",
-                        rootElement, root->Value());
+        log::warn("Deserializer expected to find root element of type: '{}' but found '{}'",
+                  rootElement, root->Value());
         return root;
     }
 

--- a/src/core/io/serialization/versionconverter.cpp
+++ b/src/core/io/serialization/versionconverter.cpp
@@ -75,9 +75,9 @@ bool xml::copyMatchingSubPropsIntoComposite(TxElement* node, const CompositeProp
                 if (p->getIdentifier() == *id &&
                     (p->getClassIdentifier() == *type ||
                      p->getClassIdentifier() == util::splitByLast(*type, '.').second)) {
-                    log::user::report(LogLevel::Info, SourceContext("VersionConverter"_sl),
-                                      "    Match for sub property: {} found in type: {}  id: {}",
-                                      p->getPath(), *type, *id);
+                    log::report(LogLevel::Info, SourceContext("VersionConverter"_sl),
+                                "    Match for sub property: {} found in type: {}  id: {}",
+                                p->getPath(), *type, *id);
 
                     list.LinkEndChild(child->Clone());
                     toBeDeleted.push_back(child);
@@ -186,8 +186,8 @@ bool xml::copyMatchingCompositeProperty(TxElement* node, const CompositeProperty
 
         if ((type == "CompositeProperty" || type == "org.inviwo.CompositeProperty") &&
             prop.getIdentifier() == id) {
-            log::user::report(LogLevel::Info, SourceContext("VersionConverter"_sl),
-                              "    Found Composite with same identifier");
+            log::report(LogLevel::Info, SourceContext("VersionConverter"_sl),
+                        "    Found Composite with same identifier");
 
             TxElement* newChild = node->InsertEndChild(*child)->ToElement();
             newChild->SetAttribute("type", prop.getClassIdentifier());
@@ -427,7 +427,7 @@ void xml::logNode(TxElement* node) {
     xml.reserve(4096);
     TiXmlPrinter printer{xml, TiXmlStreamPrint::No};
     node->Accept(&printer);
-    log::user::report(LogLevel::Info, xml);
+    log::report(LogLevel::Info, xml);
 }
 
 bool xml::renamePortIdentifier(TxElement* root, std::string_view processorClassId,

--- a/src/core/io/serialization/versionconverter.cpp
+++ b/src/core/io/serialization/versionconverter.cpp
@@ -75,9 +75,9 @@ bool xml::copyMatchingSubPropsIntoComposite(TxElement* node, const CompositeProp
                 if (p->getIdentifier() == *id &&
                     (p->getClassIdentifier() == *type ||
                      p->getClassIdentifier() == util::splitByLast(*type, '.').second)) {
-                    LogInfoCustom("VersionConverter",
-                                  "    Match for sub property: " + p->getPath() + " found in type: "
-                                      << *type << " id: " << *id);
+                    log::user::report(LogLevel::Info, SourceContext("VersionConverter"_sl),
+                                      "    Match for sub property: {} found in type: {}  id: {}",
+                                      p->getPath(), *type, *id);
 
                     list.LinkEndChild(child->Clone());
                     toBeDeleted.push_back(child);
@@ -186,7 +186,8 @@ bool xml::copyMatchingCompositeProperty(TxElement* node, const CompositeProperty
 
         if ((type == "CompositeProperty" || type == "org.inviwo.CompositeProperty") &&
             prop.getIdentifier() == id) {
-            LogInfoCustom("VersionConverter", "    Found Composite with same identifier");
+            log::user::report(LogLevel::Info, SourceContext("VersionConverter"_sl),
+                              "    Found Composite with same identifier");
 
             TxElement* newChild = node->InsertEndChild(*child)->ToElement();
             newChild->SetAttribute("type", prop.getClassIdentifier());
@@ -414,7 +415,7 @@ TxElement* xml::createNode(std::string_view desc, TxElement* parent) {
             node->SetAttribute(key, value);
         });
         if (parent) {
-           parent->LinkEndChild(node);
+            parent->LinkEndChild(node);
         }
         parent = node;
     });
@@ -426,7 +427,7 @@ void xml::logNode(TxElement* node) {
     xml.reserve(4096);
     TiXmlPrinter printer{xml, TiXmlStreamPrint::No};
     node->Accept(&printer);
-    LogInfoCustom("xml", xml);
+    log::user::report(LogLevel::Info, xml);
 }
 
 bool xml::renamePortIdentifier(TxElement* root, std::string_view processorClassId,

--- a/src/core/io/transferfunctionxmlreader.cpp
+++ b/src/core/io/transferfunctionxmlreader.cpp
@@ -100,7 +100,7 @@ void parseColorMapsNode(TransferFunction& tf, TxElement* node) {
          child = child->NextSiblingElement("ColorMap")) {
         ++count;
         if (count > 1) {
-            log::user::warn("Detected more than one ColorMap");
+            log::warn("Detected more than one ColorMap");
             return;
         }
         parseColorMapNode(tf, child);

--- a/src/core/io/transferfunctionxmlreader.cpp
+++ b/src/core/io/transferfunctionxmlreader.cpp
@@ -100,8 +100,7 @@ void parseColorMapsNode(TransferFunction& tf, TxElement* node) {
          child = child->NextSiblingElement("ColorMap")) {
         ++count;
         if (count > 1) {
-            LogWarnCustom("TransferFunctionXMLReader::loadFromXML()",
-                          "Detected more than one ColorMap");
+            log::user::warn("Detected more than one ColorMap");
             return;
         }
         parseColorMapNode(tf, child);

--- a/src/core/network/evaluationerrorhandler.cpp
+++ b/src/core/network/evaluationerrorhandler.cpp
@@ -41,14 +41,14 @@ void StandardEvaluationErrorHandler::operator()(Processor* processor, Evaluation
     try {
         throw;
     } catch (Exception& e) {
-        log::user::exception(e, "{} Error in {} : {}", id, type, e.getFullMessage());
+        log::exception(e, "{} Error in {} : {}", id, type, e.getFullMessage());
     } catch (fmt::format_error& e) {
-        log::user::report(LogLevel::Error, context, "{} Error in {} using fmt formatting: {}\n{}",
-                          id, type, e.what(), util::fmtHelp.view());
+        log::report(LogLevel::Error, context, "{} Error in {} using fmt formatting: {}\n{}", id,
+                    type, e.what(), util::fmtHelp.view());
     } catch (std::exception& e) {
-        log::user::report(LogLevel::Error, context, "{} Error in {} : {}", id, type, e.what());
+        log::report(LogLevel::Error, context, "{} Error in {} : {}", id, type, e.what());
     } catch (...) {
-        log::user::report(LogLevel::Error, context, "{} Error in {} : Unknown error", id, type);
+        log::report(LogLevel::Error, context, "{} Error in {} : Unknown error", id, type);
     }
 }
 

--- a/src/core/network/evaluationerrorhandler.cpp
+++ b/src/core/network/evaluationerrorhandler.cpp
@@ -41,18 +41,14 @@ void StandardEvaluationErrorHandler::operator()(Processor* processor, Evaluation
     try {
         throw;
     } catch (Exception& e) {
-        util::log(e.getContext(), fmt::format("{} Error in {} : {}", id, type, e.getFullMessage()),
-                  LogLevel::Error);
+        log::user::exception(e, "{} Error in {} : {}", id, type, e.getFullMessage());
     } catch (fmt::format_error& e) {
-        util::log(context,
-                  fmt::format("{} Error in {} using fmt formatting: {}\n{}", id, type, e.what(),
-                              util::fmtHelp.view()),
-                  LogLevel::Error);
+        log::user::report(LogLevel::Error, context, "{} Error in {} using fmt formatting: {}\n{}",
+                          id, type, e.what(), util::fmtHelp.view());
     } catch (std::exception& e) {
-        util::log(context, fmt::format("{} Error in {} : {}", id, type, e.what()), LogLevel::Error);
+        log::user::report(LogLevel::Error, context, "{} Error in {} : {}", id, type, e.what());
     } catch (...) {
-        util::log(context, fmt::format("{} Error in {} : Unknown error", id, type),
-                  LogLevel::Error);
+        log::user::report(LogLevel::Error, context, "{} Error in {} : Unknown error", id, type);
     }
 }
 

--- a/src/core/network/networkutils.cpp
+++ b/src/core/network/networkutils.cpp
@@ -409,7 +409,7 @@ void detail::PartialProcessorNetwork::deserialize(Deserializer& d) {
         }
 
     } catch (Exception& e) {
-        util::log(IVW_CONTEXT_CUSTOM("Paste"), e.getMessage(), LogLevel::Warn, LogAudience::User);
+        log::user::exception(e);
     }
 }
 

--- a/src/core/network/networkutils.cpp
+++ b/src/core/network/networkutils.cpp
@@ -409,7 +409,7 @@ void detail::PartialProcessorNetwork::deserialize(Deserializer& d) {
         }
 
     } catch (Exception& e) {
-        log::user::exception(e);
+        log::exception(e);
     }
 }
 

--- a/src/core/network/processornetwork.cpp
+++ b/src/core/network/processornetwork.cpp
@@ -507,10 +507,10 @@ void ProcessorNetwork::deserialize(Deserializer& d) {
     d.deserialize("ProcessorNetworkVersion", version);
 
     if (version != processorNetworkVersion_) {
-        LogNetworkSpecial((&d), LogLevel::Warn,
-                          fmt::format("Loading old workspace ({}) Processor Network version: {}. "
-                                      "Updating to version: {}.",
-                                      d.getFileName(), version, processorNetworkVersion_));
+        log::message(d, LogLevel::Warn,
+                     "Loading old workspace ({}) Processor Network version: {}. "
+                     "Updating to version: {}.",
+                     d.getFileName(), version, processorNetworkVersion_);
         ProcessorNetworkConverter nv(version);
         d.convertVersion(&nv);
     }

--- a/src/core/network/processornetworkconverter.cpp
+++ b/src/core/network/processornetworkconverter.cpp
@@ -323,8 +323,7 @@ void ProcessorNetworkConverter::updateCameraToComposite(TxElement* node) {
             // insert new node
             node->InsertEndChild(newNode);
 
-            LogNetworkWarn(
-                "Camera property updated to composite property. Workspace requires resave")
+            log::warn("Camera property updated to composite property. Workspace requires resave");
         }
     }
 }
@@ -707,8 +706,8 @@ void ProcessorNetworkConverter::updateCameraPropertyToRefs(TxElement* root) {
                         // breaks a lot of stuff
                         if (name == "aspectRatio") {
                             if (auto* max = subNode->FirstChildElement("maxvalue")) {
-                                max->SetAttribute("content",
-                                                  fmt::to_string(std::numeric_limits<float>::max()));
+                                max->SetAttribute(
+                                    "content", fmt::to_string(std::numeric_limits<float>::max()));
                             }
                             if (auto* min = subNode->FirstChildElement("minvalue")) {
                                 min->SetAttribute("content", fmt::to_string(0.0f));

--- a/src/core/network/workspaceannotations.cpp
+++ b/src/core/network/workspaceannotations.cpp
@@ -97,9 +97,9 @@ void WorkspaceAnnotations::serialize(Serializer& s) const {
             s.serialize("Canvases", canvases_, "CanvasImage");
         }
     } catch (const Exception& e) {
-        log::user::exception(e);
+        log::exception(e);
     } catch (const std::exception& e) {
-        log::user::exception(e);
+        log::exception(e);
     }
 }
 
@@ -110,9 +110,9 @@ void WorkspaceAnnotations::deserialize(Deserializer& d) {
         PropertyOwner::deserialize(d);
         d.deserialize("Canvases", canvases_, "CanvasImage");
     } catch (const Exception& e) {
-        log::user::exception(e);
+        log::exception(e);
     } catch (const std::exception& e) {
-        log::user::exception(e);
+        log::exception(e);
     }
 }
 

--- a/src/core/network/workspaceannotations.cpp
+++ b/src/core/network/workspaceannotations.cpp
@@ -97,9 +97,9 @@ void WorkspaceAnnotations::serialize(Serializer& s) const {
             s.serialize("Canvases", canvases_, "CanvasImage");
         }
     } catch (const Exception& e) {
-        util::log(e.getContext(), e.getMessage(), LogLevel::Error);
+        log::user::exception(e);
     } catch (const std::exception& e) {
-        LogWarn(e.what());
+        log::user::exception(e);
     }
 }
 
@@ -110,9 +110,9 @@ void WorkspaceAnnotations::deserialize(Deserializer& d) {
         PropertyOwner::deserialize(d);
         d.deserialize("Canvases", canvases_, "CanvasImage");
     } catch (const Exception& e) {
-        util::log(e.getContext(), e.getMessage(), LogLevel::Error);
+        log::user::exception(e);
     } catch (const std::exception& e) {
-        LogError(e.what());
+        log::user::exception(e);
     }
 }
 

--- a/src/core/network/workspacemanager.cpp
+++ b/src/core/network/workspacemanager.cpp
@@ -129,9 +129,9 @@ struct ErrorHandle {
 
     ~ErrorHandle() {
         if (!messages.empty()) {
-            log::user::error("There were errors while loading workspace: {}", filename_);
+            log::error("There were errors while loading workspace: {}", filename_);
             for (auto& message : messages) {
-                log::user::report(LogLevel::Error, message);
+                log::report(LogLevel::Error, message);
             }
         }
     }

--- a/src/core/network/workspacemanager.cpp
+++ b/src/core/network/workspacemanager.cpp
@@ -348,12 +348,11 @@ void WorkspaceManager::configureWorkspaceDeserializerAndInfo(Deserializer& deser
             if (moduleInfo->version < inviwoModule.getVersion()) {
                 auto converter = inviwoModule.getConverter(moduleInfo->version);
                 deserializer.convertVersion(converter.get());
-                LogNetworkSpecial(
-                    (&deserializer), LogLevel::Warn,
-                    fmt::format(
-                        "Loading old workspace ({}) Module version: {}. Updating to version: {}.",
-                        deserializer.getFileName(), inviwoModule.getIdentifier(),
-                        moduleInfo->version, inviwoModule.getVersion()));
+                log::message(
+                    deserializer, LogLevel::Warn,
+                    "Loading old workspace ({}) Module version: {}. Updating to version: {}.",
+                    deserializer.getFileName(), inviwoModule.getIdentifier(), moduleInfo->version,
+                    inviwoModule.getVersion());
             }
         }
     }

--- a/src/core/network/workspacemanager.cpp
+++ b/src/core/network/workspacemanager.cpp
@@ -136,7 +136,7 @@ struct ErrorHandle {
         }
     }
 
-    void operator()(ExceptionContext c) {
+    void operator()(ExceptionContext) {
         try {
             throw;
         } catch (SerializationException& error) {

--- a/src/core/network/workspacemanager.cpp
+++ b/src/core/network/workspacemanager.cpp
@@ -129,9 +129,9 @@ struct ErrorHandle {
 
     ~ErrorHandle() {
         if (!messages.empty()) {
-            LogNetworkError("There were errors while loading workspace: " << filename_);
+            log::user::error("There were errors while loading workspace: {}", filename_);
             for (auto& message : messages) {
-                LogNetworkError(message);
+                log::user::report(LogLevel::Error, message);
             }
         }
     }

--- a/src/core/network/workspaceutils.cpp
+++ b/src/core/network/workspaceutils.cpp
@@ -111,7 +111,7 @@ size_t updateWorkspaces(InviwoApplication* app, const std::filesystem::path& pat
             }
         } catch (const Exception& e) {
             log::exception(e, "Unable to convert network {} due to {}", fileName, e.getMessage());
-            NetworkLock lock(app->getProcessorNetwork());
+            const NetworkLock lock(app->getProcessorNetwork());
             app->getWorkspaceManager()->clear();
             updateGui();
         }

--- a/src/core/network/workspaceutils.cpp
+++ b/src/core/network/workspaceutils.cpp
@@ -65,7 +65,7 @@ size_t updateWorkspaces(InviwoApplication* app, const std::filesystem::path& pat
     }
 
     auto update = [&](const std::filesystem::path& fileName) mutable {
-        log::user::info("Updating workspace {}/{}: {}", ++current, total, fileName);
+        log::info("Updating workspace {}/{}: {}", ++current, total, fileName);
         auto errorCounter = std::make_shared<LogErrorCounter>();
         LogCentral::getPtr()->registerLogger(errorCounter);
 
@@ -105,13 +105,12 @@ size_t updateWorkspaces(InviwoApplication* app, const std::filesystem::path& pat
                     try {
                         throw;
                     } catch (const IgnoreException& e) {
-                        log::user::report(LogLevel::Info, e.getContext(), e.getMessage());
+                        log::report(LogLevel::Info, e.getContext(), e.getMessage());
                     }
                 });
             }
         } catch (const Exception& e) {
-            log::user::exception(e, "Unable to convert network {} due to {}", fileName,
-                                 e.getMessage());
+            log::exception(e, "Unable to convert network {} due to {}", fileName, e.getMessage());
             NetworkLock lock(app->getProcessorNetwork());
             app->getWorkspaceManager()->clear();
             updateGui();

--- a/src/core/network/workspaceutils.cpp
+++ b/src/core/network/workspaceutils.cpp
@@ -65,8 +65,7 @@ size_t updateWorkspaces(InviwoApplication* app, const std::filesystem::path& pat
     }
 
     auto update = [&](const std::filesystem::path& fileName) mutable {
-        util::logInfo(IVW_CONTEXT_CUSTOM("util::updateWorkspaces"), "Updating workspace {}/{}: {}",
-                      ++current, total, fileName);
+        log::user::info("Updating workspace {}/{}: {}", ++current, total, fileName);
         auto errorCounter = std::make_shared<LogErrorCounter>();
         LogCentral::getPtr()->registerLogger(errorCounter);
 
@@ -106,15 +105,13 @@ size_t updateWorkspaces(InviwoApplication* app, const std::filesystem::path& pat
                     try {
                         throw;
                     } catch (const IgnoreException& e) {
-                        util::log(e.getContext(), e.getMessage(), LogLevel::Info);
+                        log::user::report(LogLevel::Info, e.getContext(), e.getMessage());
                     }
                 });
             }
         } catch (const Exception& e) {
-            util::log(
-                e.getContext(),
-                fmt::format("Unable to convert network {} due to {}", fileName, e.getMessage()),
-                LogLevel::Error);
+            log::user::exception(e, "Unable to convert network {} due to {}", fileName,
+                                 e.getMessage());
             NetworkLock lock(app->getProcessorNetwork());
             app->getWorkspaceManager()->clear();
             updateGui();

--- a/src/core/network/workspaceutils.cpp
+++ b/src/core/network/workspaceutils.cpp
@@ -79,11 +79,11 @@ size_t updateWorkspaces(InviwoApplication* app, const std::filesystem::path& pat
         try {
             {
                 NetworkLock lock(app->getProcessorNetwork());
-                app->getWorkspaceManager()->load(fileName, [&](ExceptionContext ec) {
+                app->getWorkspaceManager()->load(fileName, [&](ExceptionContext) {
                     try {
                         throw;
                     } catch (const IgnoreException& e) {
-                        util::log(e.getContext(), e.getMessage(), LogLevel::Info);
+                        log::report(LogLevel::Info, e.getContext(), e.getMessage());
                     }
                 });
 
@@ -101,7 +101,7 @@ size_t updateWorkspaces(InviwoApplication* app, const std::filesystem::path& pat
             updateGui();
 
             if (dryRun == DryRun::No) {
-                app->getWorkspaceManager()->save(fileName, [&](ExceptionContext ec) {
+                app->getWorkspaceManager()->save(fileName, [&](ExceptionContext) {
                     try {
                         throw;
                     } catch (const IgnoreException& e) {

--- a/src/core/ports/portinspectormanager.cpp
+++ b/src/core/ports/portinspectormanager.cpp
@@ -153,7 +153,7 @@ ProcessorWidget* PortInspectorManager::addPortInspector(Outport* outport, ivec2 
 
             auto processorWidget = canvasProcessor->getProcessorWidget();
             if (!processorWidget) {
-                log::user::error("Problem using port inspector");
+                log::error("Problem using port inspector");
                 return nullptr;
             }
 
@@ -167,9 +167,9 @@ ProcessorWidget* PortInspectorManager::addPortInspector(Outport* outport, ivec2 
             return processorWidget;
         }
     } catch (Exception& exception) {
-        log::user::exception(exception);
+        log::exception(exception);
     } catch (...) {
-        log::user::error("Problem using port inspector");
+        log::error("Problem using port inspector");
     }
     return nullptr;
 }

--- a/src/core/ports/portinspectormanager.cpp
+++ b/src/core/ports/portinspectormanager.cpp
@@ -153,8 +153,7 @@ ProcessorWidget* PortInspectorManager::addPortInspector(Outport* outport, ivec2 
 
             auto processorWidget = canvasProcessor->getProcessorWidget();
             if (!processorWidget) {
-                util::log(IVW_CONTEXT_CUSTOM("PortInspector"), "Problem using port inspector",
-                          LogLevel::Error);
+                log::user::error("Problem using port inspector");
                 return nullptr;
             }
 
@@ -168,10 +167,9 @@ ProcessorWidget* PortInspectorManager::addPortInspector(Outport* outport, ivec2 
             return processorWidget;
         }
     } catch (Exception& exception) {
-        util::log(exception.getContext(), exception.getMessage(), LogLevel::Error);
+        log::user::exception(exception);
     } catch (...) {
-        util::log(IVW_CONTEXT_CUSTOM("PortInspector"), "Problem using port inspector",
-                  LogLevel::Error);
+        log::user::error("Problem using port inspector");
     }
     return nullptr;
 }

--- a/src/core/processors/canvasprocessor.cpp
+++ b/src/core/processors/canvasprocessor.cpp
@@ -136,7 +136,7 @@ CanvasProcessor::CanvasProcessor(InviwoApplication* app)
                                  if (auto layer = getVisibleLayer()) {
                                      util::saveLayer(*layer);
                                  } else {
-                                     LogError("Could not find visible layer");
+                                     log::error("Could not find visible layer");
                                  }
                              },
                              InvalidationLevel::Valid}
@@ -319,7 +319,7 @@ void CanvasProcessor::saveImageLayer(const std::filesystem::path& snapshotPath,
     if (auto layer = getVisibleLayer()) {
         util::saveLayer(*layer, snapshotPath, extension);
     } else {
-        LogError("Could not find visible layer");
+        log::error("Could not find visible layer");
     }
 }
 

--- a/src/core/processors/compositeprocessor.cpp
+++ b/src/core/processors/compositeprocessor.cpp
@@ -355,25 +355,24 @@ Property* CompositeProcessor::PropertyHandler::findSubProperty(Property* superPr
         } else {
             auto* superOwner = dynamic_cast<CompositeProperty*>(superProp->getOwner());
             if (!superOwner) {
-                util::logError(IVW_CONTEXT, "Could not find composite owner of property {}",
-                               superProp->getPath());
+                log::error("Could not find composite owner of property {}", superProp->getPath());
                 return nullptr;
             }
             auto* subOwner = dynamic_cast<CompositeProperty*>(self(self, superOwner));
             if (!subOwner) {
-                util::logError(IVW_CONTEXT, "Could not find sub Owner {}", superOwner->getPath());
+                log::error("Could not find sub Owner {}", superOwner->getPath());
                 return nullptr;
             }
             auto it = superOwner->find(superProp);
             if (it == superOwner->cend()) {
-                util::logError(IVW_CONTEXT, "Could not find superProp {} in  {}",
-                               superProp->getPath(), superOwner->getPath());
+                log::error("Could not find superProp {} in  {}", superProp->getPath(),
+                           superOwner->getPath());
                 return nullptr;
             }
             auto pos = std::distance(superOwner->cbegin(), superOwner->find(superProp));
             if (static_cast<size_t>(pos) >= subOwner->size()) {
-                util::logError(IVW_CONTEXT, "Size missmatch {} {} less than {}",
-                               subOwner->getPath(), subOwner->size(), pos);
+                log::error("Size missmatch {} {} less than {}", subOwner->getPath(),
+                           subOwner->size(), pos);
                 return nullptr;
             }
 

--- a/src/core/processors/compositeprocessorutils.cpp
+++ b/src/core/processors/compositeprocessorutils.cpp
@@ -254,8 +254,7 @@ void util::expandCompositeProcessorIntoNetwork(CompositeProcessor& composite) {
                 network.addProcessor(subNetwork.removeProcessor(p));
             }
         }
-        auto meta =
-            composite.createMetaData<ProcessorMetaData>(ProcessorMetaData::classIdentifier);
+        auto meta = composite.createMetaData<ProcessorMetaData>(ProcessorMetaData::classIdentifier);
         util::offsetPosition(subProcessors, meta->getPosition());
         util::setSelected(subProcessors, true);
 
@@ -288,7 +287,7 @@ void util::expandCompositeProcessorIntoNetwork(CompositeProcessor& composite) {
 
         network.removeProcessor(&composite);
     } catch (const Exception& e) {
-        util::log(e.getContext(), e.getMessage());
+        log::user::exception(e);
     }
 }
 

--- a/src/core/processors/compositeprocessorutils.cpp
+++ b/src/core/processors/compositeprocessorutils.cpp
@@ -254,7 +254,8 @@ void util::expandCompositeProcessorIntoNetwork(CompositeProcessor& composite) {
                 network.addProcessor(subNetwork.removeProcessor(p));
             }
         }
-        auto meta = composite.createMetaData<ProcessorMetaData>(ProcessorMetaData::classIdentifier);
+        auto* meta =
+            composite.createMetaData<ProcessorMetaData>(ProcessorMetaData::classIdentifier);
         util::offsetPosition(subProcessors, meta->getPosition());
         util::setSelected(subProcessors, true);
 

--- a/src/core/processors/compositeprocessorutils.cpp
+++ b/src/core/processors/compositeprocessorutils.cpp
@@ -287,7 +287,7 @@ void util::expandCompositeProcessorIntoNetwork(CompositeProcessor& composite) {
 
         network.removeProcessor(&composite);
     } catch (const Exception& e) {
-        log::user::exception(e);
+        log::exception(e);
     }
 }
 

--- a/src/core/processors/poolprocessor.cpp
+++ b/src/core/processors/poolprocessor.cpp
@@ -124,24 +124,23 @@ void PoolProcessor::invalidate(InvalidationLevel invalidationLevel, Property* so
 }
 
 std::string PoolProcessor::handleError() {
-    LogError(
-        fmt::format("An error occurred while processing background jobs of {}", getIdentifier()));
+    log::error("An error occurred while processing background jobs of {}", getIdentifier());
 
     std::string message;
     try {
         throw;
     } catch (const Exception& e) {
         message = e.getMessage();
-        util::log(e.getContext(), message, LogLevel::Error);
+        log::user::exception(e);
     } catch (const fmt::format_error& e) {
         message = fmt::format("fmt format error: {}\n{}", e.what(), util::fmtHelp.view());
-        util::log(IVW_CONTEXT, message, LogLevel::Error);
+        log::user::report(LogLevel::Error, message);
     } catch (const std::exception& e) {
         message = e.what();
-        util::log(IVW_CONTEXT, message, LogLevel::Error);
+        log::user::exception(e);
     } catch (...) {
         message = "Unknown error";
-        util::log(IVW_CONTEXT, message, LogLevel::Error);
+        log::user::exception();
     }
     for (auto port : getOutports()) {
         port->clear();

--- a/src/core/processors/poolprocessor.cpp
+++ b/src/core/processors/poolprocessor.cpp
@@ -131,16 +131,16 @@ std::string PoolProcessor::handleError() {
         throw;
     } catch (const Exception& e) {
         message = e.getMessage();
-        log::user::exception(e);
+        log::exception(e);
     } catch (const fmt::format_error& e) {
         message = fmt::format("fmt format error: {}\n{}", e.what(), util::fmtHelp.view());
-        log::user::report(LogLevel::Error, message);
+        log::report(LogLevel::Error, message);
     } catch (const std::exception& e) {
         message = e.what();
-        log::user::exception(e);
+        log::exception(e);
     } catch (...) {
         message = "Unknown error";
-        log::user::exception();
+        log::exception();
     }
     for (auto port : getOutports()) {
         port->clear();

--- a/src/core/processors/processorfactory.cpp
+++ b/src/core/processors/processorfactory.cpp
@@ -42,33 +42,33 @@ ProcessorFactory::ProcessorFactory(InviwoApplication* app) : app_{app} {}
 bool ProcessorFactory::registerObject(ProcessorFactoryObject* processor) {
     auto moduleId = [&]() {
         auto optId = util::getProcessorModuleIdentifier(processor->getClassIdentifier(), *app_);
-        return optId ? *optId : std::string("Unknown");
+        return optId.value_or(std::string_view("Unknown"));
     };
 
     if (!Register::registerObject(processor)) {
-        LogWarn(fmt::format(
+        log::warn(
             "Processor with class name: '{}' is already registered by module '{}'. This "
             "processor will be ignored",
-            processor->getClassIdentifier(), moduleId()));
+            processor->getClassIdentifier(), moduleId());
         return false;
     }
 
     if (util::splitStringView(processor->getClassIdentifier(), '.').size() < 3) {
-        LogWarn(
-            fmt::format("All processor classIdentifiers should be named using reverse DNS "
-                        "(org.inviwo.processor) not like: '{}' in module {}",
-                        processor->getClassIdentifier(), moduleId()));
+        log::warn(
+            "All processor classIdentifiers should be named using reverse DNS "
+            "(org.inviwo.processor) not like: '{}' in module {}",
+            processor->getClassIdentifier(), moduleId());
     }
     if (processor->getCategory().empty()) {
-        LogWarn(fmt::format("Processor '{}' in module '{}' has no category",
-                            processor->getClassIdentifier(), moduleId()));
+        log::warn("Processor '{}' in module '{}' has no category", processor->getClassIdentifier(),
+                  moduleId());
     } else if (processor->getCategory() == "Undefined") {
-        LogWarn(fmt::format("Processor '{}' in module '{}' has category \"Undefined\"",
-                            processor->getClassIdentifier(), moduleId()));
+        log::warn("Processor '{}' in module '{}' has category \"Undefined\"",
+                  processor->getClassIdentifier(), moduleId());
     }
     if (processor->getDisplayName().empty()) {
-        LogWarn(fmt::format("Processor '{}' in module '{}' has no display name",
-                            processor->getClassIdentifier(), moduleId()));
+        log::warn("Processor '{}' in module '{}' has no display name",
+                  processor->getClassIdentifier(), moduleId());
     }
 
     return true;

--- a/src/core/processors/processorutils.cpp
+++ b/src/core/processors/processorutils.cpp
@@ -97,11 +97,11 @@ InviwoModule* getProcessorModule(std::string_view classIdentifier, InviwoApplica
     return it != inviwoModules.end() ? &(*it) : nullptr;
 }
 
-std::optional<std::string> getProcessorModuleIdentifier(std::string_view classIdentifier,
+std::optional<std::string_view> getProcessorModuleIdentifier(std::string_view classIdentifier,
                                                         InviwoApplication& app) {
 
     if (auto m = getProcessorModule(classIdentifier, app)) {
-        return m->getIdentifier();
+        return std::string_view{m->getIdentifier()};
     } else {
         return std::nullopt;
     }

--- a/src/core/processors/processorutils.cpp
+++ b/src/core/processors/processorutils.cpp
@@ -98,7 +98,7 @@ InviwoModule* getProcessorModule(std::string_view classIdentifier, InviwoApplica
 }
 
 std::optional<std::string_view> getProcessorModuleIdentifier(std::string_view classIdentifier,
-                                                        InviwoApplication& app) {
+                                                             InviwoApplication& app) {
 
     if (auto m = getProcessorModule(classIdentifier, app)) {
         return std::string_view{m->getIdentifier()};

--- a/src/core/properties/compositeproperty.cpp
+++ b/src/core/properties/compositeproperty.cpp
@@ -79,10 +79,10 @@ void CompositeProperty::set(const CompositeProperty* src) {
         }
         propertyModified();
     } else {
-        util::logWarn(IVW_CONTEXT,
-                      "Unable to link CompositeProperties:\n{} to {}\n The number of sub "
-                      "properties differ ({} vs {})",
-                      src->getPath(), getPath(), subProperties.size(), properties_.size());
+        log::user::warn(
+            "Unable to link CompositeProperties:\n{} to {}\n The number of sub "
+            "properties differ ({} vs {})",
+            src->getPath(), getPath(), subProperties.size(), properties_.size());
     }
 }
 

--- a/src/core/properties/compositeproperty.cpp
+++ b/src/core/properties/compositeproperty.cpp
@@ -79,7 +79,7 @@ void CompositeProperty::set(const CompositeProperty* src) {
         }
         propertyModified();
     } else {
-        log::user::warn(
+        log::warn(
             "Unable to link CompositeProperties:\n{} to {}\n The number of sub "
             "properties differ ({} vs {})",
             src->getPath(), getPath(), subProperties.size(), properties_.size());

--- a/src/core/properties/filepatternproperty.cpp
+++ b/src/core/properties/filepatternproperty.cpp
@@ -264,14 +264,12 @@ void FilePatternProperty::updateFileList() {
                 }
             }
         } catch (FileException& e) {
-            LogError("Error (file exception): " << e.what());
+            log::error("Error (file exception): {}", e.what());
         }
     }
 
     // sort file names
     sort();
-
-    // LogInfo("Files matching the pattern:" << getFormattedFileList());
 }
 
 std::string FilePatternProperty::getFormattedFileList() const {
@@ -289,7 +287,7 @@ void FilePatternProperty::sort() {
 }
 
 std::string FilePatternProperty::guessFilePattern() const {
-    LogError("not implemented yet");
+    log::error("not implemented yet");
     return "";
 }
 

--- a/src/core/properties/fileproperty.cpp
+++ b/src/core/properties/fileproperty.cpp
@@ -183,7 +183,7 @@ bool FileBase::deserialize(Deserializer& d, PropertySerializationMode mode) {
         modified |= fileMode_.deserialize(d, mode);
         modified |= contentType_.deserialize(d, mode);
     } catch (SerializationException& e) {
-        LogInfo("Problem deserializing file Property: " << e.getMessage());
+        log::warn("Problem deserializing file Property: {}", e.getMessage());
     }
     return modified;
 }

--- a/src/core/properties/listproperty.cpp
+++ b/src/core/properties/listproperty.cpp
@@ -128,7 +128,7 @@ void ListProperty::set(const ListProperty* src) {
         }
         propertyModified();
     } else {
-        LogWarn("ListProperty prefab type mismatch. Unable to link");
+        log::warn("ListProperty prefab type mismatch. Unable to link");
     }
 }
 
@@ -195,7 +195,7 @@ Property* ListProperty::constructProperty(size_t prefabIndex) {
         invalidate(Property::getInvalidationLevel());
         return property;
     } else {
-        LogError("Maximum number of list entries reached (" << this->getDisplayName() << ")");
+        log::error("Maximum number of list entries reached ({})", this->getDisplayName());
     }
     return nullptr;
 }
@@ -222,7 +222,7 @@ void ListProperty::insertProperty(size_t index, Property* property, bool owner) 
         CompositeProperty::insertProperty(index, property, owner);
         invalidate(Property::getInvalidationLevel());
     } else {
-        LogError("Maximum number of list entries reached (" << this->getDisplayName() << ")");
+        log::error("Maximum number of list entries reached ({})", this->getDisplayName());
     }
 }
 

--- a/src/core/properties/property.cpp
+++ b/src/core/properties/property.cpp
@@ -240,10 +240,10 @@ void Property::serialize(Serializer& s) const {
 
 void Property::deserialize(Deserializer& d) {
     if (auto className = d.attribute("type"); !className || *className != getClassIdentifier()) {
-        LogWarn("Deserialized property: "
-                << getPath() << " with class identifier: " << getClassIdentifier()
-                << " from a serialized property with a different class identifier: "
-                << className.value_or("<missing>"));
+        log::warn(
+            "Deserialized {} with class identifier: {} from a serialized property with a different "
+            "class identifier: {}",
+            getPath(), getClassIdentifier(), className.value_or("<missing>"));
     }
 
     if (auto id = d.attribute("identifier"); id && *id != identifier_) {

--- a/src/core/properties/propertyconvertermanager.cpp
+++ b/src/core/properties/propertyconvertermanager.cpp
@@ -41,8 +41,7 @@ bool PropertyConverterManager::registerObject(PropertyConverter* converter) {
     std::string src = converter->getSourcePropertyClassIdenetifier();
     std::string dst = converter->getDestinationPropertyClassIdenetifier();
     if (canConvert(src, dst)) {
-        LogWarn("Property Converter from type " << src << " to type " << dst
-                                                << " already registered");
+        log::warn("Property Converter from type {} to type {} already registered", src, dst);
         return false;
     }
     converters_.insert(std::make_pair(std::make_pair(src, dst), converter));

--- a/src/core/properties/propertypresetmanager.cpp
+++ b/src/core/properties/propertypresetmanager.cpp
@@ -230,9 +230,9 @@ void PropertyPresetManager::loadApplicationPresets() {
             Deserializer d(filename);
             d.deserialize("PropertyPresets", appPresets_, "Preset");
         } catch (AbortException& e) {
-            LogError(e.getMessage());
+            log::user::exception(e);
         } catch (std::exception& e) {
-            LogError(e.what());
+            log::user::exception(e);
         }
     }
 }
@@ -243,7 +243,7 @@ void PropertyPresetManager::saveApplicationPresets() {
         s.serialize("PropertyPresets", appPresets_, "Preset");
         s.writeFile();
     } catch (const std::exception& e) {
-        LogWarn("Could not write application presets: " << e.what());
+        log::warn("Could not write application presets: {}", e.what());
     }
 }
 

--- a/src/core/properties/propertypresetmanager.cpp
+++ b/src/core/properties/propertypresetmanager.cpp
@@ -230,9 +230,9 @@ void PropertyPresetManager::loadApplicationPresets() {
             Deserializer d(filename);
             d.deserialize("PropertyPresets", appPresets_, "Preset");
         } catch (AbortException& e) {
-            log::user::exception(e);
+            log::exception(e);
         } catch (std::exception& e) {
-            log::user::exception(e);
+            log::exception(e);
         }
     }
 }

--- a/src/core/properties/propertywidgetfactory.cpp
+++ b/src/core/properties/propertywidgetfactory.cpp
@@ -47,9 +47,10 @@ bool PropertyWidgetFactory::registerObject(PropertyWidgetFactoryObject* property
 
     for (WidgetMap::const_iterator it = sameKeys.first; it != sameKeys.second; ++it) {
         if (semantics == it->second->getSematics()) {
-            LogWarn("Adding a PropertyWidget for a Property (" << className << ") and semantics ("
-                                                               << semantics
-                                                               << ") that is already registered.");
+            log::warn(
+                "Adding a PropertyWidget for a Property ({}) and semantics ({}) that is already "
+                "registered.",
+                className, semantics);
             return false;
         }
     }
@@ -78,15 +79,16 @@ std::unique_ptr<PropertyWidget> PropertyWidgetFactory::create(Property* property
 
     for (WidgetMap::const_iterator it = sameKeys.first; it != sameKeys.second; ++it) {
         if (PropertySemantics::Default == it->second->getSematics()) {
-            LogWarn("Requested property widget semantics ("
-                    << semantics << ") for property (" << property->getDisplayName() << ", "
-                    << property->getPath() << ") does not exist, returning default semantics.");
+            log::warn(
+                "Requested property widget semantics ({}) for property ({}, {}) does not exist, "
+                "returning default semantics.",
+                semantics, property->getDisplayName(), property->getPath());
             return it->second->create(property);
         }
     }
 
-    LogWarn("Cannot find a property widget for property: " << property->getClassIdentifier() << "("
-                                                           << semantics << ")");
+    log::warn("Cannot find a property widget for property: {} ({})", property->getClassIdentifier(),
+              semantics);
     return {};
 }
 

--- a/src/core/tests/unittests/serialize-container-test.cpp
+++ b/src/core/tests/unittests/serialize-container-test.cpp
@@ -152,7 +152,7 @@ TEST(SerialitionContainerTest, IndexFunctions) {
     deserializer.deserialize("Vector", vector, "Item",
                              deserializer::IndexFunctions{
                                  .makeNew = []() { return 0; },
-                                 .onNew = [&](int& i, size_t) {},
+                                 .onNew = [&](int&, size_t) {},
                                  .onRemove = [](int&) {},
                              });
 

--- a/src/core/tests/unittests/utilities-test.cpp
+++ b/src/core/tests/unittests/utilities-test.cpp
@@ -50,7 +50,7 @@ TEST(UtilitiesTests, StripIndentifierTest) {
 }
 
 TEST(UtilitiesTests, ValidateIdentifierTest) {
-    auto context = IvwContextCustom("utilities-test");
+    auto context = SourceContext("utilities-test"_sl);
 
     EXPECT_THROW(util::validateIdentifier("", "property", context), Exception);
     EXPECT_THROW(util::validateIdentifier("1foo", "property", context), Exception);

--- a/src/core/util/assertion.cpp
+++ b/src/core/util/assertion.cpp
@@ -61,7 +61,7 @@ void assertion(std::string_view message, SourceContext context) {
                 context.line(), context.function(), message);
 
     if (InviwoApplication::isInitialized()) {
-        auto& assertionHandler = InviwoApplication::getPtr()->getAssertionHandler();
+        const auto& assertionHandler = InviwoApplication::getPtr()->getAssertionHandler();
         if (assertionHandler) {
             assertionHandler(message, context);
         }

--- a/src/core/util/colorbrewer.cpp
+++ b/src/core/util/colorbrewer.cpp
@@ -118,8 +118,7 @@ std::map<Family, std::vector<dvec4>> getColormaps(const Category& category,
         try {
             v.emplace(family, getColormap(family, numberOfColors));
         } catch (UnsupportedNumberOfColorsException& e) {
-            LogWarnCustom("colorbrewer", "Family " << family << " omitted, reason: \n"
-                                                   << e.getMessage(););
+            log::warn("Family {} omitted, reason: {}", family, e.getMessage());
         }
     }
 

--- a/src/core/util/dialogfactory.cpp
+++ b/src/core/util/dialogfactory.cpp
@@ -33,7 +33,7 @@ namespace inviwo {
 
 bool DialogFactory::registerObject(DialogFactoryObject* dialog) {
     if (!StandardFactory<Dialog, DialogFactoryObject>::registerObject(dialog)) {
-        LogWarn("Dialog already registered: " << dialog->getClassIdentifier());
+        log::warn("Dialog already registered: {}", dialog->getClassIdentifier());
         return false;
     }
     return true;

--- a/src/core/util/exception.cpp
+++ b/src/core/util/exception.cpp
@@ -114,11 +114,11 @@ void StandardExceptionHandler::operator()(ExceptionContext context) {
     try {
         throw;
     } catch (Exception& e) {
-        util::log(e.getContext(), e.getMessage(), LogLevel::Error);
+        log::user::exception(e);
     } catch (std::exception& e) {
-        util::log(context, e.what(), LogLevel::Error);
+        log::user::exception(e);
     } catch (...) {
-        util::log(context, "Unknown error", LogLevel::Error);
+        log::user::exception();
     }
 }
 

--- a/src/core/util/exception.cpp
+++ b/src/core/util/exception.cpp
@@ -114,11 +114,11 @@ void StandardExceptionHandler::operator()(ExceptionContext context) {
     try {
         throw;
     } catch (Exception& e) {
-        log::user::exception(e);
+        log::exception(e);
     } catch (std::exception& e) {
-        log::user::exception(e);
+        log::exception(e);
     } catch (...) {
-        log::user::exception();
+        log::exception();
     }
 }
 

--- a/src/core/util/exception.cpp
+++ b/src/core/util/exception.cpp
@@ -116,9 +116,9 @@ void StandardExceptionHandler::operator()(ExceptionContext context) {
     } catch (Exception& e) {
         log::exception(e);
     } catch (std::exception& e) {
-        log::exception(e);
+        log::exception(e, context);
     } catch (...) {
-        log::exception();
+        log::exception(context);
     }
 }
 

--- a/src/core/util/filesystem.cpp
+++ b/src/core/util/filesystem.cpp
@@ -298,8 +298,7 @@ fs::path getInviwoUserSettingsPath() {
     }
 
 #else
-    LogWarnCustom("filesystem::getInviwoApplicationPath",
-                  "Get User Setting Path is not implemented for current system");
+    log::warn("Get User Setting Path is not implemented for current system");
 #endif
     return ss.str();
 }
@@ -596,8 +595,7 @@ const fs::path& findBasePath() {
         }
 #endif
 
-        LogErrorCustom(
-            "filesystem::findBasePath",
+        log::error(
             "Could not locate Inviwo base path meaning that application data might not be found.");
         return getExecutablePath();
     }();

--- a/src/core/util/imageramutils.cpp
+++ b/src/core/util/imageramutils.cpp
@@ -78,7 +78,7 @@ std::shared_ptr<Image> readImageFromDisk(std::string filename) {
         auto outLayer = reader->readData(filename);
         return std::make_shared<Image>(outLayer);
     } else {
-        LogErrorCustom("util::readImageFromDisk", "Failed to read image \'" << filename << "\'");
+        log::error("Failed to read image '{}'", filename);
         return nullptr;
     }
 }

--- a/src/core/util/logcentral.cpp
+++ b/src/core/util/logcentral.cpp
@@ -199,8 +199,8 @@ void util::log(ExceptionContext context, std::string_view message, LogLevel leve
 
 void util::log(Logger* logger, ExceptionContext context, std::string_view message, LogLevel level,
                LogAudience audience) {
-    logger->log(context.getCaller(), level, audience, context.getFile(), context.getFunction(),
-                context.getLine(), message);
+    logger->log(context.source(), level, audience, context.file(), context.function(),
+                context.line(), message);
 }
 
 std::string_view enumToStr(LogLevel ll) {

--- a/src/core/util/logcentral.cpp
+++ b/src/core/util/logcentral.cpp
@@ -35,6 +35,8 @@
 #include <inviwo/core/processors/processor.h>
 #include <inviwo/core/network/processornetwork.h>
 
+#include <chrono>
+
 namespace inviwo {
 
 bool operator==(const LogLevel& lhs, const LogVerbosity& rhs) {
@@ -186,5 +188,12 @@ std::string_view enumToStr(MessageBreakLevel ll) {
 std::ostream& operator<<(std::ostream& ss, LogLevel ll) { return ss << enumToStr(ll); }
 std::ostream& operator<<(std::ostream& ss, LogAudience la) { return ss << enumToStr(la); }
 std::ostream& operator<<(std::ostream& ss, MessageBreakLevel ll) { return ss << enumToStr(ll); }
+
+void log::detail::logDirectly(LogLevel level, SourceContext context, std::string_view message) {
+    auto& os = level == LogLevel::Error ? std::cerr : std::cout;
+    const auto time = std::chrono::system_clock::now();
+    fmt::print(os, "{:%H:%M:06.3%S} {:5} {:35} {}:{}\n{}", time, level, context.source(),
+               context.file(), context.line(), message);
+}
 
 }  // namespace inviwo

--- a/src/core/util/logfilter.cpp
+++ b/src/core/util/logfilter.cpp
@@ -52,19 +52,4 @@ void LogFilter::log(std::string_view logSource, LogLevel level, LogAudience audi
     }
 }
 
-void LogFilter::logProcessor(Processor* processor, LogLevel level, LogAudience audience,
-                             std::string_view msg, std::string_view file, std::string_view function,
-                             int line) {
-    if (level >= logVerbosity_) {
-        logger_->logProcessor(processor, level, audience, std::move(msg), file, function, line);
-    }
-}
-
-void LogFilter::logNetwork(LogLevel level, LogAudience audience, std::string_view msg,
-                           std::string_view file, std::string_view function, int line) {
-    if (level >= logVerbosity_) {
-        logger_->logNetwork(level, audience, std::move(msg), file, function, line);
-    }
-}
-
 }  // namespace inviwo

--- a/src/core/util/metadatatoproperty.cpp
+++ b/src/core/util/metadatatoproperty.cpp
@@ -137,7 +137,7 @@ void MetaDataToProperty::updateProperty(CompositeProperty& parent, const MetaDat
         if (it != factory_.end()) {
             it->second(key, meta, parent);
         } else {
-            LogErrorCustom("MetaDataToProperty", "Unsupported MetaData type");
+            log::error("Unsupported MetaData type");
         }
     }
 

--- a/src/core/util/settings/settings.cpp
+++ b/src/core/util/settings/settings.cpp
@@ -75,9 +75,9 @@ void Settings::load() {
             d.registerFactory(app_->getMetaDataFactory());
             deserialize(d);
         } catch (const Exception& e) {
-            util::log(e.getContext(), e.getMessage(), LogLevel::Error);
+            log::user::exception(e);
         } catch (const std::exception& e) {
-            LogError(e.what());
+            log::user::exception(e);
         }
     }
 }
@@ -89,9 +89,9 @@ void Settings::save() {
         serialize(s);
         s.writeFile();
     } catch (const Exception& e) {
-        util::log(e.getContext(), e.getMessage(), LogLevel::Error);
+        log::user::exception(e);
     } catch (const std::exception& e) {
-        LogWarn(e.what());
+        log::user::exception(e);
     }
 }
 

--- a/src/core/util/settings/settings.cpp
+++ b/src/core/util/settings/settings.cpp
@@ -75,9 +75,9 @@ void Settings::load() {
             d.registerFactory(app_->getMetaDataFactory());
             deserialize(d);
         } catch (const Exception& e) {
-            log::user::exception(e);
+            log::exception(e);
         } catch (const std::exception& e) {
-            log::user::exception(e);
+            log::exception(e);
         }
     }
 }
@@ -89,9 +89,9 @@ void Settings::save() {
         serialize(s);
         s.writeFile();
     } catch (const Exception& e) {
-        log::user::exception(e);
+        log::exception(e);
     } catch (const std::exception& e) {
-        log::user::exception(e);
+        log::exception(e);
     }
 }
 

--- a/src/core/util/settings/systemsettings.cpp
+++ b/src/core/util/settings/systemsettings.cpp
@@ -94,7 +94,7 @@ SystemSettings::SystemSettings(InviwoApplication* app)
 
     runtimeModuleReloading_.onChange([this]() {
         if (isDeserializing_) return;
-        log::user::info(
+        log::info(
             "Inviwo needs to be restarted for Runtime Module Reloading change to take effect");
     });
 
@@ -103,7 +103,7 @@ SystemSettings::SystemSettings(InviwoApplication* app)
 
     enableResourceTracking_.onChange([this]() {
         if (enableResourceTracking_) {
-            log::user::warn("Resource tracking is enabled, this might slow down Inviwo");
+            log::warn("Resource tracking is enabled, this might slow down Inviwo");
         }
 
         if (!enableResourceTracking_) {
@@ -114,7 +114,7 @@ SystemSettings::SystemSettings(InviwoApplication* app)
     redirectCout_.onChange([this]() {
         if (redirectCout_ && !cout_) {
             if (app_->getCommandLineParser().getLogToConsole()) {
-                log::user::warn(
+                log::warn(
                     "Cannot redirect std::cout to LogCentral when console logging is enabled");
                 redirectCout_.set(false);
                 return;
@@ -132,7 +132,7 @@ SystemSettings::SystemSettings(InviwoApplication* app)
     redirectCerr_.onChange([&]() {
         if (redirectCerr_ && !cerr_) {
             if (app_->getCommandLineParser().getLogToConsole()) {
-                log::user::warn(
+                log::warn(
                     "Cannot redirect std::cerr to LogCentral when console logging is enabled");
                 redirectCerr_.set(false);
                 return;

--- a/src/core/util/settings/systemsettings.cpp
+++ b/src/core/util/settings/systemsettings.cpp
@@ -94,7 +94,8 @@ SystemSettings::SystemSettings(InviwoApplication* app)
 
     runtimeModuleReloading_.onChange([this]() {
         if (isDeserializing_) return;
-        LogInfo("Inviwo needs to be restarted for Runtime Module Reloading change to take effect");
+        log::user::info(
+            "Inviwo needs to be restarted for Runtime Module Reloading change to take effect");
     });
 
     breakOnMessage_.onChange(
@@ -102,7 +103,7 @@ SystemSettings::SystemSettings(InviwoApplication* app)
 
     enableResourceTracking_.onChange([this]() {
         if (enableResourceTracking_) {
-            LogWarn("Resource tracking is enabled, this might slow down Inviwo");
+            log::user::warn("Resource tracking is enabled, this might slow down Inviwo");
         }
 
         if (!enableResourceTracking_) {
@@ -113,7 +114,8 @@ SystemSettings::SystemSettings(InviwoApplication* app)
     redirectCout_.onChange([this]() {
         if (redirectCout_ && !cout_) {
             if (app_->getCommandLineParser().getLogToConsole()) {
-                LogWarn("Cannot redirect std::cout to LogCentral when console logging is enabled");
+                log::user::warn(
+                    "Cannot redirect std::cout to LogCentral when console logging is enabled");
                 redirectCout_.set(false);
                 return;
             }
@@ -130,7 +132,8 @@ SystemSettings::SystemSettings(InviwoApplication* app)
     redirectCerr_.onChange([&]() {
         if (redirectCerr_ && !cerr_) {
             if (app_->getCommandLineParser().getLogToConsole()) {
-                LogWarn("Cannot redirect std::cerr to LogCentral when console logging is enabled");
+                log::user::warn(
+                    "Cannot redirect std::cerr to LogCentral when console logging is enabled");
                 redirectCerr_.set(false);
                 return;
             }

--- a/src/core/util/sourcecontext.cpp
+++ b/src/core/util/sourcecontext.cpp
@@ -33,12 +33,7 @@
 namespace inviwo {
 
 std::ostream& operator<<(std::ostream& ss, const SourceContext& ec) {
-    ss << ec.getCaller() << " (" << ec.getFile() << ":" << ec.getLine() << ")";
-    return ss;
-}
-
-std::ostream& operator<<(std::ostream& ss, const SourceLocation& ec) {
-    ss << ec.getFunction() << " (" << ec.getFile() << ":" << ec.getLine() << ")";
+    ss << ec.source() << " (" << ec.file() << ":" << ec.line() << ")";
     return ss;
 }
 

--- a/src/core/util/utilities.cpp
+++ b/src/core/util/utilities.cpp
@@ -47,11 +47,8 @@ void saveNetwork(ProcessorNetwork* network, std::string_view filename) {
         Serializer xmlSerializer(filename);
         network->serialize(xmlSerializer);
         xmlSerializer.writeFile();
-    } catch (SerializationException& exception) {
-        util::log(
-            exception.getContext(),
-            fmt::format("Unable to save network {} due to {}", filename, exception.getMessage()),
-            LogLevel::Error);
+    } catch (SerializationException& e) {
+        log::user::exception(e, "Unable to save network {} due to {}", filename, e.getMessage());
     }
 }
 
@@ -75,10 +72,12 @@ void saveAllCanvases(ProcessorNetwork* network, const std::filesystem::path& dir
     for (auto cp : allConsideredCanvases) {
         if (!cp->isValid() || !cp->isReady()) {
             std::ostringstream msg;
-            msg << "Canvas is not ready or not valid, no image saved" << std::endl;
-            msg << "    Display Name: " << cp->getDisplayName() << std::endl;
-            msg << "    Identifier: " << cp->getIdentifier() << std::endl;
-            LogErrorCustom("util::saveAllCanvases", msg.str());
+            log::user::error(
+                "Canvas is not ready or not valid, no image saved\n"
+                "    Display Name: {}\n"
+                "    Identifier: {}",
+                cp->getDisplayName(), cp->getIdentifier());
+
         } else {
 
             StrBuffer filepath;
@@ -101,7 +100,7 @@ void saveAllCanvases(ProcessorNetwork* network, const std::filesystem::path& dir
 
             auto path = dir / filepath.view();
 
-            LogInfoCustom("util::saveAllCanvases", "Saving canvas to: " << path);
+            log::user::info("Saving canvas to: {}", path);
             cp->saveImageLayer(path);
         }
         i++;

--- a/src/core/util/utilities.cpp
+++ b/src/core/util/utilities.cpp
@@ -48,7 +48,7 @@ void saveNetwork(ProcessorNetwork* network, std::string_view filename) {
         network->serialize(xmlSerializer);
         xmlSerializer.writeFile();
     } catch (SerializationException& e) {
-        log::user::exception(e, "Unable to save network {} due to {}", filename, e.getMessage());
+        log::exception(e, "Unable to save network {} due to {}", filename, e.getMessage());
     }
 }
 
@@ -72,7 +72,7 @@ void saveAllCanvases(ProcessorNetwork* network, const std::filesystem::path& dir
     for (auto cp : allConsideredCanvases) {
         if (!cp->isValid() || !cp->isReady()) {
             std::ostringstream msg;
-            log::user::error(
+            log::error(
                 "Canvas is not ready or not valid, no image saved\n"
                 "    Display Name: {}\n"
                 "    Identifier: {}",
@@ -100,7 +100,7 @@ void saveAllCanvases(ProcessorNetwork* network, const std::filesystem::path& dir
 
             auto path = dir / filepath.view();
 
-            log::user::info("Saving canvas to: {}", path);
+            log::info("Saving canvas to: {}", path);
             cp->saveImageLayer(path);
         }
         i++;

--- a/src/core/util/volumesequencesampler.cpp
+++ b/src/core/util/volumesequencesampler.cpp
@@ -62,13 +62,13 @@ VolumeSequenceSampler::VolumeSequenceSampler(std::shared_ptr<const VolumeSequenc
     }
 
     if (!(infsTime == 0 || infsTime == size)) {
-        LogWarn("Failed to create VolumeSequenceSampler due to missing data");
-        LogInfo(infsTime << " volumes of " << size << " is missing a timestamp");
+        log::user::warn("Failed to create VolumeSequenceSampler due to missing data");
+        log::user::info("{} volumes of {} is missing a timestamp", infsTime, size);
         return;
     }
     if (!(infsDuration == 0 || infsDuration == size)) {
-        LogWarn("Failed to create VolumeSequenceSampler due to missing data");
-        LogInfo(infsDuration << " volumes of " << size << " has unknown duration ");
+        log::user::warn("Failed to create VolumeSequenceSampler due to missing data");
+        log::user::info("{} volumes of {} has unknown duration ", infsDuration, size);
         return;
     }
 

--- a/src/core/util/volumesequencesampler.cpp
+++ b/src/core/util/volumesequencesampler.cpp
@@ -62,13 +62,13 @@ VolumeSequenceSampler::VolumeSequenceSampler(std::shared_ptr<const VolumeSequenc
     }
 
     if (!(infsTime == 0 || infsTime == size)) {
-        log::user::warn("Failed to create VolumeSequenceSampler due to missing data");
-        log::user::info("{} volumes of {} is missing a timestamp", infsTime, size);
+        log::warn("Failed to create VolumeSequenceSampler due to missing data");
+        log::info("{} volumes of {} is missing a timestamp", infsTime, size);
         return;
     }
     if (!(infsDuration == 0 || infsDuration == size)) {
-        log::user::warn("Failed to create VolumeSequenceSampler due to missing data");
-        log::user::info("{} volumes of {} has unknown duration ", infsDuration, size);
+        log::warn("Failed to create VolumeSequenceSampler due to missing data");
+        log::info("{} volumes of {} has unknown duration ", infsDuration, size);
         return;
     }
 

--- a/src/qt/applicationbase/qtapptools.cpp
+++ b/src/qt/applicationbase/qtapptools.cpp
@@ -261,6 +261,17 @@ void utilqt::configurePostEnqueueFront(InviwoApplication& app) {
     app.setProcessEventsCallback([]() { QApplication::instance()->processEvents(); });
 }
 
+void utilqt::configureAssertionHandler(InviwoApplication& app) {
+    app.setAssertionHandler([](std::string_view message, SourceContext context) {
+        auto error = QString{"<b>Assertion Failed</b><br>File: %1:%2<br>Function: %3<p>%4"}
+                         .arg(toQString(context.file()))
+                         .arg(context.line())
+                         .arg(toQString(context.function()))
+                         .arg(toQString(message));
+        QMessageBox::critical(nullptr, "Assertion Failed", error);
+    });
+}
+
 void utilqt::configurePoolResizeWait(InviwoApplication& app, QWidget* window) {
     app.setPoolResizeWaitCallback(
         [window, enabled = true](InviwoApplication::LongWait type) mutable {

--- a/src/qt/applicationbase/qtlocale.cpp
+++ b/src/qt/applicationbase/qtlocale.cpp
@@ -56,15 +56,14 @@ std::locale utilqt::getCurrentStdLocale() {
         for (auto&& [i, name] : util::enumerate(localeNames)) {
             try {
                 if (i != 0) {
-                    LogWarnCustom("getStdLocale", fmt::format("Falling back to locale '{}'", name));
+                    log::warn("Falling back to locale '{}'", name);
                 }
                 return std::locale(name);
             } catch (std::exception& e) {
-                LogWarnCustom("getStdLocale",
-                              fmt::format("Locale could not be set to '{}', {}", name, e.what()));
+                log::warn("Locale could not be set to '{}', {}", name, e.what());
             }
         }
-        LogWarnCustom("getStdLocale", "Using the default locale");
+        log::warn("Using the default locale");
         return std::locale{};
     }();
 

--- a/src/qt/applicationbase/undomanager.cpp
+++ b/src/qt/applicationbase/undomanager.cpp
@@ -128,7 +128,7 @@ public:
 
                         clearOldSaves(path_ / "autosaves", numRestoreFiles());
                     } catch (const std::exception& e) {
-                        LogInfo("Error saving auto save: " << e.what());
+                        log::error("Error saving auto save: {}", e.what());
                     }
                 }
             }

--- a/src/qt/editor/consolewidget.cpp
+++ b/src/qt/editor/consolewidget.cpp
@@ -438,53 +438,6 @@ void ConsoleWidget::log(std::string_view source, LogLevel level, LogAudience aud
     logEntry(std::move(e));
 }
 
-void ConsoleWidget::logProcessor(Processor* processor, LogLevel level, LogAudience audience,
-                                 std::string_view msg, std::string_view file,
-                                 std::string_view function, int line) {
-    LogTableModelEntry e{std::chrono::system_clock::now(),
-                         processor->getIdentifier(),
-                         level,
-                         audience,
-                         file,
-                         line,
-                         function,
-                         msg};
-    logEntry(std::move(e));
-}
-
-void ConsoleWidget::logNetwork(LogLevel level, LogAudience audience, std::string_view msg,
-                               std::string_view file, std::string_view function, int line) {
-    LogTableModelEntry e{std::chrono::system_clock::now(),
-                         "ProcessorNetwork",
-                         level,
-                         audience,
-                         file,
-                         line,
-                         function,
-                         msg};
-    logEntry(std::move(e));
-}
-
-void ConsoleWidget::logAssertion(std::string_view file, std::string_view function, int line,
-                                 std::string_view msg) {
-    LogTableModelEntry e{std::chrono::system_clock::now(),
-                         "Assertion",
-                         LogLevel::Error,
-                         LogAudience::Developer,
-                         file,
-                         line,
-                         function,
-                         msg};
-    logEntry(std::move(e));
-
-    auto error = QString{"<b>Assertion Failed</b><br>File: %1:%2<br>Function: %3<p>%4"}
-                     .arg(file.data())
-                     .arg(line)
-                     .arg(function.data())
-                     .arg(utilqt::toQString(msg));
-    QMessageBox::critical(nullptr, "Assertion Failed", error);
-}
-
 void ConsoleWidget::logEntry(LogTableModelEntry e) {
     {
         std::unique_lock lock{entriesMutex_};

--- a/src/qt/editor/fileassociations.cpp
+++ b/src/qt/editor/fileassociations.cpp
@@ -140,8 +140,8 @@ public:
 
         // first register the type ID of our server
         if (!SetHkcrUserRegKey(dId, utilqt::toQString(fileTypeName))) {
-            LogError("Failed to register file type: " << fileTypeName << " for document type "
-                                                      << documentId);
+            log::error("Failed to register file type: {} for document type {}", fileTypeName,
+                       documentId);
             return;
         }
 
@@ -287,14 +287,13 @@ private:
 
             if (::RegCloseKey(hKey) == ERROR_SUCCESS && lResult == ERROR_SUCCESS) return true;
 
-            LogError("Error in setting Registry value: '"
-                     << utilqt::fromQString(value) << "' for key '" << utilqt::fromQString(key)
-                     << "'.");
+            log::error("Error in setting Registry value: '{}' for key '{}'",
+                       utilqt::fromQString(value), utilqt::fromQString(key));
         } else {
             wchar_t buffer[4096];
             ::FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM, 0, lRetVal, 0, buffer, 4096, 0);
             QString szText = QString::fromUtf16((const char16_t*)buffer);
-            LogError("Error in setting Registry value: " << utilqt::fromQString(szText));
+            log::error("Error in setting Registry value: {}", utilqt::fromQString(szText));
         }
         return false;
     }

--- a/src/qt/editor/helpwidget.cpp
+++ b/src/qt/editor/helpwidget.cpp
@@ -457,8 +457,8 @@ QVariant HelpBrowser::loadResource(int type, const QUrl& resourceUrl) {
             try {
                 util::appendProcessorNetwork(app_->getProcessorNetwork(), filePath, app_);
             } catch (const Exception& e) {
-                log::user::exception(e, "Unable to append network {} due to {}", filePath,
-                                     e.getMessage());
+                log::exception(e, "Unable to append network {} due to {}", filePath,
+                               e.getMessage());
             }
             QTimer::singleShot(0, this, [this]() { backward(); });
             return {"Workspace loaded"};

--- a/src/qt/editor/helpwidget.cpp
+++ b/src/qt/editor/helpwidget.cpp
@@ -457,10 +457,8 @@ QVariant HelpBrowser::loadResource(int type, const QUrl& resourceUrl) {
             try {
                 util::appendProcessorNetwork(app_->getProcessorNetwork(), filePath, app_);
             } catch (const Exception& e) {
-                util::log(
-                    e.getContext(),
-                    fmt::format("Unable to append network {} due to {}", filePath, e.getMessage()),
-                    LogLevel::Error);
+                log::user::exception(e, "Unable to append network {} due to {}", filePath,
+                                     e.getMessage());
             }
             QTimer::singleShot(0, this, [this]() { backward(); });
             return {"Workspace loaded"};

--- a/src/qt/editor/inviwomainwindow.cpp
+++ b/src/qt/editor/inviwomainwindow.cpp
@@ -614,7 +614,7 @@ void InviwoMainWindow::addActions() {
                         utilqt::toPath(saveFileDialog.selectedFiles().at(0));
                     networkEditorView_->exportViewToFile(path, entireScene,
                                                          backgroundVisibleAction->isChecked());
-                    LogInfo("Exported network to " << path);
+                    log::user::info("Exported network to '{}'", path);
                 }
             };
         };
@@ -1242,7 +1242,7 @@ bool InviwoMainWindow::appendWorkspace() {
 bool InviwoMainWindow::openWorkspace(const std::filesystem::path& fileName, bool isExample) {
 
     if (!std::filesystem::is_regular_file(fileName)) {
-        LogError("Could not find workspace file: " << fileName);
+        log::error("Could not find workspace file: {}", fileName);
         return false;
     }
 
@@ -1303,7 +1303,7 @@ bool InviwoMainWindow::saveWorkspace(const std::filesystem::path& fileName) {
             }
         });
         updateWindowTitle();
-        LogInfo(fmt::format("Workspace saved to: {}", fileName));
+        log::user::info("Workspace saved to: {}", fileName);
         return true;
     } catch (const Exception& e) {
         util::logError(e.getContext(), "Unable to save network {} due to {}", fileName,
@@ -1649,10 +1649,10 @@ void InviwoMainWindow::dropEvent(QDropEvent* event) {
                 undoManager_.pushStateIfDirty();
             };
             app_->dispatchFrontAndForget(action);
-        } catch (Exception& e) {
-            util::logError(e.getContext(), "Exception during Drag & Drop: {}", e.getMessage());
-        } catch (std::exception& e) {
-            util::logError(IVW_CONTEXT, "Exception during Drag & Drop: {}", e.what());
+        } catch (const Exception& e) {
+            log::user::exception(e, "Exception during Drag & Drop: {}", e.getMessage());
+        } catch (const std::exception& e) {
+            log::user::error("Exception during Drag & Drop: {}", e.what());
         }
 
         event->accept();

--- a/src/qt/editor/inviwomainwindow.cpp
+++ b/src/qt/editor/inviwomainwindow.cpp
@@ -614,7 +614,7 @@ void InviwoMainWindow::addActions() {
                         utilqt::toPath(saveFileDialog.selectedFiles().at(0));
                     networkEditorView_->exportViewToFile(path, entireScene,
                                                          backgroundVisibleAction->isChecked());
-                    log::user::info("Exported network to '{}'", path);
+                    log::info("Exported network to '{}'", path);
                 }
             };
         };
@@ -1303,7 +1303,7 @@ bool InviwoMainWindow::saveWorkspace(const std::filesystem::path& fileName) {
             }
         });
         updateWindowTitle();
-        log::user::info("Workspace saved to: {}", fileName);
+        log::info("Workspace saved to: {}", fileName);
         return true;
     } catch (const Exception& e) {
         util::logError(e.getContext(), "Unable to save network {} due to {}", fileName,
@@ -1650,9 +1650,9 @@ void InviwoMainWindow::dropEvent(QDropEvent* event) {
             };
             app_->dispatchFrontAndForget(action);
         } catch (const Exception& e) {
-            log::user::exception(e, "Exception during Drag & Drop: {}", e.getMessage());
+            log::exception(e, "Exception during Drag & Drop: {}", e.getMessage());
         } catch (const std::exception& e) {
-            log::user::error("Exception during Drag & Drop: {}", e.what());
+            log::error("Exception during Drag & Drop: {}", e.what());
         }
 
         event->accept();

--- a/src/qt/editor/networkautomation.cpp
+++ b/src/qt/editor/networkautomation.cpp
@@ -401,7 +401,7 @@ auto NetworkAutomation::drop(QPointF, Qt::KeyboardModifiers modifiers, Processor
             result = Result::Split;
 
         } else {
-            LogError("Unable to add processor on connection");
+            log::error("Unable to add processor on connection");
         }
     } else if (processorTarget_) {
         util::replaceProcessor(editor_.getNetwork(), processor, processorTarget_->getProcessor());

--- a/src/qt/editor/networkeditor.cpp
+++ b/src/qt/editor/networkeditor.cpp
@@ -133,23 +133,17 @@ NetworkEditor::NetworkEditor(InviwoMainWindow* mainWindow)
                 throw;
             } catch (const Exception& e) {
                 error(fmt::format("{}: {}", type, e.getMessage()));
-                util::log(e.getContext(),
-                          fmt::format("{} Error in {} : {}", id, type, e.getFullMessage()),
-                          LogLevel::Error);
+                log::user::exception(e, "{} Error in {} : {}", id, type, e.getFullMessage());
             } catch (const fmt::format_error& e) {
                 error(fmt::format("{}: {}", type, e.what()));
-                util::log(context,
-                          fmt::format("{} Error in {} using fmt formatting: {}\n{}", id, type,
-                                      e.what(), util::fmtHelp.view()),
-                          LogLevel::Error);
+                log::user::error("{} Error in {} using fmt formatting: {}\n{}", id, type, e.what(),
+                                 util::fmtHelp.view());
             } catch (const std::exception& e) {
                 error(fmt::format("{}: {}", type, e.what()));
-                util::log(context, fmt::format("{} Error in {} : {}", id, type, e.what()),
-                          LogLevel::Error);
+                log::user::error("{} Error in {} : {}", id, type, e.what());
             } catch (...) {
                 error(fmt::format("{}: Unknown error", type));
-                util::log(context, fmt::format("{} Error in {} : Unknown error", id, type),
-                          LogLevel::Error);
+                log::user::error("{} Error in {} : Unknown error", id, type);
             }
         });
 
@@ -674,7 +668,7 @@ void NetworkEditor::contextMenuEvent(QGraphicsSceneContextMenuEvent* e) {
                     try {
                         processor->getProcessor()->setDisplayName(utilqt::fromQString(text));
                     } catch (const Exception& e) {
-                        LogError(e.getMessage());
+                        log::user::exception(e);
                     }
                 }
             });
@@ -693,7 +687,7 @@ void NetworkEditor::contextMenuEvent(QGraphicsSceneContextMenuEvent* e) {
                     try {
                         processor->getProcessor()->setIdentifier(utilqt::fromQString(text));
                     } catch (const Exception& e) {
-                        LogError(e.getMessage());
+                        log::user::exception(e);
                     }
                 }
             });
@@ -850,9 +844,10 @@ void NetworkEditor::contextMenuEvent(QGraphicsSceneContextMenuEvent* e) {
                 std::filesystem::create_directories(compDir);
                 const auto path = compDir / (filename + ".inv");
                 p->saveSubNetwork(path);
-                LogInfo("Saved Composite to \"" << path
-                                                << "\". \nComposite is now available in the "
-                                                   "Processor list (restart may be required).");
+                log::user::info(
+                    "Saved Composite to \"{}\".\nComposite is now available in the "
+                    "Processor list (restart may be required).",
+                    path);
             }
         });
         saveCompAction->setDisabled(selectedComposites.empty());
@@ -1078,7 +1073,7 @@ void NetworkEditor::paste(const QMimeData& mimeData) {
         }
 
     } catch (const Exception&) {
-        LogWarn("Paste operation failed");
+        log::warn("Paste operation failed");
     }
 }
 
@@ -1104,8 +1099,8 @@ void NetworkEditor::append(const std::filesystem::path& workspace) {
         }
 
     } catch (const Exception& e) {
-        util::logError(e.getContext(), "Unable to append network {} due to {}", workspace,
-                       e.getMessage());
+        log::user::report(LogLevel::Error, e.getContext(), "Unable to append network {} due to {}",
+                          workspace, e.getMessage());
     }
 
 }  // namespace inviwo

--- a/src/qt/editor/networkeditor.cpp
+++ b/src/qt/editor/networkeditor.cpp
@@ -133,17 +133,17 @@ NetworkEditor::NetworkEditor(InviwoMainWindow* mainWindow)
                 throw;
             } catch (const Exception& e) {
                 error(fmt::format("{}: {}", type, e.getMessage()));
-                log::user::exception(e, "{} Error in {} : {}", id, type, e.getFullMessage());
+                log::exception(e, "{} Error in {} : {}", id, type, e.getFullMessage());
             } catch (const fmt::format_error& e) {
                 error(fmt::format("{}: {}", type, e.what()));
-                log::user::error("{} Error in {} using fmt formatting: {}\n{}", id, type, e.what(),
-                                 util::fmtHelp.view());
+                log::error("{} Error in {} using fmt formatting: {}\n{}", id, type, e.what(),
+                           util::fmtHelp.view());
             } catch (const std::exception& e) {
                 error(fmt::format("{}: {}", type, e.what()));
-                log::user::error("{} Error in {} : {}", id, type, e.what());
+                log::error("{} Error in {} : {}", id, type, e.what());
             } catch (...) {
                 error(fmt::format("{}: Unknown error", type));
-                log::user::error("{} Error in {} : Unknown error", id, type);
+                log::error("{} Error in {} : Unknown error", id, type);
             }
         });
 
@@ -668,7 +668,7 @@ void NetworkEditor::contextMenuEvent(QGraphicsSceneContextMenuEvent* e) {
                     try {
                         processor->getProcessor()->setDisplayName(utilqt::fromQString(text));
                     } catch (const Exception& e) {
-                        log::user::exception(e);
+                        log::exception(e);
                     }
                 }
             });
@@ -687,7 +687,7 @@ void NetworkEditor::contextMenuEvent(QGraphicsSceneContextMenuEvent* e) {
                     try {
                         processor->getProcessor()->setIdentifier(utilqt::fromQString(text));
                     } catch (const Exception& e) {
-                        log::user::exception(e);
+                        log::exception(e);
                     }
                 }
             });
@@ -844,7 +844,7 @@ void NetworkEditor::contextMenuEvent(QGraphicsSceneContextMenuEvent* e) {
                 std::filesystem::create_directories(compDir);
                 const auto path = compDir / (filename + ".inv");
                 p->saveSubNetwork(path);
-                log::user::info(
+                log::info(
                     "Saved Composite to \"{}\".\nComposite is now available in the "
                     "Processor list (restart may be required).",
                     path);
@@ -1099,8 +1099,8 @@ void NetworkEditor::append(const std::filesystem::path& workspace) {
         }
 
     } catch (const Exception& e) {
-        log::user::report(LogLevel::Error, e.getContext(), "Unable to append network {} due to {}",
-                          workspace, e.getMessage());
+        log::report(LogLevel::Error, e.getContext(), "Unable to append network {} due to {}",
+                    workspace, e.getMessage());
     }
 
 }  // namespace inviwo

--- a/src/qt/editor/processordraghelper.cpp
+++ b/src/qt/editor/processordraghelper.cpp
@@ -151,8 +151,8 @@ bool ProcessorDragHelper::drop(QGraphicsSceneDragDropEvent* e, const ProcessorMi
         automator_.drop(e->scenePos(), e->modifiers(), *addedProcessor);
 
     } catch (Exception& exception) {
-        log::user::exception(exception, "Unable to create processor {} due to {}",
-                             utilqt::fromQString(mime->text()), exception.getMessage());
+        log::exception(exception, "Unable to create processor {} due to {}",
+                       utilqt::fromQString(mime->text()), exception.getMessage());
     }
 
     return true;

--- a/src/qt/editor/processordraghelper.cpp
+++ b/src/qt/editor/processordraghelper.cpp
@@ -140,7 +140,7 @@ bool ProcessorDragHelper::drop(QGraphicsSceneDragDropEvent* e, const ProcessorMi
     try {
         auto processor = mime->get();
         if (!processor) {
-            LogError("Unable to get processor from drag object");
+            log::error("Unable to get processor from drag object");
             return true;
         }
         editor_.clearSelection();
@@ -151,10 +151,8 @@ bool ProcessorDragHelper::drop(QGraphicsSceneDragDropEvent* e, const ProcessorMi
         automator_.drop(e->scenePos(), e->modifiers(), *addedProcessor);
 
     } catch (Exception& exception) {
-        util::log(exception.getContext(),
-                  "Unable to create processor " + utilqt::fromQString(mime->text()) + " due to " +
-                      exception.getMessage(),
-                  LogLevel::Error);
+        log::user::exception(exception, "Unable to create processor {} due to {}",
+                             utilqt::fromQString(mime->text()), exception.getMessage());
     }
 
     return true;

--- a/src/qt/editor/processorlistwidget.cpp
+++ b/src/qt/editor/processorlistwidget.cpp
@@ -90,9 +90,8 @@ void ProcessorTree::mouseMoveEvent(QMouseEvent* e) {
                     drag->exec(Qt::MoveAction);
                 }
             } catch (const std::exception& e) {
-                LogError("Error trying to create processor: " << utilqt::fromQString(id)
-                                                              << " Message:\n"
-                                                              << e.what());
+                log::error("Error trying to create processor: {} Message:\n{}",
+                           utilqt::fromQString(id), e.what());
             }
         }
     }
@@ -355,10 +354,8 @@ std::shared_ptr<Processor> ProcessorTreeWidget::createProcessor(QString cid) {
             return p;
         }
     } catch (Exception& exception) {
-        util::log(
-            exception.getContext(),
-            "Unable to create processor \"" + className + "\" due to:\n" + exception.getMessage(),
-            LogLevel::Error);
+        log::user::exception(exception, "Unable to create processor '{}' due to:\n{}", className,
+                             exception.getMessage());
     }
     return nullptr;
 }

--- a/src/qt/editor/processorlistwidget.cpp
+++ b/src/qt/editor/processorlistwidget.cpp
@@ -354,8 +354,8 @@ std::shared_ptr<Processor> ProcessorTreeWidget::createProcessor(QString cid) {
             return p;
         }
     } catch (Exception& exception) {
-        log::user::exception(exception, "Unable to create processor '{}' due to:\n{}", className,
-                             exception.getMessage());
+        log::exception(exception, "Unable to create processor '{}' due to:\n{}", className,
+                       exception.getMessage());
     }
     return nullptr;
 }

--- a/src/qt/editor/processorpreview.cpp
+++ b/src/qt/editor/processorpreview.cpp
@@ -208,8 +208,7 @@ void utilqt::saveProcessorPreviews(InviwoApplication* app, std::string& path) {
             QImageWriter writer(imgname);
             writer.write(img);
         } else {
-            LogWarnCustom("saveProcessorPreviews",
-                          "No preview generated for: \"" << classIdentifier << "\"");
+            log::warn("No preview generated for: \"{}\"", classIdentifier);
         }
     };
 

--- a/src/qt/editor/subpropertyselectiondialog.cpp
+++ b/src/qt/editor/subpropertyselectiondialog.cpp
@@ -555,7 +555,7 @@ public:
                 return false;
             }
         } catch (const Exception& e) {
-            log::user::exception(e);
+            log::exception(e);
             return false;
         }
     }

--- a/src/qt/editor/subpropertyselectiondialog.cpp
+++ b/src/qt/editor/subpropertyselectiondialog.cpp
@@ -555,7 +555,7 @@ public:
                 return false;
             }
         } catch (const Exception& e) {
-            util::log(e.getContext(), e.getMessage());
+            log::user::exception(e);
             return false;
         }
     }

--- a/src/qt/editor/toolsmenu.cpp
+++ b/src/qt/editor/toolsmenu.cpp
@@ -163,7 +163,7 @@ void createRegressionActions(QWidget* parent, InviwoApplication* app, QMenu* men
                     const auto lname = toLower(utilqt::fromQString(name));
 
                     log::info("Creating regression test {}", lname);
-                    if (auto module = app->getModuleByIdentifier(modulename)) {
+                    if (auto* module = app->getModuleByIdentifier(modulename)) {
                         const auto regressiondir = module->getPath(ModulePath::RegressionTests);
                         const auto testdir = regressiondir / lname;
                         if (std::filesystem::is_directory(testdir)) {

--- a/src/qt/editor/toolsmenu.cpp
+++ b/src/qt/editor/toolsmenu.cpp
@@ -134,9 +134,9 @@ void createProcessorDocMenu(InviwoApplication* app, QMenu* docsMenu) {
                 oss << "*/\n";
 
                 QApplication::clipboard()->setText(utilqt::toQString(oss.str()));
-                LogInfoCustom("ToolMenu", "DOXYGEN Template code for processor "
-                                              << dispName << " copied to clipboard");
-                LogInfoCustom("ToolMenu", oss.str());
+                log::user::info("DOXYGEN Template code for processor {} copied to clipboard",
+                                dispName);
+                log::user::report(LogLevel::Info, oss.str());
             });
         }
     }
@@ -163,22 +163,20 @@ void createRegressionActions(QWidget* parent, InviwoApplication* app, QMenu* men
                 if (ok) {
                     const auto lname = toLower(utilqt::fromQString(name));
 
-                    LogInfoCustom("ToolMenu", "Creating regression test " << lname);
+                    log::user::info("Creating regression test {}", lname);
                     if (auto module = app->getModuleByIdentifier(modulename)) {
                         const auto regressiondir = module->getPath(ModulePath::RegressionTests);
                         const auto testdir = regressiondir / lname;
                         if (std::filesystem::is_directory(testdir)) {
-                            LogErrorCustom(
-                                "ToolMenu",
-                                "Dir: \"" << testdir << "\" already exits. use a different name");
+                            log::user::error("Dir: \"{}\" already exits. use a different name",
+                                             testdir);
                             return;
                         }
                         try {
                             std::filesystem::create_directories(testdir);
 
                             const auto workspaceName = testdir / (lname + ".inv");
-                            LogInfoCustom("ToolMenu",
-                                          "Saving regression workspace to: " << workspaceName);
+                            log::user::error("Saving regression workspace to: {}", workspaceName);
 
                             app->getWorkspaceManager()->save(workspaceName);
                             util::exportAllFiles(
@@ -188,9 +186,8 @@ void createRegressionActions(QWidget* parent, InviwoApplication* app, QMenu* men
                                 Overwrite::Yes);
 
                         } catch (const Exception& error) {
-                            LogErrorCustom("ToolsMenu",
-                                           fmt::format("Failed to create regression test: {}",
-                                                       error.getMessage()));
+                            log::user::error("Failed to create regression test: {}",
+                                             error.getMessage());
                             // TODO delete testdir here
                         }
                     }
@@ -232,7 +229,7 @@ ToolsMenu::ToolsMenu(InviwoMainWindow* win) : QMenu(tr("&Tools"), win) {
                 qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
             });
         } catch (const Exception& e) {
-            util::log(e.getContext(), e.getMessage(), LogLevel::Error);
+            log::user::exception(e);
         }
     });
 
@@ -245,7 +242,7 @@ ToolsMenu::ToolsMenu(InviwoMainWindow* win) : QMenu(tr("&Tools"), win) {
                 qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
             });
         } catch (const Exception& e) {
-            util::log(e.getContext(), e.getMessage(), LogLevel::Error);
+            log::user::exception(e);
         }
     });
 
@@ -259,7 +256,7 @@ ToolsMenu::ToolsMenu(InviwoMainWindow* win) : QMenu(tr("&Tools"), win) {
                 qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
             });
         } catch (const Exception& e) {
-            util::log(e.getContext(), e.getMessage(), LogLevel::Error);
+            log::user::exception(e);
         }
     });
 
@@ -273,7 +270,7 @@ ToolsMenu::ToolsMenu(InviwoMainWindow* win) : QMenu(tr("&Tools"), win) {
                 qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
             });
         } catch (const Exception& e) {
-            util::log(e.getContext(), e.getMessage(), LogLevel::Error);
+            log::user::exception(e);
         }
     });
 
@@ -294,7 +291,7 @@ ToolsMenu::ToolsMenu(InviwoMainWindow* win) : QMenu(tr("&Tools"), win) {
                     qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
                 });
             } catch (const Exception& e) {
-                util::log(e.getContext(), e.getMessage(), LogLevel::Error);
+                log::user::exception(e);
             }
         }
     });
@@ -317,7 +314,7 @@ ToolsMenu::ToolsMenu(InviwoMainWindow* win) : QMenu(tr("&Tools"), win) {
                     qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
                 });
             } catch (const Exception& e) {
-                util::log(e.getContext(), e.getMessage(), LogLevel::Error);
+                log::user::exception(e);
             }
         }
     });
@@ -354,10 +351,10 @@ ToolsMenu::ToolsMenu(InviwoMainWindow* win) : QMenu(tr("&Tools"), win) {
                     }};
                 processor->accept(visitor);
             } catch (const Exception& e) {
-                util::log(e.getContext(), e.getMessage());
+                log::user::exception(e);
             }
         }
-        LogInfo(buffer);
+        log::user::report(LogLevel::Info, buffer);
     });
 
 }  // namespace inviwo

--- a/src/qt/editor/toolsmenu.cpp
+++ b/src/qt/editor/toolsmenu.cpp
@@ -134,9 +134,8 @@ void createProcessorDocMenu(InviwoApplication* app, QMenu* docsMenu) {
                 oss << "*/\n";
 
                 QApplication::clipboard()->setText(utilqt::toQString(oss.str()));
-                log::user::info("DOXYGEN Template code for processor {} copied to clipboard",
-                                dispName);
-                log::user::report(LogLevel::Info, oss.str());
+                log::info("DOXYGEN Template code for processor {} copied to clipboard", dispName);
+                log::report(LogLevel::Info, oss.str());
             });
         }
     }
@@ -163,20 +162,19 @@ void createRegressionActions(QWidget* parent, InviwoApplication* app, QMenu* men
                 if (ok) {
                     const auto lname = toLower(utilqt::fromQString(name));
 
-                    log::user::info("Creating regression test {}", lname);
+                    log::info("Creating regression test {}", lname);
                     if (auto module = app->getModuleByIdentifier(modulename)) {
                         const auto regressiondir = module->getPath(ModulePath::RegressionTests);
                         const auto testdir = regressiondir / lname;
                         if (std::filesystem::is_directory(testdir)) {
-                            log::user::error("Dir: \"{}\" already exits. use a different name",
-                                             testdir);
+                            log::error("Dir: \"{}\" already exits. use a different name", testdir);
                             return;
                         }
                         try {
                             std::filesystem::create_directories(testdir);
 
                             const auto workspaceName = testdir / (lname + ".inv");
-                            log::user::error("Saving regression workspace to: {}", workspaceName);
+                            log::error("Saving regression workspace to: {}", workspaceName);
 
                             app->getWorkspaceManager()->save(workspaceName);
                             util::exportAllFiles(
@@ -186,8 +184,7 @@ void createRegressionActions(QWidget* parent, InviwoApplication* app, QMenu* men
                                 Overwrite::Yes);
 
                         } catch (const Exception& error) {
-                            log::user::error("Failed to create regression test: {}",
-                                             error.getMessage());
+                            log::error("Failed to create regression test: {}", error.getMessage());
                             // TODO delete testdir here
                         }
                     }
@@ -229,7 +226,7 @@ ToolsMenu::ToolsMenu(InviwoMainWindow* win) : QMenu(tr("&Tools"), win) {
                 qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
             });
         } catch (const Exception& e) {
-            log::user::exception(e);
+            log::exception(e);
         }
     });
 
@@ -242,7 +239,7 @@ ToolsMenu::ToolsMenu(InviwoMainWindow* win) : QMenu(tr("&Tools"), win) {
                 qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
             });
         } catch (const Exception& e) {
-            log::user::exception(e);
+            log::exception(e);
         }
     });
 
@@ -256,7 +253,7 @@ ToolsMenu::ToolsMenu(InviwoMainWindow* win) : QMenu(tr("&Tools"), win) {
                 qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
             });
         } catch (const Exception& e) {
-            log::user::exception(e);
+            log::exception(e);
         }
     });
 
@@ -270,7 +267,7 @@ ToolsMenu::ToolsMenu(InviwoMainWindow* win) : QMenu(tr("&Tools"), win) {
                 qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
             });
         } catch (const Exception& e) {
-            log::user::exception(e);
+            log::exception(e);
         }
     });
 
@@ -291,7 +288,7 @@ ToolsMenu::ToolsMenu(InviwoMainWindow* win) : QMenu(tr("&Tools"), win) {
                     qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
                 });
             } catch (const Exception& e) {
-                log::user::exception(e);
+                log::exception(e);
             }
         }
     });
@@ -314,7 +311,7 @@ ToolsMenu::ToolsMenu(InviwoMainWindow* win) : QMenu(tr("&Tools"), win) {
                     qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
                 });
             } catch (const Exception& e) {
-                log::user::exception(e);
+                log::exception(e);
             }
         }
     });
@@ -351,10 +348,10 @@ ToolsMenu::ToolsMenu(InviwoMainWindow* win) : QMenu(tr("&Tools"), win) {
                     }};
                 processor->accept(visitor);
             } catch (const Exception& e) {
-                log::user::exception(e);
+                log::exception(e);
             }
         }
-        log::user::report(LogLevel::Info, buffer);
+        log::report(LogLevel::Info, buffer);
     });
 
 }  // namespace inviwo

--- a/src/qt/editor/toolsmetamenu.cpp
+++ b/src/qt/editor/toolsmetamenu.cpp
@@ -64,9 +64,9 @@ void addInviwoMetaAction(QMenu* menu) {
                 meta::Creator creator(filesystem::findBasePath(), {}, {}, {true, false, false, ss});
                 func(creator, std::filesystem::path{path});
 
-                LogInfoCustom("Meta", ss.str());
+                log::user::report(LogLevel::Info, ss.str());
             } catch (const std::runtime_error& e) {
-                LogErrorCustom("Meta", e.what());
+                log::user::exception(e);
             }
         }
     };

--- a/src/qt/editor/toolsmetamenu.cpp
+++ b/src/qt/editor/toolsmetamenu.cpp
@@ -64,9 +64,9 @@ void addInviwoMetaAction(QMenu* menu) {
                 meta::Creator creator(filesystem::findBasePath(), {}, {}, {true, false, false, ss});
                 func(creator, std::filesystem::path{path});
 
-                log::user::report(LogLevel::Info, ss.str());
+                log::report(LogLevel::Info, ss.str());
             } catch (const std::runtime_error& e) {
-                log::user::exception(e);
+                log::exception(e);
             }
         }
     };

--- a/src/qt/editor/welcomewidget.cpp
+++ b/src/qt/editor/welcomewidget.cpp
@@ -701,9 +701,9 @@ void WelcomeWidget::showEvent(QShowEvent* event) {
             model_->updateExampleEntries();
             model_->updateRegressionTestEntries();
         } catch (const Exception& e) {
-            util::log(e.getContext(), e.getMessage(), LogLevel::Error);
+            log::user::exception(e);
         } catch (const std::exception& e) {
-            util::log(IVW_CONTEXT, e.what(), LogLevel::Error);
+            log::user::exception(e);
         }
         expandTreeView();
     }

--- a/src/qt/editor/welcomewidget.cpp
+++ b/src/qt/editor/welcomewidget.cpp
@@ -701,9 +701,9 @@ void WelcomeWidget::showEvent(QShowEvent* event) {
             model_->updateExampleEntries();
             model_->updateRegressionTestEntries();
         } catch (const Exception& e) {
-            log::user::exception(e);
+            log::exception(e);
         } catch (const std::exception& e) {
-            log::user::exception(e);
+            log::exception(e);
         }
         expandTreeView();
     }

--- a/tests/integrationtests/inviwo-integrationtests.cpp
+++ b/tests/integrationtests/inviwo-integrationtests.cpp
@@ -109,22 +109,18 @@ int main(int argc, char** argv) {
         ret = RUN_ALL_TESTS();
 
         if (ret) {
-            LogErrorCustom("IntegrationTests::runAllTests",
-                           "Some unit tests did not pass, see console output for details");
+            log::error("Some unit tests did not pass, see console output for details");
         }
 
         size_t warnCountAfter = logCounter->getWarnCount();
         size_t errCountAfter = logCounter->getErrorCount();
 
         if (warnCount != warnCountAfter) {
-            LogWarnCustom("IntegrationTests::runAllTest", "The integration test runs generated "
-                                                              << (warnCountAfter - warnCount)
-                                                              << " warnings");
+            log::warn("The integration test runs generated {} warnings",
+                      warnCountAfter - warnCount);
         }
         if (errCount != errCountAfter) {
-            LogWarnCustom("IntegrationTests::runAllTest", "The integration test runs generated "
-                                                              << (errCountAfter - errCount)
-                                                              << " errors");
+            log::warn("The integration test runs generated {} errors", errCountAfter - errCount);
         }
     }
 


### PR DESCRIPTION
SourceContext refactoring
Core: better log functions, in namespace log:: uses std::source_location. No need for any macros! 
Better ScopedClocks 
Various: Remove uses of Log* macros in favor of new log::* functions
Various: remove the use of LogAudience in new log API, since it is not really used for anything
Core: Removed the rarely used logProcessor/logNetwork/logAssertion from Loggers and logCentral