### PR TITLE
chore: update vcpkg baseline to 9b965a1168

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,7 @@
   "vcpkg-configuration": {
     "default-registry": {
       "kind": "builtin",
-      "baseline": "2a097d761428092eed3e356b846671d02f04b688"
+      "baseline": "9b965a116838c6cdcd36bca60d1b81b030c8ab8d"
     },
     "overlay-ports": [
       "./tools/vcpkg"


### PR DESCRIPTION
## vcpkg baseline update

Updated baseline from `2a097d7614` to `9b965a1168`.

### Changed dependencies
```
assimp: 6.0.4 -> 6.0.4
cimg: 3.7.5 -> 3.7.6
hdf5: 2.1.1 -> 2.1.1
openexr: 3.4.11 -> 3.4.12
qtbase: 6.10.3 -> 6.11.0
qtsvg: 6.10.3 -> 6.11.0
roaring: 4.6.1 -> 4.7.0
utfcpp: 4.0.9 -> 4.1.1
vtk: 9.3.0-pv5.12.1 -> 9.3.0-pv5.12.1
```

Full vcpkg commit: https://github.com/microsoft/vcpkg/commit/9b965a116838c6cdcd36bca60d1b81b030c8ab8d
