### PR TITLE
Core: unit fix

### DIFF
--- a/src/core/datastructures/unitsystem.cpp
+++ b/src/core/datastructures/unitsystem.cpp
@@ -55,6 +55,35 @@ constexpr std::array<
                {"count", "#", [](units::detail::unit_data u) { return u.count(); }},
                {"radian", "rad", [](units::detail::unit_data u) { return u.radian(); }}}};
 
+/**
+ * Compare two units @p a and @p b where positive units are preferred
+ */
+bool lessThan(const units::detail::unit_data& a, const units::detail::unit_data& b) {
+    if (a.meter() != b.meter()) {
+        return a.meter() > b.meter();
+    } else if (a.kg() != b.kg()) {
+        return a.kg() > b.kg();
+    } else if (a.second() != b.second()) {
+        return a.second() > b.second();
+    } else if (a.ampere() != b.ampere()) {
+        return a.ampere() > b.ampere();
+    } else if (a.kelvin() != b.kelvin()) {
+        return a.kelvin() > b.kelvin();
+    } else if (a.mole() != b.mole()) {
+        return a.mole() > b.mole();
+    } else if (a.candela() != b.candela()) {
+        return a.candela() > b.candela();
+    } else if (a.currency() != b.currency()) {
+        return a.currency() > b.currency();
+    } else if (a.count() != b.count()) {
+        return a.count() > b.count();
+    } else if (a.radian() != b.radian()) {
+        return a.radian() > b.radian();
+    } else {
+        return false;
+    }
+}
+
 template <typename OP>
 constexpr bool any(units::detail::unit_data a, units::detail::unit_data b, OP op) {
     for (auto&& [name, abbr, getter] : baseUnits) {
@@ -155,6 +184,7 @@ util::findBestSetOfNamedUnits(Unit unit, const unitgroups::EnabledGroups& enable
     for (const auto& [base, descs] : groups) {
         bases.push_back(base);
     }
+    std::ranges::sort(bases, lessThan);
 
     std::vector<std::vector<std::pair<units::detail::unit_data, int>>> matches;
     {

--- a/src/core/tests/unittests/unitsystem-test.cpp
+++ b/src/core/tests/unittests/unitsystem-test.cpp
@@ -73,4 +73,16 @@ TEST(Unitsystem, unitsystem) {
     EXPECT_EQ(fmt::format("{:all}", chargeDensity * length.pow(3)), "e");
 }
 
+TEST(Unitsystem, simplification) {
+    Unit kmPerSec = units::unit_from_string("km/s");
+    Unit meterPerMilliSec = units::unit_from_string("m/ms");
+
+    EXPECT_EQ(fmt::format("{}", kmPerSec), "km/s");
+    EXPECT_EQ(fmt::format("{}", meterPerMilliSec), "km/s");
+
+    Unit kN = units::unit_from_string("kN");
+    EXPECT_EQ(fmt::format("{:si}", kN), "kgkm/s²");
+    EXPECT_EQ(fmt::format("{:ext}", kN), "kN");
+}
+
 }  // namespace inviwo


### PR DESCRIPTION
Fixes an issue with `util::findBestSetOfNamedUnits()` where the use of an unordered map causes inconsistencies between different platforms/compiles. For example, with Visual Studio `km/s` stays the same whereas with gcc the best named unit is `m/ms`.

Changes proposed in this PR:
* ensure preferred order for named units

This has been tested on: Windows and Ubuntu