### PR TITLE
Feature/plotting fixes

### DIFF
--- a/modules/plottinggl/src/processors/orthographicaxis2d.cpp
+++ b/modules/plottinggl/src/processors/orthographicaxis2d.cpp
@@ -189,6 +189,7 @@ void OrthographicAxis2D::process() {
 
     const utilgl::ClearColor clearColor{backgroundColor_.get()};
     utilgl::activateAndClearTarget(outport_);
+    const utilgl::BlendModeState blending(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
     if (auto source = inport_.getData()) {
         // if we clipContent_ we only want to draw the inport image inside of the margins
         const auto scissors =

--- a/modules/plottinggl/src/processors/parallelcoordinates/parallelcoordinates.cpp
+++ b/modules/plottinggl/src/processors/parallelcoordinates/parallelcoordinates.cpp
@@ -709,7 +709,7 @@ void ParallelCoordinates::drawLines(size2_t size) {
 }
 
 void ParallelCoordinates::linePicked(PickingEvent* p) {
-    const KeyModifier appendModifier = KeyModifier::Shift;
+    const KeyModifier appendModifier = KeyModifier::Control;
 
     if (auto df = dataFrame_.getData()) {
         // Show tooltip about current line

--- a/modules/plottinggl/src/processors/parallelcoordinates/parallelcoordinates.cpp
+++ b/modules/plottinggl/src/processors/parallelcoordinates/parallelcoordinates.cpp
@@ -709,6 +709,8 @@ void ParallelCoordinates::drawLines(size2_t size) {
 }
 
 void ParallelCoordinates::linePicked(PickingEvent* p) {
+    const KeyModifier appendModifier = KeyModifier::Shift;
+
     if (auto df = dataFrame_.getData()) {
         // Show tooltip about current line
         if (p->getHoverState() == PickingHoverState::Move ||
@@ -731,9 +733,13 @@ void ParallelCoordinates::linePicked(PickingEvent* p) {
 
         auto id = p->getPickedId();
 
-        auto selection = brushingAndLinking_.getSelectedIndices();
-        selection.flip(indexCol[id]);
-        brushingAndLinking_.select(selection);
+        if (p->modifiers().contains(appendModifier)) {
+            auto selection = brushingAndLinking_.getSelectedIndices();
+            selection.flip(indexCol[id]);
+            brushingAndLinking_.select(selection);
+        } else {
+            brushingAndLinking_.select(BitSet{id});
+        }
 
         p->markAsUsed();
         invalidate(InvalidationLevel::InvalidOutput);
@@ -992,8 +998,7 @@ BitSet ParallelCoordinates::lineIntersections(const std::array<dvec2, 2>& screen
     const auto& indexCol = iCol->getTypedBuffer()->getRAMRepresentation()->getDataContainer();
 
     BitSet b;
-    for (auto&& [left, right] :
-         std::views::zip(enabledAxes_, enabledAxes_ | std::views::drop(1))) {
+    for (auto&& [left, right] : std::views::zip(enabledAxes_, enabledAxes_ | std::views::drop(1))) {
 
         const auto leftColumnId = axes_[left].pcp->columnId();
         const auto rightColumnId = axes_[right].pcp->columnId();


### PR DESCRIPTION
Changes proposed in this PR:
 * enable blending in `OrthoGraphicAxis2D` to get correct blending for the plot contents and background
 * parallel coords selection behaving similar to scatter plot (additive selection with <Shift>)