### PR TITLE
Added bandaid fix to Surface Extraction

### DIFF
--- a/modules/base/include/modules/base/processors/surfaceextractionprocessor.h
+++ b/modules/base/include/modules/base/processors/surfaceextractionprocessor.h
@@ -33,6 +33,7 @@
 
 #include <inviwo/core/datastructures/geometry/mesh.h>  // for Mesh
 #include <inviwo/core/datastructures/volume/volume.h>  // for Volume
+#include <inviwo/core/datastructures/datasequence.h>   // for DataSequence
 #include <inviwo/core/ports/datainport.h>              // for DataInport
 #include <inviwo/core/ports/dataoutport.h>             // for DataOutport
 #include <inviwo/core/ports/outportiterable.h>         // for OutportIterable
@@ -97,6 +98,7 @@ protected:
 
     DataInport<Volume, 0, true> volume_;
     DataOutport<std::vector<std::shared_ptr<Mesh>>> outport_;
+    DataOutport<DataSequence<Mesh>> extraOutport_;
     std::vector<std::shared_ptr<Mesh>> meshes_;
 
     OptionProperty<Method> method_;

--- a/modules/base/src/processors/surfaceextractionprocessor.cpp
+++ b/modules/base/src/processors/surfaceextractionprocessor.cpp
@@ -94,6 +94,7 @@ SurfaceExtraction::SurfaceExtraction()
     : PoolProcessor(pool::Option::KeepOldResults | pool::Option::DelayDispatch)
     , volume_("volume")
     , outport_("mesh")
+    , extraOutport_("also_mesh")
     , method_("method", "Method",
               {{"marchingtetrahedron", "Marching Tetrahedron", Method::MarchingTetrahedron},
                {"marchingcubes", "Marching Cubes", Method::MarchingCubes},
@@ -106,6 +107,7 @@ SurfaceExtraction::SurfaceExtraction()
 
     addPort(volume_);
     addPort(outport_);
+    addPort(extraOutport_);
 
     addProperty(method_);
     addProperty(isoValue_);
@@ -198,6 +200,7 @@ void SurfaceExtraction::process() {
         dispatchMany(jobs, [this](std::vector<std::shared_ptr<Mesh>> result) {
             meshes_ = result;
             outport_.setData(std::make_shared<std::vector<std::shared_ptr<Mesh>>>(meshes_));
+            extraOutport_.setData(std::make_shared<DataSequence<Mesh>>(meshes_));
             newResults();
         });
     } else {  // Only update the modified ones
@@ -221,6 +224,7 @@ void SurfaceExtraction::process() {
                     meshes_[i] = result;
                 }
                 outport_.setData(std::make_shared<std::vector<std::shared_ptr<Mesh>>>(meshes_));
+                extraOutport_.setData(std::make_shared<DataSequence<Mesh>>(meshes_));
                 newResults();
             });
         }


### PR DESCRIPTION
Added extra outport featuring the new DataSequence data structure, to make it useable in Mesh Element Sequence Selector. Do with it what you will.

Band-aid for #1678 

Changes proposed in this PR:
 * Added complementary extra port featuring the new DataSequence data structure in the Surface Extraction Processor, in "surfaceextractionprocessor.cpp"
 * Made necessary changes in corresponding header file.
   * Also included header to DataSequence in the header.
 * Added lines to load the extra outport alongside the previous port.

This has been tested on: msvc-developer build preset

> Please remember to specify the environment this code been compiled and tested on:
> Windows 10 / MSVC v143 / Visual Studio / Qt 6.5.2 / CMake 4.0.0 / Python 3.11.9.
