### PR TITLE
chore: update vcpkg baseline to ff8f729804

### DIFF
--- a/modules/openglqt/src/canvasqopenglwidget.cpp
+++ b/modules/openglqt/src/canvasqopenglwidget.cpp
@@ -217,7 +217,20 @@ void CanvasQOpenGLWidget::update() {
     QOpenGLWidget::update();  // this will trigger a paint event.
 }
 
-void CanvasQOpenGLWidget::paintGL() { CanvasGL::update(); }
+void CanvasQOpenGLWidget::paintGL() {
+#if defined(__APPLE__)
+#define GL_SILENCE_DEPRECATION
+    if (auto err = glGetError(); err != GL_NO_ERROR) {
+        // The call the paintGL started to generate a GL_INVALID_ENUM error in some cases,
+        // which we ignore for now
+        if (err != GL_INVALID_ENUM) {
+            log::warn("OpenGL Error: {}", err);
+        }
+    }
+#undef GL_SILENCE_DEPRECATION
+#endif
+    CanvasGL::update();
+}
 
 void CanvasQOpenGLWidget::render(std::shared_ptr<const Image> image, LayerType layerType,
                                  size_t idx) {

--- a/modules/openglqt/src/hiddencanvasqt.cpp
+++ b/modules/openglqt/src/hiddencanvasqt.cpp
@@ -74,7 +74,16 @@ void HiddenCanvasQt::createContext() { context_->create(); }
 void HiddenCanvasQt::initializeGLEW() { OpenGLCapabilities::initializeGLEW(); }
 
 void HiddenCanvasQt::update() {}
-void HiddenCanvasQt::activate() { context_->makeCurrent(offScreenSurface_); }
+void HiddenCanvasQt::activate() {
+    context_->makeCurrent(offScreenSurface_);
+    if (auto err = glGetError(); err != GL_NO_ERROR) {
+        // The call the makeCurrent started to generate a GL_INVALID_ENUM error in some cases,
+        // which we ignore for now
+        if (err != GL_INVALID_ENUM) {
+            log::warn("OpenGL Error: {}", err);
+        }
+    }
+}
 
 std::unique_ptr<Canvas> HiddenCanvasQt::createHiddenCanvas() { return createHiddenQtCanvas(); }
 

--- a/modules/openglqt/src/hiddencanvasqt.cpp
+++ b/modules/openglqt/src/hiddencanvasqt.cpp
@@ -76,6 +76,7 @@ void HiddenCanvasQt::initializeGLEW() { OpenGLCapabilities::initializeGLEW(); }
 void HiddenCanvasQt::update() {}
 void HiddenCanvasQt::activate() {
     context_->makeCurrent(offScreenSurface_);
+#if defined(__APPLE__)
     if (auto err = glGetError(); err != GL_NO_ERROR) {
         // The call the makeCurrent started to generate a GL_INVALID_ENUM error in some cases,
         // which we ignore for now
@@ -83,6 +84,7 @@ void HiddenCanvasQt::activate() {
             log::warn("OpenGL Error: {}", err);
         }
     }
+#endif
 }
 
 std::unique_ptr<Canvas> HiddenCanvasQt::createHiddenCanvas() { return createHiddenQtCanvas(); }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,7 @@
   "vcpkg-configuration": {
     "default-registry": {
       "kind": "builtin",
-      "baseline": "40c0d758e1cc99a505b039a9a7e792154119c927"
+      "baseline": "ff8f729804f07747ee5dae7d40a4a885066f9204"
     },
     "overlay-ports": [
       "./tools/vcpkg"


### PR DESCRIPTION
## vcpkg baseline update

Updated baseline from `40c0d758e1` to `ff8f729804`.

### Changed dependencies
```
cimg: 3.7.2 -> 3.7.4
ezc3d: 1.6.1 -> 1.6.3
fast-float: 8.2.3 -> 8.2.4
ffmpeg: 8.0.1 -> 8.1
gdcm: 3.0.24 -> 3.2.2
hdf5: 2.0.0 -> 2.0.0
inja: 3.5.0 -> 3.5.0
openexr: 3.4.6 -> 3.4.7
python3: 3.12.9 -> 3.12.13
qtbase: 6.10.1 -> 6.10.2
qtsvg: 6.10.1 -> 6.10.2
roaring: 4.6.0 -> 4.6.1
```

Full vcpkg commit: https://github.com/microsoft/vcpkg/commit/ff8f729804f07747ee5dae7d40a4a885066f9204
