### PR TITLE
Feature/codeedit indent

### DIFF
--- a/include/inviwo/core/algorithm/easing.h
+++ b/include/inviwo/core/algorithm/easing.h
@@ -160,6 +160,7 @@ constexpr T ease(const T& x, Easing easing) {
                 case EasingMode::inOut:
                     return glm::quadraticEaseInOut(x);
             }
+            break;
         }
         case EasingType::cubic: {
             switch (easing.mode) {
@@ -170,6 +171,7 @@ constexpr T ease(const T& x, Easing easing) {
                 case EasingMode::inOut:
                     return glm::cubicEaseInOut(x);
             }
+            break;
         }
         case EasingType::quartic: {
             switch (easing.mode) {
@@ -180,6 +182,7 @@ constexpr T ease(const T& x, Easing easing) {
                 case EasingMode::inOut:
                     return glm::quarticEaseInOut(x);
             }
+            break;
         }
         case EasingType::quintic: {
             switch (easing.mode) {
@@ -190,6 +193,7 @@ constexpr T ease(const T& x, Easing easing) {
                 case EasingMode::inOut:
                     return glm::quinticEaseInOut(x);
             }
+            break;
         }
         case EasingType::sine: {
             switch (easing.mode) {
@@ -200,6 +204,7 @@ constexpr T ease(const T& x, Easing easing) {
                 case EasingMode::inOut:
                     return glm::sineEaseInOut(x);
             }
+            break;
         }
         case EasingType::circular: {
             switch (easing.mode) {
@@ -210,6 +215,7 @@ constexpr T ease(const T& x, Easing easing) {
                 case EasingMode::inOut:
                     return glm::circularEaseInOut(x);
             }
+            break;
         }
         case EasingType::exponential: {
             switch (easing.mode) {
@@ -220,6 +226,7 @@ constexpr T ease(const T& x, Easing easing) {
                 case EasingMode::inOut:
                     return glm::exponentialEaseInOut(x);
             }
+            break;
         }
         case EasingType::elastic: {
             switch (easing.mode) {
@@ -230,6 +237,7 @@ constexpr T ease(const T& x, Easing easing) {
                 case EasingMode::inOut:
                     return glm::elasticEaseInOut(x);
             }
+            break;
         }
         case EasingType::back: {
             switch (easing.mode) {
@@ -240,6 +248,7 @@ constexpr T ease(const T& x, Easing easing) {
                 case EasingMode::inOut:
                     return glm::backEaseInOut(x);
             }
+            break;
         }
         case EasingType::bounce: {
             switch (easing.mode) {
@@ -250,6 +259,7 @@ constexpr T ease(const T& x, Easing easing) {
                 case EasingMode::inOut:
                     return glm::bounceEaseInOut(x);
             }
+            break;
         }
     }
     throw Exception(SourceContext{}, "Got invalid Easing {}, {}", static_cast<int>(easing.mode),

--- a/modules/openglqt/include/modules/openglqt/glslsyntaxhighlight.h
+++ b/modules/openglqt/include/modules/openglqt/glslsyntaxhighlight.h
@@ -57,7 +57,7 @@ public:
     FloatVec4Property builtinFuncColor;
     FloatVec4Property commentColor;
     FloatVec4Property preProcessorColor;
-    FloatVec4Property litteralColor;
+    FloatVec4Property literalColor;
     FloatVec4Property constantColor;
     FloatVec4Property mainColor;
 };

--- a/modules/openglqt/src/glslsyntaxhighlight.cpp
+++ b/modules/openglqt/src/glslsyntaxhighlight.cpp
@@ -62,13 +62,13 @@ GLSLSyntaxHighlight::GLSLSyntaxHighlight()
     , builtinFuncColor("bultinFunc", "Built-in Function", util::ordinalColor(syntax::builtinFuncs))
     , commentColor("comment", "Comment", util::ordinalColor(syntax::comment))
     , preProcessorColor("preProcessor", "Pre-Processor", util::ordinalColor(syntax::preProcessor))
-    , litteralColor("literal", "String Literal", util::ordinalColor(syntax::literal))
+    , literalColor("literal", "String Literal", util::ordinalColor(syntax::literal))
     , constantColor("constants", "Constant", util::ordinalColor(syntax::constant))
     , mainColor("main", "Main Function", util::ordinalColor(syntax::main)) {
 
     addProperties(font, fontSize, textColor, backgroundColor, highLightColor, commentColor,
                   typeColor, keywordColor, builtinVarColor, builtinFuncColor, preProcessorColor,
-                  litteralColor, constantColor, mainColor);
+                  literalColor, constantColor, mainColor);
 
     load();
 }
@@ -319,9 +319,9 @@ std::vector<std::shared_ptr<std::function<void()>>> utilqt::setGLSLSyntaxHighlig
     mainformat.setBackground(bgColor);
     mainformat.setForeground(utilqt::toQColor(settings.mainColor));
 
-    QTextCharFormat litteralFormat;
-    litteralFormat.setBackground(bgColor);
-    litteralFormat.setForeground(utilqt::toQColor(settings.litteralColor));
+    QTextCharFormat literalFormat;
+    literalFormat.setBackground(bgColor);
+    literalFormat.setForeground(utilqt::toQColor(settings.literalColor));
 
     sh.clear();
 
@@ -343,7 +343,7 @@ std::vector<std::shared_ptr<std::function<void()>>> utilqt::setGLSLSyntaxHighlig
 
     sh.addPattern(constantsformat, "\\b([0-9]+\\.)?[0-9]+([eE][+-]?[0-9]+)?");
 
-    sh.addPattern(litteralFormat, R"("([^"\\]|\\.)*")");
+    sh.addPattern(literalFormat, R"("([^"\\]|\\.)*")");
 
     sh.addPattern(commentformat, "\\/\\/.*$");
     sh.addMultBlockPattern(commentformat, R"(/\*)"sv, R"(\*/)"sv);

--- a/modules/python3qt/include/modules/python3qt/pythonsyntaxhighlight.h
+++ b/modules/python3qt/include/modules/python3qt/pythonsyntaxhighlight.h
@@ -55,7 +55,7 @@ public:
     FloatVec4Property backgroundColor;
     FloatVec4Property highLightColor;
     FloatVec4Property keywordColor;
-    FloatVec4Property litteralColor;
+    FloatVec4Property literalColor;
     FloatVec4Property constantColor;
     FloatVec4Property commentColor;
 };

--- a/modules/python3qt/src/pythonsyntaxhighlight.cpp
+++ b/modules/python3qt/src/pythonsyntaxhighlight.cpp
@@ -56,11 +56,11 @@ PythonSyntaxHighlight::PythonSyntaxHighlight()
     , backgroundColor("background", "Background", util::ordinalColor(syntax::background))
     , highLightColor("highLight", "HighLight", util::ordinalColor(syntax::highLight))
     , keywordColor("type", "Type", util::ordinalColor(syntax::keyword))
-    , litteralColor("literal", "String Literal", util::ordinalColor(syntax::literal))
+    , literalColor("literal", "String Literal", util::ordinalColor(syntax::literal))
     , constantColor("constant", "Constant", util::ordinalColor(syntax::constant))
     , commentColor("comment", "Comment", util::ordinalColor(syntax::comment)) {
     addProperties(font, fontSize, textColor, backgroundColor, highLightColor, keywordColor,
-                  litteralColor, constantColor, commentColor);
+                  literalColor, constantColor, commentColor);
 
     load();
 }
@@ -96,9 +96,9 @@ std::vector<std::shared_ptr<std::function<void()>>> utilqt::setPythonSyntaxHighl
     commentformat.setBackground(bgColor);
     commentformat.setForeground(utilqt::toQColor(settings.commentColor));
 
-    QTextCharFormat litteralFormat;
-    litteralFormat.setBackground(bgColor);
-    litteralFormat.setForeground(utilqt::toQColor(settings.litteralColor));
+    QTextCharFormat literalFormat;
+    literalFormat.setBackground(bgColor);
+    literalFormat.setForeground(utilqt::toQColor(settings.literalColor));
 
     sh.clear();
 
@@ -110,12 +110,12 @@ std::vector<std::shared_ptr<std::function<void()>>> utilqt::setPythonSyntaxHighl
     sh.addWordBoundaryPattern(keywordformat, pythonKeywords);
     sh.addPattern(constantsformat, "\\b([0-9]+\\.)?[0-9]+([eE][+-]?[0-9]+)?");
 
-    sh.addPattern(litteralFormat, R"("([^"\\]|\\.)*")");
-    sh.addPattern(litteralFormat, R"('([^'\\]|\\.)*')");
+    sh.addPattern(literalFormat, R"("([^"\\]|\\.)*")");
+    sh.addPattern(literalFormat, R"('([^'\\]|\\.)*')");
 
     sh.addPattern(commentformat, "#.*$");
-    sh.addMultBlockPattern(litteralFormat, R"(""")"sv, R"(""")"sv);
-    sh.addMultBlockPattern(litteralFormat, R"(''')"sv, R"(''')"sv);
+    sh.addMultBlockPattern(literalFormat, R"(""")"sv, R"(""")"sv);
+    sh.addMultBlockPattern(literalFormat, R"(''')"sv, R"(''')"sv);
 
     sh.update();
 

--- a/modules/qtwidgets/include/modules/qtwidgets/codeedit.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/codeedit.h
@@ -51,11 +51,10 @@ class SyntaxHighlighter;
 
 class IVW_MODULE_QTWIDGETS_API CodeEdit : public QPlainTextEdit {
 public:
-    CodeEdit(QWidget* parent = nullptr);
+    explicit CodeEdit(QWidget* parent = nullptr);
     virtual ~CodeEdit() = default;
 
-    // QPlainTextEdit overrides
-    virtual void keyPressEvent(QKeyEvent* keyEvent) override;
+    virtual bool event(QEvent* event) override;
 
     void setLineAnnotation(std::function<std::string(int)>);
     void setLineAnnotationColor(std::function<vec4(int, vec4)>);
@@ -65,23 +64,25 @@ public:
 
 protected:
     void lineNumberAreaPaintEvent(QPaintEvent* event);
-    int lineNumberAreaWidth();
-
-    class LineNumberArea : public QWidget {
-    public:
-        LineNumberArea(CodeEdit* editor) : QWidget(editor) { codeEdit_ = editor; }
-        QSize sizeHint() const override { return QSize(codeEdit_->lineNumberAreaWidth(), 0); }
-
-    protected:
-        void paintEvent(QPaintEvent* event) override { codeEdit_->lineNumberAreaPaintEvent(event); }
-        CodeEdit* codeEdit_;
-    };
+    int lineNumberAreaWidth() const;
 
     void resizeEvent(QResizeEvent* event) override;
 
     void updateLineNumberAreaWidth(int newBlockCount);
     void highlightCurrentLine();
     void updateLineNumberArea(const QRect&, int);
+
+    class LineNumberArea : public QWidget {
+    public:
+        explicit LineNumberArea(CodeEdit* editor) : QWidget(editor) { codeEdit_ = editor; }
+        QSize sizeHint() const override { return QSize(codeEdit_->lineNumberAreaWidth(), 0); }
+
+    protected:
+        void paintEvent(QPaintEvent* event) override { codeEdit_->lineNumberAreaPaintEvent(event); }
+
+    private:
+        CodeEdit* codeEdit_;
+    };
 
     QWidget* lineNumberArea_;
     vec4 textColor_;

--- a/modules/qtwidgets/include/modules/qtwidgets/codeedit.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/codeedit.h
@@ -74,8 +74,8 @@ protected:
 
     class LineNumberArea : public QWidget {
     public:
-        explicit LineNumberArea(CodeEdit* editor) : QWidget(editor) { codeEdit_ = editor; }
-        QSize sizeHint() const override { return QSize(codeEdit_->lineNumberAreaWidth(), 0); }
+        explicit LineNumberArea(CodeEdit* editor) : QWidget(editor), codeEdit_{editor} {}
+        QSize sizeHint() const override { return {codeEdit_->lineNumberAreaWidth(), 0}; }
 
     protected:
         void paintEvent(QPaintEvent* event) override { codeEdit_->lineNumberAreaPaintEvent(event); }

--- a/modules/qtwidgets/src/codeedit.cpp
+++ b/modules/qtwidgets/src/codeedit.cpp
@@ -116,16 +116,139 @@ void CodeEdit::setAnnotationSpace(std::function<int(int)> func) {
 
 SyntaxHighlighter& CodeEdit::syntaxHighlighter() { return *sh_; }
 
-void CodeEdit::keyPressEvent(QKeyEvent* keyEvent) {
-    if (keyEvent->key() == Qt::Key_Tab) {
-        keyEvent->accept();
-        insertPlainText("    ");
+namespace detail {
+
+constexpr int singleIndent = 4;
+
+void addIndent(QTextCursor cursor) {
+    if (cursor.hasSelection()) {
+        const int start = cursor.position();
+        const int end = cursor.anchor();
+
+        cursor.setPosition(start, QTextCursor::MoveAnchor);
+        const int startBlock = cursor.block().blockNumber();
+        cursor.setPosition(end, QTextCursor::MoveAnchor);
+        const int endBlock = cursor.block().blockNumber();
+
+        const int lineCount = std::abs(endBlock - startBlock) + 1;
+        const QTextCursor::MoveOperation direction =
+            start < end ? QTextCursor::PreviousBlock : QTextCursor::NextBlock;
+
+        cursor.movePosition(QTextCursor::StartOfBlock);
+        for (int i = 0; i < lineCount; ++i) {
+            cursor.insertText(QString{" "}.repeated(singleIndent));
+            cursor.movePosition(direction);
+        }
+
+        // restore previous selection
+        if (start > end) {
+            cursor.setPosition(end + singleIndent, QTextCursor::MoveAnchor);
+            cursor.setPosition(start + singleIndent * lineCount, QTextCursor::KeepAnchor);
+        } else {
+            cursor.setPosition(end + singleIndent * lineCount, QTextCursor::MoveAnchor);
+            cursor.setPosition(start + singleIndent, QTextCursor::KeepAnchor);
+        }
     } else {
-        QPlainTextEdit::keyPressEvent(keyEvent);
+        cursor.insertText(QString{" "}.repeated(singleIndent));
     }
 }
 
-int CodeEdit::lineNumberAreaWidth() {
+int spacesToRemove(const QString& str) {
+    if (str.isEmpty()) return 0;
+    int spaces = 0;
+    while (str[spaces] == ' ' && spaces < singleIndent) {
+        ++spaces;
+    }
+    return spaces;
+}
+
+void removeIndent(QTextCursor cursor, QPlainTextEdit* parent) {
+    if (cursor.hasSelection()) {
+        const int start = cursor.position();
+        const int end = cursor.anchor();
+
+        // select entire lines based on the selection
+        if (start > end) {
+            cursor.setPosition(end);
+            cursor.movePosition(QTextCursor::StartOfBlock);
+            cursor.setPosition(start, QTextCursor::KeepAnchor);
+            cursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
+        } else {
+            cursor.setPosition(end);
+            cursor.movePosition(QTextCursor::EndOfBlock);
+            cursor.setPosition(start, QTextCursor::KeepAnchor);
+            cursor.movePosition(QTextCursor::StartOfBlock, QTextCursor::KeepAnchor);
+        }
+
+        // selectedText() contains paragraph separators U+2029 instead of line breaks
+        QStringList lines =
+            cursor.selectedText().replace(QChar{QChar::ParagraphSeparator}, "\n").split('\n');
+        const int removedFromFirstLine = !lines.empty() ? spacesToRemove(lines.front()) : 0;
+
+        int removedSpaces = 0;
+        // remove up to singleIndent spaces from the beginning of each line
+        for (auto& line : lines) {
+            int spaces = spacesToRemove(line);
+            line.remove(0, spaces);
+            removedSpaces += spaces;
+        }
+
+        cursor.insertText(lines.join('\n'));
+
+        // restore previous selection
+        if (start > end) {
+            cursor.setPosition(end - removedFromFirstLine, QTextCursor::MoveAnchor);
+            cursor.setPosition(start - removedSpaces, QTextCursor::KeepAnchor);
+        } else {
+            cursor.setPosition(end - removedSpaces, QTextCursor::MoveAnchor);
+            cursor.setPosition(start - removedFromFirstLine, QTextCursor::KeepAnchor);
+        }
+        // update visual selection in text editor
+        parent->setTextCursor(cursor);
+    } else {
+        const int start = cursor.position();
+        cursor.movePosition(QTextCursor::Left, QTextCursor::KeepAnchor, singleIndent);
+        const QString str = cursor.selectedText();
+        // determine the number of spaces to remove from the end of the string
+        int spaces = 0;
+        for (const auto& c : str | std::views::reverse) {
+            if (c != ' ') {
+                break;
+            }
+            ++spaces;
+        }
+        if (spaces > 0) {
+            cursor.setPosition(start - spaces, QTextCursor::KeepAnchor);
+            cursor.removeSelectedText();
+        }
+    }
+}
+
+}  // namespace detail
+
+bool CodeEdit::event(QEvent* event) {
+    // need to handle tab key events here, since QWidget moves the focus with Shift + Tab
+    if (event->type() == QEvent::KeyPress) {
+        auto* keyEvent = static_cast<QKeyEvent*>(event);
+        if (!(keyEvent->modifiers().testFlags(Qt::ControlModifier | Qt::AltModifier))) {
+            if (keyEvent->key() == Qt::Key_Backtab ||
+                (keyEvent->key() == Qt::Key_Tab &&
+                 keyEvent->modifiers().testFlag(Qt::ShiftModifier))) {
+                keyEvent->accept();
+                detail::removeIndent(textCursor(), this);
+                return true;
+            } else if (keyEvent->key() == Qt::Key_Tab) {
+                keyEvent->accept();
+                detail::addIndent(textCursor());
+                return true;
+            }
+        }
+    }
+
+    return QPlainTextEdit::event(event);
+}
+
+int CodeEdit::lineNumberAreaWidth() const {
     int digits = 1;
     int max = qMax(1, blockCount());
     while (max >= 10) {

--- a/modules/qtwidgets/src/codeedit.cpp
+++ b/modules/qtwidgets/src/codeedit.cpp
@@ -34,6 +34,7 @@
 #include <modules/qtwidgets/syntaxhighlighter.h>  // for SyntaxHighlighter, text
 
 #include <utility>  // for move
+#include <ranges>
 
 #include <QFont>            // for QFont
 #include <QFontMetrics>     // for QFontMetrics
@@ -188,7 +189,7 @@ void removeIndent(QTextCursor cursor, QPlainTextEdit* parent) {
         int removedSpaces = 0;
         // remove up to singleIndent spaces from the beginning of each line
         for (auto& line : lines) {
-            int spaces = spacesToRemove(line);
+            const int spaces = spacesToRemove(line);
             line.remove(0, spaces);
             removedSpaces += spaces;
         }
@@ -229,7 +230,7 @@ void removeIndent(QTextCursor cursor, QPlainTextEdit* parent) {
 bool CodeEdit::event(QEvent* event) {
     // need to handle tab key events here, since QWidget moves the focus with Shift + Tab
     if (event->type() == QEvent::KeyPress) {
-        auto* keyEvent = static_cast<QKeyEvent*>(event);
+        auto* keyEvent = dynamic_cast<QKeyEvent*>(event);
         if (!(keyEvent->modifiers().testFlags(Qt::ControlModifier | Qt::AltModifier))) {
             if (keyEvent->key() == Qt::Key_Backtab ||
                 (keyEvent->key() == Qt::Key_Tab &&

--- a/modules/webqt/include/inviwo/webqt/javascriptsyntaxhighlight.h
+++ b/modules/webqt/include/inviwo/webqt/javascriptsyntaxhighlight.h
@@ -56,7 +56,7 @@ public:
     FloatVec4Property backgroundColor;
     FloatVec4Property highLightColor;
     FloatVec4Property keywordColor;
-    FloatVec4Property litteralColor;
+    FloatVec4Property literalColor;
     FloatVec4Property constantColor;
     FloatVec4Property commentColor;
     FloatVec4Property typeColor;

--- a/modules/webqt/src/javascriptsyntaxhighlight.cpp
+++ b/modules/webqt/src/javascriptsyntaxhighlight.cpp
@@ -54,14 +54,14 @@ JavascriptSyntaxHighlight::JavascriptSyntaxHighlight()
     , backgroundColor("background", "Background", util::ordinalColor(syntax::background))
     , highLightColor("highLight", "HighLight", util::ordinalColor(syntax::highLight))
     , keywordColor("keyword", "Keyword", util::ordinalColor(syntax::keyword))
-    , litteralColor("literal", "String Literal", util::ordinalColor(syntax::literal))
+    , literalColor("literal", "String Literal", util::ordinalColor(syntax::literal))
     , constantColor("constant", "Constant", util::ordinalColor(syntax::constant))
     , commentColor("comment", "Comment", util::ordinalColor(syntax::comment))
     , typeColor{"type", "type", util::ordinalColor(syntax::type)}
     , functionColor{"function", "Function", util::ordinalColor(syntax::builtinFuncs)}
     , functionCallColor{"functionCall", "Function Call", util::ordinalColor(syntax::builtinFuncs)} {
     addProperties(font, fontSize, textColor, backgroundColor, highLightColor, keywordColor,
-                  litteralColor, constantColor, commentColor, typeColor, functionColor,
+                  literalColor, constantColor, commentColor, typeColor, functionColor,
                   functionCallColor);
 
     load();
@@ -109,9 +109,9 @@ std::vector<std::shared_ptr<std::function<void()>>> setJavascriptSyntaxHighlight
     commentformat.setBackground(bgColor);
     commentformat.setForeground(utilqt::toQColor(settings.commentColor));
 
-    QTextCharFormat litteralFormat;
-    litteralFormat.setBackground(bgColor);
-    litteralFormat.setForeground(utilqt::toQColor(settings.litteralColor));
+    QTextCharFormat literalFormat;
+    literalFormat.setBackground(bgColor);
+    literalFormat.setForeground(utilqt::toQColor(settings.literalColor));
 
     QTextCharFormat typeFormat;
     typeFormat.setBackground(bgColor);
@@ -142,7 +142,7 @@ std::vector<std::shared_ptr<std::function<void()>>> setJavascriptSyntaxHighlight
     sh.addPattern(commentformat, "//[^\n]*");
     sh.addPattern(commentformat, "/\\*.*?\\*/");
 
-    sh.addPattern(litteralFormat, R"(".*?"|'.*?'|`.*?`)");
+    sh.addPattern(literalFormat, R"(".*?"|'.*?'|`.*?`)");
 
     sh.update();
 


### PR DESCRIPTION
Changes proposed in this PR:
* refactored indentation in `CodeEdit`
 * indent for current selection can be added (tab) or removed (shift+tab)
