### PR TITLE
Python: Updates to the latest pybind11 smartholder branch, use py::classh instead of py::class_

### DIFF
--- a/modules/brushingandlinking/bindings/src/brushingandlinkingbindings.cpp
+++ b/modules/brushingandlinking/bindings/src/brushingandlinkingbindings.cpp
@@ -75,7 +75,7 @@ void exposeBnL(py::module& m) {
     brushingModification.def_static("fromAction", &fromAction);
     exposeFlags<BrushingModification>(m, brushingModification, "BrushingModifications");
 
-    py::class_<BrushingTarget>(m, "BrushingTarget")
+    py::classh<BrushingTarget>(m, "BrushingTarget")
         .def(py::init<>())
         .def(py::init<std::string_view>())
         .def(py::init<const BrushingTarget&>())
@@ -89,7 +89,7 @@ void exposeBnL(py::module& m) {
         .def_property_readonly_static("Row", [](py::object) { return BrushingTarget::Row; })
         .def_property_readonly_static("Column", [](py::object) { return BrushingTarget::Column; });
 
-    py::class_<IndexList>(m, "IndexList")
+    py::classh<IndexList>(m, "IndexList")
         .def(py::init<>())
         .def("empty", &IndexList::empty)
         .def("size", &IndexList::size)
@@ -99,7 +99,7 @@ void exposeBnL(py::module& m) {
         .def("getIndices", &IndexList::getIndices)
         .def("removeSource", &IndexList::removeSources);
 
-    py::class_<BrushingTargetsInvalidationLevel>{m, "BrushingTargetsInvalidationLevel"}
+    py::classh<BrushingTargetsInvalidationLevel>{m, "BrushingTargetsInvalidationLevel"}
         .def(py::init<BrushingModifications, InvalidationLevel>(), py::arg("mods"),
              py::arg("invalidationLevel"))
         .def(py::init<std::vector<BrushingTarget>, BrushingModifications, InvalidationLevel>(),
@@ -114,7 +114,7 @@ void exposeBnL(py::module& m) {
         .def_readwrite("modifications", &BrushingTargetsInvalidationLevel::modifications)
         .def_readwrite("invalidationLevel", &BrushingTargetsInvalidationLevel::invalidationLevel);
 
-    py::class_<BrushingAndLinkingInport, Inport>{m, "BrushingAndLinkingInport"}
+    py::classh<BrushingAndLinkingInport, Inport>{m, "BrushingAndLinkingInport"}
         .def(py::init([](std::string_view identifier) {
                  return std::make_shared<BrushingAndLinkingInport>(identifier);
              }),
@@ -161,7 +161,7 @@ void exposeBnL(py::module& m) {
                  &BrushingAndLinkingInport::getManager),
              py::return_value_policy::reference);
 
-    py::class_<BrushingAndLinkingOutport, Outport>{m, "BrushingAndLinkingOutport"}
+    py::classh<BrushingAndLinkingOutport, Outport>{m, "BrushingAndLinkingOutport"}
 
         .def(py::init<std::string_view, Document>(), py::arg("identifier"), py::arg("help"))
         .def("getManager",
@@ -171,7 +171,7 @@ void exposeBnL(py::module& m) {
         .def("getInvalidationLevels", &BrushingAndLinkingOutport::getInvalidationLevels)
         .def("setInvalidationLevels", &BrushingAndLinkingOutport::setInvalidationLevels);
 
-    py::class_<BrushingAndLinkingManager>{m, "BrushingAndLinkingManager"}
+    py::classh<BrushingAndLinkingManager>{m, "BrushingAndLinkingManager"}
         .def(py::init([](BrushingAndLinkingInport* inport) {
                  return std::make_shared<BrushingAndLinkingManager>(inport);
              }),

--- a/modules/dataframepython/bindings/src/pydataframe.cpp
+++ b/modules/dataframepython/bindings/src/pydataframe.cpp
@@ -57,7 +57,7 @@ namespace {
 
 struct DataFrameAddColumnReg {
     template <typename T>
-    auto operator()(py::class_<DataFrame>& d) {
+    auto operator()(py::classh<DataFrame>& d) {
         auto classname = Defaultvalues<T>::getName();
 
         d.def(
@@ -86,7 +86,7 @@ struct TemplateColumnReg {
         using C = TemplateColumn<T>;
         auto classname = Defaultvalues<T>::getName() + "Column";
 
-        py::class_<C, Column> col(m, classname.c_str());
+        py::classh<C, Column> col(m, classname.c_str());
         col.def_property_readonly("buffer", [](C& c) { return c.getTypedBuffer(); })
             .def(py::init<std::string_view>())
             .def("add", py::overload_cast<const T&>(&C::add))
@@ -126,7 +126,7 @@ void exposeDataFrame(pybind11::module& m) {
         .value("Ordinal", ColumnType::Ordinal)
         .value("Categorical", ColumnType::Categorical);
 
-    py::class_<Column>(m, "Column")
+    py::classh<Column>(m, "Column")
         .def_property("header", &Column::getHeader, &Column::setHeader)
         .def_property_readonly("buffer", [](Column& self) { return self.getBuffer(); })
         .def_property_readonly("size", &Column::getSize)
@@ -143,7 +143,7 @@ void exposeDataFrame(pybind11::module& m) {
     using Scalars = std::tuple<float, double, int, glm::i64, size_t, std::uint32_t>;
     util::for_each_type<Scalars>{}(TemplateColumnReg{}, m);
 
-    py::class_<CategoricalColumn, Column>(m, "CategoricalColumn")
+    py::classh<CategoricalColumn, Column>(m, "CategoricalColumn")
         .def(py::init<std::string_view>())
         .def_property_readonly("categories", &CategoricalColumn::getCategories,
                                py::return_value_policy::copy)
@@ -165,10 +165,10 @@ void exposeDataFrame(pybind11::module& m) {
             [](const CategoricalColumn& c) { return py::make_iterator(c.begin(), c.end()); },
             py::keep_alive<0, 1>());
 
-    py::class_<IndexColumn, TemplateColumn<std::uint32_t>>(m, "IndexColumn")
+    py::classh<IndexColumn, TemplateColumn<std::uint32_t>>(m, "IndexColumn")
         .def(py::init<std::string_view>());
 
-    py::class_<DataFrame> dataframe(m, "DataFrame");
+    py::classh<DataFrame> dataframe(m, "DataFrame");
     dataframe.def(py::init<std::uint32_t>(), py::arg("size") = 0)
         .def_property_readonly("cols", &DataFrame::getNumberOfColumns)
         .def_property_readonly("rows", &DataFrame::getNumberOfRows)

--- a/modules/opengl/include/modules/opengl/inviwoopengl.h
+++ b/modules/opengl/include/modules/opengl/inviwoopengl.h
@@ -48,7 +48,7 @@ namespace inviwo {
  * @param err OpenGL error enum, GLenum err = glGetError();
  * @return Returns "No error" if err == GL_NO_ERROR, otherwise the name of the error.
  */
-IVW_MODULE_OPENGL_API std::string getGLErrorString(GLenum err);
+IVW_MODULE_OPENGL_API std::string_view getGLErrorString(GLenum err);
 
 /**
  * Log the last OpenGL error if there has been an error, i.e. glGetError() != GL_NO_ERROR.

--- a/modules/opengl/src/inviwoopengl.cpp
+++ b/modules/opengl/src/inviwoopengl.cpp
@@ -71,9 +71,9 @@ std::string_view getGLErrorString(GLenum err) {
                    "effect than to set the error flag.";
         case GL_INVALID_FRAMEBUFFER_OPERATION:
             return "INVALID_FRAMEBUFFER_OPERATION";
-            break;
+        default:
+            return "Undefined error";
     }
-    return "Undefined error";
 }
 
 void LogGLError(std::string_view source, std::string_view fileName, std::string_view functionName,

--- a/modules/opengl/src/inviwoopengl.cpp
+++ b/modules/opengl/src/inviwoopengl.cpp
@@ -34,19 +34,12 @@
 
 #include <GL/glew.h>  // for glGetError, GL_NO_ERROR, GLenum, GLuint, GL_INV...
 
-#if defined(_WIN32)
-#include <inviwo/core/util/stringconversion.h>
-#endif
-
 namespace inviwo {
 
-std::string getGLErrorString(GLenum err) {
-    if (err == GL_NO_ERROR) {
-        return "No error";
-    }
-#ifdef GLEW_NO_GLU
-    std::string errorString = "";
+std::string_view getGLErrorString(GLenum err) {
     switch (err) {
+        case GL_NO_ERROR:
+            return "No error";
         case GL_INVALID_ENUM:
             return "GL_INVALID_ENUM: An unacceptable value is specified for an enumerated "
                    "argument. "
@@ -81,16 +74,6 @@ std::string getGLErrorString(GLenum err) {
             break;
     }
     return "Undefined error";
-#else
-#if defined(_WIN32)
-    const auto* errorString = gluErrorUnicodeStringEXT(err);
-    return (errorString ? util::fromWstring(errorString) : "Undefined error");
-#else
-    const auto* errorString = gluErrorString(err);
-    return (errorString ? std::string(reinterpret_cast<const char*>(errorString))
-                        : "Undefined error");
-#endif
-#endif
 }
 
 void LogGLError(std::string_view source, std::string_view fileName, std::string_view functionName,

--- a/modules/python3/CMakeLists.txt
+++ b/modules/python3/CMakeLists.txt
@@ -95,8 +95,6 @@ target_link_libraries(inviwo-module-python3 PUBLIC
     pybind11::embed
     Python3::Python
 )
-target_compile_definitions(inviwo-module-python3 PUBLIC PYBIND11_USE_SMART_HOLDER_AS_DEFAULT)
-
 
 add_subdirectory(bindings)
 

--- a/modules/python3/bindings/include/inviwopy/util/pyglmhelper.h
+++ b/modules/python3/bindings/include/inviwopy/util/pyglmhelper.h
@@ -63,12 +63,12 @@ template <typename T, size_t N>
 using ith_T = T;
 
 template <typename V, typename T, std::size_t... I>
-void addInitImpl(pybind11::class_<V>& pyv, std::index_sequence<I...>) {
+void addInitImpl(pybind11::classh<V>& pyv, std::index_sequence<I...>) {
     pyv.def(pybind11::init<ith_T<T, I>...>());
 }
 
 template <typename T, typename V, unsigned C, typename Indices = std::make_index_sequence<C>>
-void addInit(pybind11::class_<V>& pyv) {
+void addInit(pybind11::classh<V>& pyv) {
     addInitImpl<V, T>(pyv, Indices{});
 }
 
@@ -101,7 +101,7 @@ void matxx(pybind11::module& m, const std::string& prefix, const std::string& na
         return ss.str();
     }();
 
-    pybind11::class_<Mat> pym(m, classname.c_str(), pybind11::buffer_protocol{});
+    pybind11::classh<Mat> pym(m, classname.c_str(), pybind11::buffer_protocol{});
     addInit<T, Mat, Cols * Rows>(pym);
     addInit<ColumnVector, Mat, Cols>(pym);
     pym.def(pybind11::init<T>())

--- a/modules/python3/bindings/include/inviwopy/vectoridentifierwrapper.h
+++ b/modules/python3/bindings/include/inviwopy/vectoridentifierwrapper.h
@@ -129,7 +129,7 @@ void exposeVectorIdentifierWrapper(pybind11::module& m, const std::string& name)
     namespace py = pybind11;
     using VecWrapper = VectorIdentifierWrapper<V, Deref>;
 
-    py::class_<VecWrapper>(m, name.c_str())
+    py::classh<VecWrapper>(m, name.c_str())
         .def("__getattr__", &VecWrapper::getFromIdentifier, py::return_value_policy::reference)
         .def("__getitem__", &VecWrapper::getFromIdentifier, py::return_value_policy::reference)
         .def("__getitem__", &VecWrapper::getFromIndex, py::return_value_policy::reference)

--- a/modules/python3/bindings/src/inviwopy.cpp
+++ b/modules/python3/bindings/src/inviwopy.cpp
@@ -140,7 +140,9 @@ INVIWO_PYBIND_MODULE(inviwopy, m) {
     exposeDataReaders(m);
     exposeDataWriters(m);
 
-    py::classh<Settings, PropertyOwner>(m, "Settings");
+    py::classh<Settings, PropertyOwner>(m, "Settings")
+        .def("load", &Settings::load)
+        .def("save", &Settings::save);
 
     m.def("debugBreak", []() { util::debugBreak(); });
 

--- a/modules/python3/bindings/src/inviwopy.cpp
+++ b/modules/python3/bindings/src/inviwopy.cpp
@@ -140,7 +140,7 @@ INVIWO_PYBIND_MODULE(inviwopy, m) {
     exposeDataReaders(m);
     exposeDataWriters(m);
 
-    py::class_<Settings, PropertyOwner>(m, "Settings");
+    py::classh<Settings, PropertyOwner>(m, "Settings");
 
     m.def("debugBreak", []() { util::debugBreak(); });
 

--- a/modules/python3/bindings/src/properties/pyminmaxproperties.cpp
+++ b/modules/python3/bindings/src/properties/pyminmaxproperties.cpp
@@ -57,7 +57,7 @@ struct MinMaxHelper {
 
         auto classname = Defaultvalues<T>::getName() + "MinMaxProperty";
 
-        py::class_<P, Property> prop(m, classname.c_str());
+        py::classh<P, Property> prop(m, classname.c_str());
         prop.def(py::init([](std::string_view identifier, std::string_view name, Document help,
                              const T& valueMin, const T& valueMax, const T& rangeMin,
                              const T& rangeMax, const T& increment, const T& minSeparation,

--- a/modules/python3/bindings/src/properties/pyoptionproperties.cpp
+++ b/modules/python3/bindings/src/properties/pyoptionproperties.cpp
@@ -57,14 +57,14 @@ struct OptionPropertyHelper {
         auto classname = "OptionProperty" + Defaultvalues<T>::getName();
         auto optionclassname = Defaultvalues<T>::getName() + "Option";
 
-        py::class_<O>(m, optionclassname.c_str())
+        py::classh<O>(m, optionclassname.c_str())
             .def(py::init<>())
             .def(py::init<std::string_view, std::string_view, const T&>())
             .def_readwrite("id", &O::id_)
             .def_readwrite("name", &O::name_)
             .def_readwrite("value", &O::value_);
 
-        py::class_<P, BaseOptionProperty> prop(m, classname.c_str());
+        py::classh<P, BaseOptionProperty> prop(m, classname.c_str());
         prop.def(py::init([](std::string_view identifier, std::string_view name, Document help,
                              std::vector<OptionPropertyOption<T>> options, size_t selectedIndex,
                              InvalidationLevel invalidationLevel, PropertySemantics semantics) {
@@ -122,7 +122,7 @@ struct OptionPropertyHelper {
 
 void exposeOptionProperties(py::module& m) {
 
-    py::class_<BaseOptionProperty, Property>(m, "BaseOptionProperty")
+    py::classh<BaseOptionProperty, Property>(m, "BaseOptionProperty")
         .def_property_readonly("clearOptions", &BaseOptionProperty::clearOptions)
         .def_property_readonly("size", &BaseOptionProperty::size)
 

--- a/modules/python3/bindings/src/properties/pyordinalproperties.cpp
+++ b/modules/python3/bindings/src/properties/pyordinalproperties.cpp
@@ -51,7 +51,7 @@ struct OrdinalPropertyHelper {
 
         auto classname = Defaultvalues<T>::getName() + "Property";
 
-        py::class_<P, Property> prop(m, classname.c_str());
+        py::classh<P, Property> prop(m, classname.c_str());
         prop.def(py::init([](std::string_view identifier, std::string_view name, const T& value,
                              const T& min, const T& max, const T& increment,
                              InvalidationLevel invalidationLevel, PropertySemantics semantics) {

--- a/modules/python3/bindings/src/properties/pyordinalrefproperties.cpp
+++ b/modules/python3/bindings/src/properties/pyordinalrefproperties.cpp
@@ -52,7 +52,7 @@ struct OrdinalRefPropertyHelper {
 
         auto classname = Defaultvalues<T>::getName() + "RefProperty";
 
-        py::class_<P, Property> prop(m, classname.c_str());
+        py::classh<P, Property> prop(m, classname.c_str());
         prop.def(py::init([](std::string_view identifier, std::string_view name,
                              std::function<T()> get, std::function<void(const T&)> set,
                              const std::pair<T, ConstraintBehavior>& min,

--- a/modules/python3/bindings/src/pybitset.cpp
+++ b/modules/python3/bindings/src/pybitset.cpp
@@ -57,7 +57,7 @@ struct BitSetIteratorWrapper {
 void exposeBitset(pybind11::module& m) {
     namespace py = pybind11;
 
-    py::class_<BitSetIteratorWrapper>(m, "BitSetIterator")
+    py::classh<BitSetIteratorWrapper>(m, "BitSetIterator")
         .def("__next__", [](BitSetIteratorWrapper& w) {
             if (w.begin != w.end) {
                 auto val = *w.begin;
@@ -68,7 +68,7 @@ void exposeBitset(pybind11::module& m) {
             }
         });
 
-    py::class_<BitSet>(m, "BitSet")
+    py::classh<BitSet>(m, "BitSet")
         .def(py::init<>())
         .def(py::init<const std::vector<bool>&>())
         .def(py::init([](py::list list) {

--- a/modules/python3/bindings/src/pybuffer.cpp
+++ b/modules/python3/bindings/src/pybuffer.cpp
@@ -60,7 +60,7 @@ struct BufferRAMHelper {
         using T = typename DataFormat::type;
 
         std::string className = fmt::format("Buffer{}", DataFormat::str());
-        py::class_<Buffer<T, BufferTarget::Data>, BufferBase>(m, className.c_str())
+        py::classh<Buffer<T, BufferTarget::Data>, BufferBase>(m, className.c_str())
             .def(py::init<size_t>(), py::arg("size"))
             .def(py::init<size_t, BufferUsage>(), py::arg("size"),
                  py::arg("usage") = BufferUsage::Static)
@@ -74,7 +74,7 @@ struct BufferRAMHelper {
                  py::arg("data"), py::arg("usage") = BufferUsage::Static);
 
         className = fmt::format("IndexBuffer{}", DataFormat::str());
-        py::class_<Buffer<T, BufferTarget::Index>, BufferBase>(m, className.c_str())
+        py::classh<Buffer<T, BufferTarget::Index>, BufferBase>(m, className.c_str())
             .def(py::init<size_t>())
             .def(py::init<size_t, BufferUsage>())
             .def(py::init([](py::array data, BufferUsage usage) {
@@ -125,7 +125,7 @@ void exposeBuffer(pybind11::module& m) {
         .value("Adjacency", ConnectivityType::Adjacency)
         .value("StripAdjacency", ConnectivityType::StripAdjacency);
 
-    py::class_<BufferBase>(m, "Buffer")
+    py::classh<BufferBase>(m, "Buffer")
         .def(py::init([](py::array data) { return pyutil::createBuffer(data).release(); }))
         .def("clone", [](BufferBase& self) { return self.clone(); })
         .def_property("size", &BufferBase::getSize, &BufferBase::setSize)

--- a/modules/python3/bindings/src/pycamera.cpp
+++ b/modules/python3/bindings/src/pycamera.cpp
@@ -44,7 +44,7 @@ namespace inviwo {
 void exposeCamera(pybind11::module& m) {
     namespace py = pybind11;
 
-    py::class_<Camera>(m, "Camera")
+    py::classh<Camera>(m, "Camera")
         .def("clone", &Camera::clone)
         .def("updateFrom", &Camera::updateFrom)
         .def_property("lookFrom", &Camera::getLookFrom, &Camera::setLookFrom)
@@ -64,7 +64,7 @@ void exposeCamera(pybind11::module& m) {
         .def("getNormalizedDeviceFromNormalizedScreenAtFocusPointDepth",
              &Camera::getNormalizedDeviceFromNormalizedScreenAtFocusPointDepth);
 
-    py::class_<PerspectiveCamera, Camera>(m, "PerspectiveCamera")
+    py::classh<PerspectiveCamera, Camera>(m, "PerspectiveCamera")
         .def(py::init<vec3, vec3, vec3, float, float, float, float>(),
              py::arg("lookFrom") = vec3(0.0f, 0.0f, 2.0f), py::arg("lookTo") = vec3(0.0f),
              py::arg("lookUp") = vec3(0.0f, 1.0f, 0.0f), py::arg("nearPlane") = 0.01f,
@@ -72,14 +72,14 @@ void exposeCamera(pybind11::module& m) {
              py::arg("fieldOfView") = 60.f)
         .def_property("fovy", &PerspectiveCamera::getFovy, &PerspectiveCamera::setFovy);
 
-    py::class_<OrthographicCamera, Camera>(m, "OrthographicCamera")
+    py::classh<OrthographicCamera, Camera>(m, "OrthographicCamera")
         .def(py::init<vec3, vec3, vec3, float, float, float, float>(),
              py::arg("lookFrom") = vec3(0.0f, 0.0f, 2.0f), py::arg("lookTo") = vec3(0.0f),
              py::arg("lookUp") = vec3(0.0f, 1.0f, 0.0f), py::arg("nearPlane") = 0.01f,
              py::arg("farPlane") = 10000.0f, py::arg("aspectRatio") = 1.f, py::arg("width") = 60.f)
         .def_property("width", &OrthographicCamera::getWidth, &OrthographicCamera::setWidth);
 
-    py::class_<SkewedPerspectiveCamera, Camera>(m, "SkewedPerspectiveCamera")
+    py::classh<SkewedPerspectiveCamera, Camera>(m, "SkewedPerspectiveCamera")
         .def(py::init<vec3, vec3, vec3, float, float, float, float, vec2>(),
              py::arg("lookFrom") = vec3(0.0f, 0.0f, 2.0f), py::arg("lookTo") = vec3(0.0f),
              py::arg("lookUp") = vec3(0.0f, 1.0f, 0.0f), py::arg("nearPlane") = 0.01f,

--- a/modules/python3/bindings/src/pycameraproperty.cpp
+++ b/modules/python3/bindings/src/pycameraproperty.cpp
@@ -100,7 +100,7 @@ void exposeCameraProperty(pybind11::module& main, pybind11::module& properties) 
         py::arg("fitRatio") = 1.05f, py::arg("updateNearFar") = camerautil::UpdateNearFar::No,
         py::arg("updateLookRanges") = camerautil::UpdateLookRanges::No);
 
-    py::class_<CameraProperty, CompositeProperty>(properties, "CameraProperty")
+    py::classh<CameraProperty, CompositeProperty>(properties, "CameraProperty")
         .def(py::init([](const std::string& identifier, const std::string& displayName, vec3 eye,
                          vec3 center, vec3 lookUp, Inport* inport,
                          InvalidationLevel invalidationLevel, PropertySemantics semantics) {

--- a/modules/python3/bindings/src/pycompositeproperties.cpp
+++ b/modules/python3/bindings/src/pycompositeproperties.cpp
@@ -49,7 +49,7 @@ namespace inviwo {
 
 void exposeCompositeProperties(py::module& m) {
 
-    py::class_<CompositeProperty, PropertyOwner, Property>(
+    py::classh<CompositeProperty, PropertyOwner, Property>(
         m, "CompositeProperty", py::multiple_inheritance{}, py::dynamic_attr{})
         .def(py::init([](std::string_view identifier, std::string_view displayName,
                          InvalidationLevel invalidationLevel, PropertySemantics semantics) {
@@ -64,7 +64,7 @@ void exposeCompositeProperties(py::module& m) {
         .def_property("collapsed", &BoolCompositeProperty::isCollapsed,
                       py::overload_cast<bool>(&CompositeProperty::setCollapsed));
 
-    py::class_<BoolCompositeProperty, CompositeProperty>(m, "BoolCompositeProperty")
+    py::classh<BoolCompositeProperty, CompositeProperty>(m, "BoolCompositeProperty")
         .def(py::init([](std::string_view identifier, std::string_view displayName, bool checked,
                          InvalidationLevel invalidationLevel, PropertySemantics semantics) {
                  return new BoolCompositeProperty(identifier, displayName, checked,
@@ -79,7 +79,7 @@ void exposeCompositeProperties(py::module& m) {
                       &BoolCompositeProperty::setChecked)
         .def("__bool__", &BoolCompositeProperty::isChecked);
 
-    py::class_<ListProperty, CompositeProperty>(m, "ListProperty")
+    py::classh<ListProperty, CompositeProperty>(m, "ListProperty")
         .def(py::init([](std::string_view identifier, std::string_view displayName,
                          size_t maxNumberOfElements, ListPropertyUIFlags uiFlags,
                          InvalidationLevel invalidationLevel, PropertySemantics semantics) {
@@ -104,7 +104,7 @@ void exposeCompositeProperties(py::module& m) {
             return list.getPrefabs()[idx].get();
         });
 
-    py::class_<IsoTFProperty, CompositeProperty>(m, "IsoTFProperty")
+    py::classh<IsoTFProperty, CompositeProperty>(m, "IsoTFProperty")
         .def(py::init([](std::string_view identifier, std::string_view displayName,
                          const IsoValueCollection& isovalues, const TransferFunction& tf,
                          VolumeInport* volumeInport, InvalidationLevel invalidationLevel,
@@ -137,7 +137,7 @@ void exposeCompositeProperties(py::module& m) {
         .def_property("zoomH", &IsoTFProperty::getZoomH, &IsoTFProperty::setZoomH)
         .def_property("zoomV", &IsoTFProperty::getZoomV, &IsoTFProperty::setZoomV);
 
-    py::class_<FilePatternProperty, CompositeProperty>(m, "FilePatternProperty")
+    py::classh<FilePatternProperty, CompositeProperty>(m, "FilePatternProperty")
         .def(py::init([](std::string_view identifier, std::string_view displayName,
                          std::string_view pattern, std::string_view directory,
                          InvalidationLevel invalidationLevel, PropertySemantics semantics) {

--- a/modules/python3/bindings/src/pydataformat.cpp
+++ b/modules/python3/bindings/src/pydataformat.cpp
@@ -68,7 +68,7 @@ void exposeDataFormat(pybind11::module& m) {
     }
     dfid.value("NumberOfFormats", DataFormatId::NumberOfFormats);
 
-    py::class_<DataFormatBase>(m, "DataFormat")
+    py::classh<DataFormatBase>(m, "DataFormat")
         .def_property_readonly("size", &DataFormatBase::getSizeInBytes)
         .def_property_readonly("components", &DataFormatBase::getComponents)
         .def_property_readonly("precision", &DataFormatBase::getPrecision)

--- a/modules/python3/bindings/src/pydatamapper.cpp
+++ b/modules/python3/bindings/src/pydatamapper.cpp
@@ -50,7 +50,7 @@ namespace inviwo {
 void exposeDataMapper(py::module& m) {
 
     py::classh<Unit>(m, "Unit")
-        .def(py::init([](std::string unit) { return units::unit_from_string(unit); }))
+        .def(py::init([](std::string unit) { return units::unit_from_string(std::move(unit)); }))
         .def("to_string",
              [](const Unit& unit, std::string_view format = "{}") {
                  return fmt::format(fmt::runtime(format), unit);

--- a/modules/python3/bindings/src/pydatamapper.cpp
+++ b/modules/python3/bindings/src/pydatamapper.cpp
@@ -49,7 +49,7 @@ namespace inviwo {
 
 void exposeDataMapper(py::module& m) {
 
-    py::class_<Unit>(m, "Unit")
+    py::classh<Unit>(m, "Unit")
         .def(py::init([](std::string unit) { return units::unit_from_string(unit); }))
         .def("to_string",
              [](const Unit& unit, std::string_view format = "{}") {
@@ -57,14 +57,14 @@ void exposeDataMapper(py::module& m) {
              })
         .def("__repr__", [](const Unit& unit) { return fmt::format("{}", unit); });
 
-    py::class_<Axis>(m, "Axis")
+    py::classh<Axis>(m, "Axis")
         .def(py::init<std::string, Unit>())
         .def_readwrite("name", &Axis::name)
         .def_readwrite("unit", &Axis::unit)
         .def("__repr__",
              [](const Axis& axis) { return fmt::format("{}{: [}", axis.name, axis.unit); });
 
-    py::class_<DataMapper>(m, "DataMapper")
+    py::classh<DataMapper>(m, "DataMapper")
         .def(py::init())
         .def_readwrite("dataRange", &DataMapper::dataRange)
         .def_readwrite("valueRange", &DataMapper::valueRange)

--- a/modules/python3/bindings/src/pydatareaders.cpp
+++ b/modules/python3/bindings/src/pydatareaders.cpp
@@ -99,7 +99,7 @@ template <typename T>
 class TypedDataReaderFactoryWrapper {
 public:
     TypedDataReaderFactoryWrapper() = delete;
-    explicit explicitTypedDataReaderFactoryWrapper(DataReaderFactory& rf) : factory{&rf} {}
+    explicit TypedDataReaderFactoryWrapper(DataReaderFactory& rf) : factory{&rf} {}
     TypedDataReaderFactoryWrapper(const TypedDataReaderFactoryWrapper&) = default;
     TypedDataReaderFactoryWrapper(TypedDataReaderFactoryWrapper&&) = default;
     TypedDataReaderFactoryWrapper& operator=(const TypedDataReaderFactoryWrapper&) = default;

--- a/modules/python3/bindings/src/pydatareaders.cpp
+++ b/modules/python3/bindings/src/pydatareaders.cpp
@@ -104,6 +104,7 @@ public:
     TypedDataReaderFactoryWrapper(TypedDataReaderFactoryWrapper&&) = default;
     TypedDataReaderFactoryWrapper& operator=(const TypedDataReaderFactoryWrapper&) = default;
     TypedDataReaderFactoryWrapper& operator=(TypedDataReaderFactoryWrapper&&) = default;
+    ~TypedDataReaderFactoryWrapper() = default;
 
     std::vector<FileExtension> getExtensions() const { return factory->getExtensionsForType<T>(); }
     std::unique_ptr<DataReaderType<T>> getReader(

--- a/modules/python3/bindings/src/pydatawriters.cpp
+++ b/modules/python3/bindings/src/pydatawriters.cpp
@@ -87,7 +87,7 @@ public:
 #include <warn/pop>
 
 template <typename T>
-void exposeFactoryWriterType(pybind11::class_<DataWriterFactory>& r, std::string_view type) {
+void exposeFactoryWriterType(pybind11::classh<DataWriterFactory>& r, std::string_view type) {
     namespace py = pybind11;
     r.def(fmt::format("getExtensionsFor{}", type).c_str(),
           (std::vector<FileExtension>(DataWriterFactory::*)() const) &
@@ -117,7 +117,7 @@ void exposeFactoryWriterType(pybind11::class_<DataWriterFactory>& r, std::string
 template <typename T>
 void exposeWriterType(pybind11::module& m, std::string_view name) {
     namespace py = pybind11;
-    py::class_<DataWriterType<T>, DataWriter, DataWriterTypeTrampoline<T>>(
+    py::classh<DataWriterType<T>, DataWriter, DataWriterTypeTrampoline<T>>(
         m, fmt::format("{}DataWriter", name).c_str())
         .def("writeData", &DataWriterType<T>::writeData);
 }
@@ -125,7 +125,7 @@ void exposeWriterType(pybind11::module& m, std::string_view name) {
 void exposeDataWriters(pybind11::module& m) {
     namespace py = pybind11;
 
-    py::class_<DataWriter>(m, "DataWriter")
+    py::classh<DataWriter>(m, "DataWriter")
         .def("clone", &DataWriter::clone)
         .def_property_readonly("extensions", &DataWriter::getExtensions,
                                py::return_value_policy::reference_internal)
@@ -135,18 +135,16 @@ void exposeDataWriters(pybind11::module& m) {
         .def("setOption", &DataWriter::setOption)
         .def("getOption", &DataWriter::getOption);
 
-    auto fr =
-        py::class_<DataWriterFactory>(m, "DataWriterFactory")
-            .def("create",
-                 (std::unique_ptr<DataWriter>(DataWriterFactory::*)(const FileExtension&) const) &
-                     DataWriterFactory::create)
-            .def("create",
-                 (std::unique_ptr<DataWriter>(DataWriterFactory::*)(std::string_view) const) &
-                     DataWriterFactory::create)
-            .def("hasKey",
-                 (bool(DataWriterFactory::*)(std::string_view) const) & DataWriterFactory::hasKey)
-            .def("hasKey", (bool(DataWriterFactory::*)(const FileExtension&) const) &
-                               DataWriterFactory::hasKey);
+    auto fr = py::classh<DataWriterFactory>(m, "DataWriterFactory");
+    fr.def("create",
+           (std::unique_ptr<DataWriter>(DataWriterFactory::*)(const FileExtension&) const) &
+               DataWriterFactory::create)
+        .def("create", (std::unique_ptr<DataWriter>(DataWriterFactory::*)(std::string_view) const) &
+                           DataWriterFactory::create)
+        .def("hasKey",
+             (bool(DataWriterFactory::*)(std::string_view) const) & DataWriterFactory::hasKey)
+        .def("hasKey",
+             (bool(DataWriterFactory::*)(const FileExtension&) const) & DataWriterFactory::hasKey);
 
     // No good way of dealing with template return types so we manually define one for each known
     // type. https://github.com/pybind/pybind11/issues/1667#issuecomment-454348004

--- a/modules/python3/bindings/src/pydatawriters.cpp
+++ b/modules/python3/bindings/src/pydatawriters.cpp
@@ -95,6 +95,7 @@ public:
     TypedDataWriterFactoryWrapper(TypedDataWriterFactoryWrapper&&) = default;
     TypedDataWriterFactoryWrapper& operator=(const TypedDataWriterFactoryWrapper&) = default;
     TypedDataWriterFactoryWrapper& operator=(TypedDataWriterFactoryWrapper&&) = default;
+    ~TypedDataWriterFactoryWrapper() = default;
 
     std::vector<FileExtension> getExtensions() const { return factory->getExtensionsForType<T>(); }
     std::unique_ptr<DataWriterType<T>> getWriter(

--- a/modules/python3/bindings/src/pydocument.cpp
+++ b/modules/python3/bindings/src/pydocument.cpp
@@ -53,7 +53,7 @@ void exposeDocument(pybind11::module& m) {
         .value("Node", Document::ElementType::Node)
         .value("Text", Document::ElementType::Text);
 
-    py::class_<Document::Element>(doc, "Element")
+    py::classh<Document::Element>(doc, "Element")
         .def(py::init<Document::ElementType, std::string_view>(), py::arg("type"),
              py::arg("content"))
         .def(py::init<std::string_view, std::string_view, const UnorderedStringMap<std::string>&>(),
@@ -72,7 +72,7 @@ void exposeDocument(pybind11::module& m) {
         .def("emptyTag", &Document::Element::emptyTag)
         .def("noIndent", &Document::Element::noIndent);
 
-    py::class_<Document::PathComponent>(doc, "PathComponent")
+    py::classh<Document::PathComponent>(doc, "PathComponent")
         .def(py::init<int>(), py::arg("index"))
         .def(py::init<std::string_view>(), py::arg("name"))
         .def(py::init<const UnorderedStringMap<std::string>&>(), py::arg("attributes"))
@@ -82,7 +82,7 @@ void exposeDocument(pybind11::module& m) {
         .def_property_readonly_static("last", &Document::PathComponent::last)
         .def_property_readonly_static("end", &Document::PathComponent::end);
 
-    py::class_<Document::DocumentHandle>(doc, "DocumentHandle")
+    py::classh<Document::DocumentHandle>(doc, "DocumentHandle")
         .def("get", &Document::DocumentHandle::get)
         .def("insert",
              static_cast<Document::DocumentHandle (Document::DocumentHandle::*)(
@@ -101,7 +101,7 @@ void exposeDocument(pybind11::module& m) {
                  &Document::DocumentHandle::append))
         .def_property_readonly("element", [](Document::DocumentHandle& d) { return d.element(); });
 
-    py::class_<Document>(doc, "Document")
+    py::classh<Document>(doc, "Document")
         .def(py::init<>())
         .def(py::init<std::string_view>())
         .def("str", &Document::str)

--- a/modules/python3/bindings/src/pyevent.cpp
+++ b/modules/python3/bindings/src/pyevent.cpp
@@ -246,7 +246,7 @@ void exposeEvents(pybind11::module& m) {
 
     exposeFlags<TouchState>(m, touchState, "TouchStates");
 
-    py::class_<Event>(m, "Event")
+    py::classh<Event>(m, "Event")
         .def("clone", &Event::clone)
         .def("hash", &Event::hash)
         .def("shouldPropagateTo", &Event::shouldPropagateTo)
@@ -272,13 +272,13 @@ void exposeEvents(pybind11::module& m) {
             return oss.str();
         });
 
-    py::class_<InteractionEvent, Event>(m, "InteractionEvent")
+    py::classh<InteractionEvent, Event>(m, "InteractionEvent")
         .def("modifiers", &InteractionEvent::modifiers)
         .def("setModifiers", &InteractionEvent::setModifiers)
         .def("modifierNames", &InteractionEvent::modifierNames)
         .def("setToolTip", &InteractionEvent::setToolTip);
 
-    py::class_<KeyboardEvent, InteractionEvent>(m, "KeyboardEvent")
+    py::classh<KeyboardEvent, InteractionEvent>(m, "KeyboardEvent")
         .def(py::init<IvwKey, KeyState, KeyModifiers, uint32_t, const std::string&>(),
              py::arg("key") = IvwKey::Unknown, py::arg("state") = KeyState::Press,
              py::arg("modifiers") = KeyModifier::None, py::arg("nativeVirtualKey") = 0,
@@ -291,7 +291,7 @@ void exposeEvents(pybind11::module& m) {
         .def_property("text", &KeyboardEvent::text, &KeyboardEvent::setText)
         .def_property_readonly_static("chash", &KeyboardEvent::chash);
 
-    py::class_<MouseInteractionEvent, InteractionEvent>(m, "MouseInteractionEvent")
+    py::classh<MouseInteractionEvent, InteractionEvent>(m, "MouseInteractionEvent")
         .def_property("buttonState", &MouseInteractionEvent::buttonState,
                       &MouseInteractionEvent::setButtonState)
         .def_property("pos", &MouseInteractionEvent::pos, &MouseInteractionEvent::setPos)
@@ -305,7 +305,7 @@ void exposeEvents(pybind11::module& m) {
         .def_property_readonly("y", &MouseInteractionEvent::y)
         .def_property_readonly("buttonName", &MouseInteractionEvent::buttonName);
 
-    py::class_<MouseEvent, MouseInteractionEvent>(m, "MouseEvent")
+    py::classh<MouseEvent, MouseInteractionEvent>(m, "MouseEvent")
         .def(py::init<MouseButton, MouseState, MouseButtons, KeyModifiers, dvec2, uvec2, double>(),
              py::arg("button") = MouseButton::Left, py::arg("state") = MouseState::Press,
              py::arg("buttonState") = MouseButton::None, py::arg("modifiers") = KeyModifier::None,
@@ -315,7 +315,7 @@ void exposeEvents(pybind11::module& m) {
         .def_property("state", &MouseEvent::state, &MouseEvent::setState)
         .def_property_readonly_static("chash", &MouseEvent::chash);
 
-    py::class_<WheelEvent, MouseInteractionEvent>(m, "WheelEvent")
+    py::classh<WheelEvent, MouseInteractionEvent>(m, "WheelEvent")
         .def(py::init<MouseButtons, KeyModifiers, dvec2, dvec2, uvec2, double>(),
              py::arg("buttonState") = MouseButton::None, py::arg("modifiers") = KeyModifier::None,
              py::arg("delta") = dvec2(0), py::arg("normalizedPosition") = dvec2(0),
@@ -323,7 +323,7 @@ void exposeEvents(pybind11::module& m) {
         .def_property("delta", &WheelEvent::delta, &WheelEvent::setDelta)
         .def_property_readonly_static("chash", &WheelEvent::chash);
 
-    py::class_<TouchPoint>(m, "TouchPoint")
+    py::classh<TouchPoint>(m, "TouchPoint")
         .def(py::init<>())
         .def(py::init<int, TouchState, dvec2, dvec2, dvec2, uvec2, double, double>(), py::arg("id"),
              py::arg("touchState"), py::arg("posNormalized"), py::arg("prevPosNormalized"),
@@ -348,13 +348,13 @@ void exposeEvents(pybind11::module& m) {
         .value("Screen", TouchDevice::DeviceType::TouchScreen)
         .value("Pad", TouchDevice::DeviceType::TouchPad);
 
-    py::class_<TouchDevice>(m, "TouchDevice")
+    py::classh<TouchDevice>(m, "TouchDevice")
         .def(py::init<TouchDevice::DeviceType, std::string>(),
              py::arg("type") = TouchDevice::DeviceType::TouchScreen, py::arg("name") = "")
         .def_property("type", &TouchDevice::getType, &TouchDevice::setType)
         .def_property("name", &TouchDevice::getName, &TouchDevice::setName);
 
-    py::class_<TouchEvent, InteractionEvent>(m, "TouchEvent")
+    py::classh<TouchEvent, InteractionEvent>(m, "TouchEvent")
         .def(py::init<const std::vector<TouchPoint>&, const TouchDevice*, KeyModifiers>(),
              py::arg("touchPoints"), py::arg("source"), py::arg("modifiers"))
         .def("hasTouchPoints", &TouchEvent::hasTouchPoints)
@@ -374,7 +374,7 @@ void exposeEvents(pybind11::module& m) {
         .def_property_readonly_static("chash", &TouchEvent::chash)
         .def_static("getPickingState", &TouchEvent::getPickingState);
 
-    py::class_<ResizeEvent, Event>(m, "ResizeEvent")
+    py::classh<ResizeEvent, Event>(m, "ResizeEvent")
         .def(py::init<size2_t>(), py::arg("newSize"))
         .def(py::init<size2_t, size2_t>(), py::arg("newSize"), py::arg("previousSize"))
         .def(py::init<ResizeEvent>())
@@ -382,10 +382,10 @@ void exposeEvents(pybind11::module& m) {
         .def_property("previousSize", &ResizeEvent::previousSize, &ResizeEvent::setPreviousSize)
         .def_property_readonly_static("chash", &ResizeEvent::chash);
 
-    py::class_<typename ViewEvent::FlipUp>(m, "ViewEventFlipUp").def(py::init<>());
-    py::class_<typename ViewEvent::FitData>(m, "ViewEventFitData").def(py::init<>());
+    py::classh<typename ViewEvent::FlipUp>(m, "ViewEventFlipUp").def(py::init<>());
+    py::classh<typename ViewEvent::FitData>(m, "ViewEventFitData").def(py::init<>());
 
-    py::class_<ViewEvent, Event>(m, "ViewEvent")
+    py::classh<ViewEvent, Event>(m, "ViewEvent")
         .def(py::init<typename ViewEvent::Action>())
         .def_property_readonly("action", &ViewEvent::getAction)
         .def_property_readonly_static("chash", &ViewEvent::chash);

--- a/modules/python3/bindings/src/pyglmtypes.cpp
+++ b/modules/python3/bindings/src/pyglmtypes.cpp
@@ -65,12 +65,12 @@ template <typename T, size_t N>
 using ith_T = T;
 
 template <typename V, typename T, std::size_t... I>
-void addInitImpl(py::class_<V>& pyv, std::index_sequence<I...>) {
+void addInitImpl(py::classh<V>& pyv, std::index_sequence<I...>) {
     pyv.def(py::init<ith_T<T, I>...>());
 }
 
 template <typename T, typename V, unsigned C, typename Indices = std::make_index_sequence<C>>
-void addInit(py::class_<V>& pyv) {
+void addInit(py::classh<V>& pyv) {
     addInitImpl<V, T>(pyv, Indices{});
 }
 }  // namespace
@@ -90,7 +90,7 @@ void vecx(py::module& m, const std::string& prefix, const std::string& name,
         return ss.str();
     }();
 
-    py::class_<Vec> pyv(m, classname.c_str(), py::buffer_protocol{});
+    py::classh<Vec> pyv(m, classname.c_str(), py::buffer_protocol{});
     addInit<T, Vec, Dim>(pyv);
     pyv.def(py::init<T>())
         .def(py::init<Vec>())

--- a/modules/python3/bindings/src/pyimage.cpp
+++ b/modules/python3/bindings/src/pyimage.cpp
@@ -87,7 +87,7 @@ void exposeImage(py::module& m) {
         .value("Zero", ImageChannel::Zero)
         .value("One", ImageChannel::One);
 
-    py::class_<SwizzleMask>(m, "SwizzleMask")
+    py::classh<SwizzleMask>(m, "SwizzleMask")
         .def(py::init<>([]() { return swizzlemasks::rgba; }))
         .def(py::init<SwizzleMask>())
         .def(py::init<>([](ImageChannel r, ImageChannel g, ImageChannel b, ImageChannel a) {
@@ -114,7 +114,7 @@ void exposeImage(py::module& m) {
         .value("Repeat", Wrapping::Repeat)
         .value("Mirror", Wrapping::Mirror);
 
-    py::class_<Image>(m, "Image")
+    py::classh<Image>(m, "Image")
         .def(py::init<size2_t, const DataFormatBase*>())
         .def(py::init<std::shared_ptr<Layer>>())
         .def(py::init<std::vector<std::shared_ptr<Layer>>>())
@@ -141,7 +141,7 @@ void exposeImage(py::module& m) {
                             : toString(static_cast<double>(dims.x) / static_cast<double>(dims.y)));
         });
 
-    py::class_<Layer>(m, "Layer")
+    py::classh<Layer>(m, "Layer")
         .def(py::init<std::shared_ptr<LayerRepresentation>>())
         .def(py::init<size2_t, const DataFormatBase*>())
         .def(py::init<size2_t, const DataFormatBase*, LayerType, const SwizzleMask&,
@@ -215,7 +215,7 @@ void exposeImage(py::module& m) {
                 self.getSwizzleMask(), self.getInterpolation(), self.getWrapping());
         });
 
-    py::class_<LayerRepresentation>(m, "LayerRepresentation")
+    py::classh<LayerRepresentation>(m, "LayerRepresentation")
         .def_property_readonly("layertype", &LayerRepresentation::getLayerType)
         .def_property("dimensions", &LayerRepresentation::getDimensions,
                       &LayerRepresentation::setDimensions)
@@ -237,7 +237,7 @@ void exposeImage(py::module& m) {
                 self.getSwizzleMask(), self.getInterpolation(), self.getWrapping());
         });
 
-    py::class_<LayerPy, LayerRepresentation>(m, "LayerPy")
+    py::classh<LayerPy, LayerRepresentation>(m, "LayerPy")
         .def(py::init<py::array, LayerType, const SwizzleMask&, InterpolationType,
                       const Wrapping2D&>(),
              py::arg("data"), py::arg("layerType") = LayerType::Color,

--- a/modules/python3/bindings/src/pyinviwoapplication.cpp
+++ b/modules/python3/bindings/src/pyinviwoapplication.cpp
@@ -124,7 +124,7 @@ private:
 void exposeModuleIdentifierWrapper(pybind11::module& m, const std::string& name) {
     namespace py = pybind11;
 
-    py::class_<ModuleIdentifierWrapper>(m, name.c_str())
+    py::classh<ModuleIdentifierWrapper>(m, name.c_str())
         .def("__getattr__", &ModuleIdentifierWrapper::getFromIdentifier,
              py::return_value_policy::reference)
         .def("__getitem__", &ModuleIdentifierWrapper::getFromIdentifier,
@@ -156,7 +156,7 @@ void exposeInviwoApplication(pybind11::module& m) {
 
     exposeModuleIdentifierWrapper(m, "ModuleIdentifierWrapper");
 
-    py::class_<InviwoApplication>(m, "InviwoApplication", py::multiple_inheritance{})
+    py::classh<InviwoApplication>(m, "InviwoApplication", py::multiple_inheritance{})
         .def(py::init<>())
         .def(py::init<std::string>())
         .def("getBasePath", [](InviwoApplication*) { return filesystem::findBasePath(); })

--- a/modules/python3/bindings/src/pyinviwomodule.cpp
+++ b/modules/python3/bindings/src/pyinviwomodule.cpp
@@ -84,7 +84,7 @@ public:
 void exposeInviwoModule(pybind11::module& m) {
     namespace py = pybind11;
 
-    py::class_<Version>(m, "Version")
+    py::classh<Version>(m, "Version")
         .def(py::init<std::string_view>())
         .def(py::init<unsigned int, unsigned int, unsigned int, std::string_view,
                       std::string_view>(),
@@ -104,7 +104,7 @@ void exposeInviwoModule(pybind11::module& m) {
         .def(py::self == py::self)
         .def("semanticVersionEqual", &Version::semanticVersionEqual);
 
-    py::class_<LicenseInfo>(m, "LicenseInfo")
+    py::classh<LicenseInfo>(m, "LicenseInfo")
         .def(py::init<std::string_view, std::string_view, std::string_view, std::string_view,
                       std::string_view, std::string_view, const std::vector<std::string>&>(),
              py::arg("id"), py::arg("name"), py::arg("version"), py::arg("url"), py::arg("module"),
@@ -136,7 +136,7 @@ void exposeInviwoModule(pybind11::module& m) {
         .value("GLSL", ModulePath::GLSL)
         .value("CL", ModulePath::CL);
 
-    py::class_<InviwoModule>(m, "InviwoModule")
+    py::classh<InviwoModule>(m, "InviwoModule")
         .def(py::init<InviwoApplication*, std::string_view>())
         .def("__repr__",
              [](InviwoModule* m) {
@@ -151,7 +151,7 @@ void exposeInviwoModule(pybind11::module& m) {
             m->registerProcessor(std::make_unique<ProcessorFactoryObjectPythonWrapper>(pfo));
         });
 
-    py::class_<InviwoModuleFactoryObject, InviwoModuleFactoryObjectTrampoline>(
+    py::classh<InviwoModuleFactoryObject, InviwoModuleFactoryObjectTrampoline>(
         m, "InviwoModuleFactoryObject")
         .def(py::init<std::string_view, Version, std::string_view, const std::filesystem::path&,
                       Version, std::vector<std::string>, std::vector<Version>,

--- a/modules/python3/bindings/src/pylogging.cpp
+++ b/modules/python3/bindings/src/pylogging.cpp
@@ -67,9 +67,9 @@ void exposeLogging(pybind11::module& m) {
         .value("Warn", MessageBreakLevel::Warn)
         .value("Info", MessageBreakLevel::Info);
 
-    py::class_<Logger>(m, "Logger").def("log", &Logger::log);
+    py::classh<Logger>(m, "Logger").def("log", &Logger::log);
 
-    py::class_<LogCentral, Logger>(m, "LogCentral")
+    py::classh<LogCentral, Logger>(m, "LogCentral")
         .def(py::init([]() {
             auto lc = std::make_unique<LogCentral>();
             if (!LogCentral::isInitialized()) {
@@ -88,11 +88,11 @@ void exposeLogging(pybind11::module& m) {
              py::arg("audience") = LogAudience::Developer, py::arg("file") = "",
              py::arg("function") = "", py::arg("line") = 0, py::arg("msg") = "");
 
-    py::class_<ConsoleLogger, Logger>(m, "ConsoleLogger")
+    py::classh<ConsoleLogger, Logger>(m, "ConsoleLogger")
         .def(py::init<>())
         .def("log", &ConsoleLogger::log);
 
-    py::class_<FileLogger, Logger>(m, "FileLogger")
+    py::classh<FileLogger, Logger>(m, "FileLogger")
         .def(py::init<std::string>())
         .def("log", &FileLogger::log);
 

--- a/modules/python3/bindings/src/pymesh.cpp
+++ b/modules/python3/bindings/src/pymesh.cpp
@@ -56,7 +56,7 @@ namespace py = pybind11;
 
 void exposeMesh(pybind11::module& m) {
 
-    py::class_<Mesh::MeshInfo>(m, "MeshInfo")
+    py::classh<Mesh::MeshInfo>(m, "MeshInfo")
         .def(py::init<>())
         .def(py::init<DrawType, ConnectivityType>(), py::arg("dt"), py::arg("ct"))
         .def("__repr__",
@@ -68,7 +68,7 @@ void exposeMesh(pybind11::module& m) {
         .def_readwrite("dt", &Mesh::MeshInfo::dt)
         .def_readwrite("ct", &Mesh::MeshInfo::ct);
 
-    py::class_<Mesh::BufferInfo>(m, "BufferInfo")
+    py::classh<Mesh::BufferInfo>(m, "BufferInfo")
         .def(py::init<>())
         .def(py::init<BufferType>())
         .def(py::init<BufferType, int>())
@@ -93,7 +93,7 @@ void exposeMesh(pybind11::module& m) {
         return list;
     };
 
-    py::class_<Mesh>(m, "Mesh")
+    py::classh<Mesh>(m, "Mesh")
         .def(py::init<>())
         .def(py::init<DrawType, ConnectivityType>(), py::arg("dt") = DrawType::Points,
              py::arg("ct") = ConnectivityType::None)
@@ -172,59 +172,59 @@ void exposeMesh(pybind11::module& m) {
 
     auto buffertraits = m.def_submodule("buffertraits", "Module containing mesh buffertraits");
 
-    py::class_<buffertraits::PositionsBuffer3D>(buffertraits, "PositionsBuffer3D")
+    py::classh<buffertraits::PositionsBuffer3D>(buffertraits, "PositionsBuffer3D")
         .def("getVertices", &buffertraits::PositionsBuffer3D::getEditableVertices)
         .def("setVertexPosition", &buffertraits::PositionsBuffer3D::setVertexPosition);
 
-    py::class_<buffertraits::PositionsBuffer2D>(buffertraits, "PositionsBuffer2D")
+    py::classh<buffertraits::PositionsBuffer2D>(buffertraits, "PositionsBuffer2D")
         .def("getVertices", &buffertraits::PositionsBuffer2D::getEditableVertices)
         .def("setVertexPosition", &buffertraits::PositionsBuffer2D::setVertexPosition);
 
-    py::class_<buffertraits::PositionsBuffer1D>(buffertraits, "PositionsBuffer1D")
+    py::classh<buffertraits::PositionsBuffer1D>(buffertraits, "PositionsBuffer1D")
         .def("getVertices", &buffertraits::PositionsBuffer1D::getEditableVertices)
         .def("setVertexPosition", &buffertraits::PositionsBuffer1D::setVertexPosition);
 
-    py::class_<buffertraits::NormalBuffer>(buffertraits, "NormalBuffer")
+    py::classh<buffertraits::NormalBuffer>(buffertraits, "NormalBuffer")
         .def("getNormals", &buffertraits::NormalBuffer::getEditableNormals)
         .def("setVertexNormal", &buffertraits::NormalBuffer::setVertexNormal);
 
-    py::class_<buffertraits::ColorsBuffer>(buffertraits, "ColorsBuffer")
+    py::classh<buffertraits::ColorsBuffer>(buffertraits, "ColorsBuffer")
         .def("getColors", &buffertraits::ColorsBuffer::getEditableColors)
         .def("setVertexColor", &buffertraits::ColorsBuffer::setVertexColor);
 
-    py::class_<buffertraits::TexCoordBuffer<3>>(buffertraits, "TexCoordBuffer3D")
+    py::classh<buffertraits::TexCoordBuffer<3>>(buffertraits, "TexCoordBuffer3D")
         .def("getTexCoords", &buffertraits::TexCoordBuffer<3>::getEditableTexCoords)
         .def("setVertexTexCoord", &buffertraits::TexCoordBuffer<3>::setVertexTexCoord);
 
-    py::class_<buffertraits::TexCoordBuffer<2>>(buffertraits, "TexCoordBuffer2D")
+    py::classh<buffertraits::TexCoordBuffer<2>>(buffertraits, "TexCoordBuffer2D")
         .def("getTexCoords", &buffertraits::TexCoordBuffer<2>::getEditableTexCoords)
         .def("setVertexTexCoord", &buffertraits::TexCoordBuffer<2>::setVertexTexCoord);
 
-    py::class_<buffertraits::TexCoordBuffer<1>>(buffertraits, "TexCoordBuffer1D")
+    py::classh<buffertraits::TexCoordBuffer<1>>(buffertraits, "TexCoordBuffer1D")
         .def("getTexCoords", &buffertraits::TexCoordBuffer<1>::getEditableTexCoords)
         .def("setVertexTexCoord", &buffertraits::TexCoordBuffer<1>::setVertexTexCoord);
 
-    py::class_<buffertraits::CurvatureBuffer>(buffertraits, "CurvatureBuffer")
+    py::classh<buffertraits::CurvatureBuffer>(buffertraits, "CurvatureBuffer")
         .def("getCurvatures", &buffertraits::CurvatureBuffer::getEditableCurvatures)
         .def("setVertexCurvature", &buffertraits::CurvatureBuffer::setVertexCurvature);
 
-    py::class_<buffertraits::IndexBuffer>(buffertraits, "IndexBuffer")
+    py::classh<buffertraits::IndexBuffer>(buffertraits, "IndexBuffer")
         .def("getIndex", &buffertraits::IndexBuffer::getEditableIndex)
         .def("setVertexIndex", &buffertraits::IndexBuffer::setVertexIndex);
 
-    py::class_<buffertraits::RadiiBuffer>(buffertraits, "RadiiBuffer")
+    py::classh<buffertraits::RadiiBuffer>(buffertraits, "RadiiBuffer")
         .def("getRadii", &buffertraits::RadiiBuffer::getEditableRadii)
         .def("setVertexRadius", &buffertraits::RadiiBuffer::setVertexRadius);
 
-    py::class_<buffertraits::PickingBuffer>(buffertraits, "PickingBuffer")
+    py::classh<buffertraits::PickingBuffer>(buffertraits, "PickingBuffer")
         .def("getPicking", &buffertraits::PickingBuffer::getEditablePicking)
         .def("setVertexPicking", &buffertraits::PickingBuffer::setVertexPicking);
 
-    py::class_<buffertraits::ScalarMetaBuffer>(buffertraits, "ScalarMetaBuffer")
+    py::classh<buffertraits::ScalarMetaBuffer>(buffertraits, "ScalarMetaBuffer")
         .def("getScalarMeta", &buffertraits::ScalarMetaBuffer::getEditableScalarMeta)
         .def("setVertexScalarMeta", &buffertraits::ScalarMetaBuffer::setVertexScalarMeta);
 
-    py::class_<BasicMesh, Mesh, buffertraits::PositionsBuffer, buffertraits::NormalBuffer,
+    py::classh<BasicMesh, Mesh, buffertraits::PositionsBuffer, buffertraits::NormalBuffer,
                buffertraits::TexCoordBuffer<3>, buffertraits::ColorsBuffer>(m, "BasicMesh")
         .def(py::init<>())
         .def(py::init<DrawType, ConnectivityType>(), py::arg("dt") = DrawType::Points,
@@ -244,7 +244,7 @@ void exposeMesh(pybind11::module& m) {
             return self.addVertex(vertex);
         });
 
-    py::class_<ColoredMesh, Mesh, buffertraits::PositionsBuffer, buffertraits::ColorsBuffer>(
+    py::classh<ColoredMesh, Mesh, buffertraits::PositionsBuffer, buffertraits::ColorsBuffer>(
         m, "ColoredMesh")
         .def(py::init<>())
         .def(py::init<DrawType, ConnectivityType>(), py::arg("dt") = DrawType::Points,
@@ -264,7 +264,7 @@ void exposeMesh(pybind11::module& m) {
             return self.addVertex(vertex);
         });
 
-    py::class_<SphereMesh, Mesh, buffertraits::PositionsBuffer, buffertraits::RadiiBuffer,
+    py::classh<SphereMesh, Mesh, buffertraits::PositionsBuffer, buffertraits::RadiiBuffer,
                buffertraits::ColorsBuffer>(m, "SphereMesh")
         .def(py::init<>())
         .def(py::init<DrawType, ConnectivityType>(), py::arg("dt") = DrawType::Points,
@@ -284,7 +284,7 @@ void exposeMesh(pybind11::module& m) {
             return self.addVertex(vertex);
         });
 
-    py::class_<PosTexColorMesh, Mesh, buffertraits::PositionsBuffer,
+    py::classh<PosTexColorMesh, Mesh, buffertraits::PositionsBuffer,
                buffertraits::TexCoordBuffer<3>, buffertraits::ColorsBuffer>(m, "PosTexColorMesh")
         .def(py::init<>())
         .def(py::init<DrawType, ConnectivityType>(), py::arg("dt") = DrawType::Points,

--- a/modules/python3/bindings/src/pynetwork.cpp
+++ b/modules/python3/bindings/src/pynetwork.cpp
@@ -54,14 +54,14 @@ namespace py = pybind11;
 namespace inviwo {
 
 void exposeNetwork(py::module& m) {
-    py::class_<PortConnection>(m, "PortConnection")
+    py::classh<PortConnection>(m, "PortConnection")
         .def(py::init<Outport*, Inport*>())
         .def_property_readonly("inport", &PortConnection::getInport,
                                py::return_value_policy::reference)
         .def_property_readonly("outport", &PortConnection::getOutport,
                                py::return_value_policy::reference);
 
-    py::class_<PropertyLink>(m, "PropertyLink")
+    py::classh<PropertyLink>(m, "PropertyLink")
         .def(py::init<Property*, Property*>(), py::arg("src"), py::arg("dst"))
         .def_property_readonly("source", &PropertyLink::getSource,
                                py::return_value_policy::reference)
@@ -72,7 +72,7 @@ void exposeNetwork(py::module& m) {
     using ProcessorVecWrapper = VectorIdentifierWrapper<ProcessorIt, false>;
     exposeVectorIdentifierWrapper<ProcessorIt, false>(m, "ProcessorVecWrapper");
 
-    py::class_<ProcessorNetwork>(m, "ProcessorNetwork")
+    py::classh<ProcessorNetwork>(m, "ProcessorNetwork")
         .def_property_readonly("processors",
                                [](ProcessorNetwork& net) {
                                    auto range = net.processorRange();

--- a/modules/python3/bindings/src/pypickingmapper.cpp
+++ b/modules/python3/bindings/src/pypickingmapper.cpp
@@ -82,7 +82,7 @@ void exposePickingMapper(pybind11::module& m) {
 
     exposeFlags<PickingHoverState>(m, pickingHoverState, "PickingHoverStates");
 
-    py::class_<PickingEvent, Event>(m, "PickingEvent")
+    py::classh<PickingEvent, Event>(m, "PickingEvent")
         .def(py::init<const PickingAction*, InteractionEvent*, PickingState, PickingPressState,
                       PickingPressItem, PickingHoverState, PickingPressItems, size_t, size_t,
                       size_t, size_t, dvec3, dvec3>(),
@@ -123,7 +123,7 @@ void exposePickingMapper(pybind11::module& m) {
         .def("setToolTip", &PickingEvent::setToolTip)
         .def_property_readonly_static("chash", &PickingEvent::chash);
 
-    py::class_<PickingMapper>(m, "PickingMapper")
+    py::classh<PickingMapper>(m, "PickingMapper")
         .def(py::init([](Processor* p, size_t size, pybind11::function callback) {
             return new PickingMapper(p, size, [callback](PickingEvent* e) {
                 try {

--- a/modules/python3/bindings/src/pypickingmapper.cpp
+++ b/modules/python3/bindings/src/pypickingmapper.cpp
@@ -125,10 +125,10 @@ void exposePickingMapper(pybind11::module& m) {
 
     py::classh<PickingMapper>(m, "PickingMapper")
         .def(py::init([](Processor* p, size_t size, pybind11::function callback) {
-            return new PickingMapper(p, size, [callback](PickingEvent* e) {
+            return new PickingMapper(p, size, [c = std::move(callback)](PickingEvent* e) {
                 try {
                     const pybind11::gil_scoped_acquire guard{};
-                    callback(py::cast(e));
+                    c(py::cast(e));
                 } catch (const py::error_already_set& e) {
                     log::exception(e);
                 }

--- a/modules/python3/bindings/src/pyport.cpp
+++ b/modules/python3/bindings/src/pyport.cpp
@@ -65,12 +65,12 @@ struct InportCallbackHolderOutport {
 void exposePort(pybind11::module& m) {
     namespace py = pybind11;
 
-    py::class_<InportCallbackHolderVoid>(m, "InportCallbackHolderVoid")
+    py::classh<InportCallbackHolderVoid>(m, "InportCallbackHolderVoid")
         .def("reset", [](InportCallbackHolderVoid* h) { h->value.reset(); });
-    py::class_<InportCallbackHolderOutport>(m, "InportCallbackHolderOutport")
+    py::classh<InportCallbackHolderOutport>(m, "InportCallbackHolderOutport")
         .def("reset", [](InportCallbackHolderOutport* h) { h->value.reset(); });
 
-    py::class_<Port>(m, "Port")
+    py::classh<Port>(m, "Port")
         .def_property_readonly("identifier", &Port::getIdentifier)
         .def_property_readonly("processor", &Port::getProcessor, py::return_value_policy::reference)
         .def_property_readonly("classIdentifier", &Port::getClassIdentifier)
@@ -78,14 +78,14 @@ void exposePort(pybind11::module& m) {
         .def("isConnected", &Port::isConnected)
         .def("isReady", &Port::isReady);
 
-    py::class_<Outport, Port>(m, "Outport")
+    py::classh<Outport, Port>(m, "Outport")
         .def("isConnectedTo", &Outport::isConnectedTo)
         .def("getConnectedInports", &Outport::getConnectedInports,
              py::return_value_policy::reference)
         .def("hasData", &Outport::hasData)
         .def("clear", &Outport::clear);
 
-    py::class_<Inport, Port>(m, "Inport")
+    py::classh<Inport, Port>(m, "Inport")
         .def_property("optional", &Inport::isOptional, &Inport::setOptional)
         .def("isChanged", &Inport::isChanged)
         .def("canConnectTo", &Inport::canConnectTo)
@@ -116,12 +116,12 @@ void exposePort(pybind11::module& m) {
             return InportCallbackHolderOutport{p->onDisconnectScoped(std::move(func))};
         });
 
-    py::class_<PythonInport, Inport>(m, "PythonInport")
+    py::classh<PythonInport, Inport>(m, "PythonInport")
         .def(py::init<std::string, Document>(), py::arg("identifier"), py::arg("help") = Document{})
         .def("hasData", &PythonInport::hasData)
         .def("getData", &PythonInport::getData);
 
-    py::class_<PythonOutport, Outport>(m, "PythonOutport")
+    py::classh<PythonOutport, Outport>(m, "PythonOutport")
         .def(py::init<std::string, Document>(), py::arg("identifier"), py::arg("help") = Document{})
         .def("getData", &PythonOutport::getData)
         .def("setData", &PythonOutport::setData);

--- a/modules/python3/bindings/src/pyprocessors.cpp
+++ b/modules/python3/bindings/src/pyprocessors.cpp
@@ -112,14 +112,14 @@ void exposeProcessors(pybind11::module& m) {
         .value("Experimental", CodeState::Experimental)
         .value("Stable", CodeState::Stable);
 
-    py::class_<Tag>(m, "Tag")
+    py::classh<Tag>(m, "Tag")
         .def(py::init())
         .def(py::init<std::string_view>())
         .def(py::init<Tag>())
         .def("getString", &Tag::getString)
         .def(py::self | py::self);
 
-    py::class_<Tags>(m, "Tags")
+    py::classh<Tags>(m, "Tags")
         .def(py::init())
         .def(py::init<Tag>())
         .def(py::init<std::vector<Tag>>())
@@ -147,7 +147,7 @@ void exposeProcessors(pybind11::module& m) {
 
     py::implicitly_convertible<Tag, Tags>();
 
-    py::class_<ProcessorInfo>(m, "ProcessorInfo")
+    py::classh<ProcessorInfo>(m, "ProcessorInfo")
         .def(py::init<std::string, std::string, std::string, CodeState, Tags, Document>(),
              py::arg("classIdentifier"), py::arg("displayName"), py::arg("category") = "Python",
              py::arg("codeState") = CodeState::Stable, py::arg("tags") = Tags::PY,
@@ -159,12 +159,12 @@ void exposeProcessors(pybind11::module& m) {
         .def_readonly("tags", &ProcessorInfo::tags)
         .def_readonly("visible", &ProcessorInfo::visible);
 
-    py::class_<ProcessorFactoryObject, ProcessorFactoryObjectTrampoline>(m,
+    py::classh<ProcessorFactoryObject, ProcessorFactoryObjectTrampoline>(m,
                                                                          "ProcessorFactoryObject")
         .def(py::init<ProcessorInfo, std::string_view>())
         .def("getProcessorInfo", &ProcessorFactoryObject::getProcessorInfo);
 
-    py::class_<ProcessorFactory>(m, "ProcessorFactory")
+    py::classh<ProcessorFactory>(m, "ProcessorFactory")
         .def("hasKey", &ProcessorFactory::hasKey)
         .def_property_readonly("keys", &ProcessorFactory::getKeys)
         .def("create", [](ProcessorFactory* pf, std::string key) { return pf->createShared(key); })
@@ -182,7 +182,7 @@ void exposeProcessors(pybind11::module& m) {
         .def("registerObject", &ProcessorFactory::registerObject)
         .def("unRegisterObject", &ProcessorFactory::unRegisterObject);
 
-    py::class_<ProcessorWidget>(m, "ProcessorWidget", py::multiple_inheritance{})
+    py::classh<ProcessorWidget>(m, "ProcessorWidget", py::multiple_inheritance{})
         .def_property("visible", &ProcessorWidget::isVisible, &ProcessorWidget::setVisible)
         .def_property("dimensions", &ProcessorWidget::getDimensions,
                       &ProcessorWidget::setDimensions)
@@ -193,7 +193,7 @@ void exposeProcessors(pybind11::module& m) {
             return reinterpret_cast<std::intptr_t>(static_cast<void*>(w));
         });
 
-    py::class_<ProcessorWidgetFactory>(m, "ProcessorWidgetFactory")
+    py::classh<ProcessorWidgetFactory>(m, "ProcessorWidgetFactory")
         .def("registerObject", &ProcessorWidgetFactory::registerObject)
         .def("unRegisterObject", &ProcessorWidgetFactory::unRegisterObject)
         .def("create", [](ProcessorWidgetFactory* pf, Processor* p) { return pf->create(p); })
@@ -202,12 +202,12 @@ void exposeProcessors(pybind11::module& m) {
              [](ProcessorWidgetFactory* pf, std::string_view id) { return pf->hasKey(id); })
         .def("getkeys", &ProcessorWidgetFactory::getKeys);
 
-    py::class_<ProcessorWidgetFactoryObject, ProcessorWidgetFactoryObjectTrampoline>(
+    py::classh<ProcessorWidgetFactoryObject, ProcessorWidgetFactoryObjectTrampoline>(
         m, "ProcessorWidgetFactoryObject")
         .def(py::init<const std::string&>())
         .def("getClassIdentifier", &ProcessorWidgetFactoryObject::getClassIdentifier);
 
-    py::class_<ProcessorMetaData>(m, "ProcessorMetaData")
+    py::classh<ProcessorMetaData>(m, "ProcessorMetaData")
         .def_property("position", &ProcessorMetaData::getPosition, &ProcessorMetaData::setPosition)
         .def_property("selected", &ProcessorMetaData::isSelected, &ProcessorMetaData::setSelected)
         .def_property("visible", &ProcessorMetaData::isVisible, &ProcessorMetaData::setVisible);
@@ -221,7 +221,7 @@ void exposeProcessors(pybind11::module& m) {
     exposeVectorIdentifierWrapper<typename std::vector<Outport*>::const_iterator>(
         m, "OutportVectorWrapper");
 
-    py::class_<Processor, PropertyOwner, ProcessorTrampoline>(
+    py::classh<Processor, PropertyOwner, ProcessorTrampoline>(
         m, "Processor", py::multiple_inheritance{}, py::dynamic_attr{})
         .def(py::init<const std::string&, const std::string&>())
         .def("__repr__", &Processor::getIdentifier)
@@ -303,7 +303,7 @@ void exposeProcessors(pybind11::module& m) {
         .def("getPredecessors", [](Processor* p) { return util::getPredecessors(p); })
         .def("getSuccessors", [](Processor* p) { return util::getSuccessors(p); });
 
-    py::class_<CanvasProcessor, Processor>(m, "CanvasProcessor")
+    py::classh<CanvasProcessor, Processor>(m, "CanvasProcessor")
         .def_property("size", &CanvasProcessor::getCanvasSize, &CanvasProcessor::setCanvasSize)
         .def("getUseCustomDimensions", &CanvasProcessor::getUseCustomDimensions)
         .def_property_readonly("customDimensions", &CanvasProcessor::getCustomDimensions)

--- a/modules/python3/bindings/src/pyproperties.cpp
+++ b/modules/python3/bindings/src/pyproperties.cpp
@@ -109,9 +109,9 @@ void exposeProperties(py::module& m) {
         });
 
     py::classh<PropertyFactory>(m, "PropertyFactory")
-        .def("hasKey", [](PropertyFactory* pf, std::string key) { return pf->hasKey(key); })
+        .def("hasKey", [](PropertyFactory* pf, std::string_view key) { return pf->hasKey(key); })
         .def_property_readonly("keys", [](PropertyFactory* pf) { return pf->getKeys(); })
-        .def("create", [](PropertyFactory* pf, std::string key) { return pf->create(key); });
+        .def("create", [](PropertyFactory* pf, std::string_view key) { return pf->create(key); });
 
     py::classh<PropertyWidget>(m, "PropertyWidget", py::multiple_inheritance{})
         .def_property_readonly("property", &PropertyWidget::getProperty,

--- a/modules/python3/bindings/src/pyproperties.cpp
+++ b/modules/python3/bindings/src/pyproperties.cpp
@@ -88,7 +88,7 @@ void exposeProperties(py::module& m) {
                                   .value("Remove", ListPropertyUIFlag::Remove);
     exposeFlags<ListPropertyUIFlag>(m, listPropertyUIFlag, "ListPropertyUIFlags");
 
-    py::class_<PropertySemantics>(m, "PropertySemantics")
+    py::classh<PropertySemantics>(m, "PropertySemantics")
         .def(py::init())
         .def(py::init<std::string>(), py::arg("semantic"))
         .def("getString", &PropertySemantics::getString)
@@ -108,12 +108,12 @@ void exposeProperties(py::module& m) {
             return fmt::format("<PropertySemantics: '{}'>", s.getString());
         });
 
-    py::class_<PropertyFactory>(m, "PropertyFactory")
+    py::classh<PropertyFactory>(m, "PropertyFactory")
         .def("hasKey", [](PropertyFactory* pf, std::string key) { return pf->hasKey(key); })
         .def_property_readonly("keys", [](PropertyFactory* pf) { return pf->getKeys(); })
         .def("create", [](PropertyFactory* pf, std::string key) { return pf->create(key); });
 
-    py::class_<PropertyWidget>(m, "PropertyWidget", py::multiple_inheritance{})
+    py::classh<PropertyWidget>(m, "PropertyWidget", py::multiple_inheritance{})
         .def_property_readonly("property", &PropertyWidget::getProperty,
                                py::return_value_policy::reference)
 
@@ -125,7 +125,7 @@ void exposeProperties(py::module& m) {
             return reinterpret_cast<std::intptr_t>(static_cast<void*>(w));
         });
 
-    py::class_<PropertyEditorWidget>(m, "PropertyEditorWidget", py::multiple_inheritance{})
+    py::classh<PropertyEditorWidget>(m, "PropertyEditorWidget", py::multiple_inheritance{})
         .def_property("visible", &PropertyEditorWidget::isVisible,
                       &PropertyEditorWidget::setVisible)
         .def_property("dimensions", &PropertyEditorWidget::getDimensions,
@@ -136,7 +136,7 @@ void exposeProperties(py::module& m) {
             return reinterpret_cast<std::intptr_t>(static_cast<void*>(w));
         });
 
-    py::class_<Property>(m, "Property")
+    py::classh<Property>(m, "Property")
         .def_property("identifier", &Property::getIdentifier, &Property::setIdentifier)
         .def_property("displayName", &Property::getDisplayName, &Property::setDisplayName)
         .def_property("readOnly", &Property::getReadOnly, &Property::setReadOnly)
@@ -166,7 +166,7 @@ void exposeProperties(py::module& m) {
         .def("getHelp", static_cast<Document& (Property::*)()>(&Property::getHelp))
         .def("getDescription", &Property::getDescription);
 
-    py::class_<TransferFunctionProperty, Property>(m, "TransferFunctionProperty")
+    py::classh<TransferFunctionProperty, Property>(m, "TransferFunctionProperty")
         .def(py::init([](std::string_view identifier, std::string_view displayName, Document help,
                          const TransferFunction& value, VolumeInport* volumeInport,
                          InvalidationLevel invalidationLevel, PropertySemantics semantics) {
@@ -231,7 +231,7 @@ void exposeProperties(py::module& m) {
             return oss.str();
         });
 
-    py::class_<IsoValueProperty, Property>(m, "IsoValueProperty")
+    py::classh<IsoValueProperty, Property>(m, "IsoValueProperty")
         .def(py::init([](std::string_view identifier, std::string_view displayName, Document help,
                          const IsoValueCollection& value, VolumeInport* volumeInport,
                          PropertySemantics semantics) {
@@ -279,7 +279,7 @@ void exposeProperties(py::module& m) {
             return oss.str();
         });
 
-    py::class_<StringProperty, Property> strProperty(m, "StringProperty");
+    py::classh<StringProperty, Property> strProperty(m, "StringProperty");
     strProperty
         .def(py::init([](std::string_view identifier, std::string_view displayName, Document help,
                          std::string_view value, InvalidationLevel invalidationLevel,
@@ -315,7 +315,7 @@ void exposeProperties(py::module& m) {
         .value("Directory", FileMode::Directory)
         .value("ExistingFiles", FileMode::ExistingFiles);
 
-    py::class_<FileExtension>(m, "FileExtension")
+    py::classh<FileExtension>(m, "FileExtension")
         .def(py::init<>())
         .def(py::init<std::string, std::string>(), py::arg("ext"), py::arg("desc"))
         .def("toString", &FileExtension::toString)
@@ -326,7 +326,7 @@ void exposeProperties(py::module& m) {
         .def_readwrite("extension", &FileExtension::extension_)
         .def_readwrite("description", &FileExtension::description_);
 
-    py::class_<FileProperty, Property> fileProperty(m, "FileProperty");
+    py::classh<FileProperty, Property> fileProperty(m, "FileProperty");
     fileProperty
         .def(py::init([](std::string_view identifier, std::string_view displayName, Document help,
                          std::string_view value, std::string_view contentType,
@@ -368,7 +368,7 @@ void exposeProperties(py::module& m) {
                       &FileProperty::setSelectedExtension)
         .def("__repr__", [](FileProperty& p) { return fmt::format("FileProperty({})", p.get()); });
 
-    py::class_<DirectoryProperty, FileProperty> dirProperty(m, "DirectoryProperty");
+    py::classh<DirectoryProperty, FileProperty> dirProperty(m, "DirectoryProperty");
     dirProperty
         .def(py::init([](std::string_view identifier, std::string_view displayName, Document help,
                          std::string_view value, std::string_view contentType,
@@ -393,7 +393,7 @@ void exposeProperties(py::module& m) {
         .def("__repr__",
              [](DirectoryProperty& p) { return fmt::format("DirectoryProperty({})", p.get()); });
 
-    py::class_<BoolProperty, Property> boolProperty(m, "BoolProperty");
+    py::classh<BoolProperty, Property> boolProperty(m, "BoolProperty");
     boolProperty
         .def(py::init([](std::string_view identifier, std::string_view displayName, Document help,
                          bool value, InvalidationLevel invalidationLevel,
@@ -419,7 +419,7 @@ void exposeProperties(py::module& m) {
         .def("__bool__", &BoolProperty::get)
         .def("__repr__", [](BoolProperty& p) { return fmt::format("BoolProperty({})", p.get()); });
 
-    py::class_<ButtonProperty, Property>(m, "ButtonProperty")
+    py::classh<ButtonProperty, Property>(m, "ButtonProperty")
         .def(py::init([](std::string_view identifier, std::string_view displayName,
                          InvalidationLevel invalidationLevel, PropertySemantics semantics) {
                  return new ButtonProperty(identifier, displayName, invalidationLevel, semantics);
@@ -447,11 +447,11 @@ void exposeProperties(py::module& m) {
              py::arg("semantics") = PropertySemantics::Default)
         .def("press", &ButtonProperty::pressButton);
 
-    py::class_<ButtonGroupProperty::Button>(m, "ButtonGroupPropertyButton")
+    py::classh<ButtonGroupProperty::Button>(m, "ButtonGroupPropertyButton")
         .def(py::init<std::optional<std::string>, std::optional<std::string>,
                       std::optional<std::string>, std::function<void()>>());
 
-    py::class_<ButtonGroupProperty, Property>(m, "ButtonGroupProperty")
+    py::classh<ButtonGroupProperty, Property>(m, "ButtonGroupProperty")
         .def(py::init([](std::string_view identifier, std::string_view displayName,
                          InvalidationLevel invalidationLevel, PropertySemantics semantics) {
                  return new ButtonGroupProperty(identifier, displayName, invalidationLevel,

--- a/modules/python3/bindings/src/pypropertyowner.cpp
+++ b/modules/python3/bindings/src/pypropertyowner.cpp
@@ -53,7 +53,7 @@ void exposePropertyOwner(pybind11::module& m) {
     exposeVectorIdentifierWrapper<typename std::vector<Property*>::const_iterator>(
         m, "PropertyVecWrapper");
 
-    py::class_<PropertyOwner>(m, "PropertyOwner", py::multiple_inheritance{}, py::dynamic_attr{})
+    py::classh<PropertyOwner>(m, "PropertyOwner", py::multiple_inheritance{}, py::dynamic_attr{})
         .def(
             "__getattr__",
             [](PropertyOwner& po, const std::string& key) {

--- a/modules/python3/bindings/src/pytfprimitiveset.cpp
+++ b/modules/python3/bindings/src/pytfprimitiveset.cpp
@@ -93,7 +93,7 @@ void exposeTFPrimitiveSet(pybind11::module& m) {
         .value("Relative", TFPrimitiveSetType::Relative)
         .value("Absolute", TFPrimitiveSetType::Absolute);
 
-    py::class_<TFPrimitiveData>(m, "TFPrimitiveData")
+    py::classh<TFPrimitiveData>(m, "TFPrimitiveData")
         .def(py::init())
         .def(py::init<double, vec4>())
         .def(py::init([](double iso, const std::string& color) {
@@ -111,7 +111,7 @@ void exposeTFPrimitiveSet(pybind11::module& m) {
         .def(py::self == py::self)
         .def(py::self != py::self);
 
-    py::class_<TFPrimitive>(m, "TFPrimitive")
+    py::classh<TFPrimitive>(m, "TFPrimitive")
         .def(py::init([](double pos, const vec4& color) { return new TFPrimitive(pos, color); }),
              py::arg("pos") = 0.0, py::arg("color") = vec4(0.0f))
         .def(py::init([](double iso, const std::string& color) {
@@ -139,7 +139,7 @@ void exposeTFPrimitiveSet(pybind11::module& m) {
         .def(py::self == py::self)
         .def(py::self != py::self);
 
-    py::class_<TFPrimitiveSet>(m, "TFPrimitiveSet")
+    py::classh<TFPrimitiveSet>(m, "TFPrimitiveSet")
         .def(py::init([](const std::vector<TFPrimitiveData>& values, TFPrimitiveSetType type) {
                  return new TFPrimitiveSet(values, type);
              }),
@@ -187,7 +187,7 @@ void exposeTFPrimitiveSet(pybind11::module& m) {
             return oss.str();
         });
 
-    py::class_<TransferFunction, TFPrimitiveSet>(m, "TransferFunction")
+    py::classh<TransferFunction, TFPrimitiveSet>(m, "TransferFunction")
         .def(py::init([]() { return TransferFunction(); }))
         .def(py::init([](const std::vector<TFPrimitiveData>& values) {
                  return new TransferFunction(values);
@@ -223,7 +223,7 @@ void exposeTFPrimitiveSet(pybind11::module& m) {
             return oss.str();
         });
 
-    py::class_<IsoValueCollection, TFPrimitiveSet>(m, "IsoValueCollection")
+    py::classh<IsoValueCollection, TFPrimitiveSet>(m, "IsoValueCollection")
         .def(py::init([](const std::vector<TFPrimitiveData>& values, TFPrimitiveSetType type) {
                  return new IsoValueCollection(values, type);
              }),

--- a/modules/python3/bindings/src/pyvolume.cpp
+++ b/modules/python3/bindings/src/pyvolume.cpp
@@ -58,7 +58,7 @@ namespace inviwo {
 void exposeVolume(pybind11::module& m) {
     namespace py = pybind11;
 
-    py::class_<Volume>(m, "Volume")
+    py::classh<Volume>(m, "Volume")
         .def(py::init<std::shared_ptr<VolumeRepresentation>>())
         .def(py::init<size3_t, const DataFormatBase*, const SwizzleMask&, InterpolationType,
                       const Wrapping3D&>(),
@@ -119,7 +119,7 @@ void exposeVolume(pybind11::module& m) {
                 volume.dataMap.valueAxis.unit, volume.getModelMatrix(), volume.getWorldMatrix());
         });
 
-    py::class_<VolumeRepresentation>(m, "VolumeRepresentation")
+    py::classh<VolumeRepresentation>(m, "VolumeRepresentation")
         .def_property("dimensions", &VolumeRepresentation::getDimensions,
                       &VolumeRepresentation::setDimensions)
         .def_property("swizzleMask", &VolumeRepresentation::getSwizzleMask,
@@ -133,7 +133,7 @@ void exposeVolume(pybind11::module& m) {
         .def("getOwner", &VolumeRepresentation::getOwner)
         .def_property_readonly("format", &VolumeRepresentation::getDataFormat);
 
-    py::class_<VolumePy, VolumeRepresentation>(m, "VolumePy")
+    py::classh<VolumePy, VolumeRepresentation>(m, "VolumePy")
         .def(py::init<py::array, const SwizzleMask&, InterpolationType, const Wrapping3D&>(),
              py::arg("data"), py::arg("swizzleMask") = swizzlemasks::rgba,
              py::arg("interpolation") = InterpolationType::Linear,
@@ -146,7 +146,7 @@ void exposeVolume(pybind11::module& m) {
         .def_property_readonly(
             "data", static_cast<const py::array& (VolumePy::*)() const>(&VolumePy::data));
 
-    py::class_<VolumeSequence>(m, "VolumeSequence", py::module_local(false))
+    py::classh<VolumeSequence>(m, "VolumeSequence", py::module_local(false))
         .def(py::init<>())
         .def(py::init<std::span<std::shared_ptr<const Volume>>>(), py::arg("volumes"))
         .def(py::init<const VolumeSequence&>(), "Copy constructor")

--- a/modules/python3/include/modules/python3/pybindflags.h
+++ b/modules/python3/include/modules/python3/pybindflags.h
@@ -54,7 +54,7 @@ void exposeFlags(pybind11::module& m, std::string_view name) {
 
     using Iter = typename flags::flags<E>::iterator;
 
-    py::class_<Iter>(m, fmt::format("{}Iterator", name).c_str())
+    py::classh<Iter>(m, fmt::format("{}Iterator", name).c_str())
         .def(py::init<Iter>())
         .def("__iter__", [](Iter& self) { return Iter{self}; })
         .def("__next__", [](Iter& self) {
@@ -65,7 +65,7 @@ void exposeFlags(pybind11::module& m, std::string_view name) {
             }
         });
 
-    py::class_<flags::flags<E>> flags(m, SafeCStr{name}.c_str());
+    py::classh<flags::flags<E>> flags(m, SafeCStr{name}.c_str());
     flags.def(py::init([]() { return flags::flags<E>{flags::empty}; }))
         .def(py::init<E>())
         .def(py::init<flags::flags<E>>())

--- a/modules/python3/include/modules/python3/pyportutils.h
+++ b/modules/python3/include/modules/python3/pyportutils.h
@@ -73,20 +73,20 @@ struct IterRangeGenerator : iter_range<Iter> {
 }  // namespace util
 
 template <typename Iter>
-pybind11::class_<util::IterRangeGenerator<Iter>> exposeIterRangeGenerator(pybind11::handle& m,
+pybind11::classh<util::IterRangeGenerator<Iter>> exposeIterRangeGenerator(pybind11::handle& m,
                                                                           const std::string& name) {
 
-    return pybind11::class_<util::IterRangeGenerator<Iter>>(m,
+    return pybind11::classh<util::IterRangeGenerator<Iter>>(m,
                                                             StrBuffer{"{}Generator", name}.c_str())
         .def("__next__", &util::IterRangeGenerator<Iter>::next);
 }
 
 template <typename Port>
-pybind11::class_<Port, Outport> exposeOutport(pybind11::module& m, const std::string& name) {
+pybind11::classh<Port, Outport> exposeOutport(pybind11::module& m, const std::string& name) {
     namespace py = pybind11;
     using T = typename Port::type;
 
-    return pybind11::class_<Port, Outport>(m, StrBuffer{"{}Outport", name}.c_str())
+    return pybind11::classh<Port, Outport>(m, StrBuffer{"{}Outport", name}.c_str())
         .def(py::init<std::string, Document>(), py::arg("identifier"), py::arg("help") = Document{})
         .def("getData", &Port::getData)
         .def("detatchData", &Port::detachData)
@@ -94,11 +94,11 @@ pybind11::class_<Port, Outport> exposeOutport(pybind11::module& m, const std::st
 }
 
 template <typename Port>
-pybind11::class_<Port, Inport> exposeInport(pybind11::module& m, const std::string& name) {
+pybind11::classh<Port, Inport> exposeInport(pybind11::module& m, const std::string& name) {
 
     namespace py = pybind11;
 
-    pybind11::class_<Port, Inport> pyInport{m, StrBuffer{"{}Inport", name}.c_str()};
+    pybind11::classh<Port, Inport> pyInport{m, StrBuffer{"{}Inport", name}.c_str()};
 
     exposeIterRangeGenerator<typename Port::const_iterator>(pyInport, "Data");
     exposeIterRangeGenerator<typename Port::const_iterator_port>(pyInport, "OutportAndData");

--- a/modules/python3qt/src/python3qtmodule.cpp
+++ b/modules/python3qt/src/python3qtmodule.cpp
@@ -182,7 +182,7 @@ Python3QtModule::Python3QtModule(InviwoApplication* app)
                 }
             });
 
-        py::class_<PropertyListWidget>(m, "PropertyListWidget")
+        py::classh<PropertyListWidget>(m, "PropertyListWidget")
             .def(py::init([](InviwoApplication* app) {
                 auto mainwin = utilqt::getApplicationMainWindow();
                 auto plw = new PropertyListWidget(mainwin, app);

--- a/tools/vcpkg/pybind11/portfile.cmake
+++ b/tools/vcpkg/pybind11/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pybind/pybind11
-    REF 43d6bfce7d723926a1f2c5814a89e1bc81117c4b # v2.13.6 2024-09-25 + smart_holder
-    SHA512 e5c41f507d3d53cbdc1f3c0807c78187c047c373d9a71353262e1d7585c50ccda922e0299cb624366a4bfa983199aeb5911b35ee4ba762316023e381c96ed577
+    REF aed215c4d49532a1b162ea11cd96f77bd3540fed # v2.13.6 2025-02-24 + smart_holder
+    SHA512 15d4619d97226fc3de2125cfcb845c5498c1288e149e26bc0eb6588bb2f96ad4270f3ced1fb6f591934ba487e5e2dc6bfdbab190ab7a067aee60e7129ad73890
     HEAD_REF smart_holder
     PATCHES
         include-fix.patch

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,7 @@
   "vcpkg-configuration": {
     "default-registry": {
       "kind": "builtin",
-      "baseline": "26abb5b33f976246a5f2cdc45cdd073d51caff06"
+      "baseline": "11be7f536538ace43f867c8efb3d624c43b6af54"
     },
     "overlay-ports": [
       "./tools/vcpkg"


### PR DESCRIPTION
Fixes #...

Changes proposed in this PR:
 * ...
 * ...
 * ...

This has been tested on: ...

> Thank you for contributing to the Inviwo repository! Please ensure the following: 
> - Code is error and warning free
> - Code follows the Inviwo coding guidelines: 
>   https://github.com/inviwo/inviwo/wiki/Coding-Conventions
> - New Code / Processors follows the Inviwo documentation guidelines: 
>   https://github.com/inviwo/inviwo/wiki/Documentation-guide
> - New Code / processors are tested in a unittest and / or regression test: 
>   https://github.com/inviwo/inviwo/wiki/Manual#testing
> 
> Please remember to specify the environment this code been compiled and tested on:
> Operating System / Compiler / IDE / QT / CMake / Python versions.