### PR TITLE
Feature/animation fixes

### DIFF
--- a/.github/presets/linux.json
+++ b/.github/presets/linux.json
@@ -20,7 +20,8 @@
       "name": "gha-static",
       "inherits" : ["gha"],
       "cacheVariables": {
-        "BUILD_SHARED_LIBS":  { "type": "BOOL", "value": "OFF"}
+        "BUILD_SHARED_LIBS":  { "type": "BOOL", "value": "OFF"},
+        "IVW_TEST_UNIT_TESTS": { "type": "BOOL", "value": "OFF"}
       }
     },
     {

--- a/.github/workflows/inviwo.yml
+++ b/.github/workflows/inviwo.yml
@@ -13,7 +13,7 @@ permissions:
 env:
   VCPKG_CACHE_TOKEN: ${{ secrets.VCPKG_CACHE_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  VCPKG_FEATURE_FLAGS: dependencygraph
+  # VCPKG_FEATURE_FLAGS: dependencygraph // Does not work at the moment
   CCACHE_BASEDIR: ${{ github.workspace }}
   CCACHE_NODIRECT: true
   CCACHE_NODEPEND: true

--- a/modules/animation/src/animationcontroller.cpp
+++ b/modules/animation/src/animationcontroller.cpp
@@ -410,7 +410,7 @@ void AnimationController::render() {
                         if (recorderFactory->options()->isChecked()) {
                             std::shared_ptr<Recorder> recorder = recorderFactory->create(
                                 {.dimensions = imageExporter->getImage()->getDimensions(),
-                                 .frameRate = static_cast<int>(framesPerSecond.get()),
+                                 .frameRate = static_cast<int>(renderFPS.get()),
                                  .expectedNumberOfFrames = numFrames,
                                  .sourceName = std::string{p->getIdentifier()}});
 

--- a/modules/ffmpeg/src/outputstream.cpp
+++ b/modules/ffmpeg/src/outputstream.cpp
@@ -63,7 +63,16 @@ OutputStream::OutputStream(Format& format, Options opts)
 
     codec.ctx->gop_size = 12; /* emit one intra frame every twelve frames at most */
 
-    codec.ctx->pix_fmt = AV_PIX_FMT_YUV420P;  // seems many codecs handle this one?
+    // Dynamically select the best pixel format the codec supports,
+    // minimizing conversion loss from the source format (e.g., AV_PIX_FMT_RGBA).
+    const enum AVPixelFormat* formats = nullptr;
+    avcodec_get_supported_config(codec.ctx, nullptr, AVCodecConfig::AV_CODEC_CONFIG_PIX_FORMAT, 0,
+                                 (const void**)&formats, nullptr);
+    if (formats) {
+        codec.ctx->pix_fmt = avcodec_find_best_pix_fmt_of_list(formats, sourceFormat, 0, nullptr);
+    } else {
+        codec.ctx->pix_fmt = AV_PIX_FMT_YUV420P;  // safe fallback
+    }
 
     if (codec.ctx->codec_id == AV_CODEC_ID_MPEG2VIDEO) {
         /* just for testing, we also add B-frames */

--- a/modules/ffmpeg/src/outputstream.cpp
+++ b/modules/ffmpeg/src/outputstream.cpp
@@ -67,7 +67,7 @@ OutputStream::OutputStream(Format& format, Options opts)
     // minimizing conversion loss from the source format (e.g., AV_PIX_FMT_RGBA).
     const enum AVPixelFormat* formats = nullptr;
     avcodec_get_supported_config(codec.ctx, nullptr, AVCodecConfig::AV_CODEC_CONFIG_PIX_FORMAT, 0,
-                                 (const void**)&formats, nullptr);
+                                 reinterpret_cast<const void**>(&formats), nullptr);
     if (formats) {
         codec.ctx->pix_fmt = avcodec_find_best_pix_fmt_of_list(formats, sourceFormat, 0, nullptr);
     } else {

--- a/resources/stylesheets/inviwo.qss
+++ b/resources/stylesheets/inviwo.qss
@@ -551,6 +551,9 @@ QComboBox::down-arrow {
 QComboBox::down-arrow:disabled {
      image: url(:/svgicons/arrow-down-disabled.svg);
 }
+QDockWidget#AnimationEditorWidget QComboBox QAbstractItemView {
+    background: #323235;
+}
 
 
 /************************ 


### PR DESCRIPTION
Fixes
 * broken stylesheet/transparent background of OptionProperties in the Animation Editor
 * rendering an animation used the wrong fps setting
 * query ffmpeg pixel formats for codecs since not all support yuv420p (e.g. h264)
