### PR TITLE
Core/Various: deprecate Mesh::getNumberOfIndicies in favor of Mesh::g…

### DIFF
--- a/include/inviwo/core/datastructures/geometry/mesh.h
+++ b/include/inviwo/core/datastructures/geometry/mesh.h
@@ -262,7 +262,13 @@ public:
     MeshInfo getIndexMeshInfo(size_t idx) const;
 
     size_t getNumberOfBuffers() const;
+
+    // clang-format off
+    [[deprecated("Mesh::getNumberOfIndicies is deprecated, use getNumberOfIndices (deprecated since 2025-10-04)")]]
     size_t getNumberOfIndicies() const;
+    // clang-format on
+
+    size_t getNumberOfIndices() const;
 
     /**
      * \brief Append another mesh to this mesh

--- a/modules/base/src/properties/meshinformationproperty.cpp
+++ b/modules/base/src/properties/meshinformationproperty.cpp
@@ -216,7 +216,7 @@ void MeshInformationProperty::updateForNewMesh(const Mesh& mesh) {
     const auto numBuffers = mesh.getNumberOfBuffers();
 
     numBuffers_.set(numBuffers);
-    numIndexBuffers_.set(mesh.getNumberOfIndicies());
+    numIndexBuffers_.set(mesh.getNumberOfIndices());
 
     // transformations
     modelTransform_.set(mesh.getModelMatrix());
@@ -247,7 +247,7 @@ void MeshInformationProperty::updateForNewMesh(const Mesh& mesh) {
 
     // update buffer information
     detail::allocateBufferProps<MeshBufferInformationProperty>(&buffers_, "meshbuffer", numBuffers);
-    const auto numIndexBuffers = std::min(mesh.getNumberOfIndicies(), maxShownIndexBuffers_);
+    const auto numIndexBuffers = std::min(mesh.getNumberOfIndices(), maxShownIndexBuffers_);
     detail::allocateBufferProps<IndexBufferInformationProperty>(&indexBuffers_, "indexbuffer",
                                                                 numIndexBuffers);
 

--- a/modules/base/tests/unittests/marchingcubes-test.cpp
+++ b/modules/base/tests/unittests/marchingcubes-test.cpp
@@ -276,8 +276,8 @@ TEST(Marchingcubes, minimal) {
 
     EXPECT_EQ(data1, data2);
 
-    ASSERT_EQ(mesh1->getNumberOfIndicies(), 1);
-    ASSERT_EQ(mesh2->getNumberOfIndicies(), 1);
+    ASSERT_EQ(mesh1->getNumberOfIndices(), 1);
+    ASSERT_EQ(mesh2->getNumberOfIndices(), 1);
 
     auto indBuffer1 = mesh1->getIndices(0);
     auto indBuffer2 = mesh2->getIndices(0);
@@ -322,8 +322,8 @@ TEST(Marchingcubes, sphere) {
     EXPECT_EQ(data1, data2);  the order are not the same...
     */
 
