### PR TITLE
BaseGL: property for enabling/disabling LayerGL processors

### DIFF
--- a/modules/basegl/include/modules/basegl/processors/layerprocessing/layerglprocessor.h
+++ b/modules/basegl/include/modules/basegl/processors/layerprocessing/layerglprocessor.h
@@ -32,6 +32,7 @@
 #include <modules/basegl/baseglmoduledefine.h>
 
 #include <inviwo/core/processors/processor.h>
+#include <inviwo/core/properties/boolproperty.h>
 #include <inviwo/core/ports/layerport.h>
 #include <modules/opengl/shader/shader.h>
 #include <modules/opengl/buffer/framebufferobject.h>
@@ -102,6 +103,7 @@ protected:
     LayerOutport outport_;
 
 private:
+    BoolProperty enabled_;
     LayerConfig config;
     Shader shader_;
     std::vector<std::pair<FrameBufferObject, std::shared_ptr<Layer>>> cache_;

--- a/modules/basegl/src/processors/layerprocessing/layerglprocessor.cpp
+++ b/modules/basegl/src/processors/layerprocessing/layerglprocessor.cpp
@@ -43,13 +43,15 @@
 namespace inviwo {
 
 LayerGLProcessor::LayerGLProcessor(Shader shader)
-    : Processor()
-    , inport_("inport", "The input layer"_help)
-    , outport_("outport", "Resulting output layer"_help)
+    : Processor{}
+    , inport_{"inport", "The input layer"_help}
+    , outport_{"outport", "Resulting output layer"_help}
+    , enabled_{"enabled", "Enabled", true}
     , config{}
-    , shader_(std::move(shader)) {
+    , shader_{std::move(shader)} {
 
     addPorts(inport_, outport_);
+    addProperty(enabled_);
     shader_.onReload([this]() { invalidate(InvalidationLevel::InvalidResources); });
 }
 
@@ -63,6 +65,11 @@ void LayerGLProcessor::initializeResources() {
 }
 
 void LayerGLProcessor::process() {
+    if (!enabled_) {
+        outport_.setData(inport_.getData());
+        return;
+    }
+
     const auto& input = *inport_.getData();
     if (const auto newConfig = outputConfig(input); config != newConfig) {
         cache_.clear();


### PR DESCRIPTION
Changes proposed in this PR:
 * added `BoolProperty` to `LayerGLProcessor` to enable/disable processing of the input, for example in LayerNormalization or LayerColorMapping