### PR TITLE
chore: update vcpkg baseline to b70085cf11

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,7 @@
   "vcpkg-configuration": {
     "default-registry": {
       "kind": "builtin",
-      "baseline": "dc31f86a441067d6c2e9e4ad52988eb41ef4f442"
+      "baseline": "b70085cf11b06cbf15ef066c58738b02838c3c51"
     },
     "overlay-ports": [
       "./tools/vcpkg"


### PR DESCRIPTION
## vcpkg baseline update

Updated baseline from `dc31f86a44` to `b70085cf11`.

### Changed dependencies
```
cimg: 4.0.3 -> 4.0.4
ezc3d: 1.7.0 -> 1.7.2
ffmpeg: 9.0 -> 9.0.1
hdf5: 2.1.1 -> 2.2.0
openexr: 3.4.13 -> 3.4.15
```

Full vcpkg commit: https://github.com/microsoft/vcpkg/commit/b70085cf11b06cbf15ef066c58738b02838c3c51
