### PR TITLE
chore: update vcpkg baseline to dc31f86a44

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,7 @@
   "vcpkg-configuration": {
     "default-registry": {
       "kind": "builtin",
-      "baseline": "eb35a05cc21c69ec1399f7532b7dd61d271ac0d1"
+      "baseline": "dc31f86a441067d6c2e9e4ad52988eb41ef4f442"
     },
     "overlay-ports": [
       "./tools/vcpkg"


### PR DESCRIPTION
## vcpkg baseline update

Updated baseline from `eb35a05cc2` to `dc31f86a44`.

### Changed dependencies
```
cimg: 3.7.6 -> 4.0.3
fast-float: 8.2.6 -> 8.2.10
ffmpeg: 8.1.1 -> 9.0
fmt: 12.1.0 -> 12.2.0
gdcm: 3.2.5 -> 3.2.7
glfw3: 3.4 -> 3.5.1
graphviz: 15.0.0 -> 15.1.1
gtest: 1.17.0 -> 1.18.0
libjpeg-turbo: 3.1.4.1 -> 3.2.0
openexr: 3.4.12 -> 3.4.13
pybind11: 3.0.1 -> 3.1.0
qtbase: 6.11.1 -> 6.11.1
roaring: 4.7.0 -> 4.7.2
tiff: 4.7.1 -> 4.7.2
tracy: 0.13.1 -> 0.13.1
vtk: 9.3.0-pv5.12.1 -> 9.3.0-pv5.12.1
zlib: 1.3.2 -> 1.3.2
```

Full vcpkg commit: https://github.com/microsoft/vcpkg/commit/dc31f86a441067d6c2e9e4ad52988eb41ef4f442
