### PR TITLE
animation: add IsoValueProperty support and CompositeProperty track decomposition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,7 @@ if (track) {
 // New usage
 auto tracks = animation.add(property);
 for (auto track : tracks) {
-    if (track) {
-        track->addKeyframe(time);
-    }
+    track->addKeyframe(time);
 }
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,40 @@ All Inviwo Python submodules are now automatically imported into `inviwopy` with
 - `ivwanimation` is now accessible as `inviwopy.animation`
 - `ivwjson` is now accessible as `inviwopy.json`
 
+## 2026-05-26 Added IsoValueProperty support and CompositeProperty track decomposition in Animation module
+
+The Animation module now supports `IsoValueProperty` with new interpolation modes and introduces changes to how tracks are added for `CompositeProperty`.
+
+- `Animation::add(Property*)` now returns a `std::vector<BasePropertyTrack*>` instead of a single pointer. For `CompositeProperty`, this method recursively adds tracks for all sub-properties when no direct track mapping exists.
+- `IsoValueProperty` is now registered in the Animation module with three interpolation modes: `Fade`, `Blend`, and `Constant`.
+- Default animation interpolation for `TransferFunctionProperty` and `IsoValueProperty` has been updated.
+- New interpolation strategies for `IsoValueProperty`:
+  - **Fade**: Interpolates iso-values by matching them at equal positions and fading unmatched ones in or out.
+  - **Blend**: Matches iso-values by index order, interpolating paired values and fading unmatched ones.
+- `addKeyframe()` and `addKeyframeSequence()` now iterate over all tracks returned by the updated `Animation::add(Property*)` method.
+
+### Migration guide
+
+- Update code that uses `Animation::add(Property*)`, `addKeyframe(Property*, Seconds)`, or `addKeyframeSequence(Property*, Seconds)` to handle the new return type `std::vector<BasePropertyTrack*>` and `std::vector<Keyframe*>`/`std::vector<KeyframeSequence*>` respectively.
+- If you are using `IsoValueProperty` in animations, you can now specify the interpolation mode (`Fade`, `Blend`, or `Constant`) when creating tracks. Ensure that your code accounts for these new options if applicable.
+
+#### Example
+```cpp
+// Old usage
+auto track = animation.add(property);
+if (track) {
+    track->addKeyframe(time);
+}
+
+// New usage
+auto tracks = animation.add(property);
+for (auto track : tracks) {
+    if (track) {
+        track->addKeyframe(time);
+    }
+}
+```
+
 ## 2026-05-08 `getIdentifier` now returns `std::string_view`
 The `getIdentifier` method in several core classes has been updated to return `std::string_view` instead of `const std::string&`. This change improves performance by avoiding unnecessary string copies and allocations.
 

--- a/include/inviwo/core/properties/isovalueproperty.h
+++ b/include/inviwo/core/properties/isovalueproperty.h
@@ -146,13 +146,4 @@ private:
     TFData data_;
 };
 
-template <>
-struct InviwoDefaults<IsoValueCollection> {
-    static constexpr auto get() {
-        return InviwoDefaultData{StaticString{"IsoValueCollection"}, uvec2(1, 1),
-                                 IsoValueCollection{}, IsoValueCollection{},
-                                 IsoValueCollection{}, IsoValueCollection{}};
-    }
-};
-
 }  // namespace inviwo

--- a/include/inviwo/core/properties/isovalueproperty.h
+++ b/include/inviwo/core/properties/isovalueproperty.h
@@ -39,6 +39,7 @@
 #include <inviwo/core/datastructures/histogram.h>
 #include <inviwo/core/ports/volumeport.h>
 #include <inviwo/core/datastructures/tfdata.h>
+#include <inviwo/core/util/defaultvalues.h>
 
 namespace inviwo {
 
@@ -56,6 +57,7 @@ class IVW_CORE_API IsoValueProperty : public Property,
 public:
     virtual std::string_view getClassIdentifier() const override;
     static constexpr std::string_view classIdentifier{"org.inviwo.IsoValueProperty"};
+    using value_type = IsoValueCollection;
 
     IsoValueProperty(std::string_view identifier, std::string_view displayName, Document help,
                      const IsoValueCollection& value = {}, TFData port = {},
@@ -142,6 +144,15 @@ private:
     ValueWrapper<HistogramSelection> histogramSelection_;
 
     TFData data_;
+};
+
+template <>
+struct InviwoDefaults<IsoValueCollection> {
+    static constexpr auto get() {
+        return InviwoDefaultData{StaticString{"IsoValueCollection"}, uvec2(1, 1),
+                                 IsoValueCollection{}, IsoValueCollection{},
+                                 IsoValueCollection{}, IsoValueCollection{}};
+    }
 };
 
 }  // namespace inviwo

--- a/include/inviwo/core/util/intersection.h
+++ b/include/inviwo/core/util/intersection.h
@@ -1,0 +1,234 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2026 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <inviwo/core/common/inviwocoredefine.h>
+
+#include <ranges>
+#include <iterator>
+#include <concepts>
+#include <functional>
+#include <type_traits>
+#include <utility>
+#include <memory>
+
+namespace inviwo::views {
+
+template <std::ranges::input_range V1, std::ranges::input_range V2,
+          typename Comp = std::ranges::less>
+    requires std::ranges::view<V1> && std::ranges::view<V2> &&
+             std::common_reference_with<std::ranges::range_reference_t<V1>,
+                                        std::ranges::range_reference_t<V2>> &&
+             std::common_with<std::ranges::range_value_t<V1>, std::ranges::range_value_t<V2>> &&
+             std::indirect_strict_weak_order<Comp, std::ranges::iterator_t<V1>,
+                                             std::ranges::iterator_t<V2>>
+class set_intersection : public std::ranges::view_interface<set_intersection<V1, V2, Comp>> {
+public:
+    using value_type =
+        std::common_type_t<std::ranges::range_value_t<V1>, std::ranges::range_value_t<V2>>;
+
+    using reference = std::common_reference_t<std::ranges::range_reference_t<V1>,
+                                              std::ranges::range_reference_t<V2>>;
+
+    using difference_type = std::common_type_t<std::ranges::range_difference_t<V1>,
+                                               std::ranges::range_difference_t<V2>>;
+
+private:
+    static constexpr bool both_forward =
+        std::ranges::forward_range<V1> && std::ranges::forward_range<V2>;
+
+    static constexpr bool both_common =
+        std::ranges::common_range<V1> && std::ranges::common_range<V2>;
+
+    V1 base1_{};
+    V2 base2_{};
+    Comp comp_{};
+
+public:
+    class iterator {
+    public:
+        using iterator_concept =
+            std::conditional_t<both_forward, std::forward_iterator_tag, std::input_iterator_tag>;
+        // Stay at input_iterator_tag: operator* returns common_reference_t which may be a
+        // prvalue. C++20's iterator_category contract requires an lvalue reference for
+        // anything stronger than input.
+        using iterator_category = std::input_iterator_tag;
+        using value_type = set_intersection::value_type;
+        using reference = set_intersection::reference;
+        using difference_type = set_intersection::difference_type;
+        using pointer = void;
+
+    private:
+        using It1 = std::ranges::iterator_t<V1>;
+        using It2 = std::ranges::iterator_t<V2>;
+        using Sen1 = std::ranges::sentinel_t<V1>;
+        using Sen2 = std::ranges::sentinel_t<V2>;
+
+        It1 it1_{};
+        Sen1 end1_{};
+        It2 it2_{};
+        Sen2 end2_{};
+        Comp* comp_ = nullptr;
+
+        friend class set_intersection;
+
+        // Advance both cursors until they point at equivalent elements (an element of the
+        // intersection) or one range is exhausted. This keeps the iterator on a valid
+        // intersection element between increments.
+        void satisfy() {
+            while (it1_ != end1_ && it2_ != end2_) {
+                if ((*comp_)(*it1_, *it2_)) {
+                    ++it1_;
+                } else if ((*comp_)(*it2_, *it1_)) {
+                    ++it2_;
+                } else {
+                    return;  // equivalent -> found an intersection element
+                }
+            }
+            // One range is exhausted, there are no more intersection elements. Canonicalize
+            // to a unique past-the-end state so end() and iterator equality are well-defined.
+            if constexpr (both_forward && both_common) {
+                it1_ = end1_;
+                it2_ = end2_;
+            }
+        }
+
+    public:
+        iterator() = default;
+
+        iterator(It1 it1, Sen1 end1, It2 it2, Sen2 end2, Comp& comp)
+            : it1_(std::move(it1))
+            , end1_(std::move(end1))
+            , it2_(std::move(it2))
+            , end2_(std::move(end2))
+            , comp_(std::addressof(comp)) {
+            satisfy();
+        }
+
+        reference operator*() const { return static_cast<reference>(*it1_); }
+
+        iterator& operator++() {
+            ++it1_;
+            ++it2_;
+            satisfy();
+            return *this;
+        }
+
+        // For input-only, operator++(int) must return void. For forward, it must return
+        // a copy of the iterator (the "multipass" post-increment).
+        decltype(auto) operator++(int) {
+            if constexpr (both_forward) {
+                auto tmp = *this;
+                ++(*this);
+                return tmp;
+            } else {
+                ++(*this);
+            }
+        }
+
+        friend bool operator==(const iterator& it, std::default_sentinel_t) {
+            return it.it1_ == it.end1_ || it.it2_ == it.end2_;
+        }
+
+        // Iterator/iterator equality: only meaningful (and only required) for forward.
+        friend bool operator==(const iterator& a, const iterator& b)
+            requires both_forward
+        {
+            return a.it1_ == b.it1_ && a.it2_ == b.it2_;
+        }
+    };
+
+    set_intersection()
+        requires std::default_initializable<V1> && std::default_initializable<V2> &&
+                     std::default_initializable<Comp>
+    = default;
+
+    constexpr set_intersection(V1 b1, V2 b2, Comp c = Comp{})
+        : base1_(std::move(b1)), base2_(std::move(b2)), comp_(std::move(c)) {}
+
+    constexpr V1 base1() const&
+        requires std::copy_constructible<V1>
+    {
+        return base1_;
+    }
+    constexpr V2 base2() const&
+        requires std::copy_constructible<V2>
+    {
+        return base2_;
+    }
+    constexpr V1 base1() && { return std::move(base1_); }
+    constexpr V2 base2() && { return std::move(base2_); }
+
+    constexpr iterator begin() {
+        return iterator{std::ranges::begin(base1_), std::ranges::end(base1_),
+                        std::ranges::begin(base2_), std::ranges::end(base2_), comp_};
+    }
+
+    // When both bases are forward + common, expose a real end() iterator so the view
+    // models common_range. Otherwise fall back to default_sentinel.
+    constexpr auto end() {
+        if constexpr (both_forward && both_common) {
+            return iterator{std::ranges::end(base1_), std::ranges::end(base1_),
+                            std::ranges::end(base2_), std::ranges::end(base2_), comp_};
+        } else {
+            return std::default_sentinel;
+        }
+    }
+};
+
+template <std::ranges::viewable_range R1, std::ranges::viewable_range R2,
+          typename Comp = std::ranges::less>
+set_intersection(R1&&, R2&&, Comp = {})
+    -> set_intersection<std::views::all_t<R1>, std::views::all_t<R2>, Comp>;
+
+namespace detail {
+template <std::ranges::view V2, typename Comp = std::ranges::less>
+class set_intersection_adaptor
+    : public std::ranges::range_adaptor_closure<set_intersection_adaptor<V2, Comp>> {
+    V2 r2_;
+    Comp comp_;
+
+public:
+    constexpr set_intersection_adaptor(V2 r2, Comp comp = {})
+        : r2_(std::move(r2)), comp_(std::move(comp)) {}
+
+    template <std::ranges::viewable_range R1>
+    constexpr auto operator()(R1&& r1) const {
+        return set_intersection{std::views::all(std::forward<R1>(r1)), r2_, comp_};
+    }
+};
+}  // namespace detail
+
+template <std::ranges::viewable_range R2, typename Comp = std::ranges::less>
+constexpr auto set_intersection_with(R2&& r2, Comp comp = {}) {
+    return detail::set_intersection_adaptor<std::views::all_t<R2>, Comp>{
+        std::views::all(std::forward<R2>(r2)), std::move(comp)};
+}
+
+}  // namespace inviwo::views

--- a/include/inviwo/core/util/intersection.h
+++ b/include/inviwo/core/util/intersection.h
@@ -71,7 +71,7 @@ class set_intersection_adaptor
     Comp comp_;
 
 public:
-    constexpr set_intersection_adaptor(V2 r2, Comp comp = {})
+    explicit constexpr set_intersection_adaptor(V2 r2, Comp comp = {})
         : r2_(std::move(r2)), comp_(std::move(comp)) {}
 
     template <std::ranges::viewable_range R1>

--- a/include/inviwo/core/util/intersection.h
+++ b/include/inviwo/core/util/intersection.h
@@ -29,177 +29,33 @@
 #pragma once
 
 #include <inviwo/core/common/inviwocoredefine.h>
+#include <inviwo/core/util/settransform.h>
 
 #include <ranges>
-#include <iterator>
 #include <concepts>
 #include <functional>
-#include <type_traits>
+#include <optional>
 #include <utility>
