### PR TITLE
CMake: enable clang tidy checks in msvc

### DIFF
--- a/cmake/compileoptions.cmake
+++ b/cmake/compileoptions.cmake
@@ -148,7 +148,7 @@ function(ivw_define_standard_properties)
                 # Qt adds uint ushort to the global namespace which creatas many of these warnings.
                 list(APPEND comp_opts "/wd4459") # declaration of 'identifier' hides global declaration
             endif()
-            target_link_options(${target} PRIVATE 
+            target_link_options(${target} PRIVATE
                 $<$<CONFIG:Debug,RelWithDebInfo>:/debug:full>
             )
 
@@ -156,6 +156,13 @@ function(ivw_define_standard_properties)
             if(IVW_CFG_MSVC_ADDRESS_SANITIZER)
                 list(APPEND comp_opts "/fsanitize=address")
             endif()
+
+            set_target_properties(${target}
+                PROPERTIES
+                    VS_GLOBAL_EnableClangTidyCodeAnalysis "true"
+                    VS_GLOBAL_ClangTidyExtraArgs "--config-file=${IVW_ROOT_DIR}/.clang-tidy"
+            )
+
         endif()
         if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
             "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")


### PR DESCRIPTION
make mcvc code analysis also run clang tidy with our options

Changes proposed in this PR:
 * ...
 * ...
 * ...

This has been tested on: ...

> Thank you for contributing to the Inviwo repository! Please ensure the following: 
> - Code is error and warning free
> - Code follows the Inviwo coding guidelines: 
>   https://github.com/inviwo/inviwo/wiki/Coding-Conventions
> - New Code / Processors follows the Inviwo documentation guidelines: 
>   https://github.com/inviwo/inviwo/wiki/Documentation-guide
> - New Code / processors are tested in a unittest and / or regression test: 
>   https://github.com/inviwo/inviwo/wiki/Manual#testing
> 
> Please remember to specify the environment this code been compiled and tested on:
> Operating System / Compiler / IDE / QT / CMake / Python versions.
