### PR TITLE
chore: update vcpkg baseline to eb35a05cc2

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,7 @@
   "vcpkg-configuration": {
     "default-registry": {
       "kind": "builtin",
-      "baseline": "9b965a116838c6cdcd36bca60d1b81b030c8ab8d"
+      "baseline": "eb35a05cc21c69ec1399f7532b7dd61d271ac0d1"
     },
     "overlay-ports": [
       "./tools/vcpkg"


### PR DESCRIPTION
## vcpkg baseline update

Updated baseline from `9b965a1168` to `eb35a05cc2`.

### Changed dependencies
```
assimp: 6.0.4 -> 6.0.4
bext-sml: 1.1.13 -> 1.2.0
fast-float: 8.2.5 -> 8.2.6
ffmpeg: 8.1.1 -> 8.1.1
graphviz: 14.1.2 -> 15.0.0
minizip: 1.3.1 -> 1.3.2
qtbase: 6.11.0 -> 6.11.1
qtsvg: 6.11.0 -> 6.11.1
zlib: 1.3.2 -> 1.3.2
```

Full vcpkg commit: https://github.com/microsoft/vcpkg/commit/eb35a05cc21c69ec1399f7532b7dd61d271ac0d1
