### PR TITLE
Feature/networkeval

### DIFF
--- a/include/inviwo/core/processors/processor.h
+++ b/include/inviwo/core/processors/processor.h
@@ -326,6 +326,16 @@ public:
     virtual void setValid() override;
 
     /**
+     * Called by the network if Processor::process threw an exception. Reset by Processor::setValid.
+     */
+    virtual void setProcessAborted();
+
+    /**
+     * Returns true if the last call to Processor::process was aborted with an exception.
+     */
+    bool isProcessAborted() const;
+
+    /**
      * Triggers invalidation.
      * Perform only full reimplementation of this function, meaning never call
      * Processor::invalidate()
@@ -466,6 +476,7 @@ private:
 
     std::string identifier_;
     std::string displayName_;
+    bool processAborted_;
     std::vector<Inport*> inports_;
     std::vector<Outport*> outports_;
     std::vector<std::unique_ptr<Inport>> ownedInports_;

--- a/modules/oit/src/processors/linerasterizer.cpp
+++ b/modules/oit/src/processors/linerasterizer.cpp
@@ -125,10 +125,6 @@ LineRasterizer::LineRasterizer()
     addPort(inport_);
 
     addProperties(forceOpaque_, lineSettings_);
-
-    inport_.onChange([this]() { invalidate(InvalidationLevel::InvalidResources); });
-
-    invalidate(InvalidationLevel::InvalidResources);
 }
 
 void LineRasterizer::initializeResources() {

--- a/src/core/network/processornetworkevaluator.cpp
+++ b/src/core/network/processornetworkevaluator.cpp
@@ -124,6 +124,7 @@ void ProcessorNetworkEvaluator::evaluate() {
                     }
                 } catch (...) {
                     exceptionHandler_(processor, EvaluationType::InitResource, SourceContext{});
+                    processor->setValid();
                     continue;
                 }
 
@@ -134,6 +135,7 @@ void ProcessorNetworkEvaluator::evaluate() {
                     }
                 } catch (...) {
                     exceptionHandler_(processor, EvaluationType::PortOnChange, SourceContext{});
+                    processor->setValid();
                     continue;
                 }
 
@@ -151,6 +153,7 @@ void ProcessorNetworkEvaluator::evaluate() {
 
                 } catch (...) {
                     exceptionHandler_(processor, EvaluationType::Process, SourceContext{});
+                    processor->setValid();
                 }
 
                 processor->notifyObserversFinishedProcess(processor);

--- a/src/core/network/processornetworkevaluator.cpp
+++ b/src/core/network/processornetworkevaluator.cpp
@@ -116,7 +116,7 @@ void ProcessorNetworkEvaluator::evaluate() {
 
     for (auto* processor : processorsSorted_) {
         if (!processor->isValid()) {
-            if (processor->isReady()) {
+            if (processor->isReady() && !processor->isProcessAborted()) {
                 try {
                     // re-initialize resources (e.g., shaders) if necessary
                     if (processor->getInvalidationLevel() >= InvalidationLevel::InvalidResources) {
@@ -124,7 +124,7 @@ void ProcessorNetworkEvaluator::evaluate() {
                     }
                 } catch (...) {
                     exceptionHandler_(processor, EvaluationType::InitResource, SourceContext{});
-                    processor->setValid();
+                    processor->setProcessAborted();
                     continue;
                 }
 
@@ -135,7 +135,7 @@ void ProcessorNetworkEvaluator::evaluate() {
                     }
                 } catch (...) {
                     exceptionHandler_(processor, EvaluationType::PortOnChange, SourceContext{});
-                    processor->setValid();
+                    processor->setProcessAborted();
                     continue;
                 }
 
@@ -153,7 +153,7 @@ void ProcessorNetworkEvaluator::evaluate() {
 
                 } catch (...) {
                     exceptionHandler_(processor, EvaluationType::Process, SourceContext{});
-                    processor->setValid();
+                    processor->setProcessAborted();
                 }
 
                 processor->notifyObserversFinishedProcess(processor);

--- a/src/core/processors/processor.cpp
+++ b/src/core/processors/processor.cpp
@@ -69,6 +69,7 @@ Processor::Processor(std::string_view identifier, std::string_view displayName)
                 [this]() { return inports_.empty(); }}
     , identifier_(identifier)
     , displayName_{displayName}
+    , processAborted_{false}
     , network_(nullptr) {
 
     if (!identifier_.empty()) {
@@ -317,6 +318,7 @@ void Processor::invalidate(InvalidationLevel invalidationLevel, Property* modifi
         // invalid. Hence we need to make sure we invalidate them again
         for (auto& port : outports_) port->invalidate(InvalidationLevel::InvalidOutput);
     }
+    processAborted_ = false;
     notifyObserversInvalidationEnd(this);
 }
 
@@ -462,9 +464,14 @@ void Processor::deserialize(Deserializer& d) {
 
 void Processor::setValid() {
     PropertyOwner::setValid();
+    processAborted_ = false;
     setInportsChanged(false);
     for (auto* outport : outports_) outport->setValid();
 }
+
+void Processor::setProcessAborted() { processAborted_ = true; }
+
+bool Processor::isProcessAborted() const { return processAborted_; }
 
 void Processor::invokeEvent(Event* event) {
     if (event->hash() == PickingEvent::chash()) {


### PR DESCRIPTION
Fixes 
 * infinite network evaluations caused by exceptions thrown in process()

Changes proposed in this PR:
 * set processors to valid after handling the exceptions
