### PR TITLE
QtWidgets: BoolComposite property widget fix, closes #1955

### DIFF
--- a/modules/qtwidgets/include/modules/qtwidgets/properties/boolcompositepropertywidgetqt.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/properties/boolcompositepropertywidgetqt.h
@@ -46,12 +46,11 @@ class Property;
 class IVW_MODULE_QTWIDGETS_API BoolCompositePropertyWidgetQt : public CollapsibleGroupBoxWidgetQt,
                                                                public CompositePropertyObserver {
 public:
-    BoolCompositePropertyWidgetQt(BoolCompositeProperty* property);
+    explicit BoolCompositePropertyWidgetQt(BoolCompositeProperty* property);
 
     virtual bool isChecked() const override;
     virtual bool isCollapsed() const override;
 
-    virtual void onSetDisplayName(Property* property, const std::string& displayName) override;
     virtual void onSetCollapsed(bool value) override;
 
     virtual void initState() override;

--- a/modules/qtwidgets/src/properties/boolcompositepropertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/boolcompositepropertywidgetqt.cpp
@@ -34,11 +34,9 @@
 #include <inviwo/core/properties/compositepropertyobserver.h>
 #include <inviwo/core/properties/propertyobserver.h>
 #include <inviwo/core/properties/propertyownerobserver.h>
-#include <modules/qtwidgets/editablelabelqt.h>
 #include <modules/qtwidgets/properties/collapsiblegroupboxwidgetqt.h>
 
 #include <functional>
-#include <vector>
 
 namespace inviwo {
 
@@ -80,7 +78,7 @@ void BoolCompositePropertyWidgetQt::initState() {
     CollapsibleGroupBoxWidgetQt::setCollapsed(boolCompProperty_->isCollapsed());
     CollapsibleGroupBoxWidgetQt::setChecked(boolCompProperty_->getBoolProperty()->get());
 
-    for (auto& prop : boolCompProperty_->getProperties()) {
+    for (const auto& prop : boolCompProperty_->getProperties()) {
         if (prop != boolCompProperty_->getBoolProperty()) {
             addProperty(prop);
         }
@@ -108,12 +106,8 @@ void BoolCompositePropertyWidgetQt::updateFromProperty() {
     CollapsibleGroupBoxWidgetQt::setChecked(boolCompProperty_->getBoolProperty()->get());
 }
 
-void BoolCompositePropertyWidgetQt::onSetDisplayName(Property*, const std::string& displayName) {
-    displayName_ = displayName;
-    label_->setText(displayName);
-}
-
 bool BoolCompositePropertyWidgetQt::isChecked() const { return boolCompProperty_->isChecked(); }
+
 void BoolCompositePropertyWidgetQt::setChecked(bool checked) {
     CollapsibleGroupBoxWidgetQt::setChecked(checked);
     util::exceptionGuard([&]() { boolCompProperty_->setChecked(checked); });


### PR DESCRIPTION
Fixes #1955