### PR TITLE
Feature/warnfixes

### DIFF
--- a/cmake/compileoptions.cmake
+++ b/cmake/compileoptions.cmake
@@ -149,7 +149,7 @@ function(ivw_define_standard_properties)
                 list(APPEND comp_opts "/wd4459") # declaration of 'identifier' hides global declaration
             endif()
             target_link_options(${target} PRIVATE 
-                $<$<CONFIG:Debug,RelWithDebInfo>:/debug:fastlink>
+                $<$<CONFIG:Debug,RelWithDebInfo>:/debug:full>
             )
 
             option(IVW_CFG_MSVC_ADDRESS_SANITIZER "Enable Visual Studio Address Sanitizer" OFF)

--- a/include/inviwo/core/algorithm/markdown.h
+++ b/include/inviwo/core/algorithm/markdown.h
@@ -61,21 +61,21 @@ IVW_CORE_API Document unindentMd2doc(std::string_view markdown);
 /**
  * Parse a markdown string and convert to an inviwo document.
  */
-inline Document operator"" _md(const char* str, size_t len) {
+inline Document operator""_md(const char* str, size_t len) {
     return util::md2doc(std::string_view(str, len));
 }
 
 /**
  * Parse a markdown string and convert to an inviwo document.
  */
-inline Document operator"" _help(const char* str, size_t len) {
+inline Document operator""_help(const char* str, size_t len) {
     return util::md2doc(std::string_view(str, len));
 }
 
 /**
  * Unindent and parse a markdown string and convert to an inviwo document.
  */
-inline Document operator"" _unindentHelp(const char* str, size_t len) {
+inline Document operator""_unindentHelp(const char* str, size_t len) {
     return util::unindentMd2doc(std::string_view(str, len));
 }
 

--- a/include/inviwo/core/util/unindent.h
+++ b/include/inviwo/core/util/unindent.h
@@ -170,7 +170,7 @@ inline std::string unindent(std::string_view str) {
  * ```
  * str will become an std::string
  */
-inline std::string operator"" _unindent(const char* str, size_t len) {
+inline std::string operator""_unindent(const char* str, size_t len) {
     const auto newlen = indent::length(str, str + len);
     std::string res(newlen, char{});
     indent::copy(str, str + len, res.begin());


### PR DESCRIPTION
Changes proposed in this PR:
 * changed `/debug:fastlink` to `/debug:full` since `fastlink` was removed in Visual Studio 2026, see [MSVC /DEBUG reference](https://learn.microsoft.com/en-us/cpp/build/reference/debug-generate-debug-info?view=msvc-180) 
 * fixed deprecated user-defined literal operators (deprecated in C++23, see https://gcc.gnu.org/pipermail/gcc-patches/2024-November/668299.html) 

This has been tested on: Visual Studio 2026, gcc 15.2.0
