### PR TITLE
Feature/python updates

### DIFF
--- a/modules/dataframepython/src/dataframepythonmodule.cpp
+++ b/modules/dataframepython/src/dataframepythonmodule.cpp
@@ -39,6 +39,7 @@ DataFramePythonModule::DataFramePythonModule(InviwoApplication* app)
     : InviwoModule(app, "DataFramePython") {
 
     try {
+        const pybind11::gil_scoped_acquire gil;
         pybind11::module::import("ivwdataframe");
     } catch (const std::exception& e) {
         throw ModuleInitException(e.what());

--- a/modules/dataframepython/tests/unittests/column-test.cpp
+++ b/modules/dataframepython/tests/unittests/column-test.cpp
@@ -91,12 +91,15 @@ col = ivwdataframe.{0}Column('{0}Col')
 }  // namespace
 
 TEST(ColumnTests, Create) {
+    pybind11::gil_scoped_acquire guard{};
     using Scalars = std::tuple<float, double, int, glm::i64, size_t, std::uint32_t>;
 
     util::for_each_type<Scalars>{}(CreateColumnScript{});
 }
 
 TEST(ColumnTests, CategoricalColumn) {
+    pybind11::gil_scoped_acquire guard{};
+
     const std::string source = R"delim(
 import inviwopy
 import ivwdataframe
@@ -124,6 +127,8 @@ col.add('a')
 }
 
 TEST(ColumnTests, FloatColumn) {
+    pybind11::gil_scoped_acquire guard{};
+
     const std::string source = R"delim(
 import inviwopy
 import ivwdataframe
@@ -153,6 +158,8 @@ col.buffer.data = np.array([0.0, 0.1, 0.5, 1.0, 2.0, 10.0], dtype=np.single)
 }
 
 TEST(ColumnTests, DataAccess) {
+    pybind11::gil_scoped_acquire guard{};
+
     const std::string source = R"delim(
 import inviwopy
 import ivwdataframe
@@ -188,6 +195,8 @@ col.set(2, 5.0)
 }
 
 TEST(ColumnAppend, IntColumn) {
+    pybind11::gil_scoped_acquire guard{};
+
     const std::string source = R"delim(
 import inviwopy
 import ivwdataframe
@@ -225,6 +234,8 @@ col.append(col2)
 }
 
 TEST(ColumnAppend, Categorical) {
+    pybind11::gil_scoped_acquire guard{};
+
     const std::string source = R"delim(
 import inviwopy
 import ivwdataframe

--- a/modules/dataframepython/tests/unittests/column-test.cpp
+++ b/modules/dataframepython/tests/unittests/column-test.cpp
@@ -91,14 +91,14 @@ col = ivwdataframe.{0}Column('{0}Col')
 }  // namespace
 
 TEST(ColumnTests, Create) {
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
     using Scalars = std::tuple<float, double, int, glm::i64, size_t, std::uint32_t>;
 
     util::for_each_type<Scalars>{}(CreateColumnScript{});
 }
 
 TEST(ColumnTests, CategoricalColumn) {
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
 
     const std::string source = R"delim(
 import inviwopy
@@ -127,7 +127,7 @@ col.add('a')
 }
 
 TEST(ColumnTests, FloatColumn) {
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
 
     const std::string source = R"delim(
 import inviwopy
@@ -158,7 +158,7 @@ col.buffer.data = np.array([0.0, 0.1, 0.5, 1.0, 2.0, 10.0], dtype=np.single)
 }
 
 TEST(ColumnTests, DataAccess) {
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
 
     const std::string source = R"delim(
 import inviwopy
@@ -195,7 +195,7 @@ col.set(2, 5.0)
 }
 
 TEST(ColumnAppend, IntColumn) {
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
 
     const std::string source = R"delim(
 import inviwopy
@@ -234,7 +234,7 @@ col.append(col2)
 }
 
 TEST(ColumnAppend, Categorical) {
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
 
     const std::string source = R"delim(
 import inviwopy

--- a/modules/dataframepython/tests/unittests/dataframe-test.cpp
+++ b/modules/dataframepython/tests/unittests/dataframe-test.cpp
@@ -87,6 +87,8 @@ d.add{0}Column('{0}Col')
 }  // namespace
 
 TEST(DataFrameTests, Create) {
+    pybind11::gil_scoped_acquire guard{};
+
     const std::string source = R"delim(
 import inviwopy
 import ivwdataframe
@@ -112,12 +114,16 @@ d2 = ivwdataframe.DataFrame(10)
 }
 
 TEST(DataFrameTests, AddColumn) {
+    pybind11::gil_scoped_acquire guard{};
+
     using Scalars = std::tuple<float, double, int, glm::i64, std::uint32_t>;
 
     util::for_each_type<Scalars>{}(AddColumnScript{});
 }
 
 TEST(DataFrameTests, AddCategoricalColumn) {
+    pybind11::gil_scoped_acquire guard{};
+    
     const std::string colname = "CatColumn";
 
     const std::string source = fmt::format(R"delim(
@@ -145,6 +151,8 @@ d.addCategoricalColumn('{}')
 }
 
 TEST(DataFrameTests, AddCategoricalColumnData) {
+    pybind11::gil_scoped_acquire guard{};
+
     const std::string colname = "CatColumn";
 
     const std::string source = fmt::format(R"delim(
@@ -181,6 +189,8 @@ d.updateIndex()
 }
 
 TEST(DataFrameTests, AddColumnFromBuffer) {
+    pybind11::gil_scoped_acquire guard{};
+
     const std::string colName = "FloatCol";
 
     const std::string source = fmt::format(R"delim(
@@ -211,6 +221,8 @@ d.updateIndex()
 }
 
 TEST(DataFrameTests, RowAccess) {
+    pybind11::gil_scoped_acquire guard{};
+
     const size_t rowIndex = 1;
 
     const std::string source = R"delim(

--- a/modules/dataframepython/tests/unittests/dataframe-test.cpp
+++ b/modules/dataframepython/tests/unittests/dataframe-test.cpp
@@ -87,7 +87,7 @@ d.add{0}Column('{0}Col')
 }  // namespace
 
 TEST(DataFrameTests, Create) {
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
 
     const std::string source = R"delim(
 import inviwopy
@@ -114,7 +114,7 @@ d2 = ivwdataframe.DataFrame(10)
 }
 
 TEST(DataFrameTests, AddColumn) {
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
 
     using Scalars = std::tuple<float, double, int, glm::i64, std::uint32_t>;
 
@@ -122,8 +122,8 @@ TEST(DataFrameTests, AddColumn) {
 }
 
 TEST(DataFrameTests, AddCategoricalColumn) {
-    pybind11::gil_scoped_acquire guard{};
-    
+    const pybind11::gil_scoped_acquire guard{};
+
     const std::string colname = "CatColumn";
 
     const std::string source = fmt::format(R"delim(
@@ -151,7 +151,7 @@ d.addCategoricalColumn('{}')
 }
 
 TEST(DataFrameTests, AddCategoricalColumnData) {
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
 
     const std::string colname = "CatColumn";
 
@@ -189,7 +189,7 @@ d.updateIndex()
 }
 
 TEST(DataFrameTests, AddColumnFromBuffer) {
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
 
     const std::string colName = "FloatCol";
 
@@ -221,7 +221,7 @@ d.updateIndex()
 }
 
 TEST(DataFrameTests, RowAccess) {
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
 
     const size_t rowIndex = 1;
 

--- a/modules/python3/bindings/src/pypickingmapper.cpp
+++ b/modules/python3/bindings/src/pypickingmapper.cpp
@@ -127,7 +127,7 @@ void exposePickingMapper(pybind11::module& m) {
         .def(py::init([](Processor* p, size_t size, pybind11::function callback) {
             return new PickingMapper(p, size, [callback](PickingEvent* e) {
                 try {
-                    pybind11::gil_scoped_acquire guard{};
+                    const pybind11::gil_scoped_acquire guard{};
                     callback(py::cast(e));
                 } catch (const py::error_already_set& e) {
                     log::exception(e);

--- a/modules/python3/bindings/src/pypickingmapper.cpp
+++ b/modules/python3/bindings/src/pypickingmapper.cpp
@@ -127,6 +127,7 @@ void exposePickingMapper(pybind11::module& m) {
         .def(py::init([](Processor* p, size_t size, pybind11::function callback) {
             return new PickingMapper(p, size, [callback](PickingEvent* e) {
                 try {
+                    pybind11::gil_scoped_acquire guard{};
                     callback(py::cast(e));
                 } catch (const py::error_already_set& e) {
                     log::exception(e);

--- a/modules/python3/bindings/src/pyprocessors.cpp
+++ b/modules/python3/bindings/src/pyprocessors.cpp
@@ -51,6 +51,7 @@
 #include <inviwo/core/processors/processorwidgetfactory.h>
 #include <inviwo/core/processors/processorwidgetfactoryobject.h>
 #include <inviwo/core/network/processornetwork.h>
+#include <inviwo/core/network/networkutils.h>
 #include <inviwo/core/metadata/processormetadata.h>
 #include <inviwo/core/common/inviwoapplication.h>
 #include <inviwo/core/datastructures/image/layer.h>
@@ -296,7 +297,11 @@ void exposeProcessors(pybind11::module& m) {
             [](Processor* p) {
                 return p->getMetaData<ProcessorMetaData>(ProcessorMetaData::classIdentifier);
             },
-            py::return_value_policy::reference);
+            py::return_value_policy::reference)
+        .def("getDirectPredecessors", [](Processor* p) { return util::getDirectPredecessors(p); })
+        .def("getDirectSuccessors", [](Processor* p) { return util::getDirectSuccessors(p); })
+        .def("getPredecessors", [](Processor* p) { return util::getPredecessors(p); })
+        .def("getSuccessors", [](Processor* p) { return util::getSuccessors(p); });
 
     py::class_<CanvasProcessor, Processor>(m, "CanvasProcessor")
         .def_property("size", &CanvasProcessor::getCanvasSize, &CanvasProcessor::setCanvasSize)

--- a/modules/python3/include/modules/python3/layerpy.h
+++ b/modules/python3/include/modules/python3/layerpy.h
@@ -64,7 +64,9 @@ public:
             const Wrapping2D& wrapping = LayerConfig::defaultWrapping);
 
     explicit LayerPy(const LayerReprConfig& config);
-
+    LayerPy(LayerPy&&) = delete;
+    LayerPy& operator=(const LayerPy&) = delete;
+    LayerPy& operator=(LayerPy&&) = delete;
     virtual ~LayerPy();
 
     LayerPy* clone() const override;
@@ -90,6 +92,9 @@ public:
     const pybind11::array& data() const { return data_; }
 
 private:
+    LayerPy(const LayerPy&);
+
+    std::optional<pybind11::gil_scoped_acquire> gil_;
     SwizzleMask swizzleMask_;
     InterpolationType interpolation_;
     Wrapping2D wrapping_;

--- a/modules/python3/include/modules/python3/pythoninterpreter.h
+++ b/modules/python3/include/modules/python3/pythoninterpreter.h
@@ -33,6 +33,7 @@
 #include <modules/python3/pythonexecutionoutputobservable.h>
 
 #include <filesystem>
+#include <pytypedefs.h>
 
 namespace inviwo {
 class Python3Module;
@@ -50,6 +51,7 @@ public:
 private:
     bool embedded_;
     bool isInit_;
+    PyThreadState* tstate_;
 };
 
 }  // namespace inviwo

--- a/modules/python3/include/modules/python3/volumepy.h
+++ b/modules/python3/include/modules/python3/volumepy.h
@@ -41,6 +41,7 @@
 
 #include <memory>     // for shared_ptr
 #include <typeindex>  // for type_index
+#include <optional>
 
 namespace inviwo {
 
@@ -64,7 +65,9 @@ public:
              const Wrapping3D& wrapping = VolumeConfig::defaultWrapping);
 
     explicit VolumePy(const VolumeReprConfig& config);
-
+    VolumePy(VolumePy&&) = delete;
+    VolumePy& operator=(const VolumePy&) = delete;
+    VolumePy& operator=(VolumePy&&) = delete;
     virtual ~VolumePy();
 
     VolumePy* clone() const override;
@@ -90,6 +93,9 @@ public:
     virtual void updateResource(const ResourceMeta& meta) const override;
 
 private:
+    VolumePy(const VolumePy&);
+
+    std::optional<pybind11::gil_scoped_acquire> gil_;
     SwizzleMask swizzleMask_;
     InterpolationType interpolation_;
     Wrapping3D wrapping_;

--- a/modules/python3/src/layerpy.cpp
+++ b/modules/python3/src/layerpy.cpp
@@ -63,23 +63,31 @@ const DataFormatBase* format(pybind11::array data) {
 LayerPy::LayerPy(pybind11::array data, LayerType type, const SwizzleMask& swizzleMask,
                  InterpolationType interpolation, const Wrapping2D& wrapping)
     : LayerRepresentation(type)
+    , gil_{std::in_place}
     , swizzleMask_{swizzleMask}
     , interpolation_{interpolation}
     , wrapping_{wrapping}
     , data_{data}
-    , dims_{data_.shape(1), data_.shape(0)} {}
+    , dims_{data_.shape(1), data_.shape(0)} {
+
+    gil_.reset();
+}
 
 LayerPy::LayerPy(size2_t dimensions, LayerType type, const DataFormatBase* format,
                  const SwizzleMask& swizzleMask, InterpolationType interpolation,
                  const Wrapping2D& wrapping)
     : LayerRepresentation(type)
+    , gil_{std::in_place}
     , swizzleMask_{swizzleMask}
     , interpolation_{interpolation}
     , wrapping_{wrapping}
     , data_{pybind11::array(pyutil::toNumPyFormat(format),
                             pybind11::array::ShapeContainer{dimensions.y, dimensions.x,
-                                                            getDataFormat()->getComponents()})}
-    , dims_{dimensions} {}
+                                                            format->getComponents()})}
+    , dims_{dimensions} {
+
+    gil_.reset();
+}
 
 LayerPy::LayerPy(const LayerReprConfig& config)
     : LayerPy{config.dimensions.value_or(LayerConfig::defaultDimensions),
@@ -89,7 +97,19 @@ LayerPy::LayerPy(const LayerReprConfig& config)
               config.interpolation.value_or(LayerConfig::defaultInterpolation),
               config.wrapping.value_or(LayerConfig::defaultWrapping)} {}
 
-LayerPy::~LayerPy() {}
+LayerPy::LayerPy(const LayerPy& rhs)
+    : LayerRepresentation(rhs)
+    , gil_{std::in_place}
+    , swizzleMask_{rhs.swizzleMask_}
+    , interpolation_{rhs.interpolation_}
+    , wrapping_{rhs.wrapping_}
+    , data_{rhs.data_.request()}
+    , dims_{rhs.dims_} {
+
+    gil_.reset();
+}
+
+LayerPy::~LayerPy() { gil_.emplace(); }
 
 LayerPy* LayerPy::clone() const { return new LayerPy(*this); }
 
@@ -97,6 +117,7 @@ std::type_index LayerPy::getTypeIndex() const { return std::type_index(typeid(La
 
 void LayerPy::setDimensions(size2_t dimensions) {
     if (dimensions != dims_) {
+        pybind11::gil_scoped_acquire guard{};
         data_ = pybind11::array(data_.dtype(),
                                 pybind11::array::ShapeContainer{dimensions.y, dimensions.x,
                                                                 getDataFormat()->getComponents()});
@@ -104,7 +125,10 @@ void LayerPy::setDimensions(size2_t dimensions) {
     }
 }
 
-const DataFormatBase* LayerPy::getDataFormat() const { return format(data_); }
+const DataFormatBase* LayerPy::getDataFormat() const {
+    pybind11::gil_scoped_acquire guard{};
+    return format(data_);
+}
 
 const size2_t& LayerPy::getDimensions() const { return dims_; }
 
@@ -124,6 +148,7 @@ bool LayerPy::copyRepresentationsTo(LayerRepresentation*) const { return false; 
 
 std::shared_ptr<LayerPy> LayerRAM2PyConverter::createFrom(
     std::shared_ptr<const LayerRAM> source) const {
+    pybind11::gil_scoped_acquire guard{};
 
     pybind11::array data = source->dispatch<pybind11::array>([](auto lr) {
         using ValueType = util::PrecisionValueType<decltype(lr)>;
@@ -154,6 +179,7 @@ std::shared_ptr<LayerPy> LayerRAM2PyConverter::createFrom(
 
 void LayerRAM2PyConverter::update(std::shared_ptr<const LayerRAM> source,
                                   std::shared_ptr<LayerPy> destination) const {
+    pybind11::gil_scoped_acquire guard{};
     destination->setDimensions(source->getDimensions());
     destination->setSwizzleMask(source->getSwizzleMask());
     destination->setInterpolation(source->getInterpolation());
@@ -170,6 +196,7 @@ void LayerRAM2PyConverter::update(std::shared_ptr<const LayerRAM> source,
 
 std::shared_ptr<LayerRAM> LayerPy2RAMConverter::createFrom(
     std::shared_ptr<const LayerPy> source) const {
+    pybind11::gil_scoped_acquire guard{};
 
     auto destination =
         createLayerRAM(source->getDimensions(), source->getLayerType(), source->getDataFormat(),
@@ -191,6 +218,7 @@ std::shared_ptr<LayerRAM> LayerPy2RAMConverter::createFrom(
 
 void LayerPy2RAMConverter::update(std::shared_ptr<const LayerPy> source,
                                   std::shared_ptr<LayerRAM> destination) const {
+    pybind11::gil_scoped_acquire guard{};
     destination->setDimensions(source->getDimensions());
     destination->setSwizzleMask(source->getSwizzleMask());
     destination->setInterpolation(source->getInterpolation());

--- a/modules/python3/src/python3module.cpp
+++ b/modules/python3/src/python3module.cpp
@@ -95,6 +95,8 @@ public:
 };
 
 void runScript(PythonScript& script, InviwoApplication* app) {
+    const pybind11::gil_scoped_acquire guard{};
+
     auto extra = app->getCommandLineParser().getIgnoredArgs();
     extra.insert(extra.begin(), app->getCommandLineParser().getArgs().front());
     pybind11::module::import("sys").attr("argv") = extra;

--- a/modules/python3/src/python3module.cpp
+++ b/modules/python3/src/python3module.cpp
@@ -161,6 +161,7 @@ Python3Module::Python3Module(InviwoApplication* app)
     // We need to import inviwopy to trigger the initialization code in inviwopy.cpp, this is needed
     // to be able to cast cpp/inviwo objects to python objects.
     try {
+        const pybind11::gil_scoped_acquire gil;
         pybind11::module::import("inviwopy");
     } catch (const std::exception& e) {
         throw ModuleInitException(e.what());

--- a/modules/python3/src/pythoninterpreter.cpp
+++ b/modules/python3/src/pythoninterpreter.cpp
@@ -55,6 +55,8 @@
 #include <string>       // for operator+, string, basic_string
 #include <string_view>  // for string_view
 
+#include <fmt/format.h>
+
 namespace inviwo {
 
 PythonInterpreter::PythonInterpreter() : embedded_{false}, isInit_(false) {
@@ -71,11 +73,27 @@ PythonInterpreter::PythonInterpreter() : embedded_{false}, isInit_(false) {
 #endif
 
     if (!Py_IsInitialized()) {
-
         log::info("Python version: {}", Py_GetVersion());
 
         try {
-            py::initialize_interpreter(false);
+            PyConfig config;
+            PyConfig_InitPythonConfig(&config);
+            config.parse_argv = 0;
+            config.install_signal_handlers = 0;
+            if (auto venvPath = std::getenv("VIRTUAL_ENV")) {
+
+                // Relevant documentation:
+                // https://stackoverflow.com/questions/77881387/
+                // how-to-embed-python-3-8-in-a-c-application-while-using-a-virtual-environment
+                // https://docs.python.org/3/library/site.html
+#ifdef WIN32
+                auto venvExecutable = fmt::format("{}/Scripts/python.exe", venvPath);
+#else
+                auto venvExecutable = fmt::format("{}/bin/python", venvPath);
+#endif
+                PyConfig_SetBytesString(&config, &config.executable, venvExecutable.c_str());
+            }
+            py::initialize_interpreter(&config);
         } catch (const std::exception& e) {
             throw ModuleInitException(e.what());
         }
@@ -154,7 +172,7 @@ sys.stderr = OutputRedirector(1)
 )",
                      py::globals());
 
-        tstate_ = PyEval_SaveThread();
+            tstate_ = PyEval_SaveThread();
 
         } catch (const py::error_already_set& e) {
             throw ModuleInitException(

--- a/modules/python3/src/pythoninterpreter.cpp
+++ b/modules/python3/src/pythoninterpreter.cpp
@@ -153,6 +153,9 @@ sys.stdout = OutputRedirector(0)
 sys.stderr = OutputRedirector(1)
 )",
                      py::globals());
+
+        tstate_ = PyEval_SaveThread();
+
         } catch (const py::error_already_set& e) {
             throw ModuleInitException(
                 SourceContext{}, "Error while initializing the Python Interpreter\n{}", e.what());
@@ -163,6 +166,7 @@ sys.stderr = OutputRedirector(1)
 PythonInterpreter::~PythonInterpreter() {
     namespace py = pybind11;
     if (embedded_) {
+        PyEval_RestoreThread(tstate_);
         py::finalize_interpreter();
     }
 }

--- a/modules/python3/src/pythoninterpreter.cpp
+++ b/modules/python3/src/pythoninterpreter.cpp
@@ -80,7 +80,7 @@ PythonInterpreter::PythonInterpreter() : embedded_{false}, isInit_(false) {
             PyConfig_InitPythonConfig(&config);
             config.parse_argv = 0;
             config.install_signal_handlers = 0;
-            if (auto venvPath = std::getenv("VIRTUAL_ENV")) {
+            if (char* venvPath = std::getenv("VIRTUAL_ENV")) {
 
                 // Relevant documentation:
                 // https://stackoverflow.com/questions/77881387/

--- a/modules/python3/src/pythonoutport.cpp
+++ b/modules/python3/src/pythonoutport.cpp
@@ -41,6 +41,8 @@ PythonOutport::PythonOutport(std::string_view identifier, Document help)
 }
 
 Document PythonOutport::getInfo() const {
+    pybind11::gil_scoped_acquire guard{};
+    
     Document doc;
     using P = Document::PathComponent;
     using H = utildoc::TableBuilder::Header;

--- a/modules/python3/src/pythonoutport.cpp
+++ b/modules/python3/src/pythonoutport.cpp
@@ -41,8 +41,8 @@ PythonOutport::PythonOutport(std::string_view identifier, Document help)
 }
 
 Document PythonOutport::getInfo() const {
-    pybind11::gil_scoped_acquire guard{};
-    
+    const pybind11::gil_scoped_acquire guard{};
+
     Document doc;
     using P = Document::PathComponent;
     using H = utildoc::TableBuilder::Header;

--- a/modules/python3/src/pythonprocessorfactoryobject.cpp
+++ b/modules/python3/src/pythonprocessorfactoryobject.cpp
@@ -74,6 +74,7 @@ std::shared_ptr<Processor> PythonProcessorFactoryObject::create(InviwoApplicatio
     const auto& pi = getProcessorInfo();
 
     try {
+        const pybind11::gil_scoped_acquire gil;
         auto main = py::module::import("__main__");
         py::object proc =
             main.attr(name_.c_str())(util::stripIdentifier(pi.displayName), pi.displayName);
@@ -142,6 +143,7 @@ pybind11::object compileAndRun(const std::string& expr, const std::string& name,
 PythonProcessorFactoryObjectData PythonProcessorFactoryObject::load(
     const std::filesystem::path& file) {
     namespace py = pybind11;
+    const pybind11::gil_scoped_acquire gil;
 
     auto ifs = std::ifstream(file);
     std::stringstream ss;

--- a/modules/python3/src/pythonscript.cpp
+++ b/modules/python3/src/pythonscript.cpp
@@ -63,7 +63,7 @@ PythonScript PythonScript::fromFile(const std::filesystem::path& path) {
 }
 
 PythonScript::~PythonScript() {
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
     Py_XDECREF(static_cast<PyObject*>(byteCode_));
 }
 
@@ -72,7 +72,7 @@ void PythonScript::setName(std::string_view name) { name_ = name; }
 const std::string& PythonScript::getName() const { return name_; }
 
 void PythonScript::setSource(std::string_view source) {
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
     source_ = source;
     isCompileNeeded_ = true;
     Py_XDECREF(static_cast<PyObject*>(byteCode_));
@@ -82,7 +82,7 @@ void PythonScript::setSource(std::string_view source) {
 const std::string& PythonScript::getSource() const { return source_; }
 
 bool PythonScript::compile() {
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
 
     Py_XDECREF(static_cast<PyObject*>(byteCode_));
     byteCode_ = Py_CompileString(source_.c_str(), name_.c_str(), Py_file_input);
@@ -99,7 +99,7 @@ bool PythonScript::compile() {
 bool PythonScript::run(std::function<void(pybind11::dict)> callback) {
     namespace py = pybind11;
 
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
     // Copy the dict to get a clean slate every time we run the script
     py::dict global = py::cast<py::dict>(PyDict_Copy(py::globals().ptr()));
     return run(global, callback);
@@ -109,7 +109,7 @@ bool PythonScript::run(std::unordered_map<std::string, pybind11::object> locals,
                        std::function<void(pybind11::dict)> callback) {
     namespace py = pybind11;
 
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
     // Copy the dict to get a clean slate every time we run the script
     py::dict global = py::cast<py::dict>(PyDict_Copy(py::globals().ptr()));
     for (auto& item : locals) {
@@ -126,7 +126,7 @@ bool PythonScript::run(pybind11::dict locals, std::function<void(pybind11::dict)
 
     IVW_ASSERT(byteCode_ != nullptr, "No byte code");
 
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
     if (PyEval_EvalCode(static_cast<PyObject*>(byteCode_), locals.ptr(), locals.ptr())) {
         if (callback) {
             callback(locals);
@@ -139,7 +139,7 @@ bool PythonScript::run(pybind11::dict locals, std::function<void(pybind11::dict)
 }
 
 std::string PythonScript::getAndFormatError() {
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
     namespace py = pybind11;
     py::object type;
     py::object value;

--- a/modules/python3/src/pythonscript.cpp
+++ b/modules/python3/src/pythonscript.cpp
@@ -62,13 +62,17 @@ PythonScript PythonScript::fromFile(const std::filesystem::path& path) {
     return PythonScript{source, path.generic_string()};
 }
 
-PythonScript::~PythonScript() { Py_XDECREF(static_cast<PyObject*>(byteCode_)); }
+PythonScript::~PythonScript() {
+    pybind11::gil_scoped_acquire guard{};
+    Py_XDECREF(static_cast<PyObject*>(byteCode_));
+}
 
 void PythonScript::setName(std::string_view name) { name_ = name; }
 
 const std::string& PythonScript::getName() const { return name_; }
 
 void PythonScript::setSource(std::string_view source) {
+    pybind11::gil_scoped_acquire guard{};
     source_ = source;
     isCompileNeeded_ = true;
     Py_XDECREF(static_cast<PyObject*>(byteCode_));
@@ -78,6 +82,8 @@ void PythonScript::setSource(std::string_view source) {
 const std::string& PythonScript::getSource() const { return source_; }
 
 bool PythonScript::compile() {
+    pybind11::gil_scoped_acquire guard{};
+
     Py_XDECREF(static_cast<PyObject*>(byteCode_));
     byteCode_ = Py_CompileString(source_.c_str(), name_.c_str(), Py_file_input);
     isCompileNeeded_ = !checkCompileError();
@@ -93,6 +99,7 @@ bool PythonScript::compile() {
 bool PythonScript::run(std::function<void(pybind11::dict)> callback) {
     namespace py = pybind11;
 
+    pybind11::gil_scoped_acquire guard{};
     // Copy the dict to get a clean slate every time we run the script
     py::dict global = py::cast<py::dict>(PyDict_Copy(py::globals().ptr()));
     return run(global, callback);
@@ -102,6 +109,7 @@ bool PythonScript::run(std::unordered_map<std::string, pybind11::object> locals,
                        std::function<void(pybind11::dict)> callback) {
     namespace py = pybind11;
 
+    pybind11::gil_scoped_acquire guard{};
     // Copy the dict to get a clean slate every time we run the script
     py::dict global = py::cast<py::dict>(PyDict_Copy(py::globals().ptr()));
     for (auto& item : locals) {
@@ -112,13 +120,13 @@ bool PythonScript::run(std::unordered_map<std::string, pybind11::object> locals,
 
 bool PythonScript::run(pybind11::dict locals, std::function<void(pybind11::dict)> callback) {
     namespace py = pybind11;
-
     if (isCompileNeeded_ && !compile()) {
         return false;
     }
 
     IVW_ASSERT(byteCode_ != nullptr, "No byte code");
 
+    pybind11::gil_scoped_acquire guard{};
     if (PyEval_EvalCode(static_cast<PyObject*>(byteCode_), locals.ptr(), locals.ptr())) {
         if (callback) {
             callback(locals);
@@ -131,6 +139,7 @@ bool PythonScript::run(pybind11::dict locals, std::function<void(pybind11::dict)
 }
 
 std::string PythonScript::getAndFormatError() {
+    pybind11::gil_scoped_acquire guard{};
     namespace py = pybind11;
     py::object type;
     py::object value;

--- a/modules/python3/src/pythonscript.cpp
+++ b/modules/python3/src/pythonscript.cpp
@@ -63,8 +63,14 @@ PythonScript PythonScript::fromFile(const std::filesystem::path& path) {
 }
 
 PythonScript::~PythonScript() {
-    const pybind11::gil_scoped_acquire guard{};
-    Py_XDECREF(static_cast<PyObject*>(byteCode_));
+    try {
+        const pybind11::gil_scoped_acquire guard{};
+        Py_XDECREF(static_cast<PyObject*>(byteCode_));
+    } catch (const std::exception& e) {
+        log::exception(e);
+    } catch (...) {
+        log::exception("Unable to acquire the Python GIL");
+    }
 }
 
 void PythonScript::setName(std::string_view name) { name_ = name; }

--- a/modules/python3/src/pyutils.cpp
+++ b/modules/python3/src/pyutils.cpp
@@ -54,6 +54,8 @@ void addModulePath(const std::filesystem::path& path) {
     }
 
     std::string pathConv{path.generic_string()};
+
+    const pybind11::gil_scoped_acquire gil;
     py::module::import("sys").attr("path").cast<py::list>().append(pathConv);
 }
 
@@ -65,6 +67,8 @@ void removeModulePath(const std::filesystem::path& path) {
     }
 
     std::string pathConv{path.generic_string()};
+
+    const pybind11::gil_scoped_acquire gil;
     py::module::import("sys").attr("path").attr("remove")(pathConv);
 }
 

--- a/modules/python3/src/volumepy.cpp
+++ b/modules/python3/src/volumepy.cpp
@@ -126,7 +126,7 @@ VolumePy::VolumePy(const VolumePy& rhs)
     , dims_{rhs.dims_} {
 
     resource::add(resource::toPY(data_), Resource{.dims = glm::size4_t{dims_, 0},
-                                                  .format = getDataFormat()->getId(),
+                                                  .format = format(data_)->getId(),
                                                   .desc = "VolumePY"});
 
     gil_.reset();

--- a/modules/python3/src/volumepy.cpp
+++ b/modules/python3/src/volumepy.cpp
@@ -76,20 +76,24 @@ const DataFormatBase* format(pybind11::array data) {
 VolumePy::VolumePy(pybind11::array data, const SwizzleMask& swizzleMask,
                    InterpolationType interpolation, const Wrapping3D& wrapping)
     : VolumeRepresentation()
+    , gil_{std::in_place}
     , swizzleMask_{swizzleMask}
     , interpolation_{interpolation}
     , wrapping_{wrapping}
-    , data_{data}
+    , data_{std::move(data)}
     , dims_{data_.shape(2), data_.shape(1), data_.shape(0)} {
 
     resource::add(resource::toPY(data_), Resource{.dims = glm::size4_t{dims_, 0},
                                                   .format = format(data_)->getId(),
                                                   .desc = "VolumePY"});
+
+    gil_.reset();
 }
 
 VolumePy::VolumePy(size3_t dimensions, const DataFormatBase* format, const SwizzleMask& swizzleMask,
                    InterpolationType interpolation, const Wrapping3D& wrapping)
     : VolumeRepresentation()
+    , gil_{std::in_place}
     , swizzleMask_{swizzleMask}
     , interpolation_{interpolation}
     , wrapping_{wrapping}
@@ -101,6 +105,8 @@ VolumePy::VolumePy(size3_t dimensions, const DataFormatBase* format, const Swizz
     resource::add(
         resource::toPY(data_),
         Resource{.dims = glm::size4_t{dims_, 0}, .format = format->getId(), .desc = "VolumePY"});
+
+    gil_.reset();
 }
 
 VolumePy::VolumePy(const VolumeReprConfig& config)
@@ -110,16 +116,40 @@ VolumePy::VolumePy(const VolumeReprConfig& config)
                config.interpolation.value_or(VolumeConfig::defaultInterpolation),
                config.wrapping.value_or(VolumeConfig::defaultWrapping)} {}
 
-VolumePy::~VolumePy() { resource::remove(resource::toPY(data_)); }
+VolumePy::VolumePy(const VolumePy& rhs)
+    : VolumeRepresentation(rhs)
+    , gil_{std::in_place}
+    , swizzleMask_{rhs.swizzleMask_}
+    , interpolation_{rhs.interpolation_}
+    , wrapping_{rhs.wrapping_}
+    , data_{rhs.data_.request()}
+    , dims_{rhs.dims_} {
+
+    resource::add(resource::toPY(data_), Resource{.dims = glm::size4_t{dims_, 0},
+                                                  .format = getDataFormat()->getId(),
+                                                  .desc = "VolumePY"});
+
+    gil_.reset();
+}
+
+VolumePy::~VolumePy() {
+    gil_.emplace();
+    resource::remove(resource::toPY(data_));
+}
 
 VolumePy* VolumePy::clone() const { return new VolumePy(*this); }
 
 std::type_index VolumePy::getTypeIndex() const { return std::type_index(typeid(VolumePy)); }
 
-const DataFormatBase* VolumePy::getDataFormat() const { return format(data_); }
+const DataFormatBase* VolumePy::getDataFormat() const {
+    pybind11::gil_scoped_acquire guard{};
+    return format(data_);
+}
 
 void VolumePy::setDimensions(size3_t dimensions) {
     if (dimensions != dims_) {
+        pybind11::gil_scoped_acquire guard{};
+
         const auto old = resource::remove(resource::toPY(data_));
         data_ = pybind11::array(
             data_.dtype(), pybind11::array::ShapeContainer{dimensions.z, dimensions.y, dimensions.x,
@@ -145,11 +175,13 @@ void VolumePy::setWrapping(const Wrapping3D& wrapping) { wrapping_ = wrapping; }
 Wrapping3D VolumePy::getWrapping() const { return wrapping_; }
 
 void VolumePy::updateResource(const ResourceMeta& meta) const {
+    pybind11::gil_scoped_acquire guard{};
     resource::meta(resource::toPY(data_), meta);
 }
 
 std::shared_ptr<VolumePy> VolumeRAM2PyConverter::createFrom(
     std::shared_ptr<const VolumeRAM> volumeSrc) const {
+    pybind11::gil_scoped_acquire guard{};
 
     pybind11::array data = volumeSrc->dispatch<pybind11::array>([](auto vr) {
         using ValueType = util::PrecisionValueType<decltype(vr)>;
@@ -179,6 +211,8 @@ std::shared_ptr<VolumePy> VolumeRAM2PyConverter::createFrom(
 
 void VolumeRAM2PyConverter::update(std::shared_ptr<const VolumeRAM> volumeSrc,
                                    std::shared_ptr<VolumePy> volumeDst) const {
+    pybind11::gil_scoped_acquire guard{};
+
     volumeDst->setDimensions(volumeSrc->getDimensions());
     volumeDst->setSwizzleMask(volumeSrc->getSwizzleMask());
     volumeDst->setInterpolation(volumeSrc->getInterpolation());
@@ -195,6 +229,7 @@ void VolumeRAM2PyConverter::update(std::shared_ptr<const VolumeRAM> volumeSrc,
 
 std::shared_ptr<VolumeRAM> VolumePy2RAMConverter::createFrom(
     std::shared_ptr<const VolumePy> volumeSrc) const {
+    pybind11::gil_scoped_acquire guard{};
 
     auto volumeDst = createVolumeRAM(volumeSrc->getDimensions(), volumeSrc->getDataFormat(),
                                      nullptr, volumeSrc->getSwizzleMask(),
@@ -216,6 +251,7 @@ std::shared_ptr<VolumeRAM> VolumePy2RAMConverter::createFrom(
 
 void VolumePy2RAMConverter::update(std::shared_ptr<const VolumePy> volumeSrc,
                                    std::shared_ptr<VolumeRAM> volumeDst) const {
+    pybind11::gil_scoped_acquire guard{};
     volumeDst->setDimensions(volumeSrc->getDimensions());
     volumeDst->setSwizzleMask(volumeSrc->getSwizzleMask());
     volumeDst->setInterpolation(volumeSrc->getInterpolation());

--- a/modules/python3/tests/unittests/numpy-test.cpp
+++ b/modules/python3/tests/unittests/numpy-test.cpp
@@ -77,7 +77,7 @@ TEST(Python3Scripts, SimpleBufferTest) {
     intBuffer.getEditableRAMRepresentation()->getDataContainer()[1] = 1;
     intBuffer.getEditableRAMRepresentation()->getDataContainer()[3] = 3;
 
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
 
     bool status = false;
     script.run({{"intBuffer", pybind11::cast(static_cast<BufferBase*>(&intBuffer),

--- a/modules/python3/tests/unittests/numpy-test.cpp
+++ b/modules/python3/tests/unittests/numpy-test.cpp
@@ -77,6 +77,8 @@ TEST(Python3Scripts, SimpleBufferTest) {
     intBuffer.getEditableRAMRepresentation()->getDataContainer()[1] = 1;
     intBuffer.getEditableRAMRepresentation()->getDataContainer()[3] = 3;
 
+    pybind11::gil_scoped_acquire guard{};
+
     bool status = false;
     script.run({{"intBuffer", pybind11::cast(static_cast<BufferBase*>(&intBuffer),
                                              pybind11::return_value_policy::reference)}},

--- a/modules/python3/tests/unittests/python-representations.cpp
+++ b/modules/python3/tests/unittests/python-representations.cpp
@@ -58,7 +58,7 @@
 namespace inviwo {
 
 TEST(Python3Representations, LayerPy2RAM) {
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
 
     // create a 4 x 3 layer with two identical channels
     // voxel values increase in x direction
@@ -104,7 +104,7 @@ arr.shape = (3, 4, 2)
 }
 
 TEST(Python3Representations, LayerRAM2Py) {
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
 
     // a 4 x 3 x 1 volume with two identical channels
     // voxel values increase in x direction
@@ -149,7 +149,7 @@ result = np.array_equal(expected, arr.flatten())
 }
 
 TEST(Python3Representations, VolumePy2RAM) {
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
 
     // create a 4 x 3 x 1 volume with two identical channels
     // voxel values increase in x direction
@@ -195,8 +195,8 @@ arr.shape = (1, 3, 4, 2)
 }
 
 TEST(Python3Representations, VolumeRAM2Py) {
-    pybind11::gil_scoped_acquire guard{};
-    
+    const pybind11::gil_scoped_acquire guard{};
+
     // a 4 x 3 x 1 volume with two identical channels
     // voxel values increase in x direction
     std::array<int, 24> data = {0, 0, 1, 1, 2, 2, 3, 3, 4,  4,  5,  5,

--- a/modules/python3/tests/unittests/python-representations.cpp
+++ b/modules/python3/tests/unittests/python-representations.cpp
@@ -58,6 +58,8 @@
 namespace inviwo {
 
 TEST(Python3Representations, LayerPy2RAM) {
+    pybind11::gil_scoped_acquire guard{};
+
     // create a 4 x 3 layer with two identical channels
     // voxel values increase in x direction
     PythonScript s;
@@ -102,6 +104,8 @@ arr.shape = (3, 4, 2)
 }
 
 TEST(Python3Representations, LayerRAM2Py) {
+    pybind11::gil_scoped_acquire guard{};
+
     // a 4 x 3 x 1 volume with two identical channels
     // voxel values increase in x direction
     std::array<int, 24> data = {0, 0, 1, 1, 2, 2, 3, 3, 4,  4,  5,  5,
@@ -145,6 +149,8 @@ result = np.array_equal(expected, arr.flatten())
 }
 
 TEST(Python3Representations, VolumePy2RAM) {
+    pybind11::gil_scoped_acquire guard{};
+
     // create a 4 x 3 x 1 volume with two identical channels
     // voxel values increase in x direction
     PythonScript s;
@@ -189,6 +195,8 @@ arr.shape = (1, 3, 4, 2)
 }
 
 TEST(Python3Representations, VolumeRAM2Py) {
+    pybind11::gil_scoped_acquire guard{};
+    
     // a 4 x 3 x 1 volume with two identical channels
     // voxel values increase in x direction
     std::array<int, 24> data = {0, 0, 1, 1, 2, 2, 3, 3, 4,  4,  5,  5,

--- a/modules/python3/tests/unittests/scripts-test.cpp
+++ b/modules/python3/tests/unittests/scripts-test.cpp
@@ -54,7 +54,7 @@ std::filesystem::path getPath() {
 }  // namespace
 
 TEST(Python3Scripts, GrabReturnValues) {
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
 
     auto script = PythonScript::fromFile(getPath() / "grabreturnvalue.py");
 
@@ -85,7 +85,7 @@ TEST(Python3Scripts, GrabReturnValues) {
 }
 
 TEST(Python3Scripts, PassValues) {
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
 
     auto script = PythonScript::fromFile(getPath() / "passvalues.py");
 
@@ -112,7 +112,7 @@ TEST(Python3Scripts, PassValues) {
 }
 
 TEST(Python3Scripts, GLMTest) {
-    pybind11::gil_scoped_acquire guard{};
+    const pybind11::gil_scoped_acquire guard{};
 
     auto script = PythonScript::fromFile(getPath() / "glm.py");
 
@@ -182,8 +182,8 @@ TEST(Python3Scripts, GLMTest) {
 }
 
 TEST(Python3Scripts, OptionPropertyTest) {
-    pybind11::gil_scoped_acquire guard{};
-    
+    const pybind11::gil_scoped_acquire guard{};
+
     auto script = PythonScript::fromFile(getPath() / "option_property.py");
 
     bool status = false;

--- a/modules/python3/tests/unittests/scripts-test.cpp
+++ b/modules/python3/tests/unittests/scripts-test.cpp
@@ -54,6 +54,8 @@ std::filesystem::path getPath() {
 }  // namespace
 
 TEST(Python3Scripts, GrabReturnValues) {
+    pybind11::gil_scoped_acquire guard{};
+
     auto script = PythonScript::fromFile(getPath() / "grabreturnvalue.py");
 
     bool status = false;
@@ -83,6 +85,8 @@ TEST(Python3Scripts, GrabReturnValues) {
 }
 
 TEST(Python3Scripts, PassValues) {
+    pybind11::gil_scoped_acquire guard{};
+
     auto script = PythonScript::fromFile(getPath() / "passvalues.py");
 
     bool status = false;
@@ -108,6 +112,8 @@ TEST(Python3Scripts, PassValues) {
 }
 
 TEST(Python3Scripts, GLMTest) {
+    pybind11::gil_scoped_acquire guard{};
+
     auto script = PythonScript::fromFile(getPath() / "glm.py");
 
     bool status = false;
@@ -176,6 +182,8 @@ TEST(Python3Scripts, GLMTest) {
 }
 
 TEST(Python3Scripts, OptionPropertyTest) {
+    pybind11::gil_scoped_acquire guard{};
+    
     auto script = PythonScript::fromFile(getPath() / "option_property.py");
 
     bool status = false;

--- a/modules/python3gl/src/layerpytoglconverter.cpp
+++ b/modules/python3gl/src/layerpytoglconverter.cpp
@@ -35,6 +35,8 @@ namespace inviwo {
 
 std::shared_ptr<LayerGL> LayerPy2GLConverter::createFrom(
     std::shared_ptr<const LayerPy> source) const {
+    const pybind11::gil_scoped_acquire guard{};
+
     auto destination = std::make_shared<LayerGL>(source->getDimensions(), source->getLayerType(),
                                                  source->getDataFormat(), source->getSwizzleMask(),
                                                  source->getInterpolation(), source->getWrapping());
@@ -56,6 +58,8 @@ std::shared_ptr<LayerGL> LayerPy2GLConverter::createFrom(
 
 void LayerPy2GLConverter::update(std::shared_ptr<const LayerPy> source,
                                  std::shared_ptr<LayerGL> destination) const {
+    const pybind11::gil_scoped_acquire guard{};
+
     destination->setDimensions(source->getDimensions());
     destination->setSwizzleMask(source->getSwizzleMask());
     destination->setInterpolation(source->getInterpolation());
@@ -76,6 +80,7 @@ void LayerPy2GLConverter::update(std::shared_ptr<const LayerPy> source,
 
 std::shared_ptr<LayerPy> LayerGL2PyConverter::createFrom(
     std::shared_ptr<const LayerGL> source) const {
+    const pybind11::gil_scoped_acquire guard{};
     auto destination = std::make_shared<LayerPy>(source->getDimensions(), source->getLayerType(),
                                                  source->getDataFormat(), source->getSwizzleMask(),
                                                  source->getInterpolation(), source->getWrapping());
@@ -97,6 +102,7 @@ std::shared_ptr<LayerPy> LayerGL2PyConverter::createFrom(
 
 void LayerGL2PyConverter::update(std::shared_ptr<const LayerGL> source,
                                  std::shared_ptr<LayerPy> destination) const {
+    const pybind11::gil_scoped_acquire guard{};
     destination->setDimensions(source->getDimensions());
     destination->setSwizzleMask(source->getSwizzleMask());
     destination->setInterpolation(source->getInterpolation());

--- a/modules/python3gl/src/volumepytoglconverter.cpp
+++ b/modules/python3gl/src/volumepytoglconverter.cpp
@@ -37,7 +37,7 @@ namespace inviwo {
 
 std::shared_ptr<VolumeGL> VolumePy2GLConverter::createFrom(
     std::shared_ptr<const VolumePy> volumeSrc) const {
-    pybind11::gil_scoped_acquire gil;
+    const pybind11::gil_scoped_acquire gil;
 
     auto volumeDst = std::make_shared<VolumeGL>(
         volumeSrc->getDimensions(), volumeSrc->getDataFormat(), volumeSrc->getSwizzleMask(),
@@ -60,7 +60,7 @@ std::shared_ptr<VolumeGL> VolumePy2GLConverter::createFrom(
 
 void VolumePy2GLConverter::update(std::shared_ptr<const VolumePy> volumeSrc,
                                   std::shared_ptr<VolumeGL> volumeDst) const {
-    pybind11::gil_scoped_acquire gil;
+    const pybind11::gil_scoped_acquire gil;
 
     volumeDst->setDimensions(volumeSrc->getDimensions());
     volumeDst->setSwizzleMask(volumeSrc->getSwizzleMask());
@@ -82,7 +82,7 @@ void VolumePy2GLConverter::update(std::shared_ptr<const VolumePy> volumeSrc,
 
 std::shared_ptr<VolumePy> VolumeGL2PyConverter::createFrom(
     std::shared_ptr<const VolumeGL> volumeSrc) const {
-    pybind11::gil_scoped_acquire gil;
+    const pybind11::gil_scoped_acquire gil;
     auto volumeDst = std::make_shared<VolumePy>(
         volumeSrc->getDimensions(), volumeSrc->getDataFormat(), volumeSrc->getSwizzleMask(),
         volumeSrc->getInterpolation(), volumeSrc->getWrapping());
@@ -104,7 +104,7 @@ std::shared_ptr<VolumePy> VolumeGL2PyConverter::createFrom(
 
 void VolumeGL2PyConverter::update(std::shared_ptr<const VolumeGL> volumeSrc,
                                   std::shared_ptr<VolumePy> volumeDst) const {
-    pybind11::gil_scoped_acquire gil;
+    const pybind11::gil_scoped_acquire gil;
 
     volumeDst->setDimensions(volumeSrc->getDimensions());
     volumeDst->setSwizzleMask(volumeSrc->getSwizzleMask());

--- a/modules/python3qt/src/python3qtmodule.cpp
+++ b/modules/python3qt/src/python3qtmodule.cpp
@@ -104,6 +104,7 @@ Python3QtModule::Python3QtModule(InviwoApplication* app)
     namespace py = pybind11;
 
     try {
+        const pybind11::gil_scoped_acquire gil;
         auto inviwopy = py::module::import("inviwopy");
         auto m = inviwopy.def_submodule("qt", "Qt dependent stuff");
 


### PR DESCRIPTION
Allow calling python from other threads than the main thread that initialized python. 
We now have to ensure that we acquire the gil before calling into python everywhere. 

Make the embedded python interpreter respect VIRTUAL_ENV
and some python fixes for workspace scripts.