### PR TITLE
Feature/minbbox

### DIFF
--- a/include/inviwo/core/algorithm/boundingbox.h
+++ b/include/inviwo/core/algorithm/boundingbox.h
@@ -53,10 +53,18 @@ class Volume;
 
 namespace util {
 
+/**
+ * Extend the given @p boundingBox so that none of its extents are zero.
+ *
+ * @param boundingBox  the bounding box to be fixed
+ * @return adjusted bounding box with guaranteed minimal extent
+ */
+IVW_CORE_API mat4 minExtentBoundingBox(mat4 boundingBox);
+
 IVW_CORE_API std::optional<mat4> boundingBoxUnion(const std::optional<mat4>& a,
                                                   const std::optional<mat4>& b);
 /**
- * Calculate a bounding box of the \p layer in world space. The bounding box is represented using a
+ * Calculate a bounding box of the @p layer in world space. The bounding box is represented using a
  * mat4, where all positions are between `bbox * (x,y,z,1)` where x, y, and z are between 0 and 1.
  * The bounding box will have a depth equal to a 1000th of the length of the cross product of the
  * layer's first two basis vectors.

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -823,6 +823,7 @@ ivw_group("Header Files" BASE "${CMAKE_CURRENT_BINARY_DIR}/include/inviwo/core/"
 set(TEST_FILES
     tests/unittests/bitset-test.cpp
     tests/unittests/brickiterator-test.cpp
+    tests/unittests/boundingbox-test.cpp
     tests/unittests/colorconversion-test.cpp
     tests/unittests/commandlineparser-test.cpp
     tests/unittests/compositeproperty-test.cpp

--- a/src/core/algorithm/boundingbox.cpp
+++ b/src/core/algorithm/boundingbox.cpp
@@ -37,20 +37,19 @@
 
 namespace inviwo::util {
 
-namespace detail {
-
+namespace {
 vec3 orthvec(const vec3& vec) {
-    vec3 u(1.0f, 0.0f, 0.0f);
-    vec3 n = glm::normalize(vec);
-    float p = glm::dot(u, n);
+    const vec3 u(1.0f, 0.0f, 0.0f);
+    const vec3 n = glm::normalize(vec);
+    const float p = glm::dot(u, n);
     if (std::abs(p) != 1.0f) {
         return glm::normalize(u - p * n);
     } else {
-        return vec3(0.0f, 1.0f, 0.0f);
+        return {0.0f, 1.0f, 0.0f};
     }
 }
 
-}  // namespace detail
+}  // namespace
 
 mat4 minExtentBoundingBox(mat4 boundingBox) {
     const float maxAspectRatio = 1000.0f;
@@ -75,10 +74,10 @@ mat4 minExtentBoundingBox(mat4 boundingBox) {
 
     if (util::almostEqual(extent[0], 0.0f)) {
         if (util::almostEqual(extent[1], 0.0f)) {
-            boundingBox[1] = vec4{detail::orthvec(vec3{boundingBox[2]}) * minExtent, 0.0f};
+            boundingBox[1] = vec4{orthvec(vec3{boundingBox[2]}) * minExtent, 0.0f};
             extent[1] = minExtent;
         } else if (util::almostEqual(extent[2], 0.0f)) {
-            boundingBox[2] = vec4{detail::orthvec(vec3{boundingBox[1]}) * minExtent, 0.0f};
+            boundingBox[2] = vec4{orthvec(vec3{boundingBox[1]}) * minExtent, 0.0f};
             extent[2] = minExtent;
         }
         const vec3 v =
@@ -87,7 +86,7 @@ mat4 minExtentBoundingBox(mat4 boundingBox) {
         boundingBox[0] = vec4{v, 0.0f};
     } else if (util::almostEqual(extent[1], 0.0f)) {
         if (util::almostEqual(extent[2], 0.0f)) {
-            boundingBox[2] = vec4{detail::orthvec(vec3{boundingBox[0]}) * minExtent, 0.0f};
+            boundingBox[2] = vec4{orthvec(vec3{boundingBox[0]}) * minExtent, 0.0f};
             extent[2] = minExtent;
         }
         const vec3 v =

--- a/src/core/tests/unittests/boundingbox-test.cpp
+++ b/src/core/tests/unittests/boundingbox-test.cpp
@@ -1,0 +1,132 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2025 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <gtest/gtest.h>
+#include <warn/pop>
+
+#include <inviwo/core/algorithm/boundingbox.h>
+
+namespace inviwo {
+
+TEST(boundingBox, bboxUnion) {
+    const mat4 m{1.0f};
+    EXPECT_EQ(util::boundingBoxUnion(m, std::nullopt), m);
+    EXPECT_EQ(util::boundingBoxUnion(std::nullopt, m), m);
+    EXPECT_EQ(util::boundingBoxUnion(m, m), m);
+}
+
+TEST(bboxMinExtent, regular) {
+    const mat4 m{1.0f};
+    EXPECT_EQ(util::minExtentBoundingBox(m), m);
+}
+
+TEST(bboxMinExtent, zeroBasis) {
+    const mat4 bbox = util::minExtentBoundingBox(mat4{0.0f});
+    const mat3 basis{bbox};
+    EXPECT_EQ(glm::length(bbox[0]), 1.0f);
+    EXPECT_EQ(glm::length(bbox[1]), 1.0f);
+    EXPECT_EQ(glm::length(bbox[2]), 1.0f);
+}
+
+TEST(bboxMinExtent, zeroBasisVectorA) {
+    const mat4 m{
+        vec4{0.0f},
+        vec4{1.0f, 0.0f, 0.0f, 0.0f},
+        vec4{0.0f, 1.0f, 0.0f, 0.0f},
+        vec4{0.0f, 0.0f, 0.0f, 1.0f},
+    };
+
+    const mat4 bbox = util::minExtentBoundingBox(m);
+    const mat3 basis{bbox};
+    EXPECT_GT(glm::length(bbox[0]), 0.0f);
+    EXPECT_EQ(glm::length(bbox[1]), 1.0f);
+    EXPECT_EQ(glm::length(bbox[2]), 1.0f);
+}
+
+TEST(bboxMinExtent, zeroBasisVectorB) {
+    const mat4 m{
+        vec4{1.0f, 0.0f, 0.0f, 0.0f},
+        vec4{0.0f},
+        vec4{0.0f, 1.0f, 0.0f, 0.0f},
+        vec4{0.0f, 0.0f, 0.0f, 1.0f},
+    };
+
+    const mat4 bbox = util::minExtentBoundingBox(m);
+    const mat3 basis{bbox};
+    EXPECT_EQ(glm::length(bbox[0]), 1.0f);
+    EXPECT_GT(glm::length(bbox[1]), 0.0f);
+    EXPECT_EQ(glm::length(bbox[2]), 1.0f);
+}
+
+TEST(bboxMinExtent, zeroBasisVectorC) {
+    const mat4 m{
+        vec4{1.0f, 0.0f, 0.0f, 0.0f},
+        vec4{0.0f, 1.0f, 0.0f, 0.0f},
+        vec4{0.0f},
+        vec4{0.0f, 0.0f, 0.0f, 1.0f},
+    };
+
+    const mat4 bbox = util::minExtentBoundingBox(m);
+    const mat3 basis{bbox};
+    EXPECT_EQ(glm::length(bbox[0]), 1.0f);
+    EXPECT_EQ(glm::length(bbox[1]), 1.0f);
+    EXPECT_GT(glm::length(bbox[2]), 0.0f);
+}
+
+TEST(bboxMinExtent, zeroBasisVectorsAC) {
+    const mat4 m{
+        vec4{0.0f},
+        vec4{1.0f, 0.0f, 0.0f, 0.0f},
+        vec4{0.0f},
+        vec4{0.0f, 0.0f, 0.0f, 1.0f},
+    };
+    const mat4 bbox = util::minExtentBoundingBox(m);
+    const mat3 basis{bbox};
+    EXPECT_GT(glm::length(bbox[0]), 0.0f);
+    EXPECT_EQ(glm::length(bbox[1]), 1.0f);
+    EXPECT_GT(glm::length(bbox[2]), 0.0f);
+}
+
+TEST(bboxMinExtent, zeroBasisVectorsBC) {
+    const mat4 m{
+        vec4{1.0f, 0.0f, 0.0f, 0.0f},
+        vec4{0.0f},
+        vec4{0.0f},
+        vec4{0.0f, 0.0f, 0.0f, 1.0f},
+    };
+    const mat4 bbox = util::minExtentBoundingBox(m);
+    const mat3 basis{bbox};
+    EXPECT_EQ(glm::length(bbox[0]), 1.0f);
+    EXPECT_GT(glm::length(bbox[1]), 0.0f);
+    EXPECT_GT(glm::length(bbox[2]), 0.0f);
+}
+
+}  // namespace inviwo


### PR DESCRIPTION
Fixes
* division by zero due to zero-length basis vectors when setting the camera based on the model matrix/basis

Changes proposed in this PR:
* consider minimum bounding box extent when adjusting the camera
