### PR TITLE
Core/Various: remove previousSize from ResizeEvent.

### DIFF
--- a/include/inviwo/core/interaction/events/resizeevent.h
+++ b/include/inviwo/core/interaction/events/resizeevent.h
@@ -56,7 +56,7 @@ class Outport;
  */
 class IVW_CORE_API ResizeEvent : public Event {
 public:
-    ResizeEvent(size2_t canvasSize);
+    explicit ResizeEvent(size2_t canvasSize);
     ResizeEvent(const ResizeEvent& rhs) = default;
     ResizeEvent& operator=(const ResizeEvent& that) = default;
 

--- a/include/inviwo/core/interaction/events/resizeevent.h
+++ b/include/inviwo/core/interaction/events/resizeevent.h
@@ -56,7 +56,7 @@ class Outport;
  */
 class IVW_CORE_API ResizeEvent : public Event {
 public:
-    ResizeEvent(size2_t newSize);
+    ResizeEvent(size2_t canvasSize);
     ResizeEvent(const ResizeEvent& rhs) = default;
     ResizeEvent& operator=(const ResizeEvent& that) = default;
 

--- a/include/inviwo/core/interaction/events/resizeevent.h
+++ b/include/inviwo/core/interaction/events/resizeevent.h
@@ -57,7 +57,6 @@ class Outport;
 class IVW_CORE_API ResizeEvent : public Event {
 public:
     ResizeEvent(size2_t newSize);
-    ResizeEvent(size2_t newSize, size2_t previousSize);
     ResizeEvent(const ResizeEvent& rhs) = default;
     ResizeEvent& operator=(const ResizeEvent& that) = default;
 
@@ -67,9 +66,7 @@ public:
     virtual bool shouldPropagateTo(Inport* inport, Processor* processor, Outport* source) override;
 
     size2_t size() const;
-    size2_t previousSize() const;
-    void setSize(size2_t csize);
-    void setPreviousSize(size2_t previousSize);
+    void setSize(size2_t newSize);
 
     virtual uint64_t hash() const override;
     static constexpr uint64_t chash();
@@ -78,7 +75,6 @@ public:
 
 private:
     size2_t size_;
-    size2_t previousSize_;
 };
 
 constexpr uint64_t ResizeEvent::chash() { return util::constexpr_hash("org.inviwo.ResizeEvent"); }

--- a/include/inviwo/core/processors/canvasprocessor.h
+++ b/include/inviwo/core/processors/canvasprocessor.h
@@ -129,7 +129,6 @@ private:
     void sizeChanged();
     static size2_t calcScaledSize(size2_t size, float scale);
 
-    size2_t previousImageSize_;
     ProcessorWidgetMetaData* widgetMetaData_;
 };
 

--- a/modules/base/src/processors/imageexport.cpp
+++ b/modules/base/src/processors/imageexport.cpp
@@ -104,7 +104,8 @@ void ImageExport::sendResizeEvent() {
     const size2_t newSize = outportDeterminesSize_ ? size2_t{0} : *imageSize_;
 
     if (newSize != prevSize_) {
-        ResizeEvent event{newSize, prevSize_};
+        rendercontext::activateDefault();
+        ResizeEvent event{newSize};
         this->port_.propagateEvent(&event, nullptr);
         prevSize_ = newSize;
     }

--- a/modules/base/src/processors/imageexport.cpp
+++ b/modules/base/src/processors/imageexport.cpp
@@ -48,6 +48,7 @@
 #include <inviwo/core/properties/ordinalproperty.h>
 #include <inviwo/core/util/glmvec.h>
 #include <inviwo/core/util/stdextensions.h>
+#include <inviwo/core/util/rendercontext.h>
 #include <modules/base/processors/dataexport.h>
 
 #include <functional>

--- a/modules/basegl/src/processors/imageprocessing/columnrowlayout.cpp
+++ b/modules/basegl/src/processors/imageprocessing/columnrowlayout.cpp
@@ -49,6 +49,7 @@
 #include <inviwo/core/util/assertion.h>
 #include <inviwo/core/util/glmvec.h>
 #include <inviwo/core/util/stdextensions.h>
+#include <inviwo/core/util/rendercontext.h>
 #include <modules/basegl/datastructures/splittersettings.h>
 #include <modules/basegl/properties/splitterproperty.h>
 #include <modules/basegl/rendering/splitterrenderer.h>
@@ -527,6 +528,7 @@ void Layout::calculateViews(ivec2 imgSize) {
 
 void Layout::splittersChanged() {
     const NetworkLock lock(this);
+    rendercontext::activateDefault();
     ResizeEvent e(currentDim_);
     propagateEvent(&e, &outport_);
 }

--- a/modules/basegl/src/processors/imageprocessing/imageoverlaygl.cpp
+++ b/modules/basegl/src/processors/imageprocessing/imageoverlaygl.cpp
@@ -299,7 +299,7 @@ void ImageOverlayGL::onStatusChange() {
         // update viewport stored in view manager
         viewManager_.replace(0, overlayProperty_.getViewport());
 
-        RenderContext::getPtr()->activateDefaultRenderContext();
+        rendercontext::activateDefault();
 
         ResizeEvent e(uvec2(viewManager_[0].size));
         overlayPort_.propagateEvent(&e, overlayPort_.getConnectedOutport());

--- a/modules/glfw/src/canvasprocessorwidgetglfw.cpp
+++ b/modules/glfw/src/canvasprocessorwidgetglfw.cpp
@@ -84,13 +84,12 @@ void CanvasProcessorWidgetGLFW::setOnTop(bool onTop) {
 }
 
 void CanvasProcessorWidgetGLFW::propagateResizeEvent() {
-    auto previousScreenDimensions = screenDimensions_;
     screenDimensions_ = canvas_->getFramebufferSize();
     CanvasProcessorWidget::setDimensions(screenDimensions_);
 
-    NetworkLock lock;
-    RenderContext::getPtr()->activateDefaultRenderContext();
-    ResizeEvent resizeEvent(screenDimensions_, previousScreenDimensions);
+    const NetworkLock lock{getProcessor()};
+    rendercontext::activateDefault();
+    ResizeEvent resizeEvent(screenDimensions_);
     getProcessor()->propagateEvent(&resizeEvent, nullptr);
 }
 

--- a/modules/openglqt/src/canvasqopenglwidget.cpp
+++ b/modules/openglqt/src/canvasqopenglwidget.cpp
@@ -264,21 +264,18 @@ void CanvasQOpenGLWidget::resizeEvent(QResizeEvent* event) {
     // Propagated an event with the physical (pixel) dimensions of the canvas
     // Note: QWidget::size() will return logical dimensions
     const auto dpr = window()->devicePixelRatio();
-    RenderContext::getPtr()->activateDefaultRenderContext();
 
+    rendercontext::activateDefault();
     const auto newSize = static_cast<size2_t>(dpr * utilqt::toGLM(event->size()));
-    const auto oldSize = event->oldSize().isValid()
-                             ? static_cast<size2_t>(dpr * utilqt::toGLM(event->oldSize()))
-                             : size2_t{0, 0};
-    ResizeEvent resizeEvent{newSize, oldSize};
+    ResizeEvent resizeEvent{newSize};
     propagateEvent(&resizeEvent, nullptr);
 }
 
 void CanvasQOpenGLWidget::triggerResizeEventPropagation() {
     const auto dpr = window()->devicePixelRatio();
 
-    RenderContext::getPtr()->activateDefaultRenderContext();
-    ResizeEvent resizeEvent{dpr * utilqt::toGLM(size()), dpr * utilqt::toGLM(size())};
+    rendercontext::activateDefault();
+    ResizeEvent resizeEvent{dpr * utilqt::toGLM(size())};
     propagateEvent(&resizeEvent, nullptr);
 }
 

--- a/modules/openglqt/src/processors/canvasprocessorwidgetqt.cpp
+++ b/modules/openglqt/src/processors/canvasprocessorwidgetqt.cpp
@@ -183,8 +183,8 @@ void CanvasProcessorWidgetQt::propagateEvent(Event* event, Outport* source) {
 
 void CanvasProcessorWidgetQt::propagateResizeEvent() {
     if (!canvas_->isVisible()) {
-        RenderContext::getPtr()->activateDefaultRenderContext();
-        ResizeEvent resizeEvent{getDimensions(), getDimensions()};
+        rendercontext::activateDefault();
+        ResizeEvent resizeEvent{getDimensions()};
         getProcessor()->propagateEvent(&resizeEvent, nullptr);
     } else {
         canvas_->triggerResizeEventPropagation();

--- a/modules/plottinggl/src/processors/imageplotprocessor.cpp
+++ b/modules/plottinggl/src/processors/imageplotprocessor.cpp
@@ -267,7 +267,7 @@ void ImagePlotProcessor::onStatusChange() {
     viewManager_.replace(0, viewport_);
 
     if (imgInport_.isConnected()) {
-        RenderContext::getPtr()->activateDefaultRenderContext();
+        rendercontext::activateDefault();
         ResizeEvent e(size2_t(viewManager_[0].size));
         imgInport_.propagateEvent(&e, imgInport_.getConnectedOutport());
     }

--- a/modules/python3/bindings/src/pyevent.cpp
+++ b/modules/python3/bindings/src/pyevent.cpp
@@ -499,10 +499,8 @@ void exposeEvents(pybind11::module& m) {
 
     py::classh<ResizeEvent, Event>(m, "ResizeEvent")
         .def(py::init<size2_t>(), py::arg("newSize"))
-        .def(py::init<size2_t, size2_t>(), py::arg("newSize"), py::arg("previousSize"))
         .def(py::init<ResizeEvent>())
         .def_property("size", &ResizeEvent::size, &ResizeEvent::setSize)
-        .def_property("previousSize", &ResizeEvent::previousSize, &ResizeEvent::setPreviousSize)
         .def_property_readonly_static("chash",
                                       [](const py::object&) { return ResizeEvent::chash(); });
 

--- a/src/core/interaction/events/resizeevent.cpp
+++ b/src/core/interaction/events/resizeevent.cpp
@@ -39,11 +39,7 @@
 
 namespace inviwo {
 
-ResizeEvent::ResizeEvent(size2_t canvasSize)
-    : Event(), size_(canvasSize), previousSize_(canvasSize) {}
-
-ResizeEvent::ResizeEvent(size2_t canvasSize, size2_t previousSize)
-    : Event(), size_(canvasSize), previousSize_(previousSize) {}
+ResizeEvent::ResizeEvent(size2_t canvasSize) : Event(), size_(canvasSize) {}
 
 ResizeEvent* ResizeEvent::clone() const { return new ResizeEvent(*this); }
 
@@ -58,17 +54,12 @@ bool ResizeEvent::shouldPropagateTo(Inport* inport, Processor* processor, Outpor
 
 size2_t ResizeEvent::size() const { return size_; }
 
-size2_t ResizeEvent::previousSize() const { return previousSize_; }
-
-void ResizeEvent::setSize(size2_t csize) { size_ = csize; }
-
-void ResizeEvent::setPreviousSize(size2_t previousSize) { previousSize_ = previousSize; }
+void ResizeEvent::setSize(size2_t newSize) { size_ = newSize; }
 
 uint64_t ResizeEvent::hash() const { return chash(); }
 
 void ResizeEvent::print(fmt::memory_buffer& buff) const {
-    util::printEvent(buff, "ResizeEvent", std::make_pair("size", size_),
-                     std::make_pair("prev", previousSize_));
+    util::printEvent(buff, "ResizeEvent", std::make_pair("size", size_));
 }
 
 }  // namespace inviwo

--- a/src/core/ports/imageport.cpp
+++ b/src/core/ports/imageport.cpp
@@ -151,8 +151,6 @@ void ImageOutport::pruneCache() {
 }
 
 void ImageOutport::disconnectFrom(Inport* inport) {
-    const auto oldSize = getLargestReqDim();
-
     requestedDimensions_.erase(inport);
     pruneCache();
 
@@ -169,7 +167,7 @@ void ImageOutport::disconnectFrom(Inport* inport) {
             }
         }
     }
-    ResizeEvent newEvent{newDimensions, oldSize};
+    ResizeEvent newEvent{newDimensions};
     getProcessor()->propagateEvent(&newEvent, this);
 
     DataOutport<Image>::disconnectFrom(inport);

--- a/src/core/processors/canvasprocessor.cpp
+++ b/src/core/processors/canvasprocessor.cpp
@@ -171,7 +171,6 @@ CanvasProcessor::CanvasProcessor(InviwoApplication* app)
                           "is not visible. Can be enable if you only want to save images and "
                           "not show the canvas for example"_help,
                           false}
-    , previousImageSize_(customInputDimensions_)
     , widgetMetaData_{
           createMetaData<ProcessorWidgetMetaData>(ProcessorWidgetMetaData::classIdentifier)} {
     addPort(inport_);
@@ -290,9 +289,7 @@ void CanvasProcessor::sizeChanged() {
         customInputDimensions_.set(calcScaledSize(dimensions_, aspectRatioScaling_));
     }
 
-    ResizeEvent resizeEvent{enableCustomInputDimensions_ ? customInputDimensions_ : dimensions_,
-                            previousImageSize_};
-    previousImageSize_ = resizeEvent.size();
+    ResizeEvent resizeEvent{enableCustomInputDimensions_ ? customInputDimensions_ : dimensions_};
 
     inputSize_.invalidate(InvalidationLevel::Valid, &customInputDimensions_);
     inport_.propagateEvent(&resizeEvent);

--- a/src/core/processors/canvasprocessor.cpp
+++ b/src/core/processors/canvasprocessor.cpp
@@ -277,7 +277,7 @@ size2_t CanvasProcessor::getCustomDimensions() const { return customInputDimensi
 
 void CanvasProcessor::sizeChanged() {
     const NetworkLock lock(this);
-    RenderContext::getPtr()->activateDefaultRenderContext();
+    rendercontext::activateDefault();
 
     customInputDimensions_.setVisible(enableCustomInputDimensions_);
     customInputDimensions_.setReadOnly(keepAspectRatio_);


### PR DESCRIPTION
We did mostly not set it and we never used it.

Fixes #...

Changes proposed in this PR:
 * ...
 * ...
 * ...

This has been tested on: ...

> Thank you for contributing to the Inviwo repository! Please ensure the following: 
> - Code is error and warning free
> - Code follows the Inviwo coding guidelines: 
>   https://github.com/inviwo/inviwo/wiki/Coding-Conventions
> - New Code / Processors follows the Inviwo documentation guidelines: 
>   https://github.com/inviwo/inviwo/wiki/Documentation-guide
> - New Code / processors are tested in a unittest and / or regression test: 
>   https://github.com/inviwo/inviwo/wiki/Manual#testing
> 
> Please remember to specify the environment this code been compiled and tested on:
> Operating System / Compiler / IDE / QT / CMake / Python versions.
