### PR TITLE
OpactOpt: line renderer working again

### DIFF
--- a/modules/opactopt/include/modules/opactopt/processors/directopacityoptimization.h
+++ b/modules/opactopt/include/modules/opactopt/processors/directopacityoptimization.h
@@ -93,9 +93,11 @@ protected:
         std::optional<TextureUnit> momentSettings;
     };
 
+    enum Pass { ProjectImportance = 0, ApproximateImportance = 1, ApproximateBlending = 2 };
+
     void setUniforms(Shader& shader, Units& units);
     void buildShaders();
-    void renderGeometry(int pass, Units& units);
+    void renderGeometry(const Pass pass, Units& units);
     static void resizeTexture(Texture2DArray& texture, size2_t size, size_t depth);
     void resizeImportanceSumTextures(size2_t screenSize, size_t importanceSumCoefficients);
     void resizeOpticalDepthTexture(size2_t screenSize, size_t opticalDepthCoefficients);

--- a/modules/opactopt/src/processors/directopacityoptimization.cpp
+++ b/modules/opactopt/src/processors/directopacityoptimization.cpp
@@ -602,7 +602,7 @@ void OpacityOptimization::renderGeometry(const int pass, Units& units) {
     lineAdjacencyShaders_[pass].activate();
     lineSettings(lineAdjacencyShaders_[pass]);
     draw(lineAdjacencyShaders_[pass], [](const Mesh::MeshInfo& mi) {
-        return mi.dt == DrawType::Lines && mi.ct == ConnectivityType::Adjacency;
+        return mi.dt == DrawType::Lines && (mi.ct == ConnectivityType::Adjacency || mi.ct == ConnectivityType::StripAdjacency);
     });
 
     // Points


### PR DESCRIPTION
After the latest refactoring the line renderer stopped working, here is the fix