### PR TITLE
OpactOpt: Always use normalised blending, fix blending

### DIFF
--- a/modules/opactopt/glsl/opactopt/normalise.frag
+++ b/modules/opactopt/glsl/opactopt/normalise.frag
@@ -60,10 +60,8 @@ void main(void) {
     vec4 imageColorValue = texelFetch(imageColor, ivec2(gl_FragCoord.xy), 0);
     float imageDepthValue = texelFetch(imageDepth, ivec2(gl_FragCoord.xy), 0).x;
 
-#ifdef NORMALISE
     // divide by normalization weight
     if (imageColorValue.a != 0.0) imageColorValue.rgb /= imageColorValue.a;  
-#endif
 
     // set alpha using optical depth
     float tauall = total(opticalDepthCoeffs, N_OPTICAL_DEPTH_COEFFICIENTS);
@@ -76,15 +74,14 @@ void main(void) {
     float bgDepthValue = texelFetch(bgDepth, ivec2(gl_FragCoord.xy), 0).x;
 
     vec4 color = imageDepthValue < bgDepthValue ?
-                    premultipliedAlphaBlend(imageColorValue, bgColorValue) :
-                    premultipliedAlphaBlend(bgColorValue, imageColorValue);
+                    alphaBlend(imageColorValue, bgColorValue) :
+                    alphaBlend(bgColorValue, imageColorValue);
 
     if (bgDepthValue < imageDepthValue) {
         picking = texelFetch(bgPicking, ivec2(gl_FragCoord.xy), 0);
     }
 
     float depth = min(imageDepthValue, bgDepthValue);
-
 #else
     float depth = imageDepthValue;
     vec4 color = imageColorValue;

--- a/modules/opactopt/include/modules/opactopt/processors/directopacityoptimization.h
+++ b/modules/opactopt/include/modules/opactopt/processors/directopacityoptimization.h
@@ -158,7 +158,6 @@ protected:
     OptionProperty<Type> approximationMethod_;
     IntProperty importanceSumCoefficients_;
     IntProperty opticalDepthCoefficients_;
-    BoolProperty normalizedBlending_;
     FloatProperty coeffTexFixedPointFactor_;
 
     GLFormat imageFormat_;

--- a/modules/opactopt/src/processors/directopacityoptimization.cpp
+++ b/modules/opactopt/src/processors/directopacityoptimization.cpp
@@ -184,10 +184,6 @@ OpacityOptimization::OpacityOptimization()
                                                ConstraintBehavior::Immutable),
                                 approximations::get(approximationMethod_).inc,
                                 InvalidationLevel::InvalidResources}
-    , normalizedBlending_{"normalizedBlending", "Normalized blending",
-                          "Normalize the approximate blending, "
-                          "this reduces over- and under-saturation"_help,
-                          true, InvalidationLevel::InvalidResources}
     , coeffTexFixedPointFactor_{"coeffTexFixedPointFactor",
                                 "Coefficient texture fixed point factor",
                                 "Fixed point multiplier "
@@ -252,7 +248,7 @@ OpacityOptimization::OpacityOptimization()
     if (!OpenGLCapabilities::isExtensionSupported("GL_NV_shader_atomic_float")) {
         approximationProperties_.addProperty(coeffTexFixedPointFactor_);
     }
-    approximationProperties_.addProperties(normalizedBlending_, smoothing_);
+    approximationProperties_.addProperties(smoothing_);
 
     approximationMethod_.onChange([this]() {
         const auto& ap = approximations::get(approximationMethod_);
@@ -404,7 +400,6 @@ void OpacityOptimization::buildShaders() {
         Shader& shader = normalize_;
         auto* frag = shader.getFragmentShaderObject();
         clearAndAddExtensionsAndDefines(frag);
-        frag->setShaderDefine("NORMALISE", normalizedBlending_);
         frag->setShaderDefine("BACKGROUND_AVAILABLE", backgroundPort_.hasData());
 
         shader.build();


### PR DESCRIPTION
- Remove the "Normalised blending option", always use normalise blending
- Use correct blend function