### PR TITLE
Feature/qt numberwidget

### DIFF
--- a/include/inviwo/core/properties/ordinalproperty.h
+++ b/include/inviwo/core/properties/ordinalproperty.h
@@ -290,7 +290,7 @@ IVW_CORE_API OrdinalPropertyState<vec3> ordinalLight(
 /**
  * A factory function for configuring a OrdinalProperty representing a generic vector, with a
  * symmetric range around zero, and Ignored boundary constraints. The invalidation level defaults to
- * InvalidOutput, and the property semantics to SpinBox.
+ * InvalidOutput, and the property semantics to Default.
  * @param value the default value for the property
  * @param minMax used to construct the range of the property like min = T{-minMax}, max = T{minMax}.
  * The constraint behavior will be Ignore.
@@ -306,7 +306,7 @@ OrdinalPropertyState<T> ordinalSymmetricVector(const T& value = {0}, const U& mi
                 ConstraintBehavior::Ignore,
                 T{static_cast<V>(0.1)},
                 InvalidationLevel::InvalidOutput,
-                PropertySemantics::SpinBox};
+                PropertySemantics::Default};
     } else if constexpr (std::is_signed_v<util::value_type_t<T>>) {
         return {value,
                 T{-minMax},
@@ -315,7 +315,7 @@ OrdinalPropertyState<T> ordinalSymmetricVector(const T& value = {0}, const U& mi
                 ConstraintBehavior::Ignore,
                 T{static_cast<V>(1)},
                 InvalidationLevel::InvalidOutput,
-                PropertySemantics::SpinBox};
+                PropertySemantics::Default};
     } else {
         return {value,
                 T{static_cast<V>(0)},
@@ -324,14 +324,14 @@ OrdinalPropertyState<T> ordinalSymmetricVector(const T& value = {0}, const U& mi
                 ConstraintBehavior::Ignore,
                 T{static_cast<V>(1)},
                 InvalidationLevel::InvalidOutput,
-                PropertySemantics::SpinBox};
+                PropertySemantics::Default};
     }
 }
 
 /**
  * A factory function for configuring a OrdinalProperty representing a count. It will have a
  * Immutable min at zero and an upper Ignored max. The increment will be one. The invalidation level
- * defaults to InvalidOutput, and the property semantics to SpinBox.
+ * defaults to InvalidOutput, and the property semantics to Default.
  * @param value the default value for the property
  * @param max used to construct the max value. The max constraint behavior will be Ignore.
 
@@ -346,13 +346,13 @@ OrdinalPropertyState<T> ordinalCount(const T& value = T{0}, const U& max = U{100
             ConstraintBehavior::Ignore,
             T{static_cast<V>(1)},
             InvalidationLevel::InvalidOutput,
-            PropertySemantics::SpinBox};
+            PropertySemantics::Default};
 }
 
 /**
  * A factory function for configuring a OrdinalProperty representing a length. It will have a
  * Immutable min at zero and an upper Ignored max. The invalidation level defaults to InvalidOutput,
- * and the property semantics to SpinBox.
+ * and the property semantics to Default.
  * @param value the default value for the property
  * @param max used to construct the max value. The max constraint behavior will be Ignore.
  */
@@ -366,7 +366,7 @@ OrdinalPropertyState<T> ordinalLength(const T& value = T{0}, const U& max = U{10
             ConstraintBehavior::Ignore,
             T{static_cast<V>(0.1)},
             InvalidationLevel::InvalidOutput,
-            PropertySemantics::SpinBox};
+            PropertySemantics::Default};
 }
 
 /**

--- a/modules/qtwidgets/CMakeLists.txt
+++ b/modules/qtwidgets/CMakeLists.txt
@@ -16,6 +16,7 @@ set(MOC_FILES
     include/modules/qtwidgets/inviwowidgetsqt.h
     include/modules/qtwidgets/lightpositionwidgetqt.h
     include/modules/qtwidgets/lineeditqt.h
+    include/modules/qtwidgets/numberwidget.h
     include/modules/qtwidgets/ordinaleditorwidget.h
     include/modules/qtwidgets/processors/processordockwidgetqt.h    
     include/modules/qtwidgets/properties/colorlineedit.h
@@ -117,6 +118,7 @@ set(SOURCE_FILES
     src/lineeditqt.cpp
     src/mousecursorutils.cpp
     src/numberlineedit.cpp
+    src/numberwidget.cpp
     src/ordinalbasewidget.cpp
     src/ordinaleditorwidget.cpp
     src/processors/processordockwidgetqt.cpp

--- a/modules/qtwidgets/include/modules/qtwidgets/numberwidget.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/numberwidget.h
@@ -55,8 +55,8 @@ struct IVW_MODULE_QTWIDGETS_API NumberWidgetConfig {
     std::optional<bool> wrapping = std::nullopt;
 
     static constexpr auto defaultInteraction = Interaction::Dragging;
-    static constexpr std::string_view defaultPrefix;
-    static constexpr std::string_view defaultPostfix;
+    static constexpr std::string_view defaultPrefix{};
+    static constexpr std::string_view defaultPostfix{};
     static constexpr bool defaultBarVisible = true;
     static constexpr bool defaultWrapping = false;
 

--- a/modules/qtwidgets/include/modules/qtwidgets/numberwidget.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/numberwidget.h
@@ -55,8 +55,8 @@ struct IVW_MODULE_QTWIDGETS_API NumberWidgetConfig {
     std::optional<bool> wrapping = std::nullopt;
 
     static constexpr auto defaultInteraction = Interaction::Dragging;
-    static constexpr std::string_view defaultPrefix = "";
-    static constexpr std::string_view defaultPostfix = "";
+    static constexpr std::string_view defaultPrefix;
+    static constexpr std::string_view defaultPostfix;
     static constexpr bool defaultBarVisible = true;
     static constexpr bool defaultWrapping = false;
 
@@ -69,7 +69,7 @@ public:
     enum class PercentageBar : std::uint8_t { Invalid, Regular, Symmetric };
 
     explicit BaseNumberWidget(QWidget* parent = nullptr);
-    BaseNumberWidget(const NumberWidgetConfig& config, QWidget* parent = nullptr);
+    explicit BaseNumberWidget(const NumberWidgetConfig& config, QWidget* parent = nullptr);
     BaseNumberWidget(const BaseNumberWidget&) = default;
     BaseNumberWidget(BaseNumberWidget&&) = default;
     BaseNumberWidget& operator=(const BaseNumberWidget&) = default;
@@ -148,7 +148,7 @@ class IVW_MODULE_QTWIDGETS_API NumberWidget final : public BaseNumberWidget,
                                                     public OrdinalBaseWidget<T> {
 public:
     NumberWidget();
-    NumberWidget(const NumberWidgetConfig& config);
+    explicit NumberWidget(const NumberWidgetConfig& config);
     NumberWidget(const NumberWidget&) = default;
     NumberWidget(NumberWidget&&) = default;
     NumberWidget& operator=(const NumberWidget&) = default;

--- a/modules/qtwidgets/include/modules/qtwidgets/numberwidget.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/numberwidget.h
@@ -70,10 +70,10 @@ public:
 
     explicit BaseNumberWidget(QWidget* parent = nullptr);
     explicit BaseNumberWidget(const NumberWidgetConfig& config, QWidget* parent = nullptr);
-    BaseNumberWidget(const BaseNumberWidget&) = default;
-    BaseNumberWidget(BaseNumberWidget&&) = default;
-    BaseNumberWidget& operator=(const BaseNumberWidget&) = default;
-    BaseNumberWidget& operator=(BaseNumberWidget&&) = default;
+    BaseNumberWidget(const BaseNumberWidget&) = delete;
+    BaseNumberWidget(BaseNumberWidget&&) = delete;
+    BaseNumberWidget& operator=(const BaseNumberWidget&) = delete;
+    BaseNumberWidget& operator=(BaseNumberWidget&&) = delete;
     virtual ~BaseNumberWidget() = default;
 
     void setPrefix(std::string_view prefix);
@@ -149,10 +149,10 @@ class IVW_MODULE_QTWIDGETS_API NumberWidget final : public BaseNumberWidget,
 public:
     NumberWidget();
     explicit NumberWidget(const NumberWidgetConfig& config);
-    NumberWidget(const NumberWidget&) = default;
-    NumberWidget(NumberWidget&&) = default;
-    NumberWidget& operator=(const NumberWidget&) = default;
-    NumberWidget& operator=(NumberWidget&&) = default;
+    NumberWidget(const NumberWidget&) = delete;
+    NumberWidget(NumberWidget&&) = delete;
+    NumberWidget& operator=(const NumberWidget&) = delete;
+    NumberWidget& operator=(NumberWidget&&) = delete;
     virtual ~NumberWidget() = default;
 
     // Implements OrdinalBaseWidget

--- a/modules/qtwidgets/include/modules/qtwidgets/numberwidget.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/numberwidget.h
@@ -100,6 +100,7 @@ private:
 
     struct InteractionState {
         QPoint previousPos{};
+        Qt::KeyboardModifiers modifiers;
         bool dragging = false;
         HoverState hover = HoverState::Invalid;
     };

--- a/modules/qtwidgets/include/modules/qtwidgets/numberwidget.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/numberwidget.h
@@ -1,0 +1,333 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2025 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <modules/qtwidgets/qtwidgetsmoduledefine.h>
+#include <modules/qtwidgets/ordinalbasewidget.h>
+#include <modules/qtwidgets/inviwoqtutils.h>
+
+#include <optional>
+#include <limits>
+
+#include <QLineEdit>
+#include <QByteArray>
+
+class QEvent;
+class QMouseEvent;
+class QPaintEvent;
+
+namespace inviwo {
+
+class IVW_MODULE_QTWIDGETS_API BaseNumberWidget : public QLineEdit {
+    Q_OBJECT
+public:
+    explicit BaseNumberWidget(QWidget* parent = nullptr);
+    BaseNumberWidget(std::string_view prefix, std::string_view postfix, QWidget* parent = nullptr);
+    virtual ~BaseNumberWidget() = default;
+
+    void setPrefix(std::string_view prefix);
+    const QString& getPrefix() const;
+    void setPostfix(std::string_view postfix);
+    const QString& getPostfix() const;
+
+    void setWrapping(bool wrapping);
+    bool getWrapping() const;
+
+    void updateText();
+
+    virtual bool event(QEvent* event) override;
+
+signals:
+    void valueChanged();
+
+protected:
+    virtual void mousePressEvent(QMouseEvent* event) override;
+    virtual void mouseReleaseEvent(QMouseEvent* event) override;
+    virtual void mouseMoveEvent(QMouseEvent* event) override;
+    virtual void paintEvent(QPaintEvent* event) override;
+    virtual void changeEvent(QEvent* event) override;
+
+    virtual bool incrementValue() = 0;
+    virtual bool decrementValue() = 0;
+    virtual bool applyDelta(double deltaSteps) = 0;
+    virtual void initDragValue() = 0;
+    virtual bool valueFromTextValid(const QString& str) = 0;
+    virtual bool updateValueFromText(const QString& str) = 0;
+    virtual QString getTextFromValue(bool precise) const = 0;
+    virtual std::optional<double> getPercentage() const = 0;
+
+private:
+    enum class FocusAction : std::uint8_t { SetFocus, ClearFocus };
+    enum class HoverState : std::uint8_t { Invalid, Center, NegativeInc, PositiveInc };
+
+    QString getPrefixedText() const;
+    void updateState(FocusAction action);
+    HoverState getHoverState(QPoint mousepos) const;
+    void updateHoverState(QPoint mousepos);
+
+    struct InteractionState {
+        QPoint previousPos{};
+        bool dragging = false;
+        HoverState hover = HoverState::Invalid;
+    };
+
+    bool wrapping_;
+    QString prefix_;
+    QString postfix_;
+    InteractionState state_;
+
+    static constexpr Qt::KeyboardModifier increasedStepModifier = Qt::ControlModifier;
+    static constexpr Qt::KeyboardModifier decreasedStepModifier = Qt::ShiftModifier;
+    static constexpr double increasedStepSize = 10.0;
+    static constexpr double decreasedStepSize = 0.1;
+};
+
+template <typename T>
+class IVW_MODULE_QTWIDGETS_API NumberWidget final : public BaseNumberWidget,
+                                                    public OrdinalBaseWidget<T> {
+public:
+    NumberWidget();
+    virtual ~NumberWidget() = default;
+
+    // Implements OrdinalBaseWidget
+    virtual T getValue() const override;
+    virtual void setValue(T value) override;
+    virtual void initValue(T value) override;
+    virtual void setMinValue(T minValue, ConstraintBehavior cb) override;
+    virtual void setMaxValue(T maxValue, ConstraintBehavior cb) override;
+    virtual void setIncrement(T increment) override;
+
+protected:
+    virtual bool incrementValue() override;
+    virtual bool decrementValue() override;
+    virtual bool applyDelta(double deltaSteps) override;
+    virtual void initDragValue() override;
+    virtual bool valueFromTextValid(const QString& str) override;
+    virtual bool updateValueFromText(const QString& str) override;
+    virtual QString getTextFromValue(bool precise) const override;
+    virtual std::optional<double> getPercentage() const override;
+
+    bool updateValue(T value);
+    double getUIIncrement() const;
+
+private:
+    T value_;
+    T minValue_;
+    T maxValue_;
+    T increment_;
+    T initialDragValue_;
+    ConstraintBehavior minCB_;
+    ConstraintBehavior maxCB_;
+};
+
+template <typename T>
+inline NumberWidget<T>::NumberWidget()
+    : OrdinalBaseWidget<T>()
+    , value_{1}
+    , minValue_{0}
+    , maxValue_{2}
+    , increment_{1}
+    , initialDragValue_{0}
+    , minCB_{ConstraintBehavior::Editable}
+    , maxCB_{ConstraintBehavior::Editable} {}
+
+template <typename T>
+T NumberWidget<T>::getValue() const {
+    return value_;
+}
+template <typename T>
+void NumberWidget<T>::setValue(T value) {
+    if (value != value_) {
+        value_ = value;
+        updateText();
+        emit valueChanged();
+    }
+}
+template <typename T>
+void NumberWidget<T>::initValue(T value) {
+    value_ = value;
+    updateText();
+}
+template <typename T>
+void NumberWidget<T>::setMinValue(T minValue, ConstraintBehavior cb) {
+    minValue_ = minValue;
+    minCB_ = cb;
+}
+template <typename T>
+void NumberWidget<T>::setMaxValue(T maxValue, ConstraintBehavior cb) {
+    maxValue_ = maxValue;
+    maxCB_ = cb;
+}
+template <typename T>
+void NumberWidget<T>::setIncrement(T increment) {
+    increment_ = increment;
+}
+
+template <typename T>
+bool NumberWidget<T>::incrementValue() {
+    const T uiIncrement = getUIIncrement();
+    if (maxValue_ - uiIncrement < value_) {
+        if (getWrapping()) {
+            const T delta = maxValue_ - value_;
+            return updateValue(minValue_ + uiIncrement - delta);
+        } else {
+            return updateValue(maxValue_);
+        }
+    } else {
+        return updateValue(value_ + uiIncrement);
+    }
+}
+
+template <typename T>
+bool NumberWidget<T>::decrementValue() {
+    const T uiIncrement = getUIIncrement();
+    if (minValue_ + uiIncrement > value_) {
+        if (getWrapping()) {
+            const T delta = value_ - minValue_;
+            return updateValue(maxValue_ - uiIncrement + delta);
+        } else {
+            return updateValue(minValue_);
+        }
+    } else {
+        return updateValue(value_ - uiIncrement);
+    }
+}
+
+template <typename T>
+bool NumberWidget<T>::applyDelta(double deltaSteps) {
+    if (deltaSteps == 0.0) {
+        return false;
+    }
+
+    T delta = static_cast<T>(deltaSteps * getUIIncrement());
+    if (getWrapping()) {
+        if constexpr (std::is_floating_point_v<T>) {
+            delta = std::fmod(delta, maxValue_ - minValue_);
+        } else {
+            delta = delta % (maxValue_ - minValue_);
+        }
+        if (maxValue_ - delta < initialDragValue_) {
+            delta -= maxValue_ - minValue_;
+        } else if (minValue_ - delta > initialDragValue_) {
+            delta += maxValue_ - minValue_;
+        }
+        return updateValue(initialDragValue_ + delta);
+    }
+
+    if (delta > 0) {
+        if (maxCB_ == ConstraintBehavior::Ignore) {
+            if (std::numeric_limits<T>::max() - delta < initialDragValue_) {
+                return updateValue(std::numeric_limits<T>::max());
+            } else {
+                return updateValue(initialDragValue_ + delta);
+            }
+        } else if (maxValue_ - delta < initialDragValue_) {
+            return updateValue(maxValue_);
+        } else {
+            return updateValue(initialDragValue_ + delta);
+        }
+    } else {
+        if (minCB_ == ConstraintBehavior::Ignore) {
+            if (std::numeric_limits<T>::lowest() - delta > initialDragValue_) {
+                return updateValue(std::numeric_limits<T>::lowest());
+            } else {
+                return updateValue(initialDragValue_ + delta);
+            }
+        } else if (minValue_ - delta > initialDragValue_) {
+            return updateValue(minValue_);
+        } else {
+            return updateValue(initialDragValue_ + delta);
+        }
+    }
+}
+
+template <typename T>
+void NumberWidget<T>::initDragValue() {
+    // Need to keep track of the current value when mouse dragging starts to have an absolute delta.
+    // Otherwise the incremental delta between two events might be too small for updating integer
+    // values.
+    initialDragValue_ = value_;
+}
+
+template <typename T>
+bool NumberWidget<T>::valueFromTextValid(const QString& str) {
+    return utilqt::numericValueFromString<T>(str).has_value();
+}
+
+template <typename T>
+bool NumberWidget<T>::updateValueFromText(const QString& str) {
+    if (auto newValue = utilqt::numericValueFromString<T>(str); newValue && *newValue != value_) {
+        value_ = *newValue;
+        return true;
+    }
+    return false;
+}
+
+template <typename T>
+QString NumberWidget<T>::getTextFromValue(bool precise) const {
+    if constexpr (std::is_floating_point_v<T>) {
+        if (precise) {
+            return utilqt::formatAsNonscientific(value_);
+        } else {
+            return QString::number(value_, 'f', utilqt::decimals(increment_));
+        }
+    } else {
+        return QString::number(value_);
+    }
+}
+
+template <typename T>
+std::optional<double> NumberWidget<T>::getPercentage() const {
+    if (minValue_ == std::numeric_limits<T>::lowest() ||
+        maxValue_ == std::numeric_limits<T>::max()) {
+        return std::nullopt;
+    }
+    return static_cast<double>(value_ - minValue_) / static_cast<double>(maxValue_ - minValue_);
+}
+
+template <typename T>
+bool NumberWidget<T>::updateValue(T v) {
+    if (value_ != v) {
+        value_ = v;
+        return true;
+    }
+    return false;
+}
+
+template <typename T>
+double NumberWidget<T>::getUIIncrement() const {
+    if (minValue_ == std::numeric_limits<T>::lowest() ||
+        maxValue_ == std::numeric_limits<T>::max()) {
+        return static_cast<double>(increment_);
+    }
+
+    return static_cast<double>(maxValue_ - minValue_) / static_cast<double>(width());
+}
+
+}  // namespace inviwo

--- a/modules/qtwidgets/include/modules/qtwidgets/properties/ordinalminmaxtextpropertywidgetqt.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/properties/ordinalminmaxtextpropertywidgetqt.h
@@ -35,7 +35,7 @@
 #include <inviwo/core/properties/minmaxproperty.h>                  // IWYU pragma: keep
 #include <inviwo/core/util/glm.h>                                   // for almostEqual
 #include <modules/qtwidgets/editablelabelqt.h>                      // for EditableLabelQt
-#include <modules/qtwidgets/ordinaleditorwidget.h>                  // for OrdinalEditorWidget
+#include <modules/qtwidgets/numberwidget.h>                         // for NumberWidget
 #include <modules/qtwidgets/properties/propertysettingswidgetqt.h>  // for MinMaxPropertySetting...
 #include <modules/qtwidgets/properties/propertywidgetqt.h>          // for PropertyWidgetQt
 
@@ -77,8 +77,8 @@ protected:
     MinMaxPropertySettingsWidgetQt<T>* settings_;
     EditableLabelQt* label_;
     MinMaxProperty<T>* minMaxProperty_;
-    OrdinalEditorWidget<T>* min_;
-    OrdinalEditorWidget<T>* max_;
+    NumberWidget<T>* min_;
+    NumberWidget<T>* max_;
 };
 
 using DoubleMinMaxTextPropertyWidgetQt = OrdinalMinMaxTextPropertyWidgetQt<double, double>;
@@ -94,8 +94,14 @@ OrdinalMinMaxTextPropertyWidgetQt<BT, T>::OrdinalMinMaxTextPropertyWidgetQt(
     , settings_(nullptr)
     , label_(new EditableLabelQt(this, property_))
     , minMaxProperty_(property)
-    , min_{new OrdinalEditorWidget<T>()}
-    , max_{new OrdinalEditorWidget<T>()} {
+    , min_{new NumberWidget<T>{NumberWidgetConfig{
+          .interaction = NumberWidgetConfig::Interaction::NoDragging,
+          .barVisible = false,
+      }}}
+    , max_{new NumberWidget<T>{NumberWidgetConfig{
+          .interaction = NumberWidgetConfig::Interaction::NoDragging,
+          .barVisible = false,
+      }}} {
 
     setFocusPolicy(min_->focusPolicy());
     setFocusProxy(min_);
@@ -127,9 +133,9 @@ OrdinalMinMaxTextPropertyWidgetQt<BT, T>::OrdinalMinMaxTextPropertyWidgetQt(
     textsp.setHorizontalStretch(3);
     textWidget->setSizePolicy(textsp);
 
-    connect(min_, &OrdinalEditorWidget<T>::valueChanged, this,
+    connect(min_, &NumberWidget<T>::valueChanged, this,
             &OrdinalMinMaxTextPropertyWidgetQt<BT, T>::updateFromMin);
-    connect(max_, &OrdinalEditorWidget<T>::valueChanged, this,
+    connect(max_, &NumberWidget<T>::valueChanged, this,
             &OrdinalMinMaxTextPropertyWidgetQt<BT, T>::updateFromMax);
 
     setFixedHeight(sizeHint().height());

--- a/modules/qtwidgets/src/inviwoqtutils.cpp
+++ b/modules/qtwidgets/src/inviwoqtutils.cpp
@@ -633,6 +633,31 @@ void setFullScreenAndOnTop(QWidget* widget, bool fullScreen, bool onTop) {
     widget->setVisible(visible);
 }
 
+QString formatAsNonscientific(double value) {
+    // QString always uses QLocale::C
+    const int visibleDigits = 8;
+    const double scientificRepThreshold = 1e-6;
+
+    if (std::abs(value) < scientificRepThreshold) {
+        return QString::number(value, 'g', visibleDigits + 1);
+    } else {
+        const int int_digits =
+            static_cast<int>(std::floor(std::log10(std::max(std::abs(value), 1.0)))) + 1;
+
+        QString str = QString::number(value, 'f', std::max(visibleDigits + 1 - int_digits, 1));
+        if (str.contains('.')) {
+            // remove trailing zeros
+            while (*str.rbegin() == '0') {
+                str.chop(1);
+            }
+            if (*str.rbegin() == '.') {
+                str.chop(1);
+            }
+        }
+        return str;
+    }
+}
+
 QString toQString(const std::filesystem::path& path) {
     auto str = path.generic_u8string();
     return QString::fromUtf8(reinterpret_cast<char*>(str.data()), str.size());

--- a/modules/qtwidgets/src/numberwidget.cpp
+++ b/modules/qtwidgets/src/numberwidget.cpp
@@ -1,0 +1,330 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2025 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <modules/qtwidgets/numberwidget.h>
+#include <modules/qtwidgets/inviwoqtutils.h>
+
+#include <QGuiApplication>
+#include <QPaintEvent>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QStyleOption>
+#include <QStyleOptionFrame>
+#include <QPainter>
+#include <QSvgRenderer>
+#include <QFontMetrics>
+
+namespace inviwo {
+
+BaseNumberWidget::BaseNumberWidget(QWidget* parent) : BaseNumberWidget{{}, {}, parent} {}
+
+BaseNumberWidget::BaseNumberWidget(std::string_view prefix, std::string_view postfix,
+                                   QWidget* parent)
+    : QLineEdit{parent}
+    , wrapping_{false}
+    , prefix_{utilqt::toQString(prefix)}
+    , postfix_{utilqt::toQString(postfix)} {
+
+    QSizePolicy sp = sizePolicy();
+    sp.setHorizontalPolicy(QSizePolicy::Minimum);
+    setSizePolicy(sp);
+
+    updateState(FocusAction::ClearFocus);
+    setFocusPolicy(Qt::TabFocus);
+    setMouseTracking(true);
+
+    QObject::connect(this, &QLineEdit::textEdited, this, [this](const QString& text) {
+        if (valueFromTextValid(text)) {
+            setProperty("invalid", QVariant{});
+        } else {
+            setProperty("invalid", true);
+        }
+        style()->unpolish(this);
+        style()->polish(this);
+    });
+}
+
+void BaseNumberWidget::setPrefix(std::string_view prefix) {
+    prefix_ = utilqt::toQString(prefix);
+    updateText();
+}
+
+const QString& BaseNumberWidget::getPrefix() const { return prefix_; }
+
+void BaseNumberWidget::setPostfix(std::string_view postfix) {
+    postfix_ = utilqt::toQString(postfix);
+    updateText();
+}
+
+const QString& BaseNumberWidget::getPostfix() const { return postfix_; }
+
+void BaseNumberWidget::setWrapping(bool wrapping) { wrapping_ = wrapping; }
+
+bool BaseNumberWidget::getWrapping() const { return wrapping_; }
+
+bool BaseNumberWidget::event(QEvent* event) {
+    if (event->type() == QEvent::ReadOnlyChange) {
+        updateHoverState(mapFromGlobal(QCursor::pos()));
+        QSignalBlocker blocker{this};
+        updateText();
+    } else if (!isReadOnly() && isEnabled()) {
+        if (event->type() == QEvent::FocusIn) {
+            updateState(FocusAction::SetFocus);
+        } else if (event->type() == QEvent::FocusOut) {
+            if (updateValueFromText(text())) {
+                emit valueChanged();
+            }
+            updateState(FocusAction::ClearFocus);
+        } else if (event->type() == QEvent::KeyPress) {
+            const auto* keyEvent = static_cast<QKeyEvent*>(event);
+
+            if (keyEvent->key() == Qt::Key_Escape) {
+                // cancel editing
+                QSignalBlocker blocker{this};
+                updateText();
+                clearFocus();
+                return true;
+            } else if (keyEvent->key() == Qt::Key_Return || keyEvent->key() == Qt::Key_Enter) {
+                // commit changes
+                clearFocus();
+                return true;
+            }
+        }
+    }
+    return QLineEdit::event(event);
+}
+
+void BaseNumberWidget::mousePressEvent(QMouseEvent* event) {
+    if (!hasFocus() && !isReadOnly() && isEnabled() && event->button() == Qt::LeftButton) {
+        state_.previousPos = event->pos();
+        state_.dragging = false;
+        event->accept();
+    } else {
+        QLineEdit::mousePressEvent(event);
+    }
+}
+
+void BaseNumberWidget::mouseReleaseEvent(QMouseEvent* event) {
+    if (!hasFocus() && !isReadOnly() && isEnabled() && event->button() == Qt::LeftButton) {
+        event->accept();
+        if (!state_.dragging) {
+            switch (state_.hover) {
+                case HoverState::PositiveInc:
+                    incrementValue();
+                    emit valueChanged();
+                    update();
+                    break;
+                case HoverState::NegativeInc:
+                    decrementValue();
+                    emit valueChanged();
+                    update();
+                    break;
+                case HoverState::Center:
+                default:
+                    // mouse left click on center and no movement, start editing
+                    setFocus(Qt::TabFocusReason);
+                    break;
+            }
+        }
+        state_.dragging = false;
+    } else {
+        QLineEdit::mouseReleaseEvent(event);
+    }
+}
+
+void BaseNumberWidget::mouseMoveEvent(QMouseEvent* event) {
+    updateHoverState(event->pos());
+
+    // ignore dragging as long as movement delta is too small
+    if (!hasFocus() && !isReadOnly() && isEnabled() && event->buttons().testFlag(Qt::LeftButton)) {
+        event->accept();
+        const int delta = (event->pos() - state_.previousPos).x();
+        if (!state_.dragging) {
+            const int minimalMovement = 3;
+            state_.dragging = std::abs(delta) > minimalMovement;
+            if (state_.dragging) {
+                setCursor(Qt::SizeHorCursor);
+                state_.hover = HoverState::Center;
+                initDragValue();
+            }
+        } else {
+            double deltaStep = static_cast<double>(delta);
+            if (QGuiApplication::queryKeyboardModifiers().testFlag(increasedStepModifier)) {
+                deltaStep *= increasedStepSize;
+            } else if (QGuiApplication::queryKeyboardModifiers().testFlag(decreasedStepModifier)) {
+                deltaStep *= decreasedStepSize;
+            }
+            applyDelta(deltaStep);
+            emit valueChanged();
+            update();
+        }
+    } else {
+        QLineEdit::mouseMoveEvent(event);
+    }
+}
+
+void BaseNumberWidget::paintEvent(QPaintEvent* event) {
+    const int borderWidth = 1;
+    const int incrementWidth = height() * 2 / 3;
+    QStyleOptionFrame panel;
+    initStyleOption(&panel);
+    const bool hover = panel.state.testFlag(QStyle::State_MouseOver);
+
+    if (!hasFocus() && !isReadOnly() && isEnabled()) {
+        constexpr std::string_view arrowLeft{":/svgicons/arrow-left-enabled.svg"};
+        constexpr std::string_view arrowRight{":/svgicons/arrow-right-enabled.svg"};
+
+        QPainter painter{this};
+        style()->drawPrimitive(QStyle::PE_PanelLineEdit, &panel, &painter, this);
+        QRect r = style()->subElementRect(QStyle::SE_LineEditContents, &panel, this);
+        painter.setPen(Qt::NoPen);
+        painter.setClipRect(r);
+        painter.setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing);
+
+        QRect interiorRect{rect().adjusted(borderWidth, borderWidth, -borderWidth, -borderWidth)};
+
+        // draw percentage bar in the center part
+        if (auto percentage = getPercentage(); percentage.has_value()) {
+            const QRect centerRect{QPoint{borderWidth, borderWidth},
+                                   QPoint{static_cast<int>(interiorRect.width() * *percentage),
+                                          height() - 2 * borderWidth}};
+            const QBrush percentageBrush{hover ? "#1e70a8" : "#103a57"};
+            painter.setBrush(percentageBrush);
+            painter.drawRect(centerRect);
+        }
+
+        if (hover) {
+            QRect arrowRect{interiorRect.topLeft(), QSize{incrementWidth, interiorRect.height()}};
+
+            const QBrush bgActive{"#185987"};
+
+            if (state_.hover == HoverState::NegativeInc) {
+                painter.setBrush(bgActive);
+                painter.drawRect(arrowRect);
+            }
+
+            QSvgRenderer renderer(utilqt::toQString(arrowLeft));
+            renderer.setAspectRatioMode(Qt::KeepAspectRatio);
+            renderer.render(&painter, arrowRect);
+
+            arrowRect.moveRight(width() - borderWidth);
+            if (state_.hover == HoverState::PositiveInc) {
+                painter.setBrush(bgActive);
+                painter.drawRect(arrowRect);
+            }
+
+            renderer.load(utilqt::toQString(arrowRight));
+            renderer.setAspectRatioMode(Qt::KeepAspectRatio);
+            renderer.render(&painter, arrowRect);
+        }
+
+        painter.setFont(font());
+        painter.setPen(palette().color(QPalette::Text));
+        painter.drawText(event->rect(), Qt::AlignCenter, getPrefixedText());
+    } else {
+        QLineEdit::paintEvent(event);
+    }
+}
+
+void BaseNumberWidget::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::EnabledChange) {
+        updateText();
+    }
+    QLineEdit::changeEvent(event);
+}
+
+void BaseNumberWidget::updateText() {
+    const QString str = (isReadOnly() || !isEnabled()) ? getPrefixedText() : getTextFromValue(true);
+    if (str != text()) {
+        setText(str);
+    }
+}
+
+QString BaseNumberWidget::getPrefixedText() const {
+    return QString("%1%2%3%4")
+        .arg(prefix_)
+        .arg(prefix_.length() > 0 ? ": " : "")
+        .arg(getTextFromValue(false))
+        .arg(postfix_);
+}
+
+void BaseNumberWidget::updateState(FocusAction action) {
+    if (action == FocusAction::SetFocus) {
+        // update textual representation
+        updateText();
+    }
+    setProperty("invalid", QVariant{});
+    style()->unpolish(this);
+    style()->polish(this);
+    setAlignment(action == FocusAction::SetFocus ? Qt::AlignLeft : Qt::AlignCenter);
+
+    updateHoverState(mapFromGlobal(QCursor::pos()));
+}
+
+auto BaseNumberWidget::getHoverState(QPoint mousepos) const -> HoverState {
+    const int incrementWidth = height() * 2 / 3;
+
+    if (hasFocus() || isReadOnly() || !isEnabled()) {
+        return HoverState::Invalid;
+    }
+    if (mousepos.x() < incrementWidth) {
+        return HoverState::NegativeInc;
+    } else if (mousepos.x() > width() - incrementWidth) {
+        return HoverState::PositiveInc;
+    } else {
+        return HoverState::Center;
+    }
+}
+
+void BaseNumberWidget::updateHoverState(QPoint mousepos) {
+    if (state_.dragging) {
+        return;
+    }
+
+    if (auto hoverState = getHoverState(mousepos); hoverState != state_.hover) {
+        state_.hover = hoverState;
+        update();
+
+        switch (state_.hover) {
+            case HoverState::Invalid:
+                setCursor(Qt::IBeamCursor);
+                break;
+            case HoverState::Center:
+                setCursor(Qt::SizeHorCursor);
+                break;
+            case HoverState::NegativeInc:
+            case HoverState::PositiveInc:
+            default:
+                unsetCursor();
+                break;
+        }
+    }
+}
+
+}  // namespace inviwo

--- a/modules/qtwidgets/src/numberwidget.cpp
+++ b/modules/qtwidgets/src/numberwidget.cpp
@@ -171,13 +171,20 @@ void BaseNumberWidget::mouseMoveEvent(QMouseEvent* event) {
             if (state_.dragging) {
                 setCursor(Qt::SizeHorCursor);
                 state_.hover = HoverState::Center;
+                state_.modifiers = QGuiApplication::queryKeyboardModifiers();
                 initDragValue();
             }
         } else {
             auto deltaStep = static_cast<double>(delta);
-            if (QGuiApplication::queryKeyboardModifiers().testFlag(increasedStepModifier)) {
+            if (auto modifiers = QGuiApplication::queryKeyboardModifiers(); modifiers != state_.modifiers) {
+                initDragValue();
+                state_.previousPos = event->pos();
+                state_.modifiers = modifiers;
+            }
+
+            if (state_.modifiers.testFlag(increasedStepModifier)) {
                 deltaStep *= increasedStepSize;
-            } else if (QGuiApplication::queryKeyboardModifiers().testFlag(decreasedStepModifier)) {
+            } else if (state_.modifiers.testFlag(decreasedStepModifier)) {
                 deltaStep *= decreasedStepSize;
             }
             applyDragDelta(deltaStep);

--- a/resources/stylesheets/inviwo.qss
+++ b/resources/stylesheets/inviwo.qss
@@ -376,6 +376,7 @@ QPushButton:focus, QToolButton:focus {
 QLineEdit#ColorLineEdit[input="valid"] {
     border: 0.0625em solid #1a800d;
 }
+QLineEdit[invalid=true],
 QLineEdit#ColorLineEdit[input="invalid"] {
     border: 0.0625em solid #801717;
 }

--- a/resources/stylesheets/inviwo.qss
+++ b/resources/stylesheets/inviwo.qss
@@ -373,6 +373,9 @@ QPushButton:focus, QToolButton:focus {
     border: 0.0625em solid #268bd2;
 }
 
+QLineEdit#NumberWidget:!focus:!disabled {
+    background: #2a2a2d;
+}
 QLineEdit#ColorLineEdit[input="valid"] {
     border: 0.0625em solid #1a800d;
 }

--- a/resources/svgicons/arrow-right-enabled.svg
+++ b/resources/svgicons/arrow-right-enabled.svg
@@ -2,24 +2,23 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="13"
    height="13"
    viewBox="0 0 3.4395833 3.4395833"
    version="1.1"
    id="svg821"
-   sodipodi:docname="remove-small.svg"
+   sodipodi:docname="arrow-right-enabled.svg"
    inkscape:export-filename="P:\Documents\images\icons\inviwo\8x8\delete-small.png"
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs815" />
   <sodipodi:namedview
@@ -30,8 +29,8 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="26.326129"
-     inkscape:cx="-6.5091827"
-     inkscape:cy="5.9674199"
+     inkscape:cx="-6.5144405"
+     inkscape:cy="5.9826494"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
@@ -40,16 +39,22 @@
      fit-margin-left="0"
      fit-margin-right="0"
      fit-margin-bottom="0"
-     inkscape:window-width="1920"
-     inkscape:window-height="1137"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1">
+     inkscape:window-width="3200"
+     inkscape:window-height="1711"
+     inkscape:window-x="3591"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
        id="grid1917"
        originx="-0.2742147"
-       originy="0.26457829" />
+       originy="0.26457829"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <metadata
      id="metadata818">
@@ -59,7 +64,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -68,11 +73,6 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(-0.2742147,-293.82499)">
-    <path
-       id="path1943"
-       style="fill:none;fill-opacity:1;stroke:#999999;stroke-width:0.34448749;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 0,293.03125 -1.8520801,1.85208 m -1.3e-6,-1.85208 1.8520827,1.85208"
-       inkscape:connector-curvature="0" />
     <path
        style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#999999;stroke-width:0.39687499;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        d="m 1.3325513,296.83248 1.32291,-1.32291 -1.32291,-1.32292"

--- a/src/core/properties/cameraproperty.cpp
+++ b/src/core/properties/cameraproperty.cpp
@@ -75,18 +75,18 @@ CameraProperty::CameraProperty(std::string_view identifier, std::string_view dis
           "lookFrom", "Look from", "Position in world space of the camera"_help,
           []() { return vec3{}; }, [](const vec3&) {}, {-vec3(100.0f), ConstraintBehavior::Ignore},
           {vec3(100.0f), ConstraintBehavior::Ignore}, vec3(0.1f), InvalidationLevel::InvalidOutput,
-          PropertySemantics{"SphericalSpinBox"})
+          PropertySemantics{"Spherical"})
     , lookTo_(
           "lookTo", "Look to", "Focus point of the camera in world space"_help,
           []() { return vec3{}; }, [](const vec3&) {}, {-vec3(100.0f), ConstraintBehavior::Ignore},
           {vec3(100.0f), ConstraintBehavior::Ignore}, vec3(0.1f), InvalidationLevel::InvalidOutput,
-          PropertySemantics::SpinBox)
+          PropertySemantics::Default)
     , lookUp_(
           "lookUp", "Look up",
           "Up direction for the camera, should be orthogonal to lookTo - LookFrom"_help,
           []() { return vec3(1.0f, 1.0f, 1.0f); }, [](const vec3&) {},
           {-vec3(1.0f), ConstraintBehavior::Immutable}, {vec3(1.0f), ConstraintBehavior::Immutable},
-          vec3(0.1f), InvalidationLevel::InvalidOutput, PropertySemantics::SpinBox)
+          vec3(0.1f), InvalidationLevel::InvalidOutput, PropertySemantics::Default)
     , aspectRatio_(
           "aspectRatio", "Aspect Ratio",
           "Aspect ratio (width / height) of the camera viewport. This is automatically set "


### PR DESCRIPTION
Fixes
 * several issues related to the current `NumberLineEdit` like fixed decimals, out-of-sync state between UI and property, ...

Changes proposed in this PR:
 * new, simpler widget `NumberWidget` for editing numbers based on QLineEdit that is inspired by Blender's FloatWidgets
 * when not in focus, the values can be dragged or incremented/decremented
 * the widget also has prefix and suffix support
 * the input is validated on-the-fly and flagged when invalid 
![image](https://github.com/user-attachments/assets/9bfc1ad7-4d37-496a-85c2-1b53604bb628)
--- 

*CameraProperty with updated number widgets*
![image](https://github.com/user-attachments/assets/dcefb904-7db8-48c4-979c-39e02401275f)

--- 

*Value dragging & editing*
<video src='https://github.com/user-attachments/assets/cb14317f-2a7e-480e-beaa-fa7739702ea1' width=432/>



