### PR TITLE
OpactOpt: Fix linking error on Linux/Mac

### DIFF
--- a/modules/opactopt/include/modules/opactopt/processors/directopacityoptimisation.h
+++ b/modules/opactopt/include/modules/opactopt/processors/directopacityoptimisation.h
@@ -152,7 +152,7 @@ protected:
 
     Texture1D gaussianKernel_;
     BoolCompositeProperty smoothing_;
-    static const int gaussianKernelMaxRadius_ = 50;
+    static const int gaussianKernelMaxRadius_;
     IntProperty gaussianRadius_;
     FloatProperty gaussianSigma_;
     bool gaussianKernelInitialized_ = false;

--- a/modules/opactopt/src/processors/directopacityoptimisation.cpp
+++ b/modules/opactopt/src/processors/directopacityoptimisation.cpp
@@ -54,6 +54,8 @@
 
 namespace inviwo {
 
+const int OpacityOptimisation::gaussianKernelMaxRadius_ = 50;
+
 const ProcessorInfo OpacityOptimisation::processorInfo_{
     "org.inviwo.OpacityOptimisation",  // Class identifier
     "Opacity Optimisation",            // Display name


### PR DESCRIPTION
I noticed there was a linking error on Linux/Mac during the the integration tests. This should fix it.