### PR TITLE
Core: Make TFLookupTable::getRepresentation const to be consistent with Data::getRepresentation

### DIFF
--- a/include/inviwo/core/datastructures/tflookuptable.h
+++ b/include/inviwo/core/datastructures/tflookuptable.h
@@ -55,7 +55,7 @@ public:
     void setTransferFunction(TransferFunction& tf);
 
     template <typename T>
-    const T* getRepresentation() {
+    const T* getRepresentation() const {
         if (invalid_) {
             calc();
         }
@@ -70,13 +70,14 @@ protected:
     virtual void onTFMaskChanged(const TFPrimitiveSet& set, dvec2 mask) override;
 
 private:
-    void calc();
+    void calc() const;
 
     TransferFunction* tf_;  // Should not be null
     size_t size_;
-    bool invalid_;
-    std::shared_ptr<LayerRAMPrecision<vec4>> repr_;
-    std::unique_ptr<Layer> data_;
+    // Mutable due to modification in const context by getRepresentation()/calc()
+    mutable bool invalid_;
+    mutable std::shared_ptr<LayerRAMPrecision<vec4>> repr_;
+    mutable std::unique_ptr<Layer> data_;
 };
 
 }  // namespace inviwo

--- a/include/inviwo/core/properties/transferfunctionproperty.h
+++ b/include/inviwo/core/properties/transferfunctionproperty.h
@@ -241,7 +241,7 @@ public:
     const TFData& data() const { return data_; }
 
     template <typename T>
-    const T* getRepresentation() {
+    const T* getRepresentation() const {
         return lookup_.getRepresentation<T>();
     }
     size_t getLookUpTableSize() const { return lookup_.getSize(); }

--- a/src/core/datastructures/tflookuptable.cpp
+++ b/src/core/datastructures/tflookuptable.cpp
@@ -54,7 +54,7 @@ void TFLookupTable::setTransferFunction(TransferFunction& tf) {
     }
 }
 
-void TFLookupTable::calc() {
+void TFLookupTable::calc() const {
     if (!repr_) {
         repr_ = std::make_shared<LayerRAMPrecision<vec4>>(size2_t{size_, 1});
     }


### PR DESCRIPTION
Enables use of TFLookupTable in an inport.
