### PR TITLE
DataFrame: typeids 

### DIFF
--- a/modules/dataframe/include/inviwo/dataframe/dataframemoduledefine.h
+++ b/modules/dataframe/include/inviwo/dataframe/dataframemoduledefine.h
@@ -1,20 +1,36 @@
 #pragma once
 
+
 #ifdef INVIWO_ALL_DYN_LINK  // DYNAMIC
 // If we are building DLL files we must declare dllexport/dllimport
 #ifdef IVW_MODULE_DATAFRAME_EXPORTS
 #ifdef _WIN32
 #define IVW_MODULE_DATAFRAME_API __declspec(dllexport)
+#define IVW_MODULE_DATAFRAME_EXT
+#define IVW_MODULE_DATAFRAME_TMPL_EXP
+#define IVW_MODULE_DATAFRAME_TMPL_INST __declspec(dllexport)
 #else  // UNIX (GCC)
 #define IVW_MODULE_DATAFRAME_API __attribute__((visibility("default")))
+#define IVW_MODULE_DATAFRAME_EXT
+#define IVW_MODULE_DATAFRAME_TMPL_EXP __attribute__((__visibility__("default")))
+#define IVW_MODULE_DATAFRAME_TMPL_INST
 #endif
 #else
 #ifdef _WIN32
 #define IVW_MODULE_DATAFRAME_API __declspec(dllimport)
+#define IVW_MODULE_DATAFRAME_EXT extern
+#define IVW_MODULE_DATAFRAME_TMPL_EXP __declspec(dllimport)
+#define IVW_MODULE_DATAFRAME_TMPL_INST
 #else
 #define IVW_MODULE_DATAFRAME_API
+#define IVW_MODULE_DATAFRAME_EXT extern
+#define IVW_MODULE_DATAFRAME_TMPL_EXP __attribute__((__visibility__("default")))
+#define IVW_MODULE_DATAFRAME_TMPL_INST
 #endif
 #endif
 #else  // STATIC
 #define IVW_MODULE_DATAFRAME_API
+#define IVW_MODULE_DATAFRAME_EXT extern
+#define IVW_MODULE_DATAFRAME_TMPL_EXP
+#define IVW_MODULE_DATAFRAME_TMPL_INST
 #endif

--- a/modules/dataframe/include/inviwo/dataframe/datastructures/dataframe.h
+++ b/modules/dataframe/include/inviwo/dataframe/datastructures/dataframe.h
@@ -360,4 +360,13 @@ struct DataTraits<DataFrame> {
     }
 };
 
+extern template class IVW_MODULE_DATAFRAME_TMPL_EXP DataInport<DataFrame>;
+extern template class IVW_MODULE_DATAFRAME_TMPL_EXP DataInport<DataFrame, 0, false>;
+extern template class IVW_MODULE_DATAFRAME_TMPL_EXP DataInport<DataFrame, 0, true>;
+extern template class IVW_MODULE_DATAFRAME_TMPL_EXP DataInport<DataSequence<DataFrame>>;
+extern template class IVW_MODULE_DATAFRAME_TMPL_EXP DataInport<DataSequence<DataFrame>, 0, false>;
+extern template class IVW_MODULE_DATAFRAME_TMPL_EXP DataInport<DataSequence<DataFrame>, 0, true>;
+extern template class IVW_MODULE_DATAFRAME_TMPL_EXP DataOutport<DataFrame>;
+extern template class IVW_MODULE_DATAFRAME_TMPL_EXP DataOutport<DataSequence<DataFrame>>;
+
 }  // namespace inviwo

--- a/modules/dataframe/src/datastructures/dataframe.cpp
+++ b/modules/dataframe/src/datastructures/dataframe.cpp
@@ -292,4 +292,13 @@ std::vector<std::shared_ptr<Column>>::const_iterator DataFrame::begin() const {
 
 std::vector<std::shared_ptr<Column>>::iterator DataFrame::end() { return columns_.end(); }
 
+template class IVW_MODULE_DATAFRAME_TMPL_INST DataInport<DataFrame>;
+template class IVW_MODULE_DATAFRAME_TMPL_INST DataInport<DataFrame, 0, false>;
+template class IVW_MODULE_DATAFRAME_TMPL_INST DataInport<DataFrame, 0, true>;
+template class IVW_MODULE_DATAFRAME_TMPL_INST DataInport<DataSequence<DataFrame>>;
+template class IVW_MODULE_DATAFRAME_TMPL_INST DataInport<DataSequence<DataFrame>, 0, false>;
+template class IVW_MODULE_DATAFRAME_TMPL_INST DataInport<DataSequence<DataFrame>, 0, true>;
+template class IVW_MODULE_DATAFRAME_TMPL_INST DataOutport<DataFrame>;
+template class IVW_MODULE_DATAFRAME_TMPL_INST DataOutport<DataSequence<DataFrame>>;
+
 }  // namespace inviwo


### PR DESCRIPTION
ensure that we have global typeids for DataFrame Related types

This can be an issue on macos. where the typeid for templates can differ across dylibs.

Fixes #...

Changes proposed in this PR:
 * ...
 * ...
 * ...

This has been tested on: ...

> Thank you for contributing to the Inviwo repository! Please ensure the following: 
> - Code is error and warning free
> - Code follows the Inviwo coding guidelines: 
>   https://github.com/inviwo/inviwo/wiki/Coding-Conventions
> - New Code / Processors follows the Inviwo documentation guidelines: 
>   https://github.com/inviwo/inviwo/wiki/Documentation-guide
> - New Code / processors are tested in a unittest and / or regression test: 
>   https://github.com/inviwo/inviwo/wiki/Manual#testing
> 
> Please remember to specify the environment this code been compiled and tested on:
> Operating System / Compiler / IDE / QT / CMake / Python versions.
