### PR TITLE
Fix/webbrowser accelerated paint

### DIFF
--- a/modules/webbrowser/include/modules/webbrowser/renderhandlergl.h
+++ b/modules/webbrowser/include/modules/webbrowser/renderhandlergl.h
@@ -110,7 +110,7 @@ private:
     struct BrowserData {
         BrowserData() { texture2D.initialize(nullptr); }
         size2_t viewRect{1, 1};
-        Texture2D texture2D{size2_t{1, 1}, GL_BGRA, GL_RGBA, GL_UNSIGNED_BYTE, GL_NEAREST};
+        Texture2D texture2D{size2_t{1, 1}, GL_RGBA, GL_RGBA8, GL_UNSIGNED_BYTE, GL_NEAREST};
         CefRect popupRect;
         CefRect originalPopupRect;
         std::function<void(Texture2D&)> onRender;

--- a/modules/webbrowser/src/webbrowserutil.cpp
+++ b/modules/webbrowser/src/webbrowserutil.cpp
@@ -28,6 +28,7 @@
  *********************************************************************************/
 
 #include <modules/webbrowser/webbrowserutil.h>
+#include <modules/opengl/openglcapabilities.h> // for OpenGLCapabilities
 
 #include <tuple>  // for tuple
 #include <cmath>
@@ -47,7 +48,10 @@ std::tuple<CefWindowInfo, CefBrowserSettings> getDefaultBrowserSettings() {
 #endif
 
 #if defined(WIN32)
-    windowInfo.shared_texture_enabled = true;
+    if (OpenGLCapabilities::isExtensionSupported("EXT_external_objects_win32")) {
+        // RenderhandlerGL::OnAcceleratedPaint requires this extension for sharing textures
+        windowInfo.shared_texture_enabled = true;
+    }
 #endif
 
     CefBrowserSettings browserSettings;


### PR DESCRIPTION




Changes proposed in this PR:
 * Fixes Webbrowser OpenGL error on Intel cards.
 * Fix color issue due to incorrect texture format
 From 
![image](https://github.com/user-attachments/assets/1b27da04-1f28-458c-a1ab-8acca259c5ed)
To
![image](https://github.com/user-attachments/assets/7840c558-5344-43c4-b2c3-8d74a87930a9)


This has been tested on: Windows with Intel graphics card
