### PR TITLE
OpactOpt: shader define fix and refactoring

### DIFF
--- a/modules/opactopt/glsl/opactopt/line/approxblending.frag
+++ b/modules/opactopt/glsl/opactopt/line/approxblending.frag
@@ -135,9 +135,7 @@ void main() {
     }
 
     gi *= alphamul;
-
-    // Project importance
-    float alpha = projectImportance(gi, depth, importanceSumCoeffs[0], N_IMPORTANCE_SUM_COEFFICIENTS);
+    float alpha = approximateAlpha(gi, depth, importanceSumCoeffs[0], N_IMPORTANCE_SUM_COEFFICIENTS);
 
     vec4 c = fragment.color;
 

--- a/modules/opactopt/glsl/opactopt/line/approximportancesum.frag
+++ b/modules/opactopt/glsl/opactopt/line/approximportancesum.frag
@@ -135,9 +135,7 @@ void main() {
     }
 
     gi *= alphamul;
-
-    // Project importance
-    float alpha = projectImportance(gi, depth, importanceSumCoeffs[0], N_IMPORTANCE_SUM_COEFFICIENTS);
+    float alpha = approximateAlpha(gi, depth, importanceSumCoeffs[0], N_IMPORTANCE_SUM_COEFFICIENTS);
 
     project(opticalDepthCoeffs, N_OPTICAL_DEPTH_COEFFICIENTS, depth, -log(1 - alpha));
 

--- a/modules/opactopt/glsl/opactopt/mesh/approxblending.frag
+++ b/modules/opactopt/glsl/opactopt/mesh/approxblending.frag
@@ -74,8 +74,7 @@ void main() {
     float gi = color_.a;
 #endif
 
-    // find alpha
-    float alpha = projectImportance(gi, depth, importanceSumCoeffs[0], N_IMPORTANCE_SUM_COEFFICIENTS);
+    float alpha = approximateAlpha(gi, depth, importanceSumCoeffs[0], N_IMPORTANCE_SUM_COEFFICIENTS);
 
     // find optical depth
     float taud = approximate(opticalDepthCoeffs, N_OPTICAL_DEPTH_COEFFICIENTS, depth);

--- a/modules/opactopt/glsl/opactopt/mesh/approximportancesum.frag
+++ b/modules/opactopt/glsl/opactopt/mesh/approximportancesum.frag
@@ -63,8 +63,7 @@ void main() {
     float gi = color_.a;
 #endif
 
-    // Project importance
-    float alpha = projectImportance(gi, depth, importanceSumCoeffs[0], N_IMPORTANCE_SUM_COEFFICIENTS);
+    float alpha = approximateAlpha(gi, depth, importanceSumCoeffs[0], N_IMPORTANCE_SUM_COEFFICIENTS);
 
     project(opticalDepthCoeffs, N_OPTICAL_DEPTH_COEFFICIENTS, depth, -log(1 - alpha));
 

--- a/modules/opactopt/glsl/opactopt/point/approxblending.frag
+++ b/modules/opactopt/glsl/opactopt/point/approxblending.frag
@@ -72,8 +72,7 @@ void main() {
     float gi = fragment.color.a;
 #endif
 
-    // find alpha
-    float alpha = projectImportance(gi, depth, importanceSumCoeffs[0], N_IMPORTANCE_SUM_COEFFICIENTS);
+    float alpha = approximateAlpha(gi, depth, importanceSumCoeffs[0], N_IMPORTANCE_SUM_COEFFICIENTS);
 
     // calculate normal from texture coordinates
     vec3 normal;

--- a/modules/opactopt/glsl/opactopt/point/approximportancesum.frag
+++ b/modules/opactopt/glsl/opactopt/point/approximportancesum.frag
@@ -79,8 +79,7 @@ void main() {
     float gi = fragment.color.a;
 #endif
 
-    // Project importance
-    float alpha = projectImportance(gi, depth, importanceSumCoeffs[0], N_IMPORTANCE_SUM_COEFFICIENTS);
+    float alpha = approximateAlpha(gi, depth, importanceSumCoeffs[0], N_IMPORTANCE_SUM_COEFFICIENTS);
 
     float glyphRadius = pointSize * 0.5;
     rad *= pointSize * 0.5 + borderWidth;


### PR DESCRIPTION
Fix
- Shaders not compiling when not using importance volume, wrap `importance()` in define

Refactor
- Use `textureToIndex` matrix for volume sampling in `importance()`
- Rename `projectImportance`->`approximateAlpha`
- Remove commented out `#ifdef`