### PR TITLE
chore: update vcpkg baseline to c01dc6ea73

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,7 @@
   "vcpkg-configuration": {
     "default-registry": {
       "kind": "builtin",
-      "baseline": "7c11b72a6f810293d0ce234de126b99e9ab6fa7a"
+      "baseline": "c01dc6ea7353758f2ed70df0bc29c97dfc650b3a"
     },
     "overlay-ports": [
       "./tools/vcpkg"


### PR DESCRIPTION
## vcpkg baseline update

Updated baseline from `7c11b72a6f` to `c01dc6ea73`.

### Changed dependencies
```
assimp: 6.0.2 -> 6.0.4
benchmark: 1.9.4 -> 1.9.5
cimg: 3.6.6 -> 3.7.2
fast-float: 8.2.2 -> 8.2.3
ffmpeg: 8.0.1 -> 8.0.1
glew: 2.3.0 -> 2.3.1
graphviz: 14.1.1 -> 14.1.2
hdf5: 1.14.6 -> 2.0.0
libpng: 1.6.53 -> 1.6.55
nanovg: 2019-08-30 -> 2023-08-26
openexr: 3.4.4 -> 3.4.6
python3: 3.12.9 -> 3.12.9
qtbase: 6.10.0 -> 6.10.0
tracy: 0.11.1 -> 0.13.1
vtk: 9.3.0-pv5.12.1 -> 9.3.0-pv5.12.1
```

Full vcpkg commit: https://github.com/microsoft/vcpkg/commit/c01dc6ea7353758f2ed70df0bc29c97dfc650b3a