-#include <memory>
 
 namespace inviwo::views {
 
+namespace detail {
+// Set-intersection merge function: emit an element only where both ranges hold an equivalent
+// element, skip positions unique to either range.
+struct intersection_fn {
+    template <typename T>
+    constexpr std::optional<T> operator()(const T* p1, const T* p2) const {
+        if (p1 && p2) return std::optional<T>{*p1};
+        return std::nullopt;
+    }
+};
+}  // namespace detail
+
 template <std::ranges::input_range V1, std::ranges::input_range V2,
           typename Comp = std::ranges::less>
-    requires std::ranges::view<V1> && std::ranges::view<V2> &&
-             std::common_reference_with<std::ranges::range_reference_t<V1>,
-                                        std::ranges::range_reference_t<V2>> &&
-             std::common_with<std::ranges::range_value_t<V1>, std::ranges::range_value_t<V2>> &&
-             std::indirect_strict_weak_order<Comp, std::ranges::iterator_t<V1>,
-                                             std::ranges::iterator_t<V2>>
-class set_intersection : public std::ranges::view_interface<set_intersection<V1, V2, Comp>> {
+class set_intersection : public set_transform<V1, V2, Comp, detail::intersection_fn> {
 public:
-    using value_type =
-        std::common_type_t<std::ranges::range_value_t<V1>, std::ranges::range_value_t<V2>>;
-
-    using reference = std::common_reference_t<std::ranges::range_reference_t<V1>,
-                                              std::ranges::range_reference_t<V2>>;
-
-    using difference_type = std::common_type_t<std::ranges::range_difference_t<V1>,
-                                               std::ranges::range_difference_t<V2>>;
-
-private:
-    static constexpr bool both_forward =
-        std::ranges::forward_range<V1> && std::ranges::forward_range<V2>;
-
-    static constexpr bool both_common =
-        std::ranges::common_range<V1> && std::ranges::common_range<V2>;
-
-    V1 base1_{};
-    V2 base2_{};
-    Comp comp_{};
-
-public:
-    class iterator {
-    public:
-        using iterator_concept =
-            std::conditional_t<both_forward, std::forward_iterator_tag, std::input_iterator_tag>;
-        // Stay at input_iterator_tag: operator* returns common_reference_t which may be a
-        // prvalue. C++20's iterator_category contract requires an lvalue reference for
-        // anything stronger than input.
-        using iterator_category = std::input_iterator_tag;
-        using value_type = set_intersection::value_type;
-        using reference = set_intersection::reference;
-        using difference_type = set_intersection::difference_type;
-        using pointer = void;
-
-    private:
-        using It1 = std::ranges::iterator_t<V1>;
-        using It2 = std::ranges::iterator_t<V2>;
-        using Sen1 = std::ranges::sentinel_t<V1>;
-        using Sen2 = std::ranges::sentinel_t<V2>;
-
-        It1 it1_{};
-        Sen1 end1_{};
-        It2 it2_{};
-        Sen2 end2_{};
-        Comp* comp_ = nullptr;
-
-        friend class set_intersection;
-
-        // Advance both cursors until they point at equivalent elements (an element of the
-        // intersection) or one range is exhausted. This keeps the iterator on a valid
-        // intersection element between increments.
-        void satisfy() {
-            while (it1_ != end1_ && it2_ != end2_) {
-                if ((*comp_)(*it1_, *it2_)) {
-                    ++it1_;
-                } else if ((*comp_)(*it2_, *it1_)) {
-                    ++it2_;
-                } else {
-                    return;  // equivalent -> found an intersection element
-                }
-            }
-            // One range is exhausted, there are no more intersection elements. Canonicalize
-            // to a unique past-the-end state so end() and iterator equality are well-defined.
-            if constexpr (both_forward && both_common) {
-                it1_ = end1_;
-                it2_ = end2_;
-            }
-        }
-
-    public:
-        iterator() = default;
-
-        iterator(It1 it1, Sen1 end1, It2 it2, Sen2 end2, Comp& comp)
-            : it1_(std::move(it1))
-            , end1_(std::move(end1))
-            , it2_(std::move(it2))
-            , end2_(std::move(end2))
-            , comp_(std::addressof(comp)) {
-            satisfy();
-        }
-
-        reference operator*() const { return static_cast<reference>(*it1_); }
-
-        iterator& operator++() {
-            ++it1_;
-            ++it2_;
-            satisfy();
-            return *this;
-        }
-
-        // For input-only, operator++(int) must return void. For forward, it must return
-        // a copy of the iterator (the "multipass" post-increment).
-        decltype(auto) operator++(int) {
-            if constexpr (both_forward) {
-                auto tmp = *this;
-                ++(*this);
-                return tmp;
-            } else {
-                ++(*this);
-            }
-        }
-
-        friend bool operator==(const iterator& it, std::default_sentinel_t) {
-            return it.it1_ == it.end1_ || it.it2_ == it.end2_;
-        }
-
-        // Iterator/iterator equality: only meaningful (and only required) for forward.
-        friend bool operator==(const iterator& a, const iterator& b)
-            requires both_forward
-        {
-            return a.it1_ == b.it1_ && a.it2_ == b.it2_;
-        }
-    };
-
-    set_intersection()
-        requires std::default_initializable<V1> && std::default_initializable<V2> &&
-                     std::default_initializable<Comp>
-    = default;
-
-    constexpr set_intersection(V1 b1, V2 b2, Comp c = Comp{})
-        : base1_(std::move(b1)), base2_(std::move(b2)), comp_(std::move(c)) {}
-
-    constexpr V1 base1() const&
-        requires std::copy_constructible<V1>
-    {
-        return base1_;
-    }
-    constexpr V2 base2() const&
-        requires std::copy_constructible<V2>
-    {
-        return base2_;
-    }
-    constexpr V1 base1() && { return std::move(base1_); }
-    constexpr V2 base2() && { return std::move(base2_); }
-
-    constexpr iterator begin() {
-        return iterator{std::ranges::begin(base1_), std::ranges::end(base1_),
-                        std::ranges::begin(base2_), std::ranges::end(base2_), comp_};
-    }
-
-    // When both bases are forward + common, expose a real end() iterator so the view
-    // models common_range. Otherwise fall back to default_sentinel.
-    constexpr auto end() {
-        if constexpr (both_forward && both_common) {
-            return iterator{std::ranges::end(base1_), std::ranges::end(base1_),
-                            std::ranges::end(base2_), std::ranges::end(base2_), comp_};
-        } else {
-            return std::default_sentinel;
-        }
-    }
+    using set_transform<V1, V2, Comp, detail::intersection_fn>::set_transform;
 };
 
 template <std::ranges::viewable_range R1, std::ranges::viewable_range R2,

--- a/include/inviwo/core/util/settransform.h
+++ b/include/inviwo/core/util/settransform.h
@@ -1,0 +1,262 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2026 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <inviwo/core/common/inviwocoredefine.h>
+
+#include <ranges>
+#include <iterator>
+#include <concepts>
+#include <functional>
+#include <optional>
+#include <type_traits>
+#include <utility>
+#include <memory>
+
+namespace inviwo::views {
+
+// Lazy engine shared by set_union and set_intersection (and any other sorted-merge set
+// operation). It walks two sorted ranges in lock-step and, at every merge position, invokes
+// `Fn` with two pointers into the common value type:
+//   * both non-null  -> the two ranges hold an equivalent element here
+//   * (p, nullptr)   -> `*p` exists only in the first range (or the second is exhausted)
+//   * (nullptr, p)   -> `*p` exists only in the second range (or the first is exhausted)
+// `Fn` returns a `std::optional`: an engaged value is yielded, `std::nullopt` skips the
+// position. The elements are materialized into the common value type before being passed to
+// `Fn`, so ranges yielding prvalues (e.g. transformed ranges) are supported.
+template <std::ranges::input_range V1, std::ranges::input_range V2, typename Comp, typename Fn>
+    requires std::ranges::view<V1> && std::ranges::view<V2> &&
+             std::common_with<std::ranges::range_value_t<V1>, std::ranges::range_value_t<V2>> &&
+             std::indirect_strict_weak_order<Comp, std::ranges::iterator_t<V1>,
+                                             std::ranges::iterator_t<V2>>
+class set_transform : public std::ranges::view_interface<set_transform<V1, V2, Comp, Fn>> {
+public:
+    using element_type =
+        std::common_type_t<std::ranges::range_value_t<V1>, std::ranges::range_value_t<V2>>;
+
+private:
+    using fn_result_t = std::invoke_result_t<const Fn&, const element_type*, const element_type*>;
+
+public:
+    using value_type = std::remove_cvref_t<decltype(*std::declval<fn_result_t>())>;
+    using reference = value_type;
+
+    using difference_type = std::common_type_t<std::ranges::range_difference_t<V1>,
+                                               std::ranges::range_difference_t<V2>>;
+
+private:
+    static constexpr bool both_forward =
+        std::ranges::forward_range<V1> && std::ranges::forward_range<V2>;
+
+    static constexpr bool both_common =
+        std::ranges::common_range<V1> && std::ranges::common_range<V2>;
+
+    V1 base1_{};
+    V2 base2_{};
+    Comp comp_{};
+    Fn fn_{};
+
+public:
+    class iterator {
+    public:
+        using iterator_concept =
+            std::conditional_t<both_forward, std::forward_iterator_tag, std::input_iterator_tag>;
+        // Stay at input_iterator_tag: operator* returns a materialized prvalue, and C++20's
+        // iterator_category contract requires an lvalue reference for anything stronger.
+        using iterator_category = std::input_iterator_tag;
+        using value_type = set_transform::value_type;
+        using reference = set_transform::reference;
+        using difference_type = set_transform::difference_type;
+        using pointer = void;
+
+    private:
+        using It1 = std::ranges::iterator_t<V1>;
+        using It2 = std::ranges::iterator_t<V2>;
+        using Sen1 = std::ranges::sentinel_t<V1>;
+        using Sen2 = std::ranges::sentinel_t<V2>;
+
+        It1 it1_{};
+        Sen1 end1_{};
+        It2 it2_{};
+        Sen2 end2_{};
+        Comp* comp_ = nullptr;
+        Fn* fn_ = nullptr;
+
+        friend class set_transform;
+
+        bool atEnd() const { return it1_ == end1_ && it2_ == end2_; }
+
+        // Materialize the element(s) at the current merge position into `b1`/`b2`. The side(s)
+        // that participate in the position are engaged, the other stays empty. Precondition:
+        // !atEnd().
+        void fill(std::optional<element_type>& b1, std::optional<element_type>& b2) const {
+            if (it1_ == end1_) {
+                b2.emplace(static_cast<element_type>(*it2_));
+            } else if (it2_ == end2_) {
+                b1.emplace(static_cast<element_type>(*it1_));
+            } else if ((*comp_)(*it1_, *it2_)) {
+                b1.emplace(static_cast<element_type>(*it1_));
+            } else if ((*comp_)(*it2_, *it1_)) {
+                b2.emplace(static_cast<element_type>(*it2_));
+            } else {
+                b1.emplace(static_cast<element_type>(*it1_));
+                b2.emplace(static_cast<element_type>(*it2_));
+            }
+        }
+
+        // Step to the next merge position. Precondition: !atEnd().
+        void advance() {
+            if (it1_ == end1_) {
+                ++it2_;
+            } else if (it2_ == end2_) {
+                ++it1_;
+            } else if ((*comp_)(*it1_, *it2_)) {
+                ++it1_;
+            } else if ((*comp_)(*it2_, *it1_)) {
+                ++it2_;
+            } else {
+                ++it1_;
+                ++it2_;
+            }
+        }
+
+        // Advance until `fn_` yields a value at the current position or both ranges are
+        // exhausted. This keeps the iterator on an emitted element between increments.
+        void satisfy() {
+            while (!atEnd()) {
+                std::optional<element_type> b1;
+                std::optional<element_type> b2;
+                fill(b1, b2);
+                const element_type* p1 = b1 ? std::addressof(*b1) : nullptr;
+                const element_type* p2 = b2 ? std::addressof(*b2) : nullptr;
+                if (std::invoke(*fn_, p1, p2)) return;
+                advance();
+            }
+            // Both ranges exhausted: canonicalize to a unique past-the-end state so end() and
+            // iterator equality are well-defined for common ranges.
+            if constexpr (both_forward && both_common) {
+                it1_ = end1_;
+                it2_ = end2_;
+            }
+        }
+
+    public:
+        iterator() = default;
+
+        iterator(It1 it1, Sen1 end1, It2 it2, Sen2 end2, Comp& comp, Fn& fn)
+            : it1_(std::move(it1))
+            , end1_(std::move(end1))
+            , it2_(std::move(it2))
+            , end2_(std::move(end2))
+            , comp_(std::addressof(comp))
+            , fn_(std::addressof(fn)) {
+            satisfy();
+        }
+
+        reference operator*() const {
+            std::optional<element_type> b1;
+            std::optional<element_type> b2;
+            fill(b1, b2);
+            const element_type* p1 = b1 ? std::addressof(*b1) : nullptr;
+            const element_type* p2 = b2 ? std::addressof(*b2) : nullptr;
+            return static_cast<reference>(*std::invoke(*fn_, p1, p2));
+        }
+
+        iterator& operator++() {
+            advance();
+            satisfy();
+            return *this;
+        }
+
+        // For input-only, operator++(int) must return void. For forward, it must return
+        // a copy of the iterator (the "multipass" post-increment).
+        decltype(auto) operator++(int) {
+            if constexpr (both_forward) {
+                auto tmp = *this;
+                ++(*this);
+                return tmp;
+            } else {
+                ++(*this);
+            }
+        }
+
+        friend bool operator==(const iterator& it, std::default_sentinel_t) { return it.atEnd(); }
+
+        // Iterator/iterator equality: only meaningful (and only required) for forward.
+        friend bool operator==(const iterator& a, const iterator& b)
+            requires both_forward
+        {
+            return a.it1_ == b.it1_ && a.it2_ == b.it2_;
+        }
+    };
+
+    set_transform()
+        requires std::default_initializable<V1> && std::default_initializable<V2> &&
+                     std::default_initializable<Comp> && std::default_initializable<Fn>
+    = default;
+
+    constexpr set_transform(V1 b1, V2 b2, Comp c = Comp{}, Fn f = Fn{})
+        : base1_(std::move(b1)), base2_(std::move(b2)), comp_(std::move(c)), fn_(std::move(f)) {}
+
+    constexpr V1 base1() const&
+        requires std::copy_constructible<V1>
+    {
+        return base1_;
+    }
+    constexpr V2 base2() const&
+        requires std::copy_constructible<V2>
+    {
+        return base2_;
+    }
+    constexpr V1 base1() && { return std::move(base1_); }
+    constexpr V2 base2() && { return std::move(base2_); }
+
+    constexpr iterator begin() {
+        return iterator{std::ranges::begin(base1_), std::ranges::end(base1_),
+                        std::ranges::begin(base2_), std::ranges::end(base2_), comp_, fn_};
+    }
+
+    // When both bases are forward + common, expose a real end() iterator so the view
+    // models common_range. Otherwise fall back to default_sentinel.
+    constexpr auto end() {
+        if constexpr (both_forward && both_common) {
+            return iterator{std::ranges::end(base1_), std::ranges::end(base1_),
+                            std::ranges::end(base2_), std::ranges::end(base2_), comp_, fn_};
+        } else {
+            return std::default_sentinel;
+        }
+    }
+};
+
+template <std::ranges::viewable_range R1, std::ranges::viewable_range R2, typename Comp,
+          typename Fn>
+set_transform(R1&&, R2&&, Comp, Fn)
+    -> set_transform<std::views::all_t<R1>, std::views::all_t<R2>, Comp, Fn>;
+
+}  // namespace inviwo::views

--- a/include/inviwo/core/util/settransform.h
+++ b/include/inviwo/core/util/settransform.h
@@ -112,6 +112,8 @@ public:
 
         bool atEnd() const { return it1_ == end1_ && it2_ == end2_; }
 
+        // NOLINTBEGIN(bugprone-branch-clone)
+
         // Materialize the element(s) at the current merge position into `b1`/`b2`. The side(s)
         // that participate in the position are engaged, the other stays empty. Precondition:
         // !atEnd().
@@ -145,6 +147,7 @@ public:
                 ++it2_;
             }
         }
