### PR TITLE
BaseGL: enable/disable only specific LayerGL processors

### DIFF
--- a/modules/basegl/include/modules/basegl/processors/layerprocessing/layerglprocessor.h
+++ b/modules/basegl/include/modules/basegl/processors/layerprocessing/layerglprocessor.h
@@ -101,9 +101,9 @@ protected:
 
     LayerInport inport_;
     LayerOutport outport_;
+    BoolProperty enabled_;
 
 private:
-    BoolProperty enabled_;
     LayerConfig config;
     Shader shader_;
     std::vector<std::pair<FrameBufferObject, std::shared_ptr<Layer>>> cache_;

--- a/modules/basegl/src/processors/imageprocessing/layershader.cpp
+++ b/modules/basegl/src/processors/imageprocessing/layershader.cpp
@@ -172,8 +172,8 @@ LayerShader::LayerShader()
     valueRange_.comp.addProperties(valueRange_.input, valueRange_.mode, valueRange_.output);
     valueAxis_.comp.addProperties(valueAxis_.input, valueAxis_.mode, valueAxis_.output);
 
-    addProperties(fragmentShaderSource_, inputFormat_, format_, channels_, dataRange_.comp,
-                  valueRange_.comp, valueAxis_.comp);
+    addProperties(enabled_, fragmentShaderSource_, inputFormat_, format_, channels_,
+                  dataRange_.comp, valueRange_.comp, valueAxis_.comp);
 
     inputFormat_.setReadOnly(true);
     dataRange_.input.setReadOnly(true);

--- a/modules/basegl/src/processors/layerprocessing/layercolormapping.cpp
+++ b/modules/basegl/src/processors/layerprocessing/layercolormapping.cpp
@@ -59,7 +59,7 @@ LayerColorMapping::LayerColorMapping()
               {1.0, vec4(1.0f, 1.0f, 1.0f, 1.0f)},
           }},
           &inport_) {
-    addProperties(channel_, transferFunction_);
+    addProperties(enabled_, channel_, transferFunction_);
 }
 
 void LayerColorMapping::preProcess(TextureUnitContainer& container, Shader& shader, const Layer&,

--- a/modules/basegl/src/processors/layerprocessing/layerglprocessor.cpp
+++ b/modules/basegl/src/processors/layerprocessing/layerglprocessor.cpp
@@ -51,7 +51,6 @@ LayerGLProcessor::LayerGLProcessor(Shader shader)
     , shader_{std::move(shader)} {
 
     addPorts(inport_, outport_);
-    addProperty(enabled_);
     shader_.onReload([this]() { invalidate(InvalidationLevel::InvalidResources); });
 }
 

--- a/modules/basegl/src/processors/layerprocessing/layerinvert.cpp
+++ b/modules/basegl/src/processors/layerprocessing/layerinvert.cpp
@@ -49,6 +49,8 @@ const ProcessorInfo LayerInvert::processorInfo_{
 
 const ProcessorInfo& LayerInvert::getProcessorInfo() const { return processorInfo_; }
 
-LayerInvert::LayerInvert() : LayerGLProcessor{utilgl::findShaderResource("img_invert.frag")} {}
+LayerInvert::LayerInvert() : LayerGLProcessor{utilgl::findShaderResource("img_invert.frag")} {
+    addProperty(enabled_);
+}
 
 }  // namespace inviwo

--- a/modules/basegl/src/processors/layerprocessing/layernormalization.cpp
+++ b/modules/basegl/src/processors/layerprocessing/layernormalization.cpp
@@ -65,7 +65,7 @@ LayerNormalization::LayerNormalization()
                    .set(InvalidationLevel::Valid)
                    .set("Maximum value of the input layer (read-only)"_help)} {
 
-    addProperties(normalizeIndividually_, signNormalized_, dataMin_, dataMax_);
+    addProperties(enabled_, normalizeIndividually_, signNormalized_, dataMin_, dataMax_);
     dataMin_.setReadOnly(true);
     dataMax_.setReadOnly(true);
 }


### PR DESCRIPTION
Changes proposed in this PR:
 * add `Enable` property only to specific `LayerGL` processors instead of all