### PR TITLE
Feature/port datasequence

### DIFF
--- a/include/inviwo/core/datastructures/datasequence.h
+++ b/include/inviwo/core/datastructures/datasequence.h
@@ -125,6 +125,10 @@ public:
 
     void erase(iterator pos) { data_.erase(pos.base()); }
     void erase(const_iterator begin, const_iterator end) { data_.erase(begin.base(), end.base()); }
+
+    void replace(iterator pos, std::shared_ptr<const Data> data) { *pos.base() = data; }
+    void replace(iterator pos, std::shared_ptr<Data> data) { *pos.base() = data; }
+
     void shrink_to_fit() { data_.shrink_to_fit(); }
 
     iterator begin() { return util::makeTransformIterator(getData, data_.begin()); }

--- a/include/inviwo/core/ports/outportiterable.h
+++ b/include/inviwo/core/ports/outportiterable.h
@@ -138,7 +138,7 @@ template <typename T>
 class OutportIterableWrapper {
 public:
     OutportIterableWrapper() : data_(nullptr) {}
-    OutportIterableWrapper(const DataOutport<T>& port) : data_{port.getData()} {}
+    explicit OutportIterableWrapper(const DataOutport<T>& port) : data_{port.getData()} {}
 
     std::shared_ptr<const T> get() { return data_; };
 
@@ -165,16 +165,19 @@ public:
 
     void inc() {
         ++iter_;
-        if (iter_ == iterEnd_) end_ = true;
+        if (iter_ == iterEnd_) {
+            end_ = true;
+        }
     };
 
     bool equal(const OutportIterableWrapper& rhs) const {
-        if (end_ && rhs.end_)
+        if (end_ && rhs.end_) {
             return true;
-        else if (end_ != rhs.end_)
+        } else if (end_ != rhs.end_) {
             return false;
-        else
+        } else {
             return iter_ == rhs.iter_;
+        }
     }
     bool end() const { return end_; }
 
@@ -201,16 +204,19 @@ public:
 
     void inc() {
         ++iter_;
-        if (iter_ == iterEnd_) end_ = true;
+        if (iter_ == iterEnd_) {
+            end_ = true;
+        }
     };
 
     bool equal(const OutportIterableWrapper& rhs) const {
-        if (end_ && rhs.end_)
+        if (end_ && rhs.end_) {
             return true;
-        else if (end_ != rhs.end_)
+        } else if (end_ != rhs.end_) {
             return false;
-        else
+        } else {
             return iter_ == rhs.iter_;
+        }
     }
 
     bool end() const { return end_; }
@@ -239,16 +245,19 @@ public:
 
     void inc() {
         ++iter_;
-        if (iter_ == iterEnd_) end_ = true;
+        if (iter_ == iterEnd_) {
+            end_ = true;
+        }
     };
 
     bool equal(const OutportIterableWrapper& rhs) const {
-        if (end_ && rhs.end_)
+        if (end_ && rhs.end_) {
             return true;
-        else if (end_ != rhs.end_)
+        } else if (end_ != rhs.end_) {
             return false;
-        else
+        } else {
             return iter_ == rhs.iter_;
+        }
     }
 
     bool end() const { return end_; }
@@ -277,16 +286,19 @@ public:
 
     void inc() {
         ++iter_;
-        if (iter_ == iterEnd_) end_ = true;
+        if (iter_ == iterEnd_) {
+            end_ = true;
+        }
     };
 
     bool equal(const OutportIterableWrapper& rhs) const {
-        if (end_ && rhs.end_)
+        if (end_ && rhs.end_) {
             return true;
-        else if (end_ != rhs.end_)
+        } else if (end_ != rhs.end_) {
             return false;
-        else
+        } else {
             return iter_ == rhs.iter_;
+        }
     }
 
     bool end() const { return end_; }
@@ -305,7 +317,7 @@ public:
     using Iter = typename DataSequence<T>::const_iterator;
 
     OutportIterableWrapper() : iter_(), iterEnd_(), end_(true) {}
-    OutportIterableWrapper(const DataOutport<DataSequence<T>>& port)
+    explicit OutportIterableWrapper(const DataOutport<DataSequence<T>>& port)
         : iter_{port.hasData() ? port.getData()->begin() : Iter{}}
         , iterEnd_{port.hasData() ? port.getData()->end() : Iter{}}
         , end_{iter_ == iterEnd_} {}
@@ -314,16 +326,19 @@ public:
 
     void inc() {
         ++iter_;
-        if (iter_ == iterEnd_) end_ = true;
+        if (iter_ == iterEnd_) {
+            end_ = true;
+        }
     };
 
     bool equal(const OutportIterableWrapper& rhs) const {
-        if (end_ && rhs.end_)
+        if (end_ && rhs.end_) {
             return true;
-        else if (end_ != rhs.end_)
+        } else if (end_ != rhs.end_) {
             return false;
-        else
+        } else {
             return iter_ == rhs.iter_;
+        }
     }
 
     bool end() const { return end_; }

--- a/modules/base/include/modules/base/processors/surfaceextractionprocessor.h
+++ b/modules/base/include/modules/base/processors/surfaceextractionprocessor.h
@@ -82,7 +82,7 @@ protected:
 
     DataInport<Volume, 0, true> volume_;
     DataOutport<DataSequence<Mesh>> outport_;
-    std::shared_ptr<DataSequence<Mesh>> meshes_;
+    std::vector<std::shared_ptr<Mesh>> meshes_;
 
     OptionProperty<Method> method_;
     FloatProperty isoValue_;

--- a/modules/base/include/modules/base/processors/surfaceextractionprocessor.h
+++ b/modules/base/include/modules/base/processors/surfaceextractionprocessor.h
@@ -33,6 +33,7 @@
 
 #include <inviwo/core/datastructures/geometry/mesh.h>  // for Mesh
 #include <inviwo/core/datastructures/volume/volume.h>  // for Volume
+#include <inviwo/core/datastructures/datasequence.h>   // for DataSequence
 #include <inviwo/core/ports/datainport.h>              // for DataInport
 #include <inviwo/core/ports/dataoutport.h>             // for DataOutport
 #include <inviwo/core/ports/outportiterable.h>         // for OutportIterable
@@ -50,29 +51,13 @@
 #include <memory>       // for shared_ptr
 #include <string>       // for operator==, operator+, string
 #include <string_view>  // for operator==
-#include <vector>       // for vector, operator!=, operator==
 
 #include <fmt/core.h>    // for format, format_to, basic_string_view
 #include <glm/fwd.hpp>   // for uvec3
 #include <glm/vec3.hpp>  // for operator+
 
 namespace inviwo {
-/** \docpage{org.inviwo.SurfaceExtraction, Surface Extraction}
- * ![](org.inviwo.SurfaceExtraction.png?classIdentifier=org.inviwo.SurfaceExtraction)
- *
- * ...
- *
- * ### Inports
- *   * __volume__ ...
- *
- * ### Outports
- *   * __mesh__ ...
- *
- * ### Properties
- *   * __ISO Value__ ...
- *   * __Triangle Color__ ...
- *
- */
+
 class IVW_MODULE_BASE_API SurfaceExtraction : public PoolProcessor {
 public:
     enum class Method {
@@ -96,8 +81,8 @@ protected:
     vec4 getColor(size_t i) const;
 
     DataInport<Volume, 0, true> volume_;
-    DataOutport<std::vector<std::shared_ptr<Mesh>>> outport_;
-    std::vector<std::shared_ptr<Mesh>> meshes_;
+    DataOutport<DataSequence<Mesh>> outport_;
+    std::shared_ptr<DataSequence<Mesh>> meshes_;
 
     OptionProperty<Method> method_;
     FloatProperty isoValue_;


### PR DESCRIPTION
Changes proposed in this PR:
 * `DataSequence<Data>` outports can be connected to multi-inports of type `Data`
 * the `Surface Extraction` processor now outputs a `DataSequence<Mesh>` instead of a `std::vector<std::shared_ptr<Mesh>>`

This has been tested on: lates MSVC

<img width='400px' src='https://github.com/user-attachments/assets/a1478021-4669-4848-b8f8-32847c23d22a'/>