+        // NOLINTEND(bugprone-branch-clone)
 
         // Advance until `fn_` yields a value at the current position or both ranges are
         // exhausted. This keeps the iterator on an emitted element between increments.

--- a/include/inviwo/core/util/union.h
+++ b/include/inviwo/core/util/union.h
@@ -68,7 +68,7 @@ class set_union_adaptor : public std::ranges::range_adaptor_closure<set_union_ad
     Comp comp_;
 
 public:
-    constexpr set_union_adaptor(V2 r2, Comp comp = {})
+    explicit constexpr set_union_adaptor(V2 r2, Comp comp = {})
         : r2_(std::move(r2)), comp_(std::move(comp)) {}
 
     template <std::ranges::viewable_range R1>

--- a/include/inviwo/core/util/union.h
+++ b/include/inviwo/core/util/union.h
@@ -29,171 +29,32 @@
 #pragma once
 
 #include <inviwo/core/common/inviwocoredefine.h>
+#include <inviwo/core/util/settransform.h>
 
 #include <ranges>
-#include <iterator>
 #include <concepts>
 #include <functional>
-#include <type_traits>
+#include <optional>
 #include <utility>
-#include <memory>
 
 namespace inviwo::views {
 
+namespace detail {
+// Set-union merge function: emit the element present at each merge position. When both ranges
+// hold an equivalent element the pair collapses to a single output (`p1`).
+struct union_fn {
+    template <typename T>
+    constexpr std::optional<T> operator()(const T* p1, const T* p2) const {
+        return p1 ? std::optional<T>{*p1} : std::optional<T>{*p2};
+    }
+};
+}  // namespace detail
+
 template <std::ranges::input_range V1, std::ranges::input_range V2,
           typename Comp = std::ranges::less>
-    requires std::ranges::view<V1> && std::ranges::view<V2> &&
-             std::common_reference_with<std::ranges::range_reference_t<V1>,
-                                        std::ranges::range_reference_t<V2>> &&
-             std::common_with<std::ranges::range_value_t<V1>, std::ranges::range_value_t<V2>> &&
-             std::indirect_strict_weak_order<Comp, std::ranges::iterator_t<V1>,
-                                             std::ranges::iterator_t<V2>>
-class set_union : public std::ranges::view_interface<set_union<V1, V2, Comp>> {
+class set_union : public set_transform<V1, V2, Comp, detail::union_fn> {
 public:
-    using value_type =
-        std::common_type_t<std::ranges::range_value_t<V1>, std::ranges::range_value_t<V2>>;
-
-    using reference = std::common_reference_t<std::ranges::range_reference_t<V1>,
-                                              std::ranges::range_reference_t<V2>>;
-
-    using difference_type = std::common_type_t<std::ranges::range_difference_t<V1>,
-                                               std::ranges::range_difference_t<V2>>;
-
-private:
-    static constexpr bool both_forward =
-        std::ranges::forward_range<V1> && std::ranges::forward_range<V2>;
-
-    static constexpr bool both_common =
-        std::ranges::common_range<V1> && std::ranges::common_range<V2>;
-
-    V1 base1_{};
-    V2 base2_{};
-    Comp comp_{};
-
-public:
-    class iterator {
-    public:
-        using iterator_concept =
-            std::conditional_t<both_forward, std::forward_iterator_tag, std::input_iterator_tag>;
-        // Stay at input_iterator_tag: operator* returns common_reference_t which may be a
-        // prvalue. C++20's iterator_category contract requires an lvalue reference for
-        // anything stronger than input.
-        using iterator_category = std::input_iterator_tag;
-        using value_type = set_union::value_type;
-        using reference = set_union::reference;
-        using difference_type = set_union::difference_type;
-        using pointer = void;
-
-    private:
-        using It1 = std::ranges::iterator_t<V1>;
-        using It2 = std::ranges::iterator_t<V2>;
-        using Sen1 = std::ranges::sentinel_t<V1>;
-        using Sen2 = std::ranges::sentinel_t<V2>;
-
-        It1 it1_{};
-        Sen1 end1_{};
-        It2 it2_{};
-        Sen2 end2_{};
-        Comp* comp_ = nullptr;
-
-        friend class set_union;
-
-    public:
-        iterator() = default;
-
-        iterator(It1 it1, Sen1 end1, It2 it2, Sen2 end2, Comp& comp)
-            : it1_(std::move(it1))
-            , end1_(std::move(end1))
-            , it2_(std::move(it2))
-            , end2_(std::move(end2))
-            , comp_(std::addressof(comp)) {}
-
-        reference operator*() const {
-            if (it1_ == end1_) return static_cast<reference>(*it2_);
-            if (it2_ == end2_) return static_cast<reference>(*it1_);
-            if ((*comp_)(*it2_, *it1_)) return static_cast<reference>(*it2_);
-            return static_cast<reference>(*it1_);
-        }
-
-        iterator& operator++() {
-            if (it1_ == end1_) {
-                ++it2_;
-            } else if (it2_ == end2_) {
-                ++it1_;
-            } else if ((*comp_)(*it1_, *it2_)) {
-                ++it1_;
-            } else if ((*comp_)(*it2_, *it1_)) {
-                ++it2_;
-            } else {
-                // equivalent -> set-union: emit once, skip in both
-                // For "merge" semantics (keep duplicates) replace this
-                // branch with: ++it1_;
-                ++it1_;
-                ++it2_;
-            }
-            return *this;
-        }
-
-        // For input-only, operator++(int) must return void. For forward, it must return
-        // a copy of the iterator (the "multipass" post-increment).
-        decltype(auto) operator++(int) {
-            if constexpr (both_forward) {
-                auto tmp = *this;
-                ++(*this);
-                return tmp;
-            } else {
-                ++(*this);
-            }
-        }
-
-        friend bool operator==(const iterator& it, std::default_sentinel_t) {
-            return it.it1_ == it.end1_ && it.it2_ == it.end2_;
-        }
-
-        // Iterator/iterator equality: only meaningful (and only required) for forward.
-        friend bool operator==(const iterator& a, const iterator& b)
-            requires both_forward
-        {
-            return a.it1_ == b.it1_ && a.it2_ == b.it2_;
-        }
-    };
-
-    set_union()
-        requires std::default_initializable<V1> && std::default_initializable<V2> &&
-                     std::default_initializable<Comp>
-    = default;
-
-    constexpr set_union(V1 b1, V2 b2, Comp c = Comp{})
-        : base1_(std::move(b1)), base2_(std::move(b2)), comp_(std::move(c)) {}
-
-    constexpr V1 base1() const&
-        requires std::copy_constructible<V1>
-    {
-        return base1_;
-    }
-    constexpr V2 base2() const&
-        requires std::copy_constructible<V2>
-    {
-        return base2_;
-    }
-    constexpr V1 base1() && { return std::move(base1_); }
-    constexpr V2 base2() && { return std::move(base2_); }
-
-    constexpr iterator begin() {
-        return iterator{std::ranges::begin(base1_), std::ranges::end(base1_),
-                        std::ranges::begin(base2_), std::ranges::end(base2_), comp_};
-    }
-
-    // When both bases are forward + common, expose a real end() iterator so the view
-    // models common_range. Otherwise fall back to default_sentinel.
-    constexpr auto end() {
-        if constexpr (both_forward && both_common) {
-            return iterator{std::ranges::end(base1_), std::ranges::end(base1_),
-                            std::ranges::end(base2_), std::ranges::end(base2_), comp_};
-        } else {
-            return std::default_sentinel;
-        }
-    }
+    using set_transform<V1, V2, Comp, detail::union_fn>::set_transform;
 };
 
 template <std::ranges::viewable_range R1, std::ranges::viewable_range R2,

--- a/modules/animation/CMakeLists.txt
+++ b/modules/animation/CMakeLists.txt
@@ -52,6 +52,7 @@ set(HEADER_FILES
     include/modules/animation/interpolation/camerasphericalinterpolation.h
     include/modules/animation/interpolation/constantinterpolation.h
     include/modules/animation/interpolation/interpolation.h
+    include/modules/animation/interpolation/isovaluepropertyinterpolation.h
     include/modules/animation/interpolation/linearinterpolation.h
     include/modules/animation/interpolation/transferfunctioninterpolation.h
     include/modules/animation/mainanimation.h
@@ -108,6 +109,7 @@ set(SOURCE_FILES
     src/interpolation/cameralinearinterpolation.cpp
     src/interpolation/camerasphericalinterpolation.cpp
     src/interpolation/interpolation.cpp
+    src/interpolation/isovaluepropertyinterpolation.cpp
     src/interpolation/transferfunctioninterpolation.cpp
     src/mainanimation.cpp
     src/workspaceanimations.cpp

--- a/modules/animation/include/modules/animation/datastructures/animation.h
+++ b/modules/animation/include/modules/animation/datastructures/animation.h
@@ -103,29 +103,30 @@ public:
     void add(std::unique_ptr<Track> track);
 
     /**
-     * Adds a PropertyTrack, or returns an existing it has one for the property.
+     * Adds PropertyTracks, or returns existing ones for the property.
+     * If the property is a CompositeProperty, tracks are added recursively for all sub-properties.
      * The added PropertyTrack will be removed if the property is removed.
-     * @return BasePropertyTrack if added, nullptr otherwise.
+     * @return BasePropertyTracks if added, empty otherwise.
      * @see BasePropertyTrack
      * @throws Exception if no AnimationManager has been supplied.
      */
-    BasePropertyTrack* add(Property* property);
+    std::vector<BasePropertyTrack*> add(Property* property);
     /**
-     * Add keyframe at specified time.
+     * Add keyframes at specified time.
      * Creates a new track if no track with the supplied property exists.
      * The PropertyTrack will be removed if the property is removed.
-     * @return Keyframe if successsfully added, nullptr otherwise.
+     * @return Keyframes if successsfully added, empty otherwise.
      * @throws Exception if no AnimationManager has been supplied.
      */
-    Keyframe* addKeyframe(Property* property, Seconds time);
+    std::vector<Keyframe*> addKeyframe(Property* property, Seconds time);
     /**
-     * Add sequence at specified time.
+     * Add sequences at specified time.
      * Creates a new track if no track with the supplied property exists.
      * The PropertyTrack will be removed if the property is removed.
-     * @return KeyframeSequence if successsfully added, nullptr otherwise.
+     * @return KeyframeSequences if successsfully added, empty otherwise.
      * @throws Exception if no AnimationManager has been supplied.
      */
-    KeyframeSequence* addKeyframeSequence(Property* property, Seconds time);
+    std::vector<KeyframeSequence*> addKeyframeSequence(Property* property, Seconds time);
 
     /**
      * Remove tracks at index i, indicating the order in which the track was added,

--- a/modules/animation/include/modules/animation/interpolation/constantinterpolation.h
+++ b/modules/animation/include/modules/animation/interpolation/constantinterpolation.h
@@ -42,6 +42,7 @@
 
 namespace inviwo {
 class TransferFunction;
+class IsoValueCollection;
 }
 
 namespace inviwo::animation {
@@ -97,6 +98,10 @@ std::string_view ConstantInterpolation<Key, Result>::classIdentifier() {
     } else if constexpr (std::is_same_v<V, TransferFunction>) {
         static const std::string identifier =
             "org.inviwo.animation.constantinterpolation.TransferFunction";
+        return identifier;
+    } else if constexpr (std::is_same_v<V, IsoValueCollection>) {
+        static const std::string identifier =
+            "org.inviwo.animation.constantinterpolation.IsoValueCollection";
         return identifier;
     } else {
         static const auto identifier =

--- a/modules/animation/include/modules/animation/interpolation/isovaluepropertyinterpolation.h
+++ b/modules/animation/include/modules/animation/interpolation/isovaluepropertyinterpolation.h
@@ -1,0 +1,152 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2026 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <modules/animation/animationmoduledefine.h>
+
+#include <inviwo/core/algorithm/easing.h>
+#include <inviwo/core/datastructures/isovaluecollection.h>
+#include <inviwo/core/properties/isovalueproperty.h>
+#include <inviwo/core/properties/ordinalproperty.h>
+#include <modules/animation/datastructures/animationtime.h>
+#include <modules/animation/datastructures/valuekeyframe.h>
+#include <modules/animation/datastructures/valuekeyframesequence.h>
+#include <modules/animation/interpolation/interpolation.h>
+
+#include <memory>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+namespace inviwo {
+
+class InviwoApplication;
+
+namespace animation {
+namespace detail {
+
+IVW_MODULE_ANIMATION_API double interpolationTime(Seconds t1, Seconds t2,
+                                                  std::optional<EasingType> easeIn,
+                                                  std::optional<EasingType> easeOut,
+                                                  Seconds to);
+
+IVW_MODULE_ANIMATION_API void interpolateIsoValuesFade(const IsoValueCollection& source,
+                                                        const IsoValueCollection& destination,
+                                                        double t, IsoValueCollection& out);
+
+IVW_MODULE_ANIMATION_API void interpolateIsoValuesBlend(
+    const IsoValueCollection& source, const IsoValueCollection& destination, double t,
+    IsoValueCollection& out);
+
+}  // namespace detail
+
+/**
+ * @brief Interpolates between two IsoValueProperty keyframes by matching iso-values at equal
+ * positions and fading unmatched ones in or out.
+ *
+ * Iso-values that exist at the same position in both keyframes are interpolated in both position
+ * and color. Iso-values that only exist in the source keyframe are faded out (alpha goes to zero)
+ * while iso-values that only exist in the destination keyframe are faded in (alpha comes from
+ * zero). This preserves the structural identity of iso-values across the transition.
+ */
+class IVW_MODULE_ANIMATION_API IsoValuePropertyInterpolationFade
+    : public InterpolationTyped<ValueKeyframe<IsoValueProperty::value_type>,
+                                IsoValueProperty::value_type> {
+public:
+    IsoValuePropertyInterpolationFade(InviwoApplication* app = nullptr);
+    IsoValuePropertyInterpolationFade(const IsoValuePropertyInterpolationFade&);
+    virtual ~IsoValuePropertyInterpolationFade() = default;
+    virtual IsoValuePropertyInterpolationFade* clone() const override;
+
+    virtual std::string_view getDisplayName() const override;
+    virtual std::string_view getIdentifier() const override {
+        return "IsoValuePropertyInterpolationFade";
+    }
+
+    static std::string_view classIdentifier();
+    virtual std::string_view getClassIdentifier() const override;
+
+    virtual bool equal(const Interpolation& other) const override;
+
+    virtual void operator()(
+        const std::vector<std::unique_ptr<ValueKeyframe<IsoValueProperty::value_type>>>& keys,
+        Seconds from, Seconds to, IsoValueProperty::value_type& out) const override;
+};
+
+/**
+ * @brief Interpolates between two IsoValueProperty keyframes by pairing iso-values by index order.
+ *
+ * Iso-values are matched by their order in the collection: the first iso-value of the source is
+ * paired with the first of the destination, and so on. Paired iso-values are interpolated in both
+ * position and color. Unmatched iso-values (when the two keyframes have different counts) are
+ * faded in or out. This gives a smooth blending effect when the two keyframes have similarly
+ * structured iso-value collections.
+ */
+class IVW_MODULE_ANIMATION_API IsoValuePropertyInterpolationBlend
+    : public InterpolationTyped<ValueKeyframe<IsoValueProperty::value_type>,
+                                IsoValueProperty::value_type> {
+public:
+    IsoValuePropertyInterpolationBlend(InviwoApplication* app = nullptr);
+    IsoValuePropertyInterpolationBlend(
+        const IsoValuePropertyInterpolationBlend& rhs);
+    virtual ~IsoValuePropertyInterpolationBlend() = default;
+    virtual IsoValuePropertyInterpolationBlend* clone() const override;
+
+    virtual std::string_view getDisplayName() const override;
+    virtual std::string_view getIdentifier() const override {
+        return "IsoValuePropertyInterpolationBlend";
+    }
+
+    static std::string_view classIdentifier();
+    virtual std::string_view getClassIdentifier() const override;
+
+    virtual bool equal(const Interpolation& other) const override;
+
+    virtual void operator()(
+        const std::vector<std::unique_ptr<ValueKeyframe<IsoValueProperty::value_type>>>& keys,
+        Seconds from, Seconds to, IsoValueProperty::value_type& out) const override;
+
+    OrdinalProperty<size_t> segments;
+    OrdinalProperty<double> simplify;
+};
+
+namespace detail {
+
+template <>
+struct DefaultInterpolationCreator<ValueKeyframe<IsoValueProperty::value_type>> {
+    static std::unique_ptr<IsoValuePropertyInterpolationBlend> create() {
+        return std::make_unique<IsoValuePropertyInterpolationBlend>();
+    }
+};
+
+}  // namespace detail
+
+}  // namespace animation
+
+}  // namespace inviwo

--- a/modules/animation/include/modules/animation/interpolation/isovaluepropertyinterpolation.h
+++ b/modules/animation/include/modules/animation/interpolation/isovaluepropertyinterpolation.h
@@ -51,11 +51,6 @@ class InviwoApplication;
 namespace animation {
 namespace detail {
 
-IVW_MODULE_ANIMATION_API double interpolationTime(Seconds t1, Seconds t2,
-                                                  std::optional<EasingType> easeIn,
-                                                  std::optional<EasingType> easeOut,
-                                                  Seconds to);
-
 IVW_MODULE_ANIMATION_API void interpolateIsoValuesFade(const IsoValueCollection& source,
                                                         const IsoValueCollection& destination,
                                                         double t, IsoValueCollection& out);
@@ -80,6 +75,9 @@ class IVW_MODULE_ANIMATION_API IsoValueInterpolationFade
 public:
     explicit IsoValuePropertyInterpolationFade(InviwoApplication* app = nullptr);
     IsoValuePropertyInterpolationFade(const IsoValuePropertyInterpolationFade&);
+    IsoValuePropertyInterpolationFade& operator=(const IsoValuePropertyInterpolationFade&) = delete;
+    IsoValuePropertyInterpolationFade(IsoValuePropertyInterpolationFade&&) = delete;
+    IsoValuePropertyInterpolationFade& operator=(IsoValuePropertyInterpolationFade&&) = delete;
     virtual ~IsoValuePropertyInterpolationFade() = default;
     virtual IsoValuePropertyInterpolationFade* clone() const override;
 
@@ -113,6 +111,9 @@ public:
     explicit IsoValuePropertyInterpolationBlend(InviwoApplication* app = nullptr);
     IsoValuePropertyInterpolationBlend(
         const IsoValuePropertyInterpolationBlend& rhs);
+    IsoValuePropertyInterpolationBlend& operator=(const IsoValuePropertyInterpolationBlend&) = delete;
+    IsoValuePropertyInterpolationBlend(IsoValuePropertyInterpolationBlend&&) = delete;
+    IsoValuePropertyInterpolationBlend& operator=(IsoValuePropertyInterpolationBlend&&) = delete;
     virtual ~IsoValuePropertyInterpolationBlend() = default;
     virtual IsoValuePropertyInterpolationBlend* clone() const override;
 
@@ -137,7 +138,7 @@ public:
 namespace detail {
 
 template <>
-struct DefaultInterpolationCreator<ValueKeyframe<IsoValueProperty::value_type>> {
+struct DefaultInterpolationCreator<ValueKeyframe<IsoValueCollection>> {
     static std::unique_ptr<IsoValuePropertyInterpolationBlend> create() {
         return std::make_unique<IsoValuePropertyInterpolationBlend>();
     }

--- a/modules/animation/include/modules/animation/interpolation/isovaluepropertyinterpolation.h
+++ b/modules/animation/include/modules/animation/interpolation/isovaluepropertyinterpolation.h
@@ -79,7 +79,7 @@ class IVW_MODULE_ANIMATION_API IsoValuePropertyInterpolationFade
     : public InterpolationTyped<ValueKeyframe<IsoValueProperty::value_type>,
                                 IsoValueProperty::value_type> {
 public:
-    IsoValuePropertyInterpolationFade(InviwoApplication* app = nullptr);
+    explicit IsoValuePropertyInterpolationFade(InviwoApplication* app = nullptr);
     IsoValuePropertyInterpolationFade(const IsoValuePropertyInterpolationFade&);
     virtual ~IsoValuePropertyInterpolationFade() = default;
     virtual IsoValuePropertyInterpolationFade* clone() const override;
@@ -112,7 +112,7 @@ class IVW_MODULE_ANIMATION_API IsoValuePropertyInterpolationBlend
     : public InterpolationTyped<ValueKeyframe<IsoValueProperty::value_type>,
                                 IsoValueProperty::value_type> {
 public:
-    IsoValuePropertyInterpolationBlend(InviwoApplication* app = nullptr);
+    explicit IsoValuePropertyInterpolationBlend(InviwoApplication* app = nullptr);
     IsoValuePropertyInterpolationBlend(
         const IsoValuePropertyInterpolationBlend& rhs);
     virtual ~IsoValuePropertyInterpolationBlend() = default;

--- a/modules/animation/include/modules/animation/interpolation/isovaluepropertyinterpolation.h
+++ b/modules/animation/include/modules/animation/interpolation/isovaluepropertyinterpolation.h
@@ -74,8 +74,8 @@ class IVW_MODULE_ANIMATION_API IsoValuePropertyInterpolationFade
     : public InterpolationTyped<ValueKeyframe<IsoValueCollection>,
                                 IsoValueCollection> {
 public:
-    IsoValuePropertyInterpolationFade(InviwoApplication* app = nullptr);
-    explicit IsoValuePropertyInterpolationFade(const IsoValuePropertyInterpolationFade&);
+    explicit IsoValuePropertyInterpolationFade(InviwoApplication* app = nullptr);
+    IsoValuePropertyInterpolationFade(const IsoValuePropertyInterpolationFade&);
     IsoValuePropertyInterpolationFade& operator=(const IsoValuePropertyInterpolationFade&) = delete;
     IsoValuePropertyInterpolationFade(IsoValuePropertyInterpolationFade&&) = delete;
     IsoValuePropertyInterpolationFade& operator=(IsoValuePropertyInterpolationFade&&) = delete;
@@ -110,8 +110,8 @@ class IVW_MODULE_ANIMATION_API IsoValuePropertyInterpolationBlend
     : public InterpolationTyped<ValueKeyframe<IsoValueCollection>,
                                 IsoValueCollection> {
 public:
-    IsoValuePropertyInterpolationBlend(InviwoApplication* app = nullptr);
-    explicit IsoValuePropertyInterpolationBlend(const IsoValuePropertyInterpolationBlend& rhs);
+    explicit IsoValuePropertyInterpolationBlend(InviwoApplication* app = nullptr);
+    IsoValuePropertyInterpolationBlend(const IsoValuePropertyInterpolationBlend& rhs);
     IsoValuePropertyInterpolationBlend& operator=(const IsoValuePropertyInterpolationBlend&) = delete;
     IsoValuePropertyInterpolationBlend(IsoValuePropertyInterpolationBlend&&) = delete;
     IsoValuePropertyInterpolationBlend& operator=(IsoValuePropertyInterpolationBlend&&) = delete;

--- a/modules/animation/include/modules/animation/interpolation/isovaluepropertyinterpolation.h
+++ b/modules/animation/include/modules/animation/interpolation/isovaluepropertyinterpolation.h
@@ -75,9 +75,8 @@ IVW_MODULE_ANIMATION_API void interpolateIsoValuesBlend(
  * while iso-values that only exist in the destination keyframe are faded in (alpha comes from
  * zero). This preserves the structural identity of iso-values across the transition.
  */
-class IVW_MODULE_ANIMATION_API IsoValuePropertyInterpolationFade
-    : public InterpolationTyped<ValueKeyframe<IsoValueProperty::value_type>,
-                                IsoValueProperty::value_type> {
+class IVW_MODULE_ANIMATION_API IsoValueInterpolationFade
+    : public InterpolationTyped<ValueKeyframe<IsoValueCollection>, IsoValueCollection> {
 public:
     explicit IsoValuePropertyInterpolationFade(InviwoApplication* app = nullptr);
     IsoValuePropertyInterpolationFade(const IsoValuePropertyInterpolationFade&);
@@ -86,7 +85,7 @@ public:
 
     virtual std::string_view getDisplayName() const override;
     virtual std::string_view getIdentifier() const override {
-        return "IsoValuePropertyInterpolationFade";
+        return "IsoValueInterpolationFade";
     }
 
     static std::string_view classIdentifier();
@@ -95,8 +94,8 @@ public:
     virtual bool equal(const Interpolation& other) const override;
 
     virtual void operator()(
-        const std::vector<std::unique_ptr<ValueKeyframe<IsoValueProperty::value_type>>>& keys,
-        Seconds from, Seconds to, IsoValueProperty::value_type& out) const override;
+        const std::vector<std::unique_ptr<ValueKeyframe<IsoValueCollection>>>& keys,
+        Seconds from, Seconds to, IsoValueCollection& out) const override;
 };
 
 /**
@@ -108,9 +107,8 @@ public:
  * faded in or out. This gives a smooth blending effect when the two keyframes have similarly
  * structured iso-value collections.
  */
-class IVW_MODULE_ANIMATION_API IsoValuePropertyInterpolationBlend
-    : public InterpolationTyped<ValueKeyframe<IsoValueProperty::value_type>,
-                                IsoValueProperty::value_type> {
+class IVW_MODULE_ANIMATION_API IsoValueInterpolationBlend
+    : public InterpolationTyped<ValueKeyframe<IsoValueCollection>, IsoValueCollection> {
 public:
     explicit IsoValuePropertyInterpolationBlend(InviwoApplication* app = nullptr);
     IsoValuePropertyInterpolationBlend(

--- a/modules/animation/include/modules/animation/interpolation/isovaluepropertyinterpolation.h
+++ b/modules/animation/include/modules/animation/interpolation/isovaluepropertyinterpolation.h
@@ -71,11 +71,11 @@ IVW_MODULE_ANIMATION_API void interpolateIsoValuesBlend(
  * zero). This preserves the structural identity of iso-values across the transition.
  */
 class IVW_MODULE_ANIMATION_API IsoValuePropertyInterpolationFade
-    : public InterpolationTyped<ValueKeyframe<IsoValueProperty::value_type>,
-                                IsoValueProperty::value_type> {
+    : public InterpolationTyped<ValueKeyframe<IsoValueCollection>,
+                                IsoValueCollection> {
 public:
     IsoValuePropertyInterpolationFade(InviwoApplication* app = nullptr);
-    IsoValuePropertyInterpolationFade(const IsoValuePropertyInterpolationFade&);
+    explicit IsoValuePropertyInterpolationFade(const IsoValuePropertyInterpolationFade&);
     IsoValuePropertyInterpolationFade& operator=(const IsoValuePropertyInterpolationFade&) = delete;
     IsoValuePropertyInterpolationFade(IsoValuePropertyInterpolationFade&&) = delete;
     IsoValuePropertyInterpolationFade& operator=(IsoValuePropertyInterpolationFade&&) = delete;
@@ -107,12 +107,11 @@ public:
  * structured iso-value collections.
  */
 class IVW_MODULE_ANIMATION_API IsoValuePropertyInterpolationBlend
-    : public InterpolationTyped<ValueKeyframe<IsoValueProperty::value_type>,
-                                IsoValueProperty::value_type> {
+    : public InterpolationTyped<ValueKeyframe<IsoValueCollection>,
+                                IsoValueCollection> {
 public:
     IsoValuePropertyInterpolationBlend(InviwoApplication* app = nullptr);
-    IsoValuePropertyInterpolationBlend(
-        const IsoValuePropertyInterpolationBlend& rhs);
+    explicit IsoValuePropertyInterpolationBlend(const IsoValuePropertyInterpolationBlend& rhs);
     IsoValuePropertyInterpolationBlend& operator=(const IsoValuePropertyInterpolationBlend&) = delete;
     IsoValuePropertyInterpolationBlend(IsoValuePropertyInterpolationBlend&&) = delete;
     IsoValuePropertyInterpolationBlend& operator=(IsoValuePropertyInterpolationBlend&&) = delete;
@@ -130,8 +129,8 @@ public:
     virtual bool equal(const Interpolation& other) const override;
 
     virtual void operator()(
-        const std::vector<std::unique_ptr<ValueKeyframe<IsoValueProperty::value_type>>>& keys,
-        Seconds from, Seconds to, IsoValueProperty::value_type& out) const override;
+        const std::vector<std::unique_ptr<ValueKeyframe<IsoValueCollection>>>& keys,
+        Seconds from, Seconds to, IsoValueCollection& out) const override;
 
     OrdinalProperty<size_t> segments;
     OrdinalProperty<double> simplify;

--- a/modules/animation/include/modules/animation/interpolation/isovaluepropertyinterpolation.h
+++ b/modules/animation/include/modules/animation/interpolation/isovaluepropertyinterpolation.h
@@ -70,10 +70,11 @@ IVW_MODULE_ANIMATION_API void interpolateIsoValuesBlend(
  * while iso-values that only exist in the destination keyframe are faded in (alpha comes from
  * zero). This preserves the structural identity of iso-values across the transition.
  */
-class IVW_MODULE_ANIMATION_API IsoValueInterpolationFade
-    : public InterpolationTyped<ValueKeyframe<IsoValueCollection>, IsoValueCollection> {
+class IVW_MODULE_ANIMATION_API IsoValuePropertyInterpolationFade
+    : public InterpolationTyped<ValueKeyframe<IsoValueProperty::value_type>,
+                                IsoValueProperty::value_type> {
 public:
-    explicit IsoValuePropertyInterpolationFade(InviwoApplication* app = nullptr);
+    IsoValuePropertyInterpolationFade(InviwoApplication* app = nullptr);
     IsoValuePropertyInterpolationFade(const IsoValuePropertyInterpolationFade&);
     IsoValuePropertyInterpolationFade& operator=(const IsoValuePropertyInterpolationFade&) = delete;
     IsoValuePropertyInterpolationFade(IsoValuePropertyInterpolationFade&&) = delete;
@@ -105,10 +106,11 @@ public:
  * faded in or out. This gives a smooth blending effect when the two keyframes have similarly
  * structured iso-value collections.
  */
-class IVW_MODULE_ANIMATION_API IsoValueInterpolationBlend
-    : public InterpolationTyped<ValueKeyframe<IsoValueCollection>, IsoValueCollection> {
+class IVW_MODULE_ANIMATION_API IsoValuePropertyInterpolationBlend
+    : public InterpolationTyped<ValueKeyframe<IsoValueProperty::value_type>,
+                                IsoValueProperty::value_type> {
 public:
-    explicit IsoValuePropertyInterpolationBlend(InviwoApplication* app = nullptr);
+    IsoValuePropertyInterpolationBlend(InviwoApplication* app = nullptr);
     IsoValuePropertyInterpolationBlend(
         const IsoValuePropertyInterpolationBlend& rhs);
     IsoValuePropertyInterpolationBlend& operator=(const IsoValuePropertyInterpolationBlend&) = delete;

--- a/modules/animation/include/modules/animation/interpolation/transferfunctioninterpolation.h
+++ b/modules/animation/include/modules/animation/interpolation/transferfunctioninterpolation.h
@@ -35,6 +35,7 @@
 #include <modules/animation/datastructures/animationtime.h>
 #include <modules/animation/interpolation/interpolation.h>
 #include <modules/animation/datastructures/valuekeyframe.h>
+#include <modules/animation/datastructures/valuekeyframesequence.h>
 
 #include <memory>
 #include <string>
@@ -93,6 +94,17 @@ public:
         const std::vector<std::unique_ptr<ValueKeyframe<TransferFunction>>>& keys, Seconds from,
         Seconds to, TransferFunction& out) const override;
 };
+
+namespace detail {
+
+template <>
+struct DefaultInterpolationCreator<ValueKeyframe<TransferFunction>> {
+    static std::unique_ptr<TFInterpolationOptimalTransport> create() {
+        return std::make_unique<TFInterpolationOptimalTransport>();
+    }
+};
+
+}  // namespace detail
 
 }  // namespace animation
 }  // namespace inviwo

--- a/modules/animation/include/modules/animation/mainanimation.h
+++ b/modules/animation/include/modules/animation/mainanimation.h
@@ -85,7 +85,7 @@ private:
     void addKeyframeCallback(Property* property);
     /**
      * Module callbacks must return void
-     * @see addSequence(Property* property, Seconds time)
+     * @see addKeyframeSequence(Property* property, Seconds time)
      */
     void addKeyframeSequenceCallback(Property* property);
 

--- a/modules/animation/src/animationmodule.cpp
+++ b/modules/animation/src/animationmodule.cpp
@@ -39,6 +39,7 @@
 #include <inviwo/core/properties/buttonproperty.h>
 #include <inviwo/core/properties/cameraproperty.h>
 #include <inviwo/core/properties/fileproperty.h>
+#include <inviwo/core/properties/isovalueproperty.h>
 #include <inviwo/core/properties/minmaxproperty.h>
 #include <inviwo/core/properties/optionproperty.h>
 #include <inviwo/core/properties/ordinalproperty.h>
@@ -75,6 +76,7 @@
 #include <modules/animation/interpolation/camerasphericalinterpolation.h>
 #include <modules/animation/interpolation/constantinterpolation.h>
 #include <modules/animation/interpolation/interpolation.h>
+#include <modules/animation/interpolation/isovaluepropertyinterpolation.h>
 #include <modules/animation/interpolation/linearinterpolation.h>
 #include <modules/animation/workspaceanimations.h>
 #include <modules/animation/factories/imagerecorderfactory.h>
@@ -144,9 +146,9 @@ AnimationModule::AnimationModule(InviwoApplication* app)
         interpolationHelper<PropertyType, ConstantInterpolation<ValueKeyframe<ValueType>>>();
     });
 
-    // Register properties that should not interpolate
+    // Register constant interpolation (no interpolation) properties
     util::for_each_type<
-        std::tuple<BoolProperty, FileProperty, StringProperty, TransferFunctionProperty>>{}(
+        std::tuple<BoolProperty, FileProperty, StringProperty>>{}(
         [&]<typename PropertyType>() {
             propertyHelper<PropertyType>();
             using ValueType = typename PropertyType::value_type;
@@ -169,10 +171,19 @@ AnimationModule::AnimationModule(InviwoApplication* app)
     interpolationHelper<CameraProperty, CameraLinearInterpolation>();
     interpolationHelper<CameraProperty, CameraAnimation>();
 
+    propertyHelper<TransferFunctionProperty>();
+
+    interpolationHelper<TransferFunctionProperty, TFInterpolationOptimalTransport>();
+    interpolationHelper<TransferFunctionProperty, TFInterpolationBlend>();
     interpolationHelper<TransferFunctionProperty,
                         ConstantInterpolation<ValueKeyframe<TransferFunction>>>();
-    interpolationHelper<TransferFunctionProperty, TFInterpolationBlend>();
-    interpolationHelper<TransferFunctionProperty, TFInterpolationOptimalTransport>();
+
+    propertyHelper<IsoValueProperty>();
+
+    interpolationHelper<IsoValueProperty, IsoValuePropertyInterpolationBlend>();
+    interpolationHelper<IsoValueProperty, IsoValuePropertyInterpolationFade>();
+    interpolationHelper<IsoValueProperty,
+                        ConstantInterpolation<ValueKeyframe<IsoValueProperty::value_type>>>();
 
     propertyHelper<ButtonProperty, ButtonKeyframe, ButtonKeyframeSequence>();
 

--- a/modules/animation/src/animationmodule.cpp
+++ b/modules/animation/src/animationmodule.cpp
@@ -183,7 +183,7 @@ AnimationModule::AnimationModule(InviwoApplication* app)
     interpolationHelper<IsoValueProperty, IsoValuePropertyInterpolationBlend>();
     interpolationHelper<IsoValueProperty, IsoValuePropertyInterpolationFade>();
     interpolationHelper<IsoValueProperty,
-                        ConstantInterpolation<ValueKeyframe<IsoValueProperty::value_type>>>();
+                        ConstantInterpolation<ValueKeyframe<IsoValueCollection>>>();
 
     propertyHelper<ButtonProperty, ButtonKeyframe, ButtonKeyframeSequence>();
 

--- a/modules/animation/src/datastructures/animation.cpp
+++ b/modules/animation/src/datastructures/animation.cpp
@@ -31,6 +31,7 @@
 
 #include <inviwo/core/io/serialization/deserializer.h>
 #include <inviwo/core/io/serialization/serializer.h>
+#include <inviwo/core/properties/compositeproperty.h>
 #include <inviwo/core/properties/property.h>
 #include <inviwo/core/properties/propertyowner.h>
 #include <inviwo/core/properties/propertyownerobserver.h>
@@ -126,38 +127,52 @@ void Animation::add(std::unique_ptr<Track> track) {
     trackAddedInternal(tracks_.back().get());
 }
 
-Keyframe* Animation::addKeyframe(Property* property, Seconds time) {
+std::vector<Keyframe*> Animation::addKeyframe(Property* property, Seconds time) {
+    std::vector<Keyframe*> keyframes;
     auto it = findTrack(property);
     try {
         if (it != end()) {
-            return dynamic_cast<BasePropertyTrack*>(&(*it))->addKeyFrameUsingPropertyValue(time);
-        } else if (auto basePropertyTrack = add(property)) {
-            return basePropertyTrack->addKeyFrameUsingPropertyValue(time);
+            if (auto* keyframe =
+                    dynamic_cast<BasePropertyTrack*>(&(*it))->addKeyFrameUsingPropertyValue(time)) {
+                keyframes.push_back(keyframe);
+            }
+        } else if (auto propertyTracks = add(property); !propertyTracks.empty()) {
+            for (auto* propertyTrack : propertyTracks) {
+                if (auto* keyframe = propertyTrack->addKeyFrameUsingPropertyValue(time)) {
+                    keyframes.push_back(keyframe);
+                }
+            }
         } else {
             log::warn("No matching Track found for property \"{}\"", property->getIdentifier());
         }
     } catch (const Exception& e) {
         log::exception(e);
     }
-    return nullptr;
+    return keyframes;
 }
 
-KeyframeSequence* Animation::addKeyframeSequence(Property* property, Seconds time) {
+std::vector<KeyframeSequence*> Animation::addKeyframeSequence(Property* property, Seconds time) {
+    std::vector<KeyframeSequence*> sequences;
     auto it = findTrack(property);
     std::string interpolationErrMsg;
     try {
         if (it != end()) {
-            return dynamic_cast<BasePropertyTrack*>(&(*it))->addSequenceUsingPropertyValue(time);
-        } else if (auto basePropertyTrack = add(property)) {
-            basePropertyTrack->addKeyFrameUsingPropertyValue(time);
-            return &basePropertyTrack->toTrack()->getFirst();
+            if (auto* sequence =
+                    dynamic_cast<BasePropertyTrack*>(&(*it))->addSequenceUsingPropertyValue(time)) {
+                sequences.push_back(sequence);
+            }
+        } else if (auto propertyTracks = add(property); !propertyTracks.empty()) {
+            for (auto* propertyTrack : propertyTracks) {
+                propertyTrack->addKeyFrameUsingPropertyValue(time);
+                sequences.push_back(&propertyTrack->toTrack()->getFirst());
+            }
         } else {
             log::warn("No matching Track found for property \"{}\"", property->getIdentifier());
         }
     } catch (const Exception& ex) {
         log::exception(ex);
     }
-    return nullptr;
+    return sequences;
 }
 
 Animation::iterator Animation::findTrack(Property* property) {
@@ -170,25 +185,32 @@ Animation::iterator Animation::findTrack(Property* property) {
     });
 }
 
-BasePropertyTrack* Animation::add(Property* property) {
+std::vector<BasePropertyTrack*> Animation::add(Property* property) {
     auto it = findTrack(property);
     if (it != end()) {
-        return dynamic_cast<BasePropertyTrack*>(&(*it));
-    } else {
-        if (auto track = getManager()->getTrackFactory().create(property)) {
-            if (auto basePropertyTrack = dynamic_cast<BasePropertyTrack*>(track.get())) {
-                try {
-                    basePropertyTrack->setProperty(property);
-                } catch (const Exception& e) {
-                    log::warn("{} Invalid property class identified?", e.getMessage());
-                    return nullptr;
-                }
-                add(std::move(track));
-                return basePropertyTrack;
-            }
+        if (auto* propertyTrack = dynamic_cast<BasePropertyTrack*>(&(*it))) {
+            return {propertyTrack};
         }
-        return nullptr;
     }
+
+    std::vector<BasePropertyTrack*> propertyTracks;
+    if (auto track = getManager()->getTrackFactory().create(property)) {
+        if (auto* basePropertyTrack = dynamic_cast<BasePropertyTrack*>(track.get())) {
+            propertyTracks.push_back(basePropertyTrack);
+            add(std::move(track));
+        }
+        return propertyTracks;
+    }
+
+    if (auto* composite = dynamic_cast<CompositeProperty*>(property)) {
+        for (auto* child : composite->getProperties()) {
+            auto childPropertyTracks = add(child);
+            propertyTracks.insert(propertyTracks.end(), childPropertyTracks.begin(),
+                                  childPropertyTracks.end());
+        }
+    }
+
+    return propertyTracks;
 }
 
 std::unique_ptr<Track> Animation::remove(size_t i) {

--- a/modules/animation/src/interpolation/isovaluepropertyinterpolation.cpp
+++ b/modules/animation/src/interpolation/isovaluepropertyinterpolation.cpp
@@ -1,0 +1,251 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2026 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <modules/animation/interpolation/isovaluepropertyinterpolation.h>
+
+#include <inviwo/core/datastructures/tfprimitive.h>
+
+#include <algorithm>
+#include <cmath>
+#include <tuple>
+#include <vector>
+
+namespace inviwo::animation {
+namespace {
+
+TFPrimitiveData fade(const TFPrimitive& primitive, double t) {
+    auto color = primitive.getColor();
+    color.a *= static_cast<float>(t);
+    return {primitive.getPosition(), color};
+}
+
+TFPrimitiveData fadeIn(const TFPrimitive& primitive, double t) { return fade(primitive, t); }
+
+TFPrimitiveData fadeOut(const TFPrimitive& primitive, double t) { return fade(primitive, 1.0 - t); }
+
+TFPrimitiveData interpolate(const TFPrimitive& source, const TFPrimitive& destination, double t) {
+    return {std::lerp(source.getPosition(), destination.getPosition(), t),
+            glm::mix(source.getColor(), destination.getColor(), t)};
+}
+
+std::vector<std::pair<size_t, size_t>> matchEqualPositions(const IsoValueCollection& source,
+                                                           const IsoValueCollection& destination) {
+    std::vector<std::pair<size_t, size_t>> matches;
+    std::vector<bool> matchedDestination(destination.size(), false);
+
+    for (size_t i = 0; i < source.size(); ++i) {
+        for (size_t j = 0; j < destination.size(); ++j) {
+            if (!matchedDestination[j] && source[i].getPosition() == destination[j].getPosition()) {
+                matches.emplace_back(i, j);
+                matchedDestination[j] = true;
+                break;
+            }
+        }
+    }
+    return matches;
+}
+
+std::vector<std::pair<size_t, size_t>> matchPointsByOrder(const IsoValueCollection& source,
+                                                          const IsoValueCollection& destination) {
+    std::vector<std::pair<size_t, size_t>> matches;
+    const auto count = std::min(source.size(), destination.size());
+    matches.reserve(count);
+
+    for (size_t i = 0; i < count; ++i) {
+        matches.emplace_back(i, i);
+    }
+
+    return matches;
+}
+
+template <typename Match>
+std::vector<TFPrimitiveData> interpolateIsoValues(const IsoValueCollection& source,
+                                                  const IsoValueCollection& destination, double t,
+                                                  Match match) {
+    const auto matches = match(source, destination);
+
+    std::vector<bool> matchedSource(source.size(), false);
+    std::vector<bool> matchedDestination(destination.size(), false);
+    std::vector<TFPrimitiveData> values;
+    values.reserve(source.size() + destination.size() - matches.size());
+
+    for (const auto& [i, j] : matches) {
+        values.push_back(interpolate(source[i], destination[j], t));
+        matchedSource[i] = true;
+        matchedDestination[j] = true;
+    }
+    for (size_t i = 0; i < source.size(); ++i) {
+        if (!matchedSource[i]) values.push_back(fadeOut(source[i], t));
+    }
+    for (size_t j = 0; j < destination.size(); ++j) {
+        if (!matchedDestination[j]) values.push_back(fadeIn(destination[j], t));
+    }
+    return values;
+}
+
+template <typename Value, typename InterpolateValue>
+void interpolatePropertyValue(const std::vector<std::unique_ptr<ValueKeyframe<Value>>>& keys, Seconds to,
+                              Value& out, InterpolateValue interpolateValue) {
+
+    auto it = std::upper_bound(keys.begin(), keys.end(), to, [](const auto& time, const auto& key) {
+        return time < key->getTime();
+    });
+    const auto& prev = *(*std::prev(it));
+    const auto& next = *(*it);
+
+    interpolateValue(prev, next, to, out);
+}
+
+}  // namespace
+
+namespace detail {
+
+double interpolationTime(Seconds t1, Seconds t2, std::optional<EasingType> easeIn,
+                         std::optional<EasingType> easeOut, Seconds to) {
+    return util::ease(static_cast<double>((to - t1) / (t2 - t1)), easeIn, easeOut);
+}
+
+void interpolateIsoValuesFade(const IsoValueCollection& source, const IsoValueCollection& destination,
+                               double t, IsoValueCollection& out) {
+    if (source.getType() != destination.getType()) {
+        out = source;
+        return;
+    }
+
+    out = IsoValueCollection{interpolateIsoValues(source, destination, t, matchEqualPositions),
+                             source.getType()};
+}
+
+void interpolateIsoValuesBlend(const IsoValueCollection& source,
+                                          const IsoValueCollection& destination, double t,
+                                          IsoValueCollection& out) {
+    if (source.getType() != destination.getType()) {
+        out = source;
+        return;
+    }
+
+    out = IsoValueCollection{interpolateIsoValues(source, destination, t, matchPointsByOrder),
+                             source.getType()};
+}
+
+}  // namespace detail
+
+IsoValuePropertyInterpolationFade::IsoValuePropertyInterpolationFade(InviwoApplication* app)
+    : InterpolationTyped<ValueKeyframe<IsoValueProperty::value_type>,
+                         IsoValueProperty::value_type>(app) {}
+
+IsoValuePropertyInterpolationFade::IsoValuePropertyInterpolationFade(
+    const IsoValuePropertyInterpolationFade& rhs)
+    : InterpolationTyped<ValueKeyframe<IsoValueProperty::value_type>,
+                         IsoValueProperty::value_type>(rhs) {}
+
+IsoValuePropertyInterpolationFade* IsoValuePropertyInterpolationFade::clone() const {
+    return new IsoValuePropertyInterpolationFade(*this);
+}
+
+std::string_view IsoValuePropertyInterpolationFade::getDisplayName() const { return "Fade"; }
+
+std::string_view IsoValuePropertyInterpolationFade::classIdentifier() {
+    return "org.inviwo.animation.IsoValuePropertyInterpolationFade";
+}
+
+std::string_view IsoValuePropertyInterpolationFade::getClassIdentifier() const {
+    return classIdentifier();
+}
+
+bool IsoValuePropertyInterpolationFade::equal(const Interpolation& other) const {
+    return classIdentifier() == other.getClassIdentifier();
+}
+
+void IsoValuePropertyInterpolationFade::operator()(
+    const std::vector<std::unique_ptr<ValueKeyframe<IsoValueProperty::value_type>>>& keys,
+    Seconds /*from*/, Seconds to, IsoValueProperty::value_type& out) const {
+    interpolatePropertyValue(keys, to, out, [](const auto& prev, const auto& next, Seconds time,
+                                               IsoValueCollection& value) {
+        detail::interpolateIsoValuesFade(prev.getValue(), next.getValue(),
+                                          detail::interpolationTime(prev.getTime(), next.getTime(),
+                                                                    prev.getEaseIn(),
+                                                                    next.getEaseOut(), time),
+                                          value);
+    });
+}
+
+IsoValuePropertyInterpolationBlend::IsoValuePropertyInterpolationBlend(
+    InviwoApplication* app)
+    : InterpolationTyped<ValueKeyframe<IsoValueProperty::value_type>,
+                         IsoValueProperty::value_type>(app)
+    , segments{"segments", "Segments", util::ordinalCount(16uz)}
+    , simplify{"simplify", "Simplify", util::ordinalLength(0.0, 0.1).setInc(0.0001)} {
+    addProperties(segments, simplify);
+}
+
+IsoValuePropertyInterpolationBlend::IsoValuePropertyInterpolationBlend(
+    const IsoValuePropertyInterpolationBlend& rhs)
+    : InterpolationTyped<ValueKeyframe<IsoValueProperty::value_type>,
+                         IsoValueProperty::value_type>(rhs)
+    , segments{rhs.segments}
+    , simplify{rhs.simplify} {
+    addProperties(segments, simplify);
+}
+
+IsoValuePropertyInterpolationBlend*
+IsoValuePropertyInterpolationBlend::clone() const {
+    return new IsoValuePropertyInterpolationBlend(*this);
+}
+
+std::string_view IsoValuePropertyInterpolationBlend::getDisplayName() const {
+    return "Blend";
+}
+
+std::string_view IsoValuePropertyInterpolationBlend::classIdentifier() {
+    return "org.inviwo.animation.IsoValuePropertyInterpolationBlend";
+}
+
+std::string_view IsoValuePropertyInterpolationBlend::getClassIdentifier() const {
+    return classIdentifier();
+}
+
+bool IsoValuePropertyInterpolationBlend::equal(const Interpolation& other) const {
+    return classIdentifier() == other.getClassIdentifier();
+}
+
+void IsoValuePropertyInterpolationBlend::operator()(
+    const std::vector<std::unique_ptr<ValueKeyframe<IsoValueProperty::value_type>>>& keys,
+    Seconds /*from*/, Seconds to, IsoValueProperty::value_type& out) const {
+    interpolatePropertyValue(keys, to, out, [](const auto& prev, const auto& next, Seconds time,
+                                               IsoValueCollection& value) {
+        detail::interpolateIsoValuesBlend(
+            prev.getValue(), next.getValue(),
+            detail::interpolationTime(prev.getTime(), next.getTime(), prev.getEaseIn(),
+                                      next.getEaseOut(), time),
+            value);
+    });
+}
+
+}  // namespace inviwo::animation

--- a/modules/animation/src/interpolation/isovaluepropertyinterpolation.cpp
+++ b/modules/animation/src/interpolation/isovaluepropertyinterpolation.cpp
@@ -134,8 +134,8 @@ void interpolatePropertyValue(const std::vector<std::unique_ptr<ValueKeyframe<Va
 
 namespace detail {
 
-double interpolationTime(Seconds t1, Seconds t2, std::optional<EasingType> easeIn,
-                         std::optional<EasingType> easeOut, Seconds to) {
+static double interpolationTime(Seconds t1, Seconds t2, std::optional<EasingType> easeIn,
+                                std::optional<EasingType> easeOut, Seconds to) {
     return util::ease(static_cast<double>((to - t1) / (t2 - t1)), easeIn, easeOut);
 }
 

--- a/modules/animation/src/interpolation/isovaluepropertyinterpolation.cpp
+++ b/modules/animation/src/interpolation/isovaluepropertyinterpolation.cpp
@@ -30,12 +30,16 @@
 #include <modules/animation/interpolation/isovaluepropertyinterpolation.h>
 
 #include <inviwo/core/datastructures/tfprimitive.h>
+#include <inviwo/core/util/glm.h>
+#include <inviwo/core/util/concat.h>
+#include <inviwo/core/util/settransform.h>
 
 #include <algorithm>
 #include <cmath>
 #include <limits>
 #include <tuple>
 #include <vector>
+#include <ranges>
 
 namespace inviwo::animation {
 namespace {
@@ -55,71 +59,9 @@ TFPrimitiveData interpolate(const TFPrimitive& source, const TFPrimitive& destin
             .color = glm::mix(source.getColor(), destination.getColor(), t)};
 }
 
-std::vector<std::pair<size_t, size_t>> matchEqualPositions(const IsoValueCollection& source,
-                                                           const IsoValueCollection& destination) {
-    std::vector<std::pair<size_t, size_t>> matches;
-
-    size_t i = 0;
-    size_t j = 0;
-    while (i < source.size() && j < destination.size()) {
-        const auto sourcePos = source[i].getPosition();
-        const auto destinationPos = destination[j].getPosition();
-
-        if (std::abs(sourcePos - destinationPos) <= std::numeric_limits<double>::epsilon()) {
-            matches.emplace_back(i, j);
-            ++i;
-            ++j;
-        } else if (sourcePos < destinationPos) {
-            ++i;
-        } else {
-            ++j;
-        }
-    }
-
-    return matches;
-}
-
-std::vector<std::pair<size_t, size_t>> matchPointsByOrder(const IsoValueCollection& source,
-                                                          const IsoValueCollection& destination) {
-    std::vector<std::pair<size_t, size_t>> matches;
-    const auto count = std::min(source.size(), destination.size());
-    matches.reserve(count);
-
-    for (size_t i = 0; i < count; ++i) {
-        matches.emplace_back(i, i);
-    }
-
-    return matches;
-}
-
-template <typename Match>
-std::vector<TFPrimitiveData> interpolateIsoValues(const IsoValueCollection& source,
-                                                  const IsoValueCollection& destination, double t,
-                                                  Match match) {
-    const auto matches = match(source, destination);
-
-    std::vector<bool> matchedSource(source.size(), false);
-    std::vector<bool> matchedDestination(destination.size(), false);
-    std::vector<TFPrimitiveData> values;
-    values.reserve(source.size() + destination.size() - matches.size());
-
-    for (const auto& [i, j] : matches) {
-        values.push_back(interpolate(source[i], destination[j], t));
-        matchedSource[i] = true;
-        matchedDestination[j] = true;
-    }
-    for (size_t i = 0; i < source.size(); ++i) {
-        if (!matchedSource[i]) values.push_back(fadeOut(source[i], t));
-    }
-    for (size_t j = 0; j < destination.size(); ++j) {
-        if (!matchedDestination[j]) values.push_back(fadeIn(destination[j], t));
-    }
-    return values;
-}
-
 template <typename Value, typename InterpolateValue>
-void interpolatePropertyValue(const std::vector<std::unique_ptr<ValueKeyframe<Value>>>& keys, Seconds to,
-                              Value& out, InterpolateValue interpolateValue) {
+void interpolatePropertyValue(const std::vector<std::unique_ptr<ValueKeyframe<Value>>>& keys,
+                              Seconds to, Value& out, InterpolateValue interpolateValue) {
 
     auto it = std::upper_bound(keys.begin(), keys.end(), to, [](const auto& time, const auto& key) {
         return time < key->getTime();
@@ -130,48 +72,75 @@ void interpolatePropertyValue(const std::vector<std::unique_ptr<ValueKeyframe<Va
     interpolateValue(prev, next, to, out);
 }
 
+double interpolationTime(Seconds t1, Seconds t2, std::optional<EasingType> easeIn,
+                         std::optional<EasingType> easeOut, Seconds to) {
+    return util::ease(static_cast<double>((to - t1) / (t2 - t1)), easeIn, easeOut);
+}
+
 }  // namespace
 
 namespace detail {
 
-static double interpolationTime(Seconds t1, Seconds t2, std::optional<EasingType> easeIn,
-                                std::optional<EasingType> easeOut, Seconds to) {
-    return util::ease(static_cast<double>((to - t1) / (t2 - t1)), easeIn, easeOut);
-}
-
-void interpolateIsoValuesFade(const IsoValueCollection& source, const IsoValueCollection& destination,
-                               double t, IsoValueCollection& out) {
-    if (source.getType() != destination.getType()) {
+void interpolateIsoValuesFade(const IsoValueCollection& source,
+                              const IsoValueCollection& destination, double t,
+                              IsoValueCollection& out) {
+    if (source.getMode() != destination.getMode()) {
         out = source;
         return;
     }
 
-    out = IsoValueCollection{interpolateIsoValues(source, destination, t, matchEqualPositions),
-                             source.getType()};
+    out.set(views::set_transform(
+        source, destination,
+        [](const TFPrimitive& a, const TFPrimitive& b) {
+            if (util::almostEqual(a.getPosition(), b.getPosition())) {
+                return false;
+            } else {
+                return a.getPosition() < b.getPosition();
+            }
+        },
+        [&](const TFPrimitive* src, const TFPrimitive* dst) -> std::optional<TFPrimitiveData> {
+            if (src && dst) {
+                return interpolate(*src, *dst, t);
+            } else if (src) {
+                return fadeOut(*src, t);
+            } else if (dst) {
+                return fadeIn(*dst, t);
+            } else {
+                return std::nullopt;
+            }
+        }));
 }
 
 void interpolateIsoValuesBlend(const IsoValueCollection& source,
-                                          const IsoValueCollection& destination, double t,
-                                          IsoValueCollection& out) {
-    if (source.getType() != destination.getType()) {
+                               const IsoValueCollection& destination, double t,
+                               IsoValueCollection& out) {
+    if (source.getMode() != destination.getMode()) {
         out = source;
         return;
     }
 
-    out = IsoValueCollection{interpolateIsoValues(source, destination, t, matchPointsByOrder),
-                             source.getType()};
+    auto matched = std::views::zip(source, destination) | std::views::transform([&](auto item) {
+                       return interpolate(std::get<0>(item), std::get<1>(item), t);
+                   });
+
+    const auto count = std::min(source.size(), destination.size());
+    const auto& biggerOne = source.size() < destination.size() ? destination : source;
+    const auto& op = source.size() < destination.size() ? fadeIn : fadeOut;
+    auto rest = biggerOne | std::views::drop(count) |
+                std::views::transform([&](const TFPrimitive& item) { return op(item, t); });
+    out.set(views::concat(matched, rest));
 }
 
 }  // namespace detail
 
 IsoValuePropertyInterpolationFade::IsoValuePropertyInterpolationFade(InviwoApplication* app)
-    : InterpolationTyped<ValueKeyframe<IsoValueProperty::value_type>,
-                         IsoValueProperty::value_type>(app) {}
+    : InterpolationTyped<ValueKeyframe<IsoValueProperty::value_type>, IsoValueProperty::value_type>(
+          app) {}
 
 IsoValuePropertyInterpolationFade::IsoValuePropertyInterpolationFade(
     const IsoValuePropertyInterpolationFade& rhs)
-    : InterpolationTyped<ValueKeyframe<IsoValueProperty::value_type>,
-                         IsoValueProperty::value_type>(rhs) {}
+    : InterpolationTyped<ValueKeyframe<IsoValueProperty::value_type>, IsoValueProperty::value_type>(
+          rhs) {}
 
 IsoValuePropertyInterpolationFade* IsoValuePropertyInterpolationFade::clone() const {
     return new IsoValuePropertyInterpolationFade(*this);
@@ -194,20 +163,20 @@ bool IsoValuePropertyInterpolationFade::equal(const Interpolation& other) const 
 void IsoValuePropertyInterpolationFade::operator()(
     const std::vector<std::unique_ptr<ValueKeyframe<IsoValueProperty::value_type>>>& keys,
     Seconds /*from*/, Seconds to, IsoValueProperty::value_type& out) const {
-    interpolatePropertyValue(keys, to, out, [](const auto& prev, const auto& next, Seconds time,
-                                               IsoValueCollection& value) {
-        detail::interpolateIsoValuesFade(prev.getValue(), next.getValue(),
-                                          detail::interpolationTime(prev.getTime(), next.getTime(),
-                                                                    prev.getEaseIn(),
-                                                                    next.getEaseOut(), time),
-                                          value);
-    });
+    interpolatePropertyValue(
+        keys, to, out,
+        [](const auto& prev, const auto& next, Seconds time, IsoValueCollection& value) {
+            detail::interpolateIsoValuesFade(
+                prev.getValue(), next.getValue(),
+                interpolationTime(prev.getTime(), next.getTime(), prev.getEaseIn(),
+                                  next.getEaseOut(), time),
+                value);
+        });
 }
 
-IsoValuePropertyInterpolationBlend::IsoValuePropertyInterpolationBlend(
-    InviwoApplication* app)
-    : InterpolationTyped<ValueKeyframe<IsoValueProperty::value_type>,
-                         IsoValueProperty::value_type>(app)
+IsoValuePropertyInterpolationBlend::IsoValuePropertyInterpolationBlend(InviwoApplication* app)
+    : InterpolationTyped<ValueKeyframe<IsoValueProperty::value_type>, IsoValueProperty::value_type>(
+          app)
     , segments{"segments", "Segments", util::ordinalCount(16uz)}
     , simplify{"simplify", "Simplify", util::ordinalLength(0.0, 0.1).setInc(0.0001)} {
     addProperties(segments, simplify);
@@ -215,21 +184,18 @@ IsoValuePropertyInterpolationBlend::IsoValuePropertyInterpolationBlend(
 
 IsoValuePropertyInterpolationBlend::IsoValuePropertyInterpolationBlend(
     const IsoValuePropertyInterpolationBlend& rhs)
-    : InterpolationTyped<ValueKeyframe<IsoValueProperty::value_type>,
-                         IsoValueProperty::value_type>(rhs)
+    : InterpolationTyped<ValueKeyframe<IsoValueProperty::value_type>, IsoValueProperty::value_type>(
+          rhs)
     , segments{rhs.segments}
     , simplify{rhs.simplify} {
     addProperties(segments, simplify);
 }
 
-IsoValuePropertyInterpolationBlend*
-IsoValuePropertyInterpolationBlend::clone() const {
+IsoValuePropertyInterpolationBlend* IsoValuePropertyInterpolationBlend::clone() const {
     return new IsoValuePropertyInterpolationBlend(*this);
 }
 
-std::string_view IsoValuePropertyInterpolationBlend::getDisplayName() const {
-    return "Blend";
-}
+std::string_view IsoValuePropertyInterpolationBlend::getDisplayName() const { return "Blend"; }
 
 std::string_view IsoValuePropertyInterpolationBlend::classIdentifier() {
     return "org.inviwo.animation.IsoValuePropertyInterpolationBlend";
@@ -246,14 +212,15 @@ bool IsoValuePropertyInterpolationBlend::equal(const Interpolation& other) const
 void IsoValuePropertyInterpolationBlend::operator()(
     const std::vector<std::unique_ptr<ValueKeyframe<IsoValueProperty::value_type>>>& keys,
     Seconds /*from*/, Seconds to, IsoValueProperty::value_type& out) const {
-    interpolatePropertyValue(keys, to, out, [](const auto& prev, const auto& next, Seconds time,
-                                               IsoValueCollection& value) {
-        detail::interpolateIsoValuesBlend(
-            prev.getValue(), next.getValue(),
-            detail::interpolationTime(prev.getTime(), next.getTime(), prev.getEaseIn(),
-                                      next.getEaseOut(), time),
-            value);
-    });
+    interpolatePropertyValue(
+        keys, to, out,
+        [](const auto& prev, const auto& next, Seconds time, IsoValueCollection& value) {
+            detail::interpolateIsoValuesBlend(
+                prev.getValue(), next.getValue(),
+                interpolationTime(prev.getTime(), next.getTime(), prev.getEaseIn(),
+                                  next.getEaseOut(), time),
+                value);
+        });
 }
 
 }  // namespace inviwo::animation

--- a/modules/animation/src/interpolation/isovaluepropertyinterpolation.cpp
+++ b/modules/animation/src/interpolation/isovaluepropertyinterpolation.cpp
@@ -33,6 +33,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <tuple>
 #include <vector>
 
@@ -57,17 +58,24 @@ TFPrimitiveData interpolate(const TFPrimitive& source, const TFPrimitive& destin
 std::vector<std::pair<size_t, size_t>> matchEqualPositions(const IsoValueCollection& source,
                                                            const IsoValueCollection& destination) {
     std::vector<std::pair<size_t, size_t>> matches;
-    std::vector<bool> matchedDestination(destination.size(), false);
 
-    for (size_t i = 0; i < source.size(); ++i) {
-        for (size_t j = 0; j < destination.size(); ++j) {
-            if (!matchedDestination[j] && source[i].getPosition() == destination[j].getPosition()) {
-                matches.emplace_back(i, j);
-                matchedDestination[j] = true;
-                break;
-            }
+    size_t i = 0;
+    size_t j = 0;
+    while (i < source.size() && j < destination.size()) {
+        const auto sourcePos = source[i].getPosition();
+        const auto destinationPos = destination[j].getPosition();
+
+        if (std::abs(sourcePos - destinationPos) <= std::numeric_limits<double>::epsilon()) {
+            matches.emplace_back(i, j);
+            ++i;
+            ++j;
+        } else if (sourcePos < destinationPos) {
+            ++i;
+        } else {
+            ++j;
         }
     }
+
     return matches;
 }
 

--- a/modules/animation/src/interpolation/isovaluepropertyinterpolation.cpp
+++ b/modules/animation/src/interpolation/isovaluepropertyinterpolation.cpp
@@ -42,7 +42,7 @@ namespace {
 TFPrimitiveData fade(const TFPrimitive& primitive, double t) {
     auto color = primitive.getColor();
     color.a *= static_cast<float>(t);
-    return {primitive.getPosition(), color};
+    return {.pos = primitive.getPosition(), .color = color};
 }
 
 TFPrimitiveData fadeIn(const TFPrimitive& primitive, double t) { return fade(primitive, t); }
@@ -50,8 +50,8 @@ TFPrimitiveData fadeIn(const TFPrimitive& primitive, double t) { return fade(pri
 TFPrimitiveData fadeOut(const TFPrimitive& primitive, double t) { return fade(primitive, 1.0 - t); }
 
 TFPrimitiveData interpolate(const TFPrimitive& source, const TFPrimitive& destination, double t) {
-    return {std::lerp(source.getPosition(), destination.getPosition(), t),
-            glm::mix(source.getColor(), destination.getColor(), t)};
+    return {.pos = std::lerp(source.getPosition(), destination.getPosition(), t),
+            .color = glm::mix(source.getColor(), destination.getColor(), t)};
 }
 
 std::vector<std::pair<size_t, size_t>> matchEqualPositions(const IsoValueCollection& source,

--- a/modules/animationpython/bindings/src/pyanimation.cpp
+++ b/modules/animationpython/bindings/src/pyanimation.cpp
@@ -34,6 +34,7 @@
 #include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
 #include <pybind11/chrono.h>
+#include <pybind11/native_enum.h>
 
 #include <inviwo/core/algorithm/easing.h>
 #include <inviwo/core/common/inviwoapplication.h>
@@ -94,25 +95,29 @@ struct SecondsConverter {
 };
 
 void exposeEnums(py::module& m) {
-    py::enum_<AnimationState>(m, "AnimationState")
+    py::native_enum<AnimationState>(m, "AnimationState", "enum.Enum")
         .value("Paused", AnimationState::Paused)
         .value("Playing", AnimationState::Playing)
-        .value("Rendering", AnimationState::Rendering);
+        .value("Rendering", AnimationState::Rendering)
+        .finalize();
 
-    py::enum_<PlaybackMode>(m, "PlaybackMode")
+    py::native_enum<PlaybackMode>(m, "PlaybackMode", "enum.Enum")
         .value("Once", PlaybackMode::Once)
         .value("Loop", PlaybackMode::Loop)
-        .value("Swing", PlaybackMode::Swing);
+        .value("Swing", PlaybackMode::Swing)
+        .finalize();
 
-    py::enum_<PlaybackDirection>(m, "PlaybackDirection")
+    py::native_enum<PlaybackDirection>(m, "PlaybackDirection", "enum.Enum")
         .value("Forward", PlaybackDirection::Forward)
-        .value("Backward", PlaybackDirection::Backward);
+        .value("Backward", PlaybackDirection::Backward)
+        .finalize();
 
-    py::enum_<ControlAction>(m, "ControlAction")
+    py::native_enum<ControlAction>(m, "ControlAction", "enum.Enum")
         .value("Pause", ControlAction::Pause)
-        .value("Jump", ControlAction::Jump);
+        .value("Jump", ControlAction::Jump)
+        .finalize();
 
-    py::enum_<EasingType>(m, "EasingType")
+    py::native_enum<EasingType>(m, "EasingType", "enum.Enum")
         .value("Linear", EasingType::linear)
         .value("Quadratic", EasingType::quadratic)
         .value("Cubic", EasingType::cubic)
@@ -123,12 +128,14 @@ void exposeEnums(py::module& m) {
         .value("Exponential", EasingType::exponential)
         .value("Elastic", EasingType::elastic)
         .value("Back", EasingType::back)
-        .value("Bounce", EasingType::bounce);
+        .value("Bounce", EasingType::bounce)
+        .finalize();
 
-    py::enum_<EasingMode>(m, "EasingMode")
+    py::native_enum<EasingMode>(m, "EasingMode", "enum.Enum")
         .value("In", EasingMode::in)
         .value("Out", EasingMode::out)
-        .value("InOut", EasingMode::inOut);
+        .value("InOut", EasingMode::inOut)
+        .finalize();
 }
 
 void exposeAnimationTimeState(py::module& m) {
@@ -467,7 +474,9 @@ void exposeCallbackTrack(py::module& m) {
 
 void exposeAnimationClass(py::module& m) {
     py::classh<Animation>(m, "Animation")
-        .def(py::init([](std::string_view name) { return Animation{nullptr, name}; }),
+        .def(py::init([](std::string_view name) {
+                 return Animation{nullptr, name};
+             }),
              py::arg("name") = "Animation")
         .def_property(
             "name", [](const Animation& a) -> const std::string& { return a.getName(); },
@@ -486,19 +495,19 @@ void exposeAnimationClass(py::module& m) {
             py::keep_alive<0, 1>())
         .def(
             "add", [](Animation& a, Property* property) { return a.add(property); },
-            py::return_value_policy::reference_internal, py::arg("property"))
+            py::arg("property"))
         .def(
             "addKeyframe",
             [](Animation& a, Property* property, double time) {
                 return a.addKeyframe(property, Seconds{time});
             },
-            py::return_value_policy::reference_internal, py::arg("property"), py::arg("time"))
+            py::arg("property"), py::arg("time"))
         .def(
             "addKeyframeSequence",
             [](Animation& a, Property* property, double time) {
                 return a.addKeyframeSequence(property, Seconds{time});
             },
-            py::return_value_policy::reference_internal, py::arg("property"), py::arg("time"))
+            py::arg("property"), py::arg("time"))
         .def(
             "removeTrack", [](Animation& a, size_t i) { return a.remove(i); }, py::arg("index"))
         .def(

--- a/modules/animationpython/tests/unittests/animation-test.cpp
+++ b/modules/animationpython/tests/unittests/animation-test.cpp
@@ -952,7 +952,8 @@ scaleProp = proc.scale
 
 # Set scale to 1.0 and add a keyframe at t=0
 scaleProp.value = 1.0
-track = anim.add(scaleProp)
+tracks = anim.add(scaleProp)
+track = tracks[0]
 track.addKeyFrameUsingPropertyValue(0.0)
 
 # Set scale to 10.0 and add a keyframe at t=2
@@ -1028,7 +1029,8 @@ sizeProp = proc.getPropertyByIdentifier("size")
 
 # Add keyframes: 0.0->1.0, 1.0->5.0, 2.0->3.0
 sizeProp.value = 1.0
-track = anim.add(sizeProp)
+tracks = anim.add(sizeProp)
+track = tracks[0]
 track.addKeyFrameUsingPropertyValue(0.0)
 
 sizeProp.value = 5.0

--- a/modules/animationqt/src/animationqtmodule.cpp
+++ b/modules/animationqt/src/animationqtmodule.cpp
@@ -34,6 +34,7 @@
 #include <inviwo/core/properties/boolproperty.h>
 #include <inviwo/core/properties/cameraproperty.h>
 #include <inviwo/core/properties/fileproperty.h>
+#include <inviwo/core/properties/isovalueproperty.h>
 #include <inviwo/core/properties/minmaxproperty.h>
 #include <inviwo/core/properties/optionproperty.h>
 #include <inviwo/core/properties/ordinalproperty.h>
@@ -231,8 +232,8 @@ AnimationQtModule::AnimationQtModule(InviwoApplication* app)
     util::for_each_type<std::tuple<float, double, int, unsigned int, size_t, std::string>>{}(
         Reghelper<OptionProperty>{}, *this);
 
-    util::for_each_type<
-        std::tuple<BoolProperty, FileProperty, StringProperty, TransferFunctionProperty>>{}(
+    util::for_each_type<std::tuple<BoolProperty, FileProperty, StringProperty,
+                                   TransferFunctionProperty, IsoValueProperty>>{}(
         [&]<typename Prop>() {
             registerPropertyTrackHelper<Prop, ValueKeyframe<typename Prop::value_type>>(*this);
         });

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -386,6 +386,7 @@ set(HEADER_FILES
     ${IVW_INCLUDE_DIR}/inviwo/core/util/indexmapper.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/indirectiterator.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/interpolation.h
+    ${IVW_INCLUDE_DIR}/inviwo/core/util/intersection.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/intersection/rayplaneintersection.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/intersection/raysphereintersection.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/introspection.h
@@ -787,6 +788,7 @@ set(SOURCE_FILES
     util/imageramutils.cpp
     util/imagesampler.cpp
     util/indirectiterator.cpp
+    util/intersection.cpp
     util/introspection.cpp
     util/inviwosetupinfo.cpp
     util/isstreaminsertable.cpp
@@ -886,6 +888,7 @@ set(TEST_FILES
     tests/unittests/image-tests.cpp
     tests/unittests/indirectiterator-tests.cpp
     tests/unittests/interpolation-tests.cpp
+    tests/unittests/intersection-test.cpp
     tests/unittests/inviwo-core-unittest-main.cpp
     tests/unittests/metadata-test.cpp
     tests/unittests/network-evaluator-test.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -417,6 +417,7 @@ set(HEADER_FILES
     ${IVW_INCLUDE_DIR}/inviwo/core/util/settings/settings.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/settings/systemsettings.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/settings/unitsettings.h
+    ${IVW_INCLUDE_DIR}/inviwo/core/util/settransform.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/sharedlibrary.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/shuntingyard.h
     ${IVW_INCLUDE_DIR}/inviwo/core/util/singlefileobserver.h
@@ -814,6 +815,7 @@ set(SOURCE_FILES
     util/settings/settings.cpp
     util/settings/systemsettings.cpp
     util/settings/unitsettings.cpp
+    util/settransform.cpp
     util/sharedlibrary.cpp
     util/shuntingyard.cpp
     util/singlefileobserver.cpp

--- a/src/core/tests/unittests/intersection-test.cpp
+++ b/src/core/tests/unittests/intersection-test.cpp
@@ -1,0 +1,220 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2026 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/core/util/intersection.h>
+
+#include <vector>
+#include <list>
+#include <string>
+#include <ranges>
+#include <iterator>
+#include <algorithm>
+#include <functional>
+#include <concepts>
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <gtest/gtest.h>
+#include <warn/pop>
+
+namespace inviwo {
+
+using IntView = views::set_intersection<std::ranges::ref_view<std::vector<int>>,
+                                        std::ranges::ref_view<std::vector<int>>>;
+
+static_assert(std::ranges::input_range<IntView>);
+static_assert(std::ranges::view<IntView>);
+static_assert(std::input_iterator<std::ranges::iterator_t<IntView>>);
+static_assert(std::same_as<std::ranges::range_value_t<IntView>, int>);
+
+TEST(SetIntersection, InterleavedDisjoint) {
+    std::vector<int> a{1, 3, 5, 7};
+    std::vector<int> b{2, 4, 6, 8};
+    auto v = views::set_intersection{std::views::all(a), std::views::all(b)} |
+             std::ranges::to<std::vector>();
+    EXPECT_TRUE(v.empty());
+}
+
+TEST(SetIntersection, SomeCommonElements) {
+    std::vector<int> a{1, 2, 3, 4};
+    std::vector<int> b{2, 3, 5};
+    auto v = views::set_intersection{std::views::all(a), std::views::all(b)} |
+             std::ranges::to<std::vector>();
+    EXPECT_EQ(v, (std::vector<int>{2, 3}));
+}
+
+TEST(SetIntersection, FirstEmpty) {
+    std::vector<int> a{};
+    std::vector<int> b{1, 2, 3};
+    auto v = views::set_intersection{std::views::all(a), std::views::all(b)} |
+             std::ranges::to<std::vector>();
+    EXPECT_TRUE(v.empty());
+}
+
+TEST(SetIntersection, SecondEmpty) {
+    std::vector<int> a{4, 5, 6};
+    std::vector<int> b{};
+    auto v = views::set_intersection{std::views::all(a), std::views::all(b)} |
+             std::ranges::to<std::vector>();
+    EXPECT_TRUE(v.empty());
+}
+
+TEST(SetIntersection, BothEmpty) {
+    std::vector<int> a{}, b{};
+    auto v = views::set_intersection{std::views::all(a), std::views::all(b)} |
+             std::ranges::to<std::vector>();
+    EXPECT_TRUE(v.empty());
+}
+
+TEST(SetIntersection, OneFullyBeforeOther) {
+    std::vector<int> a{1, 2, 3};
+    std::vector<int> b{10, 20, 30};
+    auto v = views::set_intersection{std::views::all(a), std::views::all(b)} |
+             std::ranges::to<std::vector>();
+    EXPECT_TRUE(v.empty());
+}
+
+TEST(SetIntersection, Identical) {
+    std::vector<int> a{1, 2, 3};
+    std::vector<int> b{1, 2, 3};
+    auto v = views::set_intersection{std::views::all(a), std::views::all(b)} |
+             std::ranges::to<std::vector>();
+    EXPECT_EQ(v, (std::vector<int>{1, 2, 3}));
+}
+
+TEST(SetIntersection, DuplicatesTakeMinCount) {
+    std::vector<int> a{2, 2, 2};
+    std::vector<int> b{2, 2};
+    auto v = views::set_intersection{std::views::all(a), std::views::all(b)} |
+             std::ranges::to<std::vector>();
+    // set-intersection semantics: run of equal elements collapses to min(|a|,|b|)
+    EXPECT_EQ(v, (std::vector<int>{2, 2}));
+}
+
+TEST(SetIntersection, CustomComparatorDescending) {
+    std::vector<int> a{7, 5, 3, 1};
+    std::vector<int> b{8, 5, 3, 2};
+    auto v =
+        views::set_intersection{std::views::all(a), std::views::all(b), std::greater<int>{}} |
+        std::ranges::to<std::vector>();
+    EXPECT_EQ(v, (std::vector<int>{5, 3}));
+}
+
+TEST(SetIntersection, WorksWithStrings) {
+    std::vector<std::string> a{"apple", "banana", "cherry"};
+    std::vector<std::string> b{"banana", "cherry", "date"};
+    auto v = views::set_intersection{std::views::all(a), std::views::all(b)} |
+             std::ranges::to<std::vector>();
+    EXPECT_EQ(v, (std::vector<std::string>{"banana", "cherry"}));
+}
+
+TEST(SetIntersection, WorksWithDifferentRangeTypes) {
+    std::vector<int> a{1, 2, 3, 4, 6};
+    std::list<int> b{2, 3, 5, 6, 7};
+    auto v = views::set_intersection{std::views::all(a), std::views::all(b)} |
+             std::ranges::to<std::vector>();
+    EXPECT_EQ(v, (std::vector<int>{2, 3, 6}));
+}
+
+TEST(SetIntersection, ChainedWithOtherViews) {
+    std::vector<int> a{1, 2, 3, 4, 5};
+    std::vector<int> b{2, 4, 6, 8};
+    auto v = views::set_intersection{std::views::all(a), std::views::all(b)} |
+             std::views::transform([](int x) { return x * 10; }) | std::ranges::to<std::vector>();
+    EXPECT_EQ(v, (std::vector<int>{20, 40}));
+}
+
+TEST(SetIntersection, PipeAdaptorClosure) {
+    std::vector<int> a{1, 3, 5};
+    std::vector<int> b{2, 3, 4, 5};
+    auto v = a | views::set_intersection_with(b) | std::ranges::to<std::vector>();
+    EXPECT_EQ(v, (std::vector<int>{3, 5}));
+}
+
+TEST(SetIntersection, IteratorIncrementPostfixCompiles) {
+    std::vector<int> a{1, 2, 3};
+    std::vector<int> b{2, 3, 4};
+    auto v = views::set_intersection{std::views::all(a), std::views::all(b)};
+    auto it = v.begin();
+    EXPECT_EQ(*it, 2);
+    it++;
+    EXPECT_EQ(*it, 3);
+    it++;
+    EXPECT_TRUE(it == std::default_sentinel);
+}
+
+using V = views::set_intersection<std::ranges::ref_view<std::vector<int>>,
+                                  std::ranges::ref_view<std::vector<int>>>;
+
+static_assert(std::ranges::forward_range<V>);
+static_assert(std::forward_iterator<std::ranges::iterator_t<V>>);
+static_assert(std::ranges::common_range<V>);
+
+TEST(SetIntersection, MultipassYieldsSameSequence) {
+    std::vector<int> a{1, 3, 5}, b{3, 4, 5};
+    auto v = views::set_intersection{std::views::all(a), std::views::all(b)};
+
+    std::vector<int> first, second;
+    for (auto x : v) first.push_back(x);
+    for (auto x : v) second.push_back(x);  // second pass
+    EXPECT_EQ(first, second);
+    EXPECT_EQ(first, (std::vector<int>{3, 5}));
+}
+
+TEST(SetIntersection, IteratorEquality) {
+    std::vector<int> a{1, 2, 3}, b{2, 3, 4};
+    auto v = views::set_intersection{std::views::all(a), std::views::all(b)};
+    auto i = v.begin();
+    auto j = v.begin();
+    EXPECT_TRUE(i == j);
+    ++i;
+    EXPECT_FALSE(i == j);
+    ++j;
+    EXPECT_TRUE(i == j);
+}
+
+TEST(SetIntersection, EndIsIteratorAndDistanceWorks) {
+    std::vector<int> a{1, 2, 3, 4, 5, 6}, b{2, 4, 6};
+    auto v = views::set_intersection{std::views::all(a), std::views::all(b)};
+    EXPECT_EQ(std::ranges::distance(v.begin(), v.end()), 3);
+    auto it = std::ranges::find(v, 4);
+    EXPECT_NE(it, v.end());
+    EXPECT_EQ(*it, 4);
+}
+
+TEST(SetIntersection, PostIncrementReturnsCopy) {
+    std::vector<int> a{1, 2, 3}, b{2, 3};
+    auto v = views::set_intersection{std::views::all(a), std::views::all(b)};
+    auto it = v.begin();
+    auto old = it++;
+    EXPECT_EQ(*old, 2);
+    EXPECT_EQ(*it, 3);
+}
+
+}  // namespace inviwo

--- a/src/core/tests/unittests/intersection-test.cpp
+++ b/src/core/tests/unittests/intersection-test.cpp
@@ -86,7 +86,8 @@ TEST(SetIntersection, SecondEmpty) {
 }
 
 TEST(SetIntersection, BothEmpty) {
-    std::vector<int> a{}, b{};
+    std::vector<int> a{};
+    std::vector<int> b{};
     auto v = views::set_intersection{std::views::all(a), std::views::all(b)} |
              std::ranges::to<std::vector>();
     EXPECT_TRUE(v.empty());
@@ -120,9 +121,8 @@ TEST(SetIntersection, DuplicatesTakeMinCount) {
 TEST(SetIntersection, CustomComparatorDescending) {
     std::vector<int> a{7, 5, 3, 1};
     std::vector<int> b{8, 5, 3, 2};
-    auto v =
-        views::set_intersection{std::views::all(a), std::views::all(b), std::greater<int>{}} |
-        std::ranges::to<std::vector>();
+    auto v = views::set_intersection{std::views::all(a), std::views::all(b), std::greater<int>{}} |
+             std::ranges::to<std::vector>();
     EXPECT_EQ(v, (std::vector<int>{5, 3}));
 }
 
@@ -177,10 +177,12 @@ static_assert(std::forward_iterator<std::ranges::iterator_t<V>>);
 static_assert(std::ranges::common_range<V>);
 
 TEST(SetIntersection, MultipassYieldsSameSequence) {
-    std::vector<int> a{1, 3, 5}, b{3, 4, 5};
+    std::vector<int> a{1, 3, 5};
+    std::vector<int> b{3, 4, 5};
     auto v = views::set_intersection{std::views::all(a), std::views::all(b)};
 
-    std::vector<int> first, second;
+    std::vector<int> first;
+    std::vector<int> second;
     for (auto x : v) first.push_back(x);
     for (auto x : v) second.push_back(x);  // second pass
     EXPECT_EQ(first, second);
@@ -188,7 +190,8 @@ TEST(SetIntersection, MultipassYieldsSameSequence) {
 }
 
 TEST(SetIntersection, IteratorEquality) {
-    std::vector<int> a{1, 2, 3}, b{2, 3, 4};
+    std::vector<int> a{1, 2, 3};
+    std::vector<int> b{2, 3, 4};
     auto v = views::set_intersection{std::views::all(a), std::views::all(b)};
     auto i = v.begin();
     auto j = v.begin();
@@ -200,7 +203,8 @@ TEST(SetIntersection, IteratorEquality) {
 }
 
 TEST(SetIntersection, EndIsIteratorAndDistanceWorks) {
-    std::vector<int> a{1, 2, 3, 4, 5, 6}, b{2, 4, 6};
+    std::vector<int> a{1, 2, 3, 4, 5, 6};
+    std::vector<int> b{2, 4, 6};
     auto v = views::set_intersection{std::views::all(a), std::views::all(b)};
     EXPECT_EQ(std::ranges::distance(v.begin(), v.end()), 3);
     auto it = std::ranges::find(v, 4);
@@ -209,7 +213,8 @@ TEST(SetIntersection, EndIsIteratorAndDistanceWorks) {
 }
 
 TEST(SetIntersection, PostIncrementReturnsCopy) {
-    std::vector<int> a{1, 2, 3}, b{2, 3};
+    std::vector<int> a{1, 2, 3};
+    std::vector<int> b{2, 3};
     auto v = views::set_intersection{std::views::all(a), std::views::all(b)};
     auto it = v.begin();
     auto old = it++;

--- a/src/core/util/intersection.cpp
+++ b/src/core/util/intersection.cpp
@@ -1,0 +1,32 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2026 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/core/util/intersection.h>
+
+namespace inviwo {}  // namespace inviwo

--- a/src/core/util/settransform.cpp
+++ b/src/core/util/settransform.cpp
@@ -1,0 +1,32 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2026 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/core/util/settransform.h>
+
+namespace inviwo {}  // namespace inviwo


### PR DESCRIPTION

Changes proposed in this PR:

- Change Animation::add(Property*) to return std::vector<BasePropertyTrack*> instead of a single pointer. When no direct track mapping exists for a CompositeProperty, the method now recurses into sub-properties so that each child can get its own track.

- Add Fade and Blend interplation for IsoValues

- Change default animation interpolation for TransferFunctionProperty and IsoValueProperty
-
- Update addKeyframe() and addKeyframeSequence() to iterate over all returned tracks from the vector-returning add(Property*).

- Register IsoValueProperty with three interpolation modes (Fade, Blend, Constant) in AnimationModule

