### PR TITLE
QtWidgets: NumberWidget minimum size hint

### DIFF
--- a/modules/qtwidgets/include/modules/qtwidgets/numberwidget.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/numberwidget.h
@@ -76,6 +76,10 @@ public:
     BaseNumberWidget& operator=(BaseNumberWidget&&) = delete;
     virtual ~BaseNumberWidget() = default;
 
+    virtual QSize sizeHint() const override;
+
+    virtual QSize minimumSizeHint() const override;
+
     void setPrefix(std::string_view prefix);
     const QString& getPrefix() const;
     void setPostfix(std::string_view postfix);
@@ -117,6 +121,7 @@ private:
     enum class FocusAction : std::uint8_t { SetFocus, ClearFocus };
     enum class HoverState : std::uint8_t { Invalid, Center, NegativeInc, PositiveInc };
 
+    QSize calcMinimumSize() const;
     void drawPercentageBar(QPainter& painter, const QRect& rect, bool hover) const;
     QString getPrefixedText() const;
     void updateState(FocusAction action);
@@ -136,6 +141,8 @@ private:
     InteractionState state_;
     NumberWidgetConfig::Interaction mode_;
     bool percentageBarVisible_;
+    mutable QSize cachedMinimumSizeHint_;
+    int minimumWidth_;
 
     static constexpr Qt::KeyboardModifier increasedStepModifier = Qt::ControlModifier;
     static constexpr Qt::KeyboardModifier decreasedStepModifier = Qt::ShiftModifier;

--- a/modules/qtwidgets/src/numberwidget.cpp
+++ b/modules/qtwidgets/src/numberwidget.cpp
@@ -50,7 +50,8 @@ BaseNumberWidget::BaseNumberWidget(const NumberWidgetConfig& config, QWidget* pa
     , prefix_{utilqt::toQString(config.prefix.value_or(NumberWidgetConfig::defaultPrefix))}
     , postfix_{utilqt::toQString(config.postfix.value_or(NumberWidgetConfig::defaultPostfix))}
     , mode_{config.interaction.value_or(NumberWidgetConfig::defaultInteraction)}
-    , percentageBarVisible_{config.barVisible.value_or(NumberWidgetConfig::defaultBarVisible)} {
+    , percentageBarVisible_{config.barVisible.value_or(NumberWidgetConfig::defaultBarVisible)}
+    , minimumWidth_{utilqt::emToPx(this, 4)} {
 
     setObjectName("NumberWidget");
     updateState(FocusAction::ClearFocus);
@@ -69,6 +70,29 @@ BaseNumberWidget::BaseNumberWidget(const NumberWidgetConfig& config, QWidget* pa
         style()->unpolish(this);
         style()->polish(this);
     });
+}
+
+QSize BaseNumberWidget::sizeHint() const {
+    if (cachedMinimumSizeHint_.isEmpty()) {
+        cachedMinimumSizeHint_ = calcMinimumSize();
+    }
+    return cachedMinimumSizeHint_;
+}
+
+QSize BaseNumberWidget::minimumSizeHint() const {
+    if (cachedMinimumSizeHint_.isEmpty()) {
+        cachedMinimumSizeHint_ = calcMinimumSize();
+    }
+    return cachedMinimumSizeHint_;
+}
+
+QSize BaseNumberWidget::calcMinimumSize() const {
+    ensurePolished();
+    QSize hint(minimumWidth_, QLineEdit::minimumSizeHint().height());
+    QStyleOptionFrame opt;
+    initStyleOption(&opt);
+
+    return style()->sizeFromContents(QStyle::CT_LineEdit, &opt, hint, this);
 }
 
 void BaseNumberWidget::setPrefix(std::string_view prefix) {

--- a/modules/qtwidgets/src/numberwidget.cpp
+++ b/modules/qtwidgets/src/numberwidget.cpp
@@ -88,7 +88,7 @@ QSize BaseNumberWidget::minimumSizeHint() const {
 
 QSize BaseNumberWidget::calcMinimumSize() const {
     ensurePolished();
-    QSize hint(minimumWidth_, QLineEdit::minimumSizeHint().height());
+    const QSize hint(minimumWidth_, QLineEdit::minimumSizeHint().height());
     QStyleOptionFrame opt;
     initStyleOption(&opt);
 


### PR DESCRIPTION
Fixes increased minimum width of PropertyWidget due to NumberWidget.

Changes proposed in this PR:
 * set minimum size hint of `NumberWidget`