### PR TITLE
Feature/canvas fixes

### DIFF
--- a/modules/openglqt/include/modules/openglqt/processors/canvaswithpropertiesprocessor.h
+++ b/modules/openglqt/include/modules/openglqt/processors/canvaswithpropertiesprocessor.h
@@ -41,12 +41,10 @@
 #include <inviwo/core/properties/optionproperty.h>
 #include <inviwo/core/properties/ordinalproperty.h>
 #include <inviwo/core/properties/stringproperty.h>
-#include <inviwo/core/util/staticstring.h>
+#include <inviwo/core/properties/eventproperty.h>
 
-#include <functional>
 #include <memory>
 #include <optional>
-#include <string>
 #include <string_view>
 #include <vector>
 
@@ -92,6 +90,7 @@ private:
     BoolProperty visible_;
     BoolProperty fullScreen_;
     BoolProperty onTop_;
+    EventProperty fullScreenEvent_;
 
     OptionProperty<LayerType> layerType_;
     IntSizeTProperty layerIndex_;

--- a/modules/openglqt/src/processors/canvasprocessorwidgetqt.cpp
+++ b/modules/openglqt/src/processors/canvasprocessorwidgetqt.cpp
@@ -181,7 +181,15 @@ void CanvasProcessorWidgetQt::propagateEvent(Event* event, Outport* source) {
     getProcessor()->propagateEvent(event, source);
 }
 
-void CanvasProcessorWidgetQt::propagateResizeEvent() { canvas_->triggerResizeEventPropagation(); }
+void CanvasProcessorWidgetQt::propagateResizeEvent() {
+    if (!canvas_->isVisible()) {
+        RenderContext::getPtr()->activateDefaultRenderContext();
+        ResizeEvent resizeEvent{getDimensions(), getDimensions()};
+        getProcessor()->propagateEvent(&resizeEvent, nullptr);
+    } else {
+        canvas_->triggerResizeEventPropagation();
+    }
+}
 
 bool CanvasProcessorWidgetQt::contextMenu(QMenu& menu, ContextMenuCategories actions) {
     if (auto* canvasProcessor = dynamic_cast<CanvasProcessor*>(getProcessor())) {

--- a/modules/openglqt/src/processors/canvaswithpropertiesprocessor.cpp
+++ b/modules/openglqt/src/processors/canvaswithpropertiesprocessor.cpp
@@ -253,7 +253,12 @@ void CanvasWithPropertiesProcessor::setProcessorWidget(
 }
 
 void CanvasWithPropertiesProcessor::propagateEvent(Event* event, Outport*) {
+    if (event->hasVisitedProcessor(this)) return;
     event->markAsVisited(this);
+    
+    invokeEvent(event);
+    if (event->hasBeenUsed()) return;
+
     inport_.propagateEvent(event);
 }
 

--- a/modules/openglqt/src/processors/canvaswithpropertiesprocessor.cpp
+++ b/modules/openglqt/src/processors/canvaswithpropertiesprocessor.cpp
@@ -127,10 +127,20 @@ CanvasWithPropertiesProcessor::CanvasWithPropertiesProcessor()
                 PropertySemantics::Text}
     , visible_{"visible", "Visible", "Toggle widget visibility"_help, true,
                InvalidationLevel::Valid}
-    , fullScreen_{"fullScreen", "Full Screen", "Toggle if the widget should be fullscreen"_help,
+    , fullScreen_{"fullScreen", "Full Screen", "Toggle if the widget should be full screen"_help,
                   false, InvalidationLevel::Valid}
     , onTop_{"onTop", "On Top", "Keep the widget on top of the inviwo main window."_help, true,
              InvalidationLevel::Valid}
+    , fullScreenEvent_{"fullScreenEvent",
+                       "Full Screen",
+                       "Shortcut to toggle full-screen mode"_help,
+                       [this](Event* event) {
+                           event->markAsUsed();
+                           fullScreen_.set(!fullScreen_);
+                       },
+                       IvwKey::F,
+                       KeyState::Press,
+                       KeyModifier::Shift}
     , layerType_{"layerType",
                  "Visible Layer",
                  "The layer type to render, color, depth of picking"_help,
@@ -198,13 +208,13 @@ CanvasWithPropertiesProcessor::CanvasWithPropertiesProcessor()
 
     addPort(inport_);
 
-    addProperties(dimensions_, position_, visible_, fullScreen_, onTop_, layerType_, layerIndex_,
-                  paths_);
+    addProperties(dimensions_, position_, visible_, fullScreen_, fullScreenEvent_, onTop_,
+                  layerType_, layerIndex_, paths_);
 
     layerIndex_.setSerializationMode(PropertySerializationMode::All);
     layerIndex_.readonlyDependsOn(layerType_, [](const auto& p) { return p != LayerType::Color; });
     inport_.onChange([&]() {
-        int layers = static_cast<int>(inport_.getData()->getNumberOfColorLayers());
+        const int layers = static_cast<int>(inport_.getData()->getNumberOfColorLayers());
         layerIndex_.setMaxValue(layers - 1);
     });
 
@@ -222,11 +232,12 @@ CanvasWithPropertiesProcessor::CanvasWithPropertiesProcessor()
 CanvasWithPropertiesProcessor::~CanvasWithPropertiesProcessor() = default;
 
 void CanvasWithPropertiesProcessor::process() {
-    if (auto widget = static_cast<CanvasWithPropertiesProcessorWidgetQt*>(processorWidget_.get())) {
+    if (auto* widget =
+            static_cast<CanvasWithPropertiesProcessorWidgetQt*>(processorWidget_.get())) {
         widget->setProperties(paths_.get());
 
         if (widget->QMainWindow::isVisible()) {
-            if (auto canvas = widget->getCanvas()) {
+            if (auto* canvas = widget->getCanvas()) {
                 canvas->render(inport_.getData(), layerType_, layerIndex_);
             }
         }
@@ -234,11 +245,12 @@ void CanvasWithPropertiesProcessor::process() {
 }
 
 void CanvasWithPropertiesProcessor::doIfNotReady() {
-    if (auto widget = static_cast<CanvasWithPropertiesProcessorWidgetQt*>(processorWidget_.get())) {
+    if (auto* widget =
+            static_cast<CanvasWithPropertiesProcessorWidgetQt*>(processorWidget_.get())) {
         widget->setProperties(paths_.get());
 
         if (widget->QMainWindow::isVisible()) {
-            if (auto canvas = widget->getCanvas()) {
+            if (auto* canvas = widget->getCanvas()) {
                 canvas->render(nullptr, layerType_, layerIndex_);
             }
         }
@@ -255,7 +267,7 @@ void CanvasWithPropertiesProcessor::setProcessorWidget(
 void CanvasWithPropertiesProcessor::propagateEvent(Event* event, Outport*) {
     if (event->hasVisitedProcessor(this)) return;
     event->markAsVisited(this);
-    
+
     invokeEvent(event);
     if (event->hasBeenUsed()) return;
 
@@ -267,7 +279,7 @@ std::optional<std::filesystem::path> CanvasWithPropertiesProcessor::exportFile(
     const std::vector<FileExtension>& candidateExtensions, Overwrite overwrite) const {
 
     if (auto data = inport_.getData()) {
-        if (auto layer = data->getLayer(layerType_, layerIndex_)) {
+        if (const auto* layer = data->getLayer(layerType_, layerIndex_)) {
             return util::saveData(*layer, path, name, candidateExtensions, overwrite);
         }
     }

--- a/modules/qtwidgets/include/modules/qtwidgets/properties/eventpropertywidgetqt.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/properties/eventpropertywidgetqt.h
@@ -47,11 +47,12 @@ class EventProperty;
 class IvwPushButton;
 class KeyboardEventMatcher;
 class MouseEventMatcher;
+class ShortcutBlockEventFilter;
 
 class IVW_MODULE_QTWIDGETS_API EventPropertyWidgetQt : public PropertyWidgetQt {
 
 public:
-    EventPropertyWidgetQt(EventProperty* eventproperty);
+    explicit EventPropertyWidgetQt(EventProperty* eventproperty);
     virtual ~EventPropertyWidgetQt();
     virtual void updateFromProperty() override;
 
@@ -73,6 +74,7 @@ private:
     EventProperty* eventProperty_;
     IvwPushButton* button_;
     EditableLabelQt* label_;
+    ShortcutBlockEventFilter* shortcutBlocker_;
 
     std::unique_ptr<EventMatcher> matcher_;
     KeyboardEventMatcher* keyMatcher_ = nullptr;

--- a/modules/qtwidgets/src/properties/eventpropertywidgetqt.cpp
+++ b/modules/qtwidgets/src/properties/eventpropertywidgetqt.cpp
@@ -57,27 +57,41 @@ class QHBoxLayout;
 
 namespace inviwo {
 
+class ShortcutBlockEventFilter : public QObject {
+public:
+    explicit ShortcutBlockEventFilter(QObject* parent = nullptr) : QObject{parent} {}
+
+    bool eventFilter(QObject*, QEvent* ev) override {
+        if (ev->type() == QEvent::ShortcutOverride) {
+            ev->accept();
+            return true;
+        }
+        return QObject::eventFilter(nullptr, ev);
+    }
+};
+
 EventPropertyWidgetQt::EventPropertyWidgetQt(EventProperty* eventproperty)
     : PropertyWidgetQt(eventproperty)
     , eventProperty_(eventproperty)
     , button_{new IvwPushButton(this)}
-    , label_{new EditableLabelQt(this, eventProperty_)} {
+    , label_{new EditableLabelQt(this, eventProperty_)}
+    , shortcutBlocker_{new ShortcutBlockEventFilter{this}} {
 
     setFocusPolicy(button_->focusPolicy());
     setFocusProxy(button_);
 
-    QHBoxLayout* hLayout = new QHBoxLayout();
+    auto* hLayout = new QHBoxLayout();
     setSpacingAndMargins(hLayout);
 
     connect(button_, &IvwPushButton::clicked, this, &EventPropertyWidgetQt::clickedSlot);
     hLayout->addWidget(label_);
 
     {
-        QWidget* widget = new QWidget(this);
+        auto* widget = new QWidget(this);
         QSizePolicy sliderPol = widget->sizePolicy();
         sliderPol.setHorizontalStretch(3);
         widget->setSizePolicy(sliderPol);
-        QGridLayout* vLayout = new QGridLayout();
+        auto* vLayout = new QGridLayout();
         widget->setLayout(vLayout);
         vLayout->setContentsMargins(0, 0, 0, 0);
         vLayout->setSpacing(0);
@@ -108,6 +122,7 @@ void EventPropertyWidgetQt::clickedSlot() {
         keyMatcher_->setKey(IvwKey::Unknown);
         grabKeyboard();
         grabMouse();
+        installEventFilter(shortcutBlocker_);
     } else if (mouseMatcher_) {
         mouseMatcher_->setModifiers(KeyModifiers(flags::none));
         mouseMatcher_->setButtons(MouseButton::None);
@@ -137,6 +152,7 @@ void EventPropertyWidgetQt::keyPressEvent(QKeyEvent* event) {
 
 void EventPropertyWidgetQt::keyReleaseEvent(QKeyEvent* event) {
     if (keyMatcher_ && (event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return)) {
+        removeEventFilter(shortcutBlocker_);
         releaseKeyboard();
         releaseMouse();
         eventProperty_->getEventMatcher()->assign(keyMatcher_);
@@ -145,6 +161,7 @@ void EventPropertyWidgetQt::keyReleaseEvent(QKeyEvent* event) {
         keyMatcher_ = nullptr;
         event->accept();
     } else if (keyMatcher_ && event->key() == Qt::Key_Escape) {
+        removeEventFilter(shortcutBlocker_);
         releaseKeyboard();
         releaseMouse();
         setButtonText();
@@ -161,6 +178,7 @@ void EventPropertyWidgetQt::keyReleaseEvent(QKeyEvent* event) {
 
 void EventPropertyWidgetQt::mousePressEvent(QMouseEvent* event) {
     if (keyMatcher_) {
+        removeEventFilter(shortcutBlocker_);
         releaseKeyboard();
         releaseMouse();
         setButtonText();
@@ -200,6 +218,7 @@ void EventPropertyWidgetQt::mouseReleaseEvent(QMouseEvent* event) {
 
 void EventPropertyWidgetQt::focusOutEvent(QFocusEvent* event) {
     if (keyMatcher_) {
+        removeEventFilter(shortcutBlocker_);
         releaseKeyboard();
         setButtonText();
         button_->setEnabled(true);

--- a/src/core/processors/canvasprocessor.cpp
+++ b/src/core/processors/canvasprocessor.cpp
@@ -134,7 +134,7 @@ CanvasProcessor::CanvasProcessor(InviwoApplication* app)
                              "Save the current layer to a file. This will open a save dialog to "
                              "specify the output file"_help,
                              [this]() {
-                                 if (auto layer = getVisibleLayer()) {
+                                 if (const auto* layer = getVisibleLayer()) {
                                      util::saveLayer(*layer);
                                  } else {
                                      log::error("Could not find visible layer");
@@ -142,11 +142,14 @@ CanvasProcessor::CanvasProcessor(InviwoApplication* app)
                              },
                              InvalidationLevel::Valid}
     , fullScreen_{"fullscreen", "Toggle Full Screen",
-                  "Show the canvas processor widget in fullscreen"_help, false}
+                  "Show the canvas processor widget in full screen"_help, false}
     , fullScreenEvent_{"fullscreenEvent",
-                       "FullScreen",
-                       "Shortcut to toggle fullscreen"_help,
-                       [this](Event*) { fullScreen_.set(!fullScreen_); },
+                       "Full Screen",
+                       "Shortcut to toggle full-screen mode"_help,
+                       [this](Event* event) {
+                           event->markAsUsed();
+                           fullScreen_.set(!fullScreen_);
+                       },
                        IvwKey::F,
                        KeyState::Press,
                        KeyModifier::Shift}
@@ -380,7 +383,7 @@ void CanvasProcessor::propagateEvent(Event* event, Outport* source) {
     invokeEvent(event);
     if (event->hasBeenUsed()) return;
 
-    if (auto resizeEvent = event->getAs<ResizeEvent>()) {
+    if (auto* resizeEvent = event->getAs<ResizeEvent>()) {
         // Avoid continues evaluation when port dimensions changes
         const NetworkLock lock(this);
         dimensions_.set(resizeEvent->size());
@@ -393,7 +396,7 @@ void CanvasProcessor::propagateEvent(Event* event, Outport* source) {
         }
     } else {
         bool used = event->hasBeenUsed();
-        for (auto inport : getInports()) {
+        for (auto* inport : getInports()) {
             if (event->shouldPropagateTo(inport, this, source)) {
                 inport->propagateEvent(event);
                 used |= event->hasBeenUsed();

--- a/src/qt/editor/inviwomainwindow.cpp
+++ b/src/qt/editor/inviwomainwindow.cpp
@@ -893,6 +893,8 @@ void InviwoMainWindow::addActions() {  // NOLINT
         auto* searchNetwork =
             editMenu_->addAction(QIcon(":/svgicons/find-network.svg"), tr("&Search Network"));
         searchNetwork->setShortcut(Qt::SHIFT | Qt::CTRL | Qt::Key_F);
+        searchNetwork->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        addAction(searchNetwork);
         connect(searchNetwork, &QAction::triggered, [this]() {
             networkEditorView_->getNetworkSearch().setVisible(true);
             networkEditorView_->getNetworkSearch().setFocus();
@@ -901,6 +903,8 @@ void InviwoMainWindow::addActions() {  // NOLINT
         auto* findAction =
             editMenu_->addAction(QIcon(":/svgicons/find-processor.svg"), tr("&Find Processor"));
         findAction->setShortcut(QKeySequence::Find);
+        findAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        addAction(findAction);
         connect(findAction, &QAction::triggered, this, [this]() {
             processorTreeWidget_->show();
             processorTreeWidget_->focusSearch();
@@ -909,6 +913,8 @@ void InviwoMainWindow::addActions() {  // NOLINT
         auto* addProcessorAction =
             editMenu_->addAction(QIcon(":/svgicons/processor-add.svg"), tr("&Add Processor"));
         addProcessorAction->setShortcut(Qt::CTRL | Qt::Key_D);
+        addProcessorAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+        addAction(addProcessorAction);
         connect(addProcessorAction, &QAction::triggered, this,
                 [this]() { processorTreeWidget_->addSelectedProcessor(); });
 


### PR DESCRIPTION
Fixes #1983 

Changes proposed in this PR:
 * added event properties toggling full-screen mode to `CanvasWithProperties`, partial fix for #1983
 * added event property to leave full-screen mode with <Esc>
 * issue where `HiddenCanvas` initially propagates an incorrect window size

This has been tested on: Windows, Qt 6.10.3