-    ASSERT_EQ(mesh1->getNumberOfIndicies(), 1);
-    ASSERT_EQ(mesh2->getNumberOfIndicies(), 1);
+    ASSERT_EQ(mesh1->getNumberOfIndices(), 1);
+    ASSERT_EQ(mesh2->getNumberOfIndices(), 1);
 
     /*
     auto indBuffer1 = mesh1->getIndices(0);

--- a/modules/basegl/src/processors/embeddedvolumeslice.cpp
+++ b/modules/basegl/src/processors/embeddedvolumeslice.cpp
@@ -145,7 +145,7 @@ void EmbeddedVolumeSlice::planeSettingsChanged() {
         embeddedMesh_.getEditableVertices()->getEditableRAMRepresentation()->getDataContainer();
     intersections.clear();
 
-    if (embeddedMesh_.getNumberOfIndicies() == 0) {
+    if (embeddedMesh_.getNumberOfIndices() == 0) {
         embeddedMesh_.addIndexBuffer(DrawType::Triangles, ConnectivityType::None);
     }
 

--- a/modules/basegl/src/processors/tuberendering.cpp
+++ b/modules/basegl/src/processors/tuberendering.cpp
@@ -163,8 +163,8 @@ void TubeRendering::process() {
     };
 
     const auto hasAnyLine = [](const Mesh& mesh, auto test) {
-        if (mesh.getNumberOfIndicies() > 0) {
-            for (size_t i = 0; i < mesh.getNumberOfIndicies(); ++i) {
+        if (mesh.getNumberOfIndices() > 0) {
+            for (size_t i = 0; i < mesh.getNumberOfIndices(); ++i) {
                 if (test(mesh.getIndexMeshInfo(i))) return true;
             }
         } else {
@@ -189,8 +189,8 @@ void TubeRendering::process() {
         MeshDrawerGL::DrawObject drawer(mesh.getRepresentation<MeshGL>(),
                                         mesh.getDefaultMeshInfo());
         utilgl::setShaderUniforms(shader, mesh, "geometry");
-        if (mesh.getNumberOfIndicies() > 0) {
-            for (size_t i = 0; i < mesh.getNumberOfIndicies(); ++i) {
+        if (mesh.getNumberOfIndices() > 0) {
+            for (size_t i = 0; i < mesh.getNumberOfIndices(); ++i) {
                 const auto mi = mesh.getIndexMeshInfo(i);
                 if (test(mi)) {
                     drawer.draw(i);

--- a/modules/basegl/src/rendering/linerenderer.cpp
+++ b/modules/basegl/src/rendering/linerenderer.cpp
@@ -147,8 +147,8 @@ void LineRenderer::render(const Mesh& mesh, const Camera& camera, size2_t screen
     }
 
     MeshDrawerGL::DrawObject drawer(mesh.getRepresentation<MeshGL>(), mesh.getDefaultMeshInfo());
-    if (mesh.getNumberOfIndicies() > 0) {
-        for (size_t i = 0; i < mesh.getNumberOfIndicies(); ++i) {
+    if (mesh.getNumberOfIndices() > 0) {
+        for (size_t i = 0; i < mesh.getNumberOfIndices(); ++i) {
             if (mesh.getIndexMeshInfo(i).dt != DrawType::Lines) continue;
             auto& shader = lineShaders_.getShader(mesh, mesh.getIndexMeshInfo(i));
             shader.activate();

--- a/modules/oit/src/processors/linerasterizer.cpp
+++ b/modules/oit/src/processors/linerasterizer.cpp
@@ -208,8 +208,8 @@ void LineRasterizer::rasterize(const ivec2& imageSize, const mat4& worldMatrixTr
         auto transform = CompositeTransform{mesh->getModelMatrix(),
                                             mesh->getWorldMatrix() * worldMatrixTransform};
 
-        if (mesh->getNumberOfIndicies() > 0) {
-            for (size_t i = 0; i < mesh->getNumberOfIndicies(); ++i) {
+        if (mesh->getNumberOfIndices() > 0) {
+            for (size_t i = 0; i < mesh->getNumberOfIndices(); ++i) {
                 if (mesh->getIndexMeshInfo(i).dt != DrawType::Lines) continue;
 
                 auto& shader = lineShaders_.getShader(*mesh, mesh->getIndexMeshInfo(i));

--- a/modules/python3/bindings/src/pymesh.cpp
+++ b/modules/python3/bindings/src/pymesh.cpp
@@ -147,11 +147,11 @@ void exposeMesh(pybind11::module& m) {
             }
             ossBuffers << ">";
 
-            if (self.getNumberOfIndicies() > 0) {
+            if (self.getNumberOfIndices() > 0) {
                 const size_t maxLines = 10;
-                const size_t numIndexBuffers = self.getNumberOfIndicies();
+                const size_t numIndexBuffers = self.getNumberOfIndices();
 
-                ossBuffers << "\n  <Indexbuffers (" << self.getNumberOfIndicies() << ")";
+                ossBuffers << "\n  <Indexbuffers (" << self.getNumberOfIndices() << ")";
                 size_t line = 0;
                 for (const auto& elem : self.getIndexBuffers()) {
                     ossBuffers << "\n    " << elem.first.dt << ", " << elem.first.ct << " ("

--- a/src/core/datastructures/geometry/mesh.cpp
+++ b/src/core/datastructures/geometry/mesh.cpp
@@ -349,6 +349,8 @@ size_t Mesh::getNumberOfBuffers() const { return buffers_.size(); }
 
 size_t Mesh::getNumberOfIndicies() const { return indices_.size(); }
 
+size_t Mesh::getNumberOfIndices() const { return indices_.size(); }
+
 void Mesh::append(const Mesh& mesh) {
     if (buffers_.size() != mesh.buffers_.size()) {
         throw Exception("Mismatched meshed, number of buffer does not match");

--- a/src/core/tests/unittests/typedmesh-test.cpp
+++ b/src/core/tests/unittests/typedmesh-test.cpp
@@ -49,7 +49,7 @@ bool operator==(const TypedMesh<BufferTraits...>& a, const TypedMesh<BufferTrait
         return false;
     }
     if ((a.getNumberOfBuffers() != b.getNumberOfBuffers()) ||
-        (a.getNumberOfIndicies() != b.getNumberOfIndicies())) {
+        (a.getNumberOfIndices() != b.getNumberOfIndices())) {
         return false;
     }
     auto compareBuffers = [](const auto& buffersA, const auto& buffersB) {


### PR DESCRIPTION
…etNumberOfIndices

Fixes #...

Changes proposed in this PR:
 * ...
 * ...
 * ...

This has been tested on: ...

> Thank you for contributing to the Inviwo repository! Please ensure the following: 
> - Code is error and warning free
> - Code follows the Inviwo coding guidelines: 
>   https://github.com/inviwo/inviwo/wiki/Coding-Conventions
> - New Code / Processors follows the Inviwo documentation guidelines: 
>   https://github.com/inviwo/inviwo/wiki/Documentation-guide
> - New Code / processors are tested in a unittest and / or regression test: 
>   https://github.com/inviwo/inviwo/wiki/Manual#testing
> 
> Please remember to specify the environment this code been compiled and tested on:
> Operating System / Compiler / IDE / QT / CMake / Python versions.
