### PR TITLE
Feature/inputselector

### DIFF
--- a/include/inviwo/core/ports/datainport.h
+++ b/include/inviwo/core/ports/datainport.h
@@ -49,10 +49,12 @@ namespace inviwo {
 /**
  * @ingroup ports
  * DataInport represents a general inport providing data as a std:shared_ptr<const T>
- * If N is set to 0 the port will accept multiple connections, and will provide a
- * std::vector<std::shared_ptr<const T>> of data. If N is larger then 1 exactly that many
- * connections are accepted. If Flat is set to true, the inport will also accept connections from
- * outport with vector data of type T and merge them into the data return data vector.
+ * If @tparam N is set to 0 the port will accept multiple connections, and will provide a
+ * std::vector<std::shared_ptr<const T>> of data. If @tparam N is greater or equal to 0 exactly
+ * @tparam N connections are accepted.
+ * If @tparam Flat is set to true, the inport will also accept
+ * connections from outports with vector data of type @tparam T and merge them into the vector
+ * returned by @c getData().
  */
 template <typename T, size_t N = 1, bool Flat = false>
 class DataInport : public Inport, public InportIterable<DataInport<T, N, Flat>, T, Flat> {

--- a/modules/base/include/modules/base/processors/inputselector.h
+++ b/modules/base/include/modules/base/processors/inputselector.h
@@ -38,9 +38,10 @@
 #include <inviwo/core/processors/processortags.h>
 #include <inviwo/core/processors/processortraits.h>
 #include <inviwo/core/properties/optionproperty.h>
+#include <inviwo/core/properties/boolproperty.h>
 #include <inviwo/core/properties/valuewrapper.h>
 #include <inviwo/core/util/assertion.h>
-#include <inviwo/core/network/processornetwork.h>    // IWYU pragma: keep
+#include <inviwo/core/network/processornetwork.h>  // IWYU pragma: keep
 
 #include <string_view>
 #include <vector>
@@ -70,20 +71,30 @@ private:
     OutportType outport_;
 
     OptionPropertySize_t selectedPort_;
+    BoolProperty includeEmptyInport_;
 };
 
 template <typename Inport, typename Outport>
 InputSelector<Inport, Outport>::InputSelector()
-    : Processor()
-    , inport_("inport", "All available inputs"_help)
-    , outport_("outport", "Selected input"_help)
-    , selectedPort_("selectedPort", "Select Inport", "Name of selected port"_help) {
+    : Processor{}
+    , inport_{"inport", "All available inputs"_help}
+    , outport_{"outport", "Selected input"_help}
+    , selectedPort_{"selectedPort", "Select Inport", "Name of selected port"_help}
+    , includeEmptyInport_{
+          "includeEmptyInport_", "Include 'Empty Inport' Option ",
+          R"(If enabled, another option is added to the inport selection which results in the 
+          outport to have no data.
+
+          Use this to toggle between rendering or hiding a bounding box, for
+          example.)"_unindentHelp,
+          false, InvalidationLevel::Valid} {
     portSettings();
 
-    addPort(inport_);
-    addPort(outport_);
+    addPorts(inport_, outport_);
 
-    auto updateOptions = [this]() {
+    constexpr size_t emptyInportIndex = std::numeric_limits<size_t>::max();
+
+    auto updateOptions = [this, emptyInportIndex]() {
         if (getNetwork()->isDeserializing()) return;
         std::vector<OptionPropertySize_tOption> options;
 
@@ -92,19 +103,26 @@ InputSelector<Inport, Outport>::InputSelector()
             const auto dispName = port->getProcessor()->getDisplayName();
             options.emplace_back(id, dispName, options.size());
         }
+        if (includeEmptyInport_) {
+            options.emplace_back("emptyInport", "Empty Inport", emptyInportIndex);
+        }
         selectedPort_.replaceOptions(options);
         selectedPort_.setCurrentStateAsDefault();
     };
 
     inport_.onConnect([updateOptions]() { updateOptions(); });
     inport_.onDisconnect([updateOptions]() { updateOptions(); });
+    includeEmptyInport_.onChange([updateOptions]() { updateOptions(); });
 
-    inport_.setIsReadyUpdater([this]() {
-        return selectedPort_.size() > 0 && inport_.getConnectedOutports().size() > *selectedPort_ &&
+    inport_.setIsReadyUpdater([this, emptyInportIndex]() {
+        if (!selectedPort_.empty() && *selectedPort_ == emptyInportIndex) {
+            return true;
+        }
+        return !selectedPort_.empty() && inport_.getConnectedOutports().size() > *selectedPort_ &&
                inport_.getConnectedOutports()[*selectedPort_]->isReady();
     });
 
-    addProperty(selectedPort_);
+    addProperties(selectedPort_, includeEmptyInport_);
 
     selectedPort_.setSerializationMode(PropertySerializationMode::All);
     setAllPropertiesCurrentStateAsDefault();
@@ -121,7 +139,15 @@ void InputSelector<Inport, Outport>::process() {
     if (selectedPort_.get() < data.size()) {
         outport_.setData(data[selectedPort_.get()]);
     } else {
-        outport_.setData(data.back());
+        if (includeEmptyInport_) {
+            if constexpr (std::is_same_v<Outport, ImageOutport>) {
+                outport_.setData(std::shared_ptr<const Image>{});
+            } else {
+                outport_.setData(nullptr);
+            }
+        } else {
+            outport_.setData(data.back());
+        }
     }
 }
 

--- a/modules/base/include/modules/base/processors/inputselector.h
+++ b/modules/base/include/modules/base/processors/inputselector.h
@@ -95,7 +95,9 @@ InputSelector<Inport, Outport>::InputSelector()
     constexpr size_t emptyInportIndex = std::numeric_limits<size_t>::max();
 
     auto updateOptions = [this, emptyInportIndex]() {
-        if (getNetwork()->isDeserializing()) return;
+        if (const auto* network = getNetwork(); network && network->isDeserializing()) {
+            return;
+        }
         std::vector<OptionPropertySize_tOption> options;
 
         for (auto port : inport_.getConnectedOutports()) {

--- a/modules/base/include/modules/base/processors/inputselector.h
+++ b/modules/base/include/modules/base/processors/inputselector.h
@@ -81,9 +81,9 @@ InputSelector<Inport, Outport>::InputSelector()
     , outport_{"outport", "Selected input"_help}
     , selectedPort_{"selectedPort", "Select Inport", "Name of selected port"_help}
     , includeEmptyInport_{
-          "includeEmptyInport_", "Include 'Empty Inport' Option ",
-          R"(If enabled, another option is added to the inport selection which results in the 
-          outport to have no data.
+          "includeEmptyInport_", "Include 'None' Option ",
+          R"(If enabled, the option 'None' is added to the inport selection which results in the 
+          outport having no data.
 
           Use this to toggle between rendering or hiding a bounding box, for
           example.)"_unindentHelp,
@@ -104,7 +104,7 @@ InputSelector<Inport, Outport>::InputSelector()
             options.emplace_back(id, dispName, options.size());
         }
         if (includeEmptyInport_) {
-            options.emplace_back("emptyInport", "Empty Inport", emptyInportIndex);
+            options.emplace_back("emptyInport", "None", emptyInportIndex);
         }
         selectedPort_.replaceOptions(options);
         selectedPort_.setCurrentStateAsDefault();

--- a/modules/basegl/include/modules/basegl/processors/layerrenderer.h
+++ b/modules/basegl/include/modules/basegl/processors/layerrenderer.h
@@ -52,7 +52,7 @@ public:
     static const ProcessorInfo processorInfo_;
 
 private:
-    LayerMultiInport inport_;
+    LayerFlatMultiInport inport_;
     ImageInport background_;
     ImageOutport outport_;
 

--- a/modules/basegl/src/processors/layerrenderer.cpp
+++ b/modules/basegl/src/processors/layerrenderer.cpp
@@ -63,8 +63,9 @@ LayerRenderer::LayerRenderer()
     , shader_{"layerrendering.vert", "layerrendering.frag", Shader::Build::No}
     , mesh_{DrawType::Triangles, ConnectivityType::Strip} {
 
-    background_.setOptional(true);
-    addPorts(inport_, background_, outport_);
+    addPort(inport_).setOptional(true);
+    addPort(background_).setOptional(true);
+    addPort(outport_);
     addProperties(camera_, trackball_);
 
     auto verticesBuffer =
@@ -73,7 +74,8 @@ LayerRenderer::LayerRenderer()
 
     mesh_.addBuffer(BufferType::PositionAttrib, verticesBuffer);
     mesh_.addBuffer(BufferType::TexCoordAttrib, verticesBuffer);
-    mesh_.addIndices(Mesh::MeshInfo(DrawType::Triangles, ConnectivityType::Strip), indices_);
+    mesh_.addIndices(Mesh::MeshInfo{.dt = DrawType::Triangles, .ct = ConnectivityType::Strip},
+                     indices_);
 
     shader_.onReload([this]() { invalidate(InvalidationLevel::InvalidResources); });
 }
@@ -87,14 +89,14 @@ void LayerRenderer::process() {
     utilgl::activateTargetAndClearOrCopySource(outport_, background_);
     shader_.activate();
 
-    utilgl::GlBoolState depthTest(GL_DEPTH_TEST, true);
-    utilgl::CullFaceState culling(GL_NONE);
-    utilgl::BlendModeState blendModeStateGL(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    const utilgl::GlBoolState depthTest(GL_DEPTH_TEST, true);
+    const utilgl::CullFaceState culling(GL_NONE);
+    const utilgl::BlendModeState blendModeStateGL(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
     utilgl::setUniforms(shader_, camera_);
     MeshDrawerGL::DrawObject drawer{mesh_.getRepresentation<MeshGL>(), mesh_.getDefaultMeshInfo()};
 
-    TextureUnit unit;
+    const TextureUnit unit;
     shader_.setUniform("colorTex", unit);
 
     for (const auto& layer : inport_) {

--- a/modules/basegl/src/processors/linerendererprocessor.cpp
+++ b/modules/basegl/src/processors/linerendererprocessor.cpp
@@ -77,7 +77,7 @@ LineRendererProcessor::LineRendererProcessor()
     , bnl_{}
     , lineRenderer_{{bnl_.getRequirement()}} {
 
-    addPort(inport_);
+    addPort(inport_).setOptional(true);
     addPort(imageInport_).setOptional(true);
     addPort(bnl_.inport);
     addPort(outport_);

--- a/modules/basegl/src/processors/meshrenderprocessorgl.cpp
+++ b/modules/basegl/src/processors/meshrenderprocessorgl.cpp
@@ -182,7 +182,7 @@ void MeshRenderProcessorGL::process() {
     TextureUnitContainer cont;
     utilgl::bind(cont, texture_);
     utilgl::setUniforms(shader_, camera_, lightingProperty_, overrideColor_, texture_);
-    for (auto mesh : inport_) {
+    for (const auto& mesh : inport_) {
         utilgl::setShaderUniforms(shader_, *mesh, "geometry");
         shader_.setUniform("pickingEnabled", meshutil::hasPickIDBuffer(mesh.get()));
         MeshDrawerGL::DrawObject drawer{mesh->getRepresentation<MeshGL>(),

--- a/modules/basegl/src/processors/meshrenderprocessorgl.cpp
+++ b/modules/basegl/src/processors/meshrenderprocessorgl.cpp
@@ -103,8 +103,9 @@ MeshRenderProcessorGL::MeshRenderProcessorGL()
     , shader_{"meshrendering.vert", "meshrendering.frag", Shader::Build::No}
     , hadTextureData_{false} {
 
-    addPorts(inport_, imageInport_, outport_);
-    imageInport_.setOptional(true);
+    addPort(inport_).setOptional(true);
+    addPort(imageInport_).setOptional(true);
+    addPort(outport_);
     addPort(texture_.inport, "Textures").setOptional(true);
 
     addProperties(camera_, meshProperties_, lightingProperty_, trackball_, layers_);

--- a/modules/basegl/src/processors/sphererenderer.cpp
+++ b/modules/basegl/src/processors/sphererenderer.cpp
@@ -104,7 +104,7 @@ SphereRenderer::SphereRenderer()
                    configureShader(shader);
                }} {
 
-    addPort(inport_);
+    addPort(inport_).setOptional(true);
     addPort(imageInport_).setOptional(true);
     addPort(texture_.inport, "Textures").setOptional(true);
     addPort(bnl_.inport);

--- a/modules/oit/src/processors/linerasterizer.cpp
+++ b/modules/oit/src/processors/linerasterizer.cpp
@@ -210,7 +210,7 @@ void LineRasterizer::rasterize(const ivec2& imageSize, const dmat4& worldMatrixT
         shader.setUniform("metaColor", texUnit.getUnitNumber());
     };
 
-    for (auto mesh : inport_) {
+    for (const auto& mesh : inport_) {
         if (mesh->getNumberOfBuffers() == 0) return;
 
         MeshDrawerGL::DrawObject drawer(*mesh);

--- a/modules/oit/src/processors/linerasterizer.cpp
+++ b/modules/oit/src/processors/linerasterizer.cpp
@@ -122,7 +122,7 @@ LineRasterizer::LineRasterizer()
                    }}
     , tfLookup_{} {
 
-    addPort(inport_);
+    addPort(inport_).setOptional(true);
 
     addProperties(forceOpaque_, lineSettings_);
 

--- a/modules/oit/src/processors/meshrasterizer.cpp
+++ b/modules/oit/src/processors/meshrasterizer.cpp
@@ -140,8 +140,9 @@ MeshRasterizer::MeshRasterizer()
     , faceSettings_{true, false}
     , shader_{"fancymeshrenderer.vert", "fancymeshrenderer.geom", "fancymeshrenderer.frag",
               Shader::Build::No} {
+
     // input and output ports
-    addPort(inport_);
+    addPort(inport_).setOptional(true);
 
     addProperties(forceOpaque_, drawSilhouette_, silhouetteColor_, normalSource_,
                   normalComputationMode_, alphaSettings_, edgeSettings_, faceSettings_[0].show_,
@@ -440,6 +441,10 @@ void MeshRasterizer::setUniforms(Shader& shader) {
 void MeshRasterizer::rasterize(const ivec2& imageSize, const dmat4& worldMatrixTransform) {
     if (inport_.isChanged() || drawSilhouette_.isModified()) {
         updateMeshes();
+    }
+
+    if (enhancedMeshes_.empty()) {
+        return;
     }
 
     if (!faceSettings_[0].show_ && !faceSettings_[1].show_) {

--- a/modules/oit/src/processors/sphererasterizer.cpp
+++ b/modules/oit/src/processors/sphererasterizer.cpp
@@ -131,7 +131,7 @@ SphereRasterizer::SphereRasterizer()
                    configureShader(shader);
                }} {
 
-    addPort(inport_);
+    addPort(inport_).setOptional(true);
     addPort(texture_.inport, "Textures").setOptional(true);
     addPort(bnl_.inport);
     addPort(labels_.strings);
@@ -164,19 +164,18 @@ UseFragmentList SphereRasterizer::usesFragmentLists() const {
 }
 
 void SphereRasterizer::rasterize(const ivec2& imageSize, const dmat4& worldMatrixTransform) {
-
     bnl_.update();
     labels_.update();
 
-    utilgl::BlendModeState blendModeStateGL(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    utilgl::GlBoolState depthTest(GL_DEPTH_TEST, usesFragmentLists() == UseFragmentList::No);
+    const utilgl::BlendModeState blendModeStateGL(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    const utilgl::GlBoolState depthTest(GL_DEPTH_TEST, usesFragmentLists() == UseFragmentList::No);
 
     TextureUnitContainer cont;
     utilgl::bind(cont, bnl_, labels_, config_, texture_);
 
     for (auto mesh : inport_) {
         auto& shader = shaders_.getShader(*mesh);
-        utilgl::Activate activate{&shader};
+        const utilgl::Activate activate{&shader};
 
         setUniforms(shader);
         shader.setUniform("viewport", vec4(0.0f, 0.0f, 2.0f / imageSize.x, 2.0f / imageSize.y));

--- a/modules/python3/processors/PythonMeshExample.py
+++ b/modules/python3/processors/PythonMeshExample.py
@@ -44,11 +44,11 @@ def ngonLineMesh(n: int, tf: ivw.data.TransferFunction):
     mesh = ivw.data.Mesh(dt=ivw.data.DrawType.Lines, ct=ivw.data.ConnectivityType.Loop)
 
     # set the model transformation of the mesh
-    mesh.modelMatrix = ivw.glm.mat4(1)
+    mesh.modelMatrix = ivw.glm.dmat4(1)
     # alternatively, the model transformation can also be modified
     # with `mesh.basis`and `mesh.offset`
-    # mesh.basis = ivw.glm.mat3(1)
-    # mesh.offset = ivw.glm.vec3(0, 0, 0)
+    # mesh.basis = ivw.glm.dmat3(1)
+    # mesh.offset = ivw.glm.dvec3(0, 0, 0)
 
     angles = np.arange(n, dtype=np.float32) * np.pi * 2.0 / n
 

--- a/modules/python3/processors/PythonVolumeExample.py
+++ b/modules/python3/processors/PythonVolumeExample.py
@@ -92,8 +92,8 @@ workspace for example usage.
         # create a Volume from the representation
         volume = ivw.data.Volume(volumerep)
 
-        volume.basis = ivw.glm.mat3(1)
-        volume.offset = ivw.glm.vec3(-0.5, -0.5, -0.5)
+        volume.basis = ivw.glm.dmat3(1)
+        volume.offset = ivw.glm.dvec3(-0.5, -0.5, -0.5)
 
         volume.dataMap.dataRange = ivw.glm.dvec2(0.0, 1.0)
         volume.dataMap.valueRange = ivw.glm.dvec2(0.0, 1.0)


### PR DESCRIPTION
Changes proposed in this PR:
 * optional "empty inport" option in `Input Selector` to toggle between forwarding the selected inport or no data.
 * adjusted mesh rendering processors to deal with the cases where the Mesh inport has no data.

This allows for more flexible networks where it is possible to toggle parts of the visualization, like the volume bounding box, without breaking the rest of the network.

<img width="844" height="548" alt="image" src="https://github.com/user-attachments/assets/035b24b7-5c10-4e80-b37f-e87a00077d09" />
