### PR TITLE
Core: case insensitive find

### DIFF
--- a/include/inviwo/core/util/stringconversion.h
+++ b/include/inviwo/core/util/stringconversion.h
@@ -431,6 +431,39 @@ private:
     }
 };
 
+namespace util {
+
+/**
+ * @brief Finds the first substring equal to @p s in @p str using case insensitive comparisons.
+ *
+ * @param str  input string
+ * @param s    string to search for
+ * @return position of the first character of the found substring, std::string_view::npos otherwise
+ */
+constexpr size_t iCaseFind(std::string_view str, std::string_view s) {
+    if (str.empty() && s.empty()) return 0;
+    if (s.size() > str.size()) return std::string_view::npos;
+    size_t p = 0;
+    while (p < str.size()) {
+        if (iCaseCmp(str.substr(p, s.size()), s)) return p;
+        ++p;
+    }
+    return std::string_view::npos;
+}
+
+/**
+ * @brief Checks if @p str contains the substring @p s in @p str using case insensitive comparisons.
+ *
+ * @param str  input string
+ * @param s    string to search for
+ * @return True if substring is found
+ */
+constexpr bool iCaseContains(std::string_view str, std::string_view s) {
+    return iCaseFind(str, s) != std::string_view::npos;
+}
+
+}  // namespace util
+
 [[deprecated("use util::parseTypeIdName() in demangle.h instead")]] IVW_CORE_API std::string
 parseTypeIdName(const char* name);
 

--- a/include/inviwo/core/util/stringconversion.h
+++ b/include/inviwo/core/util/stringconversion.h
@@ -40,6 +40,7 @@
 #include <sstream>
 #include <vector>
 #include <functional>
+#include <ranges>
 #include <cctype>
 #include <locale>
 
@@ -287,6 +288,35 @@ constexpr std::string_view rtrim(std::string_view str) noexcept {
 }
 
 /**
+ * @brief Finds the first substring equal to @p s in @p str using case insensitive comparisons.
+ *
+ * @param str  input string
+ * @param s    string to search for
+ * @return position of the first character of the found substring, std::string_view::npos otherwise
+ */
+constexpr size_t iCaseFind(std::string_view str, std::string_view substring) {
+    if (str.empty() && substring.empty()) return 0;
+    if (auto found = std::ranges::search(
+            str, substring, {}, [](unsigned char c) { return std::tolower(c); },
+            [](unsigned char c) { return std::tolower(c); });
+        !found.empty()) {
+        return static_cast<size_t>(std::distance(str.begin(), found.begin()));
+    }
+    return std::string_view::npos;
+}
+
+/**
+ * @brief Checks if @p str contains the substring @p s in @p str using case insensitive comparisons.
+ *
+ * @param str  input string
+ * @param s    string to search for
+ * @return True if substring is found
+ */
+constexpr bool iCaseContains(std::string_view str, std::string_view s) {
+    return iCaseFind(str, s) != std::string_view::npos;
+}
+
+/**
  * \brief Checks if provided string ends with suffix using case insensitive equal comparison.
  * @param str string to check last part of. Allowed to be smaller than suffix.
  * @param suffix Ending to match.
@@ -430,39 +460,6 @@ private:
         }
     }
 };
-
-namespace util {
-
-/**
- * @brief Finds the first substring equal to @p s in @p str using case insensitive comparisons.
- *
- * @param str  input string
- * @param s    string to search for
- * @return position of the first character of the found substring, std::string_view::npos otherwise
- */
-constexpr size_t iCaseFind(std::string_view str, std::string_view s) {
-    if (str.empty() && s.empty()) return 0;
-    if (s.size() > str.size()) return std::string_view::npos;
-    size_t p = 0;
-    while (p < str.size()) {
-        if (iCaseCmp(str.substr(p, s.size()), s)) return p;
-        ++p;
-    }
-    return std::string_view::npos;
-}
-
-/**
- * @brief Checks if @p str contains the substring @p s in @p str using case insensitive comparisons.
- *
- * @param str  input string
- * @param s    string to search for
- * @return True if substring is found
- */
-constexpr bool iCaseContains(std::string_view str, std::string_view s) {
-    return iCaseFind(str, s) != std::string_view::npos;
-}
-
-}  // namespace util
 
 [[deprecated("use util::parseTypeIdName() in demangle.h instead")]] IVW_CORE_API std::string
 parseTypeIdName(const char* name);

--- a/src/core/tests/unittests/stringconversion-test.cpp
+++ b/src/core/tests/unittests/stringconversion-test.cpp
@@ -140,4 +140,16 @@ TEST(StringView, trim) {
     EXPECT_EQ("a"sv, util::trim("  \r a  \r"sv));
 }
 
+TEST(StringView, iCaseContains) {
+    EXPECT_TRUE(util::iCaseContains("", ""));
+    EXPECT_FALSE(util::iCaseContains("fo", "OOB"));
+
+    EXPECT_TRUE(util::iCaseContains("foobar", "OOB"));
+    EXPECT_TRUE(util::iCaseContains("foobar", "oob"));
+    EXPECT_FALSE(util::iCaseContains("foobar", "FoOO"));
+    EXPECT_TRUE(util::iCaseContains("foobar", "FoOB"));
+    EXPECT_FALSE(util::iCaseContains("foo bar", "oob"));
+    EXPECT_FALSE(util::iCaseContains("foo bar", "OOB"));
+}
+
 }  // namespace inviwo

--- a/src/core/tests/unittests/stringconversion-test.cpp
+++ b/src/core/tests/unittests/stringconversion-test.cpp
@@ -140,6 +140,19 @@ TEST(StringView, trim) {
     EXPECT_EQ("a"sv, util::trim("  \r a  \r"sv));
 }
 
+TEST(StringView, iCaseFind) {
+    EXPECT_EQ(util::iCaseFind("", ""), 0);
+    EXPECT_EQ(util::iCaseFind("fo", "OOB"), std::string_view::npos);
+
+    EXPECT_EQ(util::iCaseFind("foobar", "OOB"), 1);
+    EXPECT_EQ(util::iCaseFind("foobar", "oob"), 1);
+    EXPECT_EQ(util::iCaseFind("foobar", "FoOO"), std::string_view::npos);
+    EXPECT_EQ(util::iCaseFind("foobar", "FoOB"), 0);
+    EXPECT_EQ(util::iCaseFind("foobar", "bAr"), 3);
+    EXPECT_EQ(util::iCaseFind("foo bar", "oob"), std::string_view::npos);
+    EXPECT_EQ(util::iCaseFind("foo bar", "OOB"), std::string_view::npos);
+}
+
 TEST(StringView, iCaseContains) {
     EXPECT_TRUE(util::iCaseContains("", ""));
     EXPECT_FALSE(util::iCaseContains("fo", "OOB"));


### PR DESCRIPTION
Changes proposed in this PR:
 * added case insensitive `util::iCaseFind()` and `util::iCaseContains()` for std::string_view