### PR TITLE
Feature/networkeditor fixes

### DIFF
--- a/include/inviwo/core/network/workspacemanager.h
+++ b/include/inviwo/core/network/workspacemanager.h
@@ -88,7 +88,7 @@ public:
     using ModifiedCallback = typename ModifiedDispatcher::Callback;
     using ModifiedHandle = typename ModifiedDispatcher::Handle;
 
-    WorkspaceManager(InviwoApplication* app);
+    explicit WorkspaceManager(InviwoApplication* app);
     ~WorkspaceManager();
 
     /**

--- a/include/inviwo/qt/editor/processorgraphicsitem.h
+++ b/include/inviwo/qt/editor/processorgraphicsitem.h
@@ -133,6 +133,7 @@ public:
 #endif
 
     void setHighlight(bool val);
+    bool isHighlighted() const;
 
     static constexpr QSizeF size{150.0, 50.0};
 

--- a/modules/qtwidgets/include/modules/qtwidgets/propertylistwidget.h
+++ b/modules/qtwidgets/include/modules/qtwidgets/propertylistwidget.h
@@ -95,7 +95,7 @@ private:
 class IVW_MODULE_QTWIDGETS_API PropertyListEvent : public QEvent {
     Q_GADGET
 public:
-    enum class Action { Add = 0, Remove = 1, FocusProperty = 2 };
+    enum class Action : std::uint8_t { Add = 0, Remove = 1, FocusProperty = 2 };
     PropertyListEvent(Action action, std::string_view identifier);
     static QEvent::Type type();
     Action action;

--- a/modules/qtwidgets/src/propertylistwidget.cpp
+++ b/modules/qtwidgets/src/propertylistwidget.cpp
@@ -245,7 +245,7 @@ QWidget* PropertyListFrame::findWidgetFor(Property* property) {
 
     std::vector<PropertyOwner*> stack{};
     QWidget* widget = nullptr;
-    auto owner = property->getOwner();
+    auto* owner = property->getOwner();
     while (owner) {
         if (auto* processor = dynamic_cast<Processor*>(owner)) {
             if (auto it = processorMap_.find(processor); it != processorMap_.end()) {
@@ -269,7 +269,7 @@ QWidget* PropertyListFrame::findWidgetFor(Property* property) {
         stack.pop_back();
         if (auto* cp = dynamic_cast<CompositeProperty*>(owner)) {
             if (auto* cw = dynamic_cast<CollapsibleGroupBoxWidgetQt*>(widget)) {
-                if (auto pw = cw->widgetForProperty(cp)) {
+                if (auto* pw = cw->widgetForProperty(cp)) {
                     widget = pw;
                     continue;
                 }
@@ -279,7 +279,7 @@ QWidget* PropertyListFrame::findWidgetFor(Property* property) {
     }
 
     if (auto* cw = dynamic_cast<CollapsibleGroupBoxWidgetQt*>(widget)) {
-        if (auto pw = cw->widgetForProperty(property)) {
+        if (auto* pw = cw->widgetForProperty(property)) {
             return pw;
         }
     }
@@ -344,14 +344,14 @@ void PropertyListWidget::removeAndDeletePropertyWidgets(Property* property) {
 bool PropertyListWidget::event(QEvent* e) {
     // The network editor will post these events.
     if (e->type() == PropertyListEvent::type()) {
-        PropertyListEvent* ple = static_cast<PropertyListEvent*>(e);
+        auto* ple = static_cast<PropertyListEvent*>(e);
         ple->accept();
 
         auto network = app_->getProcessorNetwork();
 
         switch (ple->action) {
             case PropertyListEvent::Action::Add: {
-                if (auto processor = network->getProcessorByIdentifier(ple->identifier)) {
+                if (auto* processor = network->getProcessorByIdentifier(ple->identifier)) {
                     if (processor->getNetwork() == network) {
                         addProcessorProperties(processor);
                     }
@@ -359,7 +359,7 @@ bool PropertyListWidget::event(QEvent* e) {
                 break;
             }
             case PropertyListEvent::Action::Remove: {
-                if (auto processor = network->getProcessorByIdentifier(ple->identifier)) {
+                if (auto* processor = network->getProcessorByIdentifier(ple->identifier)) {
                     if (processor->getNetwork() == network) {
                         removeProcessorProperties(processor);
                     }
@@ -367,7 +367,7 @@ bool PropertyListWidget::event(QEvent* e) {
                 break;
             }
             case PropertyListEvent::Action::FocusProperty: {
-                if (auto property = network->getProperty(ple->identifier)) {
+                if (auto* property = network->getProperty(ple->identifier)) {
                     focusProperty(property);
                 }
                 break;
@@ -391,7 +391,7 @@ QEvent::Type PropertyListEvent::type() {
 }
 
 void PropertyListWidget::focusProperty(Property* property) {
-    if (auto widget = frame_->findWidgetFor(property)) {
+    if (auto* widget = frame_->findWidgetFor(property)) {
         widget->setFocus();
     }
 }

--- a/src/core/network/processornetwork.cpp
+++ b/src/core/network/processornetwork.cpp
@@ -64,7 +64,7 @@ ProcessorNetwork::~ProcessorNetwork() {
 }
 
 Processor* ProcessorNetwork::addProcessor(std::shared_ptr<Processor> processor) {
-    NetworkLock lock(this);
+    const NetworkLock lock(this);
 
     processor->setIdentifier(util::findUniqueIdentifier(
         util::stripIdentifier(processor->getIdentifier()),
@@ -114,7 +114,7 @@ void ProcessorNetwork::removeProcessorHelper(Processor* processor) {
     // Remove all links for this processor
     auto toDelete =
         util::copy_if(links_, [&](const PropertyLink& link) { return link.involves(processor); });
-    for (auto& link : toDelete) {
+    for (const auto& link : toDelete) {
         removeLink(link.getSource(), link.getDestination());
     }
 }
@@ -212,7 +212,7 @@ void ProcessorNetwork::removeConnection(Outport* src, Inport* dst) {
 }
 
 bool ProcessorNetwork::isConnected(const PortConnection& connection) const {
-    return connections_.find(connection) != connections_.end();
+    return connections_.contains(connection);
 }
 bool ProcessorNetwork::isConnected(Outport* src, Inport* dst) const {
     return isConnected(PortConnection(src, dst));
@@ -223,7 +223,7 @@ const std::vector<PortConnection>& ProcessorNetwork::getConnections() const {
 }
 
 bool ProcessorNetwork::isPortInNetwork(Port* port) const {
-    if (auto* processor = port->getProcessor()) {
+    if (const auto* processor = port->getProcessor()) {
         if (processor == getProcessorByIdentifier(processor->getIdentifier())) {
             return true;
         }
@@ -279,7 +279,7 @@ void ProcessorNetwork::removeLink(Property* src, Property* dst) {
 }
 
 void ProcessorNetwork::onWillRemoveProperty(Property* property, size_t /*index*/) {
-    if (auto* comp = dynamic_cast<PropertyOwner*>(property)) {
+    if (const auto* comp = dynamic_cast<PropertyOwner*>(property)) {
         size_t i = 0;
         for (auto* p : comp->getProperties()) {
             onWillRemoveProperty(p, i);
@@ -289,12 +289,10 @@ void ProcessorNetwork::onWillRemoveProperty(Property* property, size_t /*index*/
 
     auto toDelete =
         util::copy_if(links_, [&](const PropertyLink& link) { return link.involves(property); });
-    for (auto& link : toDelete) removeLink(link);
+    for (const auto& link : toDelete) removeLink(link);
 }
 
-bool ProcessorNetwork::isLinked(const PropertyLink& link) const {
-    return links_.find(link) != links_.end();
-}
+bool ProcessorNetwork::isLinked(const PropertyLink& link) const { return links_.contains(link); }
 bool ProcessorNetwork::isLinked(Property* src, Property* dst) const {
     return isLinked(PropertyLink(src, dst));
 }
@@ -334,8 +332,8 @@ bool ProcessorNetwork::empty() const { return processors_.empty(); }
 size_t ProcessorNetwork::size() const { return processors_.size(); }
 
 void ProcessorNetwork::accept(NetworkVisitor& visitor) {
-    for (auto& p : processors_) {
-        p.second->accept(visitor);
+    for (const auto& [_, p] : processors_) {
+        p->accept(visitor);
     }
 }
 
@@ -361,7 +359,7 @@ void ProcessorNetwork::onProcessorPortRemoved(Processor*, Port* port) {
     auto toDelete = util::copy_if(connectionsVec_, [&](const PortConnection& item) {
         return item.getInport() == port || item.getOutport() == port;
     });
-    for (auto& item : toDelete) {
+    for (const auto& item : toDelete) {
         removeConnection(item.getOutport(), item.getInport());
     }
 }
@@ -623,7 +621,7 @@ bool ProcessorNetwork::isDeserializing() const { return deserializing_; }
 
 Property* ProcessorNetwork::getProperty(std::string_view path) const {
     const auto [processorId, propertyPath] = util::splitByFirst(path, '.');
-    if (auto* processor = getProcessorByIdentifier(processorId)) {
+    if (const auto* processor = getProcessorByIdentifier(processorId)) {
         return processor->getPropertyByPath(propertyPath);
     }
     return nullptr;
@@ -631,7 +629,7 @@ Property* ProcessorNetwork::getProperty(std::string_view path) const {
 
 Port* ProcessorNetwork::getPort(std::string_view path) const {
     const auto [processorId, portId] = util::splitByFirst(path, '.');
-    if (auto* processor = getProcessorByIdentifier(processorId)) {
+    if (const auto* processor = getProcessorByIdentifier(processorId)) {
         return processor->getPort(portId);
     }
     return nullptr;
@@ -639,7 +637,7 @@ Port* ProcessorNetwork::getPort(std::string_view path) const {
 
 Inport* ProcessorNetwork::getInport(std::string_view path) const {
     const auto [processorId, portId] = util::splitByFirst(path, '.');
-    if (auto* processor = getProcessorByIdentifier(processorId)) {
+    if (const auto* processor = getProcessorByIdentifier(processorId)) {
         return processor->getInport(portId);
     }
     return nullptr;
@@ -647,7 +645,7 @@ Inport* ProcessorNetwork::getInport(std::string_view path) const {
 
 Outport* ProcessorNetwork::getOutport(std::string_view path) const {
     const auto [processorId, portId] = util::splitByFirst(path, '.');
-    if (auto* processor = getProcessorByIdentifier(processorId)) {
+    if (const auto* processor = getProcessorByIdentifier(processorId)) {
         return processor->getOutport(portId);
     }
     return nullptr;
@@ -655,7 +653,7 @@ Outport* ProcessorNetwork::getOutport(std::string_view path) const {
 
 bool ProcessorNetwork::isPropertyInNetwork(Property* prop) const {
     if (auto* owner = prop->getOwner()) {
-        if (auto* processor = owner->getProcessor()) {
+        if (const auto* processor = owner->getProcessor()) {
             return processor == util::map_find_or_null(processors_, processor->getIdentifier(),
                                                        [](const auto& p) { return p.get(); });
         }

--- a/src/qt/editor/networkautomation.cpp
+++ b/src/qt/editor/networkautomation.cpp
@@ -98,14 +98,12 @@ void updateProcessorTarget(ProcessorGraphicsItem*& target, ProcessorGraphicsItem
 
     if (target) {
         target->setHighlight(false);
-        target->setSelected(false);
         target = nullptr;
     }
 
     if (source && source->getProcessor() != processor) {
         target = source;
         target->setHighlight(true);
-        target->setSelected(true);
     }
 }
 

--- a/src/qt/editor/networkeditor.cpp
+++ b/src/qt/editor/networkeditor.cpp
@@ -248,7 +248,7 @@ void NetworkEditor::addPropertyWidgets(Processor* processor) {
         return item.first != processor && item.second->isSelected();
     });
     if (it == processorGraphicsItems_.end() ||
-        QApplication::keyboardModifiers().testFlag(Qt::ShiftModifier)) {
+        QApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
         QCoreApplication::postEvent(
             mainWindow_->getPropertyListWidget(),
             new PropertyListEvent(PropertyListEvent::Action::Add, processor->getIdentifier()),

--- a/src/qt/editor/networkeditor.cpp
+++ b/src/qt/editor/networkeditor.cpp
@@ -244,9 +244,9 @@ void NetworkEditor::removeProcessorGraphicsItem(Processor* processor) {
 }
 
 void NetworkEditor::addPropertyWidgets(Processor* processor) {
-    auto it = std::find_if(
-        processorGraphicsItems_.begin(), processorGraphicsItems_.end(),
-        [&](const auto& item) { return item.first != processor && item.second->isSelected(); });
+    auto it = std::ranges::find_if(processorGraphicsItems_, [&](const auto& item) {
+        return item.first != processor && item.second->isSelected();
+    });
     if (it == processorGraphicsItems_.end() ||
         QApplication::keyboardModifiers().testFlag(Qt::ShiftModifier)) {
         QCoreApplication::postEvent(
@@ -272,10 +272,10 @@ ConnectionGraphicsItem* NetworkEditor::addConnectionGraphicsItem(const PortConne
     Outport* outport = connection.getOutport();
     Inport* inport = connection.getInport();
 
-    auto outProcessor = getProcessorGraphicsItem(outport->getProcessor());
-    auto inProcessor = getProcessorGraphicsItem(inport->getProcessor());
+    auto* outProcessor = getProcessorGraphicsItem(outport->getProcessor());
+    auto* inProcessor = getProcessorGraphicsItem(inport->getProcessor());
 
-    auto connectionGraphicsItem =
+    auto* connectionGraphicsItem =
         new ConnectionGraphicsItem(outProcessor->getOutportGraphicsItem(outport),
                                    inProcessor->getInportGraphicsItem(inport), connection);
 
@@ -324,8 +324,8 @@ void NetworkEditor::removeLink(LinkConnectionGraphicsItem* linkGraphicsItem) {
         linkGraphicsItem->getDestProcessorGraphicsItem()->getProcessor());
 
     rendercontext::activateDefault();
-    NetworkLock lock(network_);
-    for (auto& link : links) {
+    const NetworkLock lock(network_);
+    for (const auto& link : links) {
         network_->removeLink(link.getSource(), link.getDestination());
     }
 }
@@ -340,7 +340,7 @@ void NetworkEditor::removeLinkGraphicsItem(LinkConnectionGraphicsItem* linkGraph
 }
 
 void NetworkEditor::showLinkDialog(Processor* processor1, Processor* processor2) {
-    auto dialog = new LinkDialog(processor1, processor2, mainWindow_);
+    auto* dialog = new LinkDialog(processor1, processor2, mainWindow_);
     dialog->show();
 }
 
@@ -1094,7 +1094,7 @@ void NetworkEditor::deleteItems(QList<QGraphicsItem*> items) {
 
     // Remove Processors. It is important to remove processors last.
     util::erase_remove_if(items, [&](QGraphicsItem* item) {
-        if (auto* pgi = qgraphicsitem_cast<ProcessorGraphicsItem*>(item)) {
+        if (const auto* pgi = qgraphicsitem_cast<ProcessorGraphicsItem*>(item)) {
             network_->removeProcessor(pgi->getProcessor());
             return true;
         } else {
@@ -1421,7 +1421,7 @@ void NetworkEditor::onProcessorNetworkDidRemoveLink(const PropertyLink& property
     if (network_
             ->getLinksBetweenProcessors(propertyLink.getSource()->getOwner()->getProcessor(),
                                         propertyLink.getDestination()->getOwner()->getProcessor())
-            .size() == 0) {
+            .empty()) {
         removeLinkGraphicsItem(
             getLinkGraphicsItem(propertyLink.getSource()->getOwner()->getProcessor(),
                                 propertyLink.getDestination()->getOwner()->getProcessor()));

--- a/src/qt/editor/networkeditorview.cpp
+++ b/src/qt/editor/networkeditorview.cpp
@@ -76,9 +76,10 @@ NetworkEditorView::NetworkEditorView(NetworkEditor* networkEditor, InviwoMainWin
     NetworkEditorObserver::addObservation(editor_);
     QGraphicsView::setScene(editor_);
 
-    auto grid = new QGridLayout(viewport());
+    auto* grid = new QGridLayout(this);
     const auto space = utilqt::refSpacePx(this);
-    grid->setContentsMargins(space, space, space, space);
+    const auto scrollbarWidth = utilqt::emToPx(this, 0.75 + 0.125);  // QScrollBar in inviwo.qss
+    grid->setContentsMargins(space, space, space + scrollbarWidth, space + scrollbarWidth);
 
     {
         grid->addWidget(overlay_, 0, 0, Qt::AlignTop | Qt::AlignLeft);

--- a/src/qt/editor/networksearch.cpp
+++ b/src/qt/editor/networksearch.cpp
@@ -157,8 +157,7 @@ NetworkSearch::NetworkSearch(InviwoMainWindow* win)
                  const auto& moduleMap =
                      std::any_cast<const std::unordered_map<std::string, std::string>&>(anyData);
                  bool moduleMatch = false;
-                 auto mit = moduleMap.find(p.getClassIdentifier());
-                 if (mit != moduleMap.end()) {
+                 if (auto mit = moduleMap.find(p.getClassIdentifier()); mit != moduleMap.end()) {
                      moduleMatch |= find(mit->second, s);
                  }
                  return moduleMatch;
@@ -170,7 +169,7 @@ NetworkSearch::NetworkSearch(InviwoMainWindow* win)
     , edit_{new QLineEdit(this)} {
 
     setObjectName("NetworkSearch");
-    auto hLayout = new QHBoxLayout();
+    auto* hLayout = new QHBoxLayout();
     hLayout->setContentsMargins(0, 0, 0, 0);
     hLayout->setSpacing(0);
     hLayout->addWidget(edit_);
@@ -193,27 +192,30 @@ NetworkSearch::NetworkSearch(InviwoMainWindow* win)
 }
 
 void NetworkSearch::updateSearch(const QString& str) {
-    auto app = win_->getInviwoApplication();
-    auto network = app->getProcessorNetwork();
-    auto editor = win_->getNetworkEditor();
+    auto* app = win_->getInviwoApplication();
+    auto* network = app->getProcessorNetwork();
+    const auto* editor = win_->getNetworkEditor();
 
     if (str.isEmpty()) {
         // nothing selected
-        editor->clearSelection();
+        network->forEachProcessor([editor](Processor* p) {
+            auto* pgi = editor->getProcessorGraphicsItem(p);
+            pgi->setHighlight(false);
+        });
         return;
     }
 
     dsl_.setSearchString(utilqt::fromQString(str));
     network->forEachProcessor([&](Processor* p) {
-        bool match = dsl_.match(*p);
-        auto pgi = editor->getProcessorGraphicsItem(p);
-        pgi->setHighlight(true);
-        pgi->setSelected(match);
+        const bool match = dsl_.match(*p);
+        auto* pgi = editor->getProcessorGraphicsItem(p);
+        pgi->setHighlight(match);
     });
 }
 
 void NetworkSearch::focusInEvent(QFocusEvent*) {
     edit_->setFocus();
+    win_->getNetworkEditor()->clearSelection();
     updateSearch(edit_->text());
 }
 
@@ -222,39 +224,38 @@ void NetworkSearch::focusOutEvent(QFocusEvent*) {}
 bool NetworkSearch::eventFilter(QObject* watched, QEvent* event) {
     if (watched == edit_) {
         if (event->type() == QEvent::FocusOut) {
-            auto app = win_->getInviwoApplication();
-            auto editor = win_->getNetworkEditor();
-            auto network = app->getProcessorNetwork();
-            network->forEachProcessor(
-                [&](Processor* p) { editor->getProcessorGraphicsItem(p)->setHighlight(false); });
+            auto* app = win_->getInviwoApplication();
+            const auto* editor = win_->getNetworkEditor();
+            auto* network = app->getProcessorNetwork();
+            network->forEachProcessor([editor](Processor* p) {
+                editor->getProcessorGraphicsItem(p)->setHighlight(false);
+            });
             setVisible(false);
             return false;
         } else if (event->type() == QEvent::KeyPress) {
-            QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+            const QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
             if (keyEvent->key() == Qt::Key_Escape) {
                 edit_->text().clear();
-                auto app = win_->getInviwoApplication();
-                auto editor = win_->getNetworkEditor();
-                auto network = app->getProcessorNetwork();
-                network->forEachProcessor([&](Processor* p) {
-                    auto pgi = editor->getProcessorGraphicsItem(p);
+                auto* app = win_->getInviwoApplication();
+                const auto* editor = win_->getNetworkEditor();
+                auto* network = app->getProcessorNetwork();
+                network->forEachProcessor([editor](Processor* p) {
+                    auto* pgi = editor->getProcessorGraphicsItem(p);
                     pgi->setHighlight(false);
-                    pgi->setSelected(false);
                 });
                 setVisible(false);
                 return true;
             } else if (keyEvent->key() == Qt::Key_Return) {
                 edit_->text().clear();
-                auto app = win_->getInviwoApplication();
-                auto editor = win_->getNetworkEditor();
-                auto props = win_->getPropertyListWidget();
-                auto network = app->getProcessorNetwork();
+                auto* app = win_->getInviwoApplication();
+                const auto* editor = win_->getNetworkEditor();
+                auto* props = win_->getPropertyListWidget();
+                auto* network = app->getProcessorNetwork();
 
                 Property* selectedProperty = nullptr;
                 network->forEachProcessor([&](Processor* p) {
-                    auto pgi = editor->getProcessorGraphicsItem(p);
-                    if (pgi->isSelected()) {
-                        pgi->setSelected(false);
+                    auto* pgi = editor->getProcessorGraphicsItem(p);
+                    if (pgi->isHighlighted()) {
                         pgi->setHighlight(false);
                         pgi->setSelected(true);
 
@@ -269,7 +270,6 @@ bool NetworkSearch::eventFilter(QObject* watched, QEvent* event) {
                         }
                     } else {
                         pgi->setHighlight(false);
-                        pgi->setSelected(false);
                     }
                 });
 

--- a/src/qt/editor/processorgraphicsitem.cpp
+++ b/src/qt/editor/processorgraphicsitem.cpp
@@ -56,6 +56,7 @@
 #include <QApplication>
 #include <QGraphicsDropShadowEffect>
 #include <QPainter>
+#include <QGradient>
 #include <QStyleOptionGraphicsItem>
 #include <QVector2D>
 #include <QTextCursor>
@@ -409,7 +410,17 @@ void ProcessorGraphicsItem::paint(QPainter* p,
     p->save();
     p->setRenderHint(QPainter::Antialiasing, true);
 
-    if (isSelected()) {
+    if (highlight_) {
+        QLinearGradient gradient{QPointF{0, 0},
+                                 QPointF{ProcessorGraphicsItem::size.width() / 2.0,
+                                         ProcessorGraphicsItem::size.height() / 2.0}};
+        gradient.setColorAt(0.0, backgroundColor_);
+        gradient.setColorAt(0.3, backgroundColor_);
+        gradient.setColorAt(0.3000001, selectionColor);
+        gradient.setColorAt(1.0, selectionColor);
+        gradient.setSpread(QGradient::PadSpread);
+        p->setBrush(gradient);
+    } else if (isSelected()) {
         p->setBrush(selectionColor);
     } else {
         p->setBrush(backgroundColor_);
@@ -477,7 +488,7 @@ QVariant ProcessorGraphicsItem::itemChange(GraphicsItemChange change, const QVar
         }
         case QGraphicsItem::ItemSelectedHasChanged:
             updateWidgets();
-            if (!highlight_ && processorMeta_) {
+            if (processorMeta_) {
                 processorMeta_->setSelected(isSelected());
             }
             if (errorText_) {
@@ -665,7 +676,14 @@ void ProcessorGraphicsItem::showToolTip(QGraphicsSceneHelpEvent* e) {
     showToolTipHelper(e, utilqt::toLocalQString(doc));
 }
 
-void ProcessorGraphicsItem::setHighlight(bool val) { highlight_ = val; }
+void ProcessorGraphicsItem::setHighlight(bool val) {
+    if (val != highlight_) {
+        highlight_ = val;
+        update();
+    }
+}
+
+bool ProcessorGraphicsItem::isHighlighted() const { return highlight_; }
 
 void ProcessorGraphicsItem::processorException(std::string_view message) {
     updateStatus(std::string{message});

--- a/src/qt/editor/processorgraphicsitem.cpp
+++ b/src/qt/editor/processorgraphicsitem.cpp
@@ -537,10 +537,8 @@ void ProcessorGraphicsItem::mouseReleaseEvent(QGraphicsSceneMouseEvent* e) {
 void ProcessorGraphicsItem::updateWidgets() {
     if (isSelected()) {
         setZValue(depth::processorSelected);
-        if (!highlight_) {
-            if (auto* editor = getNetworkEditor()) {
-                editor->addPropertyWidgets(processor_);
-            }
+        if (auto* editor = getNetworkEditor()) {
+            editor->addPropertyWidgets(processor_);
         }
     } else {
         setZValue(depth::processor);

--- a/src/qt/editor/processorgraphicsitem.cpp
+++ b/src/qt/editor/processorgraphicsitem.cpp
@@ -481,7 +481,7 @@ QVariant ProcessorGraphicsItem::itemChange(GraphicsItemChange change, const QVar
                 QApplication::mouseButtons() == Qt::MouseButton::NoButton) {
                 processorMeta_->setPosition(ivec2(newPos.x(), newPos.y()));
             }
-            if (auto editor = qobject_cast<NetworkEditor*>(scene())) {
+            if (auto* editor = getNetworkEditor()) {
                 editor->updateSceneSize();
             }
             return newPos;
@@ -499,7 +499,7 @@ QVariant ProcessorGraphicsItem::itemChange(GraphicsItemChange change, const QVar
             if (processorMeta_) {
                 processorMeta_->setVisible(isVisible());
             }
-            if (auto editor = qobject_cast<NetworkEditor*>(scene())) {
+            if (auto* editor = getNetworkEditor()) {
                 editor->updateSceneSize();
             }
             break;
@@ -516,7 +516,7 @@ QVariant ProcessorGraphicsItem::itemChange(GraphicsItemChange change, const QVar
 }
 
 void ProcessorGraphicsItem::mousePressEvent(QGraphicsSceneMouseEvent* e) {
-    if (auto editor = getNetworkEditor()) {
+    if (auto* editor = getNetworkEditor()) {
         if (QApplication::keyboardModifiers() & Qt::AltModifier) {
             editor->showProcessorHelp(processor_->getClassIdentifier(), true);
             return;
@@ -525,7 +525,7 @@ void ProcessorGraphicsItem::mousePressEvent(QGraphicsSceneMouseEvent* e) {
     QGraphicsItem::mousePressEvent(e);
 }
 void ProcessorGraphicsItem::mouseReleaseEvent(QGraphicsSceneMouseEvent* e) {
-    if (auto editor = getNetworkEditor()) {
+    if (auto* editor = getNetworkEditor()) {
         if (QApplication::keyboardModifiers() & Qt::AltModifier) {
             editor->showProcessorHelp(processor_->getClassIdentifier(), true);
             return;
@@ -538,13 +538,13 @@ void ProcessorGraphicsItem::updateWidgets() {
     if (isSelected()) {
         setZValue(depth::processorSelected);
         if (!highlight_) {
-            if (auto editor = getNetworkEditor()) {
+            if (auto* editor = getNetworkEditor()) {
                 editor->addPropertyWidgets(processor_);
             }
         }
     } else {
         setZValue(depth::processor);
-        if (auto editor = getNetworkEditor()) {
+        if (auto* editor = getNetworkEditor()) {
             editor->removePropertyWidgets(processor_);
         }
     }

--- a/src/qt/editor/processorlistwidget.cpp
+++ b/src/qt/editor/processorlistwidget.cpp
@@ -172,10 +172,10 @@ ProcessorListWidget::ProcessorListWidget(InviwoMainWindow* parent, HelpWidget* h
     connect(view_->selectionModel(), &QItemSelectionModel::currentRowChanged, this,
             [this](const QModelIndex& current, const QModelIndex&) {
                 if (const auto* item = utilqt::getData(current, Role::Item).value<const Item*>()) {
-                    helpWidget_->showDocForClassName(item->info.classIdentifier);
                     if (!win_->tabifiedDockWidgets(this).contains(helpWidget_)) {
                         helpWidget_->raise();
                     }
+                    helpWidget_->showDocForClassName(item->info.classIdentifier);
                 }
             });
 


### PR DESCRIPTION
Fixes 
 * ensure that the network search widget no longer moves with the graphics scene
 * changed modifier to `<ctrl>` for adding multiple processor properties to the `PropertyListWidget`, `<shift>` and `<alt>` are already used for selecting predecessors and successors

Changes proposed in this PR:
 * changed network search highlight to distinguish it from a regular selection

**Network Search before/after**
<img width="370" alt="image" src="https://github.com/user-attachments/assets/79033340-b1f6-4dff-9053-d53d08973360" /><img width="370" alt="image" src="https://github.com/user-attachments/assets/5f75ddc2-0f00-4ec6-8e43-a29e7d9f47b4" />



This has been tested on: Windows, Qt 6.10.3