### PR TITLE
Add ffmpeg video frame readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The encode side wrappers in the FFmpeg module were renamed for symmetry with the
 - `ffmpeg::Format` in `<inviwo/ffmpeg/wrap/format.h>` is now `ffmpeg::OutputContext` in `<inviwo/ffmpeg/wrap/outputcontext.h>`
 - `ffmpeg::Codec` in `<inviwo/ffmpeg/wrap/codec.h>` is now `ffmpeg::Encoder` in `<inviwo/ffmpeg/wrap/encoder.h>`
 - `ffmpeg::OutputStream::codec` is now `ffmpeg::OutputStream::encoder`
+- `ffmpeg::Recorder::getFormat()` is now `ffmpeg::Recorder::getOutputContext()`
 
 The new counterparts are `ffmpeg::InputContext` in `<inviwo/ffmpeg/wrap/inputcontext.h>` and `ffmpeg::Decoder` in `<inviwo/ffmpeg/wrap/decoder.h>`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 Here we document changes that affect the public API or changes that needs to be communicated to other developers.
 
+## 2026-08-28 Video readers in the FFmpeg module
+
+The FFmpeg module can now read video files, not only write them. Two data readers are registered for the common video container formats (`mp4`, `mov`, `mkv`, `webm`, `avi`, ...), which means the standard `LayerSource` and `LayerSequenceSource` processors can load videos.
+
+- `FFmpegLayerReader` reads a single frame as a `Layer`
+- `FFmpegLayerSequenceReader` reads a range of frames as a `LayerSequence`
+
+Both are configured through `DataReader::setOption`. Frequently used option keys are now declared in `inviwo::reader::option` in `<inviwo/core/io/datareader.h>` so that other readers can adopt them:
+
+- `reader::option::index`, the frame to read, `std::ptrdiff_t`, negative values count from the end
+- `reader::option::count`, the number of frames to read, `std::ptrdiff_t`, negative means all. The sequence reader defaults to 100 frames since videos can be arbitrarily long.
+- `reader::option::stride`, the step between frames, `std::ptrdiff_t`
+- `videoreader::option::time`, the time in seconds of the frame to read, `double`
+- `videoreader::option::stream`, the video stream to read, `int`, negative selects the best one
+
+Frames are decoded into the closest matching `Layer` format, that is grayscale videos yield single channel Layers and sources with more than 8 bits per component yield 16 bit Layers.
+
+`inviwo::ffmpeg::Video` provides the underlying random access to video frames and can decode into an existing `Layer` to avoid repeated allocations.
+
+### Migration guide
+
+The encode side wrappers in the FFmpeg module were renamed for symmetry with the new decode side ones:
+
+- `ffmpeg::Format` in `<inviwo/ffmpeg/wrap/format.h>` is now `ffmpeg::OutputContext` in `<inviwo/ffmpeg/wrap/outputcontext.h>`
+- `ffmpeg::Codec` in `<inviwo/ffmpeg/wrap/codec.h>` is now `ffmpeg::Encoder` in `<inviwo/ffmpeg/wrap/encoder.h>`
+- `ffmpeg::OutputStream::codec` is now `ffmpeg::OutputStream::encoder`
+
+The new counterparts are `ffmpeg::InputContext` in `<inviwo/ffmpeg/wrap/inputcontext.h>` and `ffmpeg::Decoder` in `<inviwo/ffmpeg/wrap/decoder.h>`.
+
 
 ## 2026-05-27 Python JSON module
 The JSON module now provides Python bindings, enabling seamless conversion between Inviwo properties, ports, and JSON-compatible Python objects (e.g., dictionaries, lists). These bindings are available under the `inviwopy.json` submodule. Added `toJson` and `fromJson` functions in `inviwopy.json` for converting properties, inports, and outports to and from JSON-compatible Python objects.

--- a/include/inviwo/core/io/datareader.h
+++ b/include/inviwo/core/io/datareader.h
@@ -36,6 +36,7 @@
 #include <memory>
 #include <any>
 #include <ios>
+#include <string_view>
 #include <typeindex>
 
 namespace inviwo {
@@ -45,6 +46,19 @@ class MetaDataOwner;
 /**
  * @defgroup dataio Data Reader & Writers
  */
+
+/**
+ * @ingroup dataio
+ * @brief Option keys shared between data readers, @see DataReader::setOption
+ */
+namespace reader::option {
+/// Index of the item to read, `std::ptrdiff_t`. Negative values are counted from the end.
+inline constexpr std::string_view index = "index";
+/// Number of items to read, `std::ptrdiff_t`. A negative value means all remaining items.
+inline constexpr std::string_view count = "count";
+/// Step between the items to read, `std::ptrdiff_t`.
+inline constexpr std::string_view stride = "stride";
+}  // namespace reader::option
 
 /**
  * @ingroup dataio

--- a/modules/ffmpeg/CMakeLists.txt
+++ b/modules/ffmpeg/CMakeLists.txt
@@ -4,14 +4,18 @@ set(HEADER_FILES
     include/inviwo/ffmpeg/ffmpeganimationrecorder.h
     include/inviwo/ffmpeg/ffmpegmodule.h
     include/inviwo/ffmpeg/ffmpegmoduledefine.h
+    include/inviwo/ffmpeg/ffmpegvideoreader.h
     include/inviwo/ffmpeg/outputstream.h
     include/inviwo/ffmpeg/processors/movieexport.h
     include/inviwo/ffmpeg/recorder.h
     include/inviwo/ffmpeg/util.h
-    include/inviwo/ffmpeg/wrap/codec.h
+    include/inviwo/ffmpeg/video.h
     include/inviwo/ffmpeg/wrap/codecid.h
-    include/inviwo/ffmpeg/wrap/format.h
+    include/inviwo/ffmpeg/wrap/decoder.h
+    include/inviwo/ffmpeg/wrap/encoder.h
     include/inviwo/ffmpeg/wrap/frame.h
+    include/inviwo/ffmpeg/wrap/inputcontext.h
+    include/inviwo/ffmpeg/wrap/outputcontext.h
     include/inviwo/ffmpeg/wrap/outputformat.h
     include/inviwo/ffmpeg/wrap/packet.h
     include/inviwo/ffmpeg/wrap/swscale.h
@@ -21,25 +25,29 @@ ivw_group("Header Files" ${HEADER_FILES})
 set(SOURCE_FILES
     src/ffmpeganimationrecorder.cpp
     src/ffmpegmodule.cpp
+    src/ffmpegvideoreader.cpp
     src/outputstream.cpp
     src/processors/movieexport.cpp
     src/recorder.cpp
     src/util.cpp
-    src/wrap/codec.cpp
+    src/video.cpp
     src/wrap/codecid.cpp
-    src/wrap/format.cpp
+    src/wrap/decoder.cpp
+    src/wrap/encoder.cpp
     src/wrap/frame.cpp
+    src/wrap/inputcontext.cpp
+    src/wrap/outputcontext.cpp
     src/wrap/outputformat.cpp
     src/wrap/packet.cpp
     src/wrap/swscale.cpp
 )
 ivw_group("Source Files" ${SOURCE_FILES})
 
-# Disable tests until there are some
-#set(TEST_FILES
-#    tests/unittests/ffmpeg-unittest-main.cpp
-#)
-#vw_add_unittest(${TEST_FILES})
+set(TEST_FILES
+    tests/unittests/ffmpeg-unittest-main.cpp
+    tests/unittests/videoreader-test.cpp
+)
+ivw_add_unittest(${TEST_FILES})
 
 ivw_create_module(${SOURCE_FILES} ${HEADER_FILES})
 

--- a/modules/ffmpeg/include/inviwo/ffmpeg/ffmpegvideoreader.h
+++ b/modules/ffmpeg/include/inviwo/ffmpeg/ffmpegvideoreader.h
@@ -1,0 +1,121 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2026 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#pragma once
+
+#include <inviwo/ffmpeg/ffmpegmoduledefine.h>
+
+#include <inviwo/core/datastructures/image/layer.h>
+#include <inviwo/core/io/datareader.h>
+
+#include <cstddef>
+#include <optional>
+#include <string_view>
+
+namespace inviwo {
+
+/**
+ * @brief Option keys specific to the ffmpeg video readers, in addition to the ones in
+ * inviwo::reader::option
+ */
+namespace videoreader::option {
+/// Time in seconds of the frame to read, `double`. Mutually exclusive with reader::option::index,
+/// whichever was set last is used.
+inline constexpr std::string_view time = "time";
+/// Index of the video stream to read, `int`. A negative value selects the best stream.
+inline constexpr std::string_view stream = "stream";
+}  // namespace videoreader::option
+
+/**
+ * @ingroup dataio
+ * @brief Reads a single frame from a video file using ffmpeg
+ *
+ * Supported options
+ *  - reader::option::index    frame to read, `std::ptrdiff_t`, negative values count from the end,
+ *                             defaults to 0
+ *  - videoreader::option::time   time in seconds of the frame to read, `double`
+ *  - videoreader::option::stream video stream to read, `int`, defaults to -1
+ */
+class IVW_MODULE_FFMPEG_API FFmpegLayerReader : public DataReaderType<Layer> {
+public:
+    FFmpegLayerReader();
+    FFmpegLayerReader(const FFmpegLayerReader& rhs) = default;
+    virtual FFmpegLayerReader* clone() const override;
+    virtual ~FFmpegLayerReader() = default;
+
+    virtual std::shared_ptr<Layer> readData(const std::filesystem::path& filePath) override;
+    using DataReaderType<Layer>::readData;
+
+    virtual bool setOption(std::string_view key, std::any value) override;
+    virtual std::any getOption(std::string_view key) override;
+
+private:
+    std::ptrdiff_t index_ = 0;
+    std::optional<double> time_ = std::nullopt;
+    int stream_ = -1;
+};
+
+/**
+ * @ingroup dataio
+ * @brief Reads a range of frames from a video file using ffmpeg
+ *
+ * Supported options
+ *  - reader::option::index    first frame to read, `std::ptrdiff_t`, negative values count from the
+ *                             end, defaults to 0
+ *  - reader::option::count    number of frames to read, `std::ptrdiff_t`, a negative value reads
+ *                             until the end of the video, defaults to
+ *                             FFmpegLayerSequenceReader::defaultCount
+ *  - reader::option::stride   step between the frames to read, `std::ptrdiff_t`, defaults to 1
+ *  - videoreader::option::stream video stream to read, `int`, defaults to -1
+ */
+class IVW_MODULE_FFMPEG_API FFmpegLayerSequenceReader : public DataReaderType<LayerSequence> {
+public:
+    /// Videos can be arbitrarily long, only read this many frames unless told otherwise
+    static constexpr std::ptrdiff_t defaultCount = 100;
+
+    FFmpegLayerSequenceReader();
+    FFmpegLayerSequenceReader(const FFmpegLayerSequenceReader& rhs) = default;
+    virtual FFmpegLayerSequenceReader* clone() const override;
+    virtual ~FFmpegLayerSequenceReader() = default;
+
+    virtual std::shared_ptr<LayerSequence> readData(
+        const std::filesystem::path& filePath) override;
+    using DataReaderType<LayerSequence>::readData;
+
+    virtual bool setOption(std::string_view key, std::any value) override;
+    virtual std::any getOption(std::string_view key) override;
+
+private:
+    std::ptrdiff_t index_ = 0;
+    std::ptrdiff_t count_ = defaultCount;
+    std::ptrdiff_t stride_ = 1;
+    int stream_ = -1;
+};
+
+}  // namespace inviwo

--- a/modules/ffmpeg/include/inviwo/ffmpeg/ffmpegvideoreader.h
+++ b/modules/ffmpeg/include/inviwo/ffmpeg/ffmpegvideoreader.h
@@ -34,6 +34,7 @@
 #include <inviwo/core/datastructures/image/layer.h>
 #include <inviwo/core/io/datareader.h>
 
+#include <chrono>
 #include <cstddef>
 #include <optional>
 #include <string_view>
@@ -45,8 +46,8 @@ namespace inviwo {
  * inviwo::reader::option
  */
 namespace videoreader::option {
-/// Time in seconds of the frame to read, `double`. Mutually exclusive with reader::option::index,
-/// whichever was set last is used.
+/// Time of the frame to read, `std::chrono::duration<double>` seconds. Mutually exclusive with
+/// reader::option::index, whichever was set last is used.
 inline constexpr std::string_view time = "time";
 /// Index of the video stream to read, `int`. A negative value selects the best stream.
 inline constexpr std::string_view stream = "stream";
@@ -59,15 +60,20 @@ inline constexpr std::string_view stream = "stream";
  * Supported options
  *  - reader::option::index    frame to read, `std::ptrdiff_t`, negative values count from the end,
  *                             defaults to 0
- *  - videoreader::option::time   time in seconds of the frame to read, `double`
+ *  - videoreader::option::time   time of the frame to read, `std::chrono::duration<double>`
  *  - videoreader::option::stream video stream to read, `int`, defaults to -1
  */
 class IVW_MODULE_FFMPEG_API FFmpegLayerReader : public DataReaderType<Layer> {
 public:
+    using Seconds = std::chrono::duration<double>;
+
     FFmpegLayerReader();
     FFmpegLayerReader(const FFmpegLayerReader& rhs) = default;
+    FFmpegLayerReader(FFmpegLayerReader&& rhs) noexcept = default;
+    FFmpegLayerReader& operator=(const FFmpegLayerReader& that) = default;
+    FFmpegLayerReader& operator=(FFmpegLayerReader&& that) noexcept = default;
     virtual FFmpegLayerReader* clone() const override;
-    virtual ~FFmpegLayerReader() = default;
+    virtual ~FFmpegLayerReader() override = default;
 
     virtual std::shared_ptr<Layer> readData(const std::filesystem::path& filePath) override;
     using DataReaderType<Layer>::readData;
@@ -77,7 +83,7 @@ public:
 
 private:
     std::ptrdiff_t index_ = 0;
-    std::optional<double> time_ = std::nullopt;
+    std::optional<Seconds> time_ = std::nullopt;
     int stream_ = -1;
 };
 
@@ -101,11 +107,13 @@ public:
 
     FFmpegLayerSequenceReader();
     FFmpegLayerSequenceReader(const FFmpegLayerSequenceReader& rhs) = default;
+    FFmpegLayerSequenceReader(FFmpegLayerSequenceReader&& rhs) noexcept = default;
+    FFmpegLayerSequenceReader& operator=(const FFmpegLayerSequenceReader& that) = default;
+    FFmpegLayerSequenceReader& operator=(FFmpegLayerSequenceReader&& that) noexcept = default;
     virtual FFmpegLayerSequenceReader* clone() const override;
-    virtual ~FFmpegLayerSequenceReader() = default;
+    virtual ~FFmpegLayerSequenceReader() override = default;
 
-    virtual std::shared_ptr<LayerSequence> readData(
-        const std::filesystem::path& filePath) override;
+    virtual std::shared_ptr<LayerSequence> readData(const std::filesystem::path& filePath) override;
     using DataReaderType<LayerSequence>::readData;
 
     virtual bool setOption(std::string_view key, std::any value) override;

--- a/modules/ffmpeg/include/inviwo/ffmpeg/outputstream.h
+++ b/modules/ffmpeg/include/inviwo/ffmpeg/outputstream.h
@@ -32,9 +32,9 @@
 
 #include <inviwo/ffmpeg/util.h>
 
-#include <inviwo/ffmpeg/wrap/format.h>
+#include <inviwo/ffmpeg/wrap/outputcontext.h>
 #include <inviwo/ffmpeg/wrap/frame.h>
-#include <inviwo/ffmpeg/wrap/codec.h>
+#include <inviwo/ffmpeg/wrap/encoder.h>
 #include <inviwo/ffmpeg/wrap/codecid.h>
 #include <inviwo/ffmpeg/wrap/swscale.h>
 
@@ -60,14 +60,14 @@ struct IVW_MODULE_FFMPEG_API OutputStream : NoMoveCopy {
         int64_t bitRate = 400000;
     };
 
-    OutputStream(Format& format, Options opts);
+    OutputStream(OutputContext& format, Options opts);
 
     void openVideo(AVDictionary* opt_arg = nullptr);
 
     Frame* fillFrame(Frame& dst, std::function<void(AVFrame* pict, int width, int height)> filler);
 
     enum AVPixelFormat sourceFormat;
-    Codec codec;
+    Encoder encoder;
     AVStream* stream;
 
     std::optional<Frame> tmpFrame;

--- a/modules/ffmpeg/include/inviwo/ffmpeg/recorder.h
+++ b/modules/ffmpeg/include/inviwo/ffmpeg/recorder.h
@@ -34,7 +34,7 @@
 
 #include <inviwo/ffmpeg/outputstream.h>
 #include <inviwo/ffmpeg/wrap/packet.h>
-#include <inviwo/ffmpeg/wrap/format.h>
+#include <inviwo/ffmpeg/wrap/outputcontext.h>
 
 #include <thread>
 #include <queue>
@@ -55,7 +55,7 @@ public:
     ~Recorder();
 
     const OutputStream& getStream();
-    const Format& getFormat();
+    const OutputContext& getFormat();
 
     /**
      * Copies the image data in layer into a ffmpeg frames and enques that for encoding
@@ -67,7 +67,7 @@ private:
     void run();
 
     Mode mode;
-    Format out;
+    OutputContext out;
     OutputStream stream;
     Packet pkt;
 

--- a/modules/ffmpeg/include/inviwo/ffmpeg/recorder.h
+++ b/modules/ffmpeg/include/inviwo/ffmpeg/recorder.h
@@ -55,7 +55,7 @@ public:
     ~Recorder();
 
     const OutputStream& getStream();
-    const OutputContext& getFormat();
+    const OutputContext& getOutputContext();
 
     /**
      * Copies the image data in layer into a ffmpeg frames and enques that for encoding

--- a/modules/ffmpeg/include/inviwo/ffmpeg/video.h
+++ b/modules/ffmpeg/include/inviwo/ffmpeg/video.h
@@ -1,0 +1,153 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2026 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#pragma once
+
+#include <inviwo/ffmpeg/ffmpegmoduledefine.h>
+
+#include <inviwo/ffmpeg/util.h>
+#include <inviwo/ffmpeg/wrap/decoder.h>
+#include <inviwo/ffmpeg/wrap/frame.h>
+#include <inviwo/ffmpeg/wrap/inputcontext.h>
+#include <inviwo/ffmpeg/wrap/packet.h>
+#include <inviwo/ffmpeg/wrap/swscale.h>
+
+#include <inviwo/core/util/glmvec.h>
+
+#include <cstddef>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+
+extern "C" {
+#include <libavutil/avutil.h>
+}
+
+struct AVStream;
+
+namespace inviwo {
+
+class Layer;
+class DataFormatBase;
+
+namespace ffmpeg {
+
+/**
+ * @brief Random access to the frames of a video file, decoded into Layers.
+ *
+ * Frames are converted to a Layer format matching the source as closely as possible, see
+ * Info::format. Color videos are decoded into RGBA, grayscale videos into a single channel, and
+ * sources with more than 8 bits per component are decoded into 16 bit Layers.
+ *
+ * Seeking is done by seeking to the closest preceding keyframe and then decoding forward. Reading
+ * frames in order is therefore substantially faster than random access.
+ */
+class IVW_MODULE_FFMPEG_API Video : NoMoveCopy {
+public:
+    struct Info {
+        size2_t dimensions{0, 0};
+        /// Layer data format the frames are decoded into
+        const DataFormatBase* format = nullptr;
+        double frameRate = 0.0;
+        /// Duration in seconds
+        double duration = 0.0;
+        /// Number of frames, might be an estimate based on duration and frame rate
+        std::ptrdiff_t frames = 0;
+        std::string codec;
+    };
+
+    /**
+     * @brief Open @p filename and prepare the video stream @p streamIndex for decoding
+     * @param filename video file to open
+     * @param streamIndex index of the video stream to decode, -1 selects the best one
+     * @throws Exception if the file cannot be opened, holds no video stream, or if there is no
+     * decoder available for it
+     */
+    explicit Video(const std::filesystem::path& filename, int streamIndex = -1);
+    ~Video();
+
+    const Info& info() const;
+    const std::filesystem::path& filename() const;
+    int streamIndex() const;
+
+    /// Index of the frame shown at @p time seconds
+    std::ptrdiff_t frameAt(double time) const;
+
+    /**
+     * @brief Decode the frame at @p index
+     * @param index frame to read, negative values are counted from the end, that is -1 is the last
+     * frame
+     * @param reuse optional Layer to decode into. It is only used if it is non-null and matches the
+     * format, dimensions, and type of the decoded frames, otherwise it is ignored and a new Layer
+     * is allocated.
+     * @return the decoded frame, or nullptr if the stream ended before reaching @p index
+     * @throws RangeException if @p index is out of bounds
+     */
+    std::shared_ptr<Layer> readFrame(std::ptrdiff_t index, std::shared_ptr<Layer> reuse = {});
+
+    /**
+     * @brief Decode the frame following the most recently read one
+     * @param reuse optional Layer to decode into, @see readFrame
+     * @return the decoded frame, or nullptr at the end of the stream
+     */
+    std::shared_ptr<Layer> readNextFrame(std::shared_ptr<Layer> reuse = {});
+
+    /// Position the stream so that the next call to readNextFrame() returns frame @p index
+    void seekToFrame(std::ptrdiff_t index);
+
+private:
+    /// Decode the next frame into frame_, returns false at the end of the stream
+    bool decodeNextFrame();
+    /// Frame index of the frame currently held by frame_
+    std::ptrdiff_t indexOfCurrentFrame() const;
+    /// Presentation timestamp, in stream time base, of frame @p index
+    int64_t timestampOf(std::ptrdiff_t index) const;
+    std::shared_ptr<Layer> toLayer(std::shared_ptr<Layer> reuse);
+
+    InputContext input_;
+    int streamIndex_;
+    AVStream* stream_;
+    Decoder decoder_;
+    Packet packet_;
+    Frame frame_;
+
+    std::optional<SwScale> scaler_;
+    enum AVPixelFormat scalerSourceFormat_;
+    enum AVPixelFormat targetFormat_;
+
+    Info info_;
+    /// Index of the frame held by frame_, or -1 if nothing has been decoded since the last seek
+    std::ptrdiff_t current_;
+    bool draining_;
+};
+
+}  // namespace ffmpeg
+
+}  // namespace inviwo

--- a/modules/ffmpeg/include/inviwo/ffmpeg/video.h
+++ b/modules/ffmpeg/include/inviwo/ffmpeg/video.h
@@ -40,6 +40,7 @@
 
 #include <inviwo/core/util/glmvec.h>
 
+#include <chrono>
 #include <cstddef>
 #include <filesystem>
 #include <memory>
@@ -71,13 +72,14 @@ namespace ffmpeg {
  */
 class IVW_MODULE_FFMPEG_API Video : NoMoveCopy {
 public:
+    using Seconds = std::chrono::duration<double>;
+
     struct Info {
         size2_t dimensions{0, 0};
         /// Layer data format the frames are decoded into
         const DataFormatBase* format = nullptr;
         double frameRate = 0.0;
-        /// Duration in seconds
-        double duration = 0.0;
+        Seconds duration{0.0};
         /// Number of frames, might be an estimate based on duration and frame rate
         std::ptrdiff_t frames = 0;
         std::string codec;
@@ -91,14 +93,25 @@ public:
      * decoder available for it
      */
     explicit Video(const std::filesystem::path& filename, int streamIndex = -1);
+    Video(const Video&) = delete;
+    Video(Video&&) = delete;
+    Video& operator=(const Video&) = delete;
+    Video& operator=(Video&&) = delete;
     ~Video();
 
     const Info& info() const;
     const std::filesystem::path& filename() const;
     int streamIndex() const;
 
-    /// Index of the frame shown at @p time seconds
-    std::ptrdiff_t frameAt(double time) const;
+    /// Index of the frame shown at @p time
+    std::ptrdiff_t frameAt(Seconds time) const;
+    /// Presentation time of frame @p index
+    Seconds timeOf(std::ptrdiff_t index) const;
+
+    /// Index of the most recently decoded frame, or -1 if nothing has been decoded yet
+    std::ptrdiff_t currentFrame() const;
+    /// Presentation time of the most recently decoded frame
+    Seconds currentTime() const;
 
     /**
      * @brief Decode the frame at @p index
@@ -121,6 +134,8 @@ public:
 
     /// Position the stream so that the next call to readNextFrame() returns frame @p index
     void seekToFrame(std::ptrdiff_t index);
+    /// Position the stream so that the next call to readNextFrame() returns the frame at @p time
+    void seekToTime(Seconds time);
 
 private:
     /// Decode the next frame into frame_, returns false at the end of the stream
@@ -145,6 +160,8 @@ private:
     Info info_;
     /// Index of the frame held by frame_, or -1 if nothing has been decoded since the last seek
     std::ptrdiff_t current_;
+    /// Frames decoded before this index are skipped, a seek lands on the preceding keyframe
+    std::ptrdiff_t pending_;
     bool draining_;
 };
 

--- a/modules/ffmpeg/include/inviwo/ffmpeg/wrap/decoder.h
+++ b/modules/ffmpeg/include/inviwo/ffmpeg/wrap/decoder.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2023-2026 Inviwo Foundation
+ * Copyright (c) 2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,24 +26,60 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  *********************************************************************************/
+
 #pragma once
 
 #include <inviwo/ffmpeg/ffmpegmoduledefine.h>
-#include <inviwo/ffmpeg/util.h>
 
-struct AVPacket;
+#include <inviwo/ffmpeg/util.h>
+#include <inviwo/ffmpeg/wrap/frame.h>
+#include <inviwo/ffmpeg/wrap/packet.h>
+#include <inviwo/ffmpeg/wrap/codecid.h>
+
+extern "C" {
+#include <libavutil/avutil.h>
+}
+
+struct AVCodecContext;
+struct AVStream;
 
 namespace inviwo::ffmpeg {
 
-class IVW_MODULE_FFMPEG_API Packet : NoMoveCopy {
+/**
+ * @brief RAII wrapper around an AVCodecContext set up for decoding.
+ * @see Encoder for the encoding counterpart
+ */
+class IVW_MODULE_FFMPEG_API Decoder : NoMoveCopy {
 public:
-    Packet();
-    ~Packet();
+    /**
+     * @brief Create and open a decoder matching the codec parameters of @p stream
+     * @throws Exception if no decoder is available for the codec or if it cannot be opened
+     */
+    explicit Decoder(const AVStream* stream);
+    ~Decoder();
 
-    /// Release any data referenced by the packet and reset it to its default state
-    void unref();
+    void sendPacket(const Packet& pkt);
 
-    AVPacket* pkt;
+    /// Signal end of stream to the decoder, any remaining frames can then be collected with
+    /// receiveFrame()
+    void flush();
+
+    /**
+     * @brief Retrieve the next decoded frame
+     * @return 0 on success, AVERROR(EAGAIN) if more packets are needed, AVERROR_EOF if the decoder
+     * has been fully drained
+     */
+    int receiveFrame(Frame& frame);
+
+    /// Discard any buffered state, must be called after seeking
+    void reset();
+
+    CodecID codecID() const;
+    int width() const;
+    int height() const;
+    enum AVPixelFormat pixelFormat() const;
+
+    AVCodecContext* ctx;
 };
 
 }  // namespace inviwo::ffmpeg

--- a/modules/ffmpeg/include/inviwo/ffmpeg/wrap/decoder.h
+++ b/modules/ffmpeg/include/inviwo/ffmpeg/wrap/decoder.h
@@ -56,23 +56,27 @@ public:
      * @throws Exception if no decoder is available for the codec or if it cannot be opened
      */
     explicit Decoder(const AVStream* stream);
+    Decoder(const Decoder&) = delete;
+    Decoder(Decoder&&) = delete;
+    Decoder& operator=(const Decoder&) = delete;
+    Decoder& operator=(Decoder&&) = delete;
     ~Decoder();
 
-    void sendPacket(const Packet& pkt);
+    void sendPacket(const Packet& pkt) const;
 
     /// Signal end of stream to the decoder, any remaining frames can then be collected with
     /// receiveFrame()
-    void flush();
+    void flush() const;
 
     /**
      * @brief Retrieve the next decoded frame
      * @return 0 on success, AVERROR(EAGAIN) if more packets are needed, AVERROR_EOF if the decoder
      * has been fully drained
      */
-    int receiveFrame(Frame& frame);
+    int receiveFrame(Frame& frame) const;
 
     /// Discard any buffered state, must be called after seeking
-    void reset();
+    void reset() const;
 
     CodecID codecID() const;
     int width() const;

--- a/modules/ffmpeg/include/inviwo/ffmpeg/wrap/encoder.h
+++ b/modules/ffmpeg/include/inviwo/ffmpeg/wrap/encoder.h
@@ -47,16 +47,20 @@ namespace inviwo::ffmpeg {
  */
 class IVW_MODULE_FFMPEG_API Encoder : NoMoveCopy {
 public:
-    Encoder(const AVCodec* codec);
-    Encoder(CodecID codec);
-
+    explicit Encoder(const AVCodec* codec);
+    explicit Encoder(CodecID codec);
+    Encoder(const Encoder&) = delete;
+    Encoder(Encoder&&) = delete;
+    Encoder& operator=(const Encoder&) = delete;
+    Encoder& operator=(Encoder&&) = delete;
     ~Encoder();
-    void sendFrame(const Frame& frame);
-    int receivePacket(Packet& pkt);
+
+    void sendFrame(const Frame& frame) const;
+    int receivePacket(Packet& pkt) const;
 
     CodecID codecID() const;
 
-    void open(AVDictionary* opt_arg);
+    void open(AVDictionary* opt_arg) const;
 
     AVCodecContext* ctx;
 

--- a/modules/ffmpeg/include/inviwo/ffmpeg/wrap/encoder.h
+++ b/modules/ffmpeg/include/inviwo/ffmpeg/wrap/encoder.h
@@ -29,40 +29,39 @@
 #pragma once
 
 #include <inviwo/ffmpeg/ffmpegmoduledefine.h>
+
 #include <inviwo/ffmpeg/util.h>
+#include <inviwo/ffmpeg/wrap/frame.h>
 #include <inviwo/ffmpeg/wrap/packet.h>
 #include <inviwo/ffmpeg/wrap/codecid.h>
-#include <inviwo/ffmpeg/wrap/outputformat.h>
 
-#include <filesystem>
-#include <optional>
-
-struct AVOutputFormat;
-struct AVFormatContext;
-struct AVStream;
+struct AVCodec;
+struct AVCodecContext;
 struct AVDictionary;
 
 namespace inviwo::ffmpeg {
 
-class IVW_MODULE_FFMPEG_API Format : NoMoveCopy {
+/**
+ * @brief RAII wrapper around an AVCodecContext set up for encoding.
+ * @see Decoder for the decoding counterpart
+ */
+class IVW_MODULE_FFMPEG_API Encoder : NoMoveCopy {
 public:
-    Format(OutputFormat outputFormat, const std::filesystem::path& aFilename);
-    Format(const std::filesystem::path& aFilename);
-    ~Format();
-    void open();
+    Encoder(const AVCodec* codec);
+    Encoder(CodecID codec);
 
-    void writeHeader(AVDictionary** options);
+    ~Encoder();
+    void sendFrame(const Frame& frame);
+    int receivePacket(Packet& pkt);
 
-    void writeTrailer();
+    CodecID codecID() const;
 
-    void writeFrame(const Packet& pkt);
-    AVStream* newStream();
-    int queryCodec(CodecID codecId, std::optional<int> stdCompliance = std::nullopt);
+    void open(AVDictionary* opt_arg);
 
-    OutputFormat outputFormat() const;
+    AVCodecContext* ctx;
 
-    std::filesystem::path filename;
-    AVFormatContext* ctx;
+private:
+    const AVCodec* findEncoder(CodecID codecId);
 };
 
 }  // namespace inviwo::ffmpeg

--- a/modules/ffmpeg/include/inviwo/ffmpeg/wrap/frame.h
+++ b/modules/ffmpeg/include/inviwo/ffmpeg/wrap/frame.h
@@ -51,6 +51,12 @@ public:
     operator bool() const;
     void makeWritable();
 
+    /**
+     * @brief Allocate an AVFrame without any data buffers, for use as a decoder destination where
+     * the decoder provides the buffers.
+     */
+    static Frame alloc();
+
     AVFrame* frame;
 };
 

--- a/modules/ffmpeg/include/inviwo/ffmpeg/wrap/frame.h
+++ b/modules/ffmpeg/include/inviwo/ffmpeg/wrap/frame.h
@@ -40,7 +40,17 @@ namespace inviwo::ffmpeg {
 
 class IVW_MODULE_FFMPEG_API Frame {
 public:
+    /// Tag for constructing an AVFrame without data buffers, @see Frame(NoBuffers)
+    struct NoBuffers {};
+
+    /// Construct a Frame without an AVFrame, sending it to an encoder signals end of stream
     Frame();
+
+    /**
+     * @brief Allocate an AVFrame without any data buffers, for use as a decoder destination where
+     * the decoder provides the buffers.
+     */
+    explicit Frame(NoBuffers);
 
     Frame(enum AVPixelFormat pix_fmt, int width, int height);
     Frame(const Frame&) = delete;
@@ -50,12 +60,6 @@ public:
     ~Frame();
     operator bool() const;
     void makeWritable();
-
-    /**
-     * @brief Allocate an AVFrame without any data buffers, for use as a decoder destination where
-     * the decoder provides the buffers.
-     */
-    static Frame alloc();
 
     AVFrame* frame;
 };

--- a/modules/ffmpeg/include/inviwo/ffmpeg/wrap/inputcontext.h
+++ b/modules/ffmpeg/include/inviwo/ffmpeg/wrap/inputcontext.h
@@ -2,7 +2,7 @@
  *
  * Inviwo - Interactive Visualization Workshop
  *
- * Copyright (c) 2023-2026 Inviwo Foundation
+ * Copyright (c) 2026 Inviwo Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,62 +27,55 @@
  *
  *********************************************************************************/
 
-#include <inviwo/ffmpeg/wrap/codec.h>
+#pragma once
 
-#include <inviwo/core/util/exception.h>
+#include <inviwo/ffmpeg/ffmpegmoduledefine.h>
+#include <inviwo/ffmpeg/util.h>
+#include <inviwo/ffmpeg/wrap/packet.h>
 
-extern "C" {
-#include <libavcodec/avcodec.h>
-}
+#include <filesystem>
+
+struct AVFormatContext;
+struct AVStream;
 
 namespace inviwo::ffmpeg {
 
-Codec::Codec(const AVCodec* codec) : ctx{avcodec_alloc_context3(codec)} {
-    if (!ctx) {
-        throw Exception(SourceContext{}, "Could not alloc an encoding context");
-    }
-}
+/**
+ * @brief RAII wrapper around an AVFormatContext used for demuxing, that is reading media files.
+ * @see OutputContext for the muxing counterpart
+ */
+class IVW_MODULE_FFMPEG_API InputContext : NoMoveCopy {
+public:
+    explicit InputContext(const std::filesystem::path& aFilename);
+    ~InputContext();
 
-Codec::Codec(CodecID codecId) : Codec{findEncoder(codecId.id)} {}
+    /**
+     * @brief Index of the video stream ffmpeg considers the most suitable one
+     * @throws Exception if the file contains no video stream
+     */
+    int bestVideoStream() const;
 
-Codec::~Codec() { avcodec_free_context(&ctx); }
+    /**
+     * @throws RangeException if @p index is not a valid stream index
+     */
+    AVStream* stream(int index) const;
 
-void Codec::open(AVDictionary* opt_arg) {
-    AVDictionary* opt = nullptr;
-    av_dict_copy(&opt, opt_arg, 0);
+    int nbStreams() const;
 
-    /* open the codec */
-    int ret = avcodec_open2(ctx, ctx->codec, &opt);
+    /**
+     * @brief Read the next packet from the file
+     * @return false at end of file, true otherwise
+     */
+    bool readPacket(Packet& pkt);
 
-    av_dict_free(&opt);
-    if (ret < 0) {
-        throw Exception(SourceContext{}, "Could not open video codec: {}", Error{ret});
-    }
-}
+    /**
+     * @brief Seek to the keyframe at or before @p timestamp, given in the time base of stream
+     * @p streamIndex
+     */
+    void seek(int streamIndex, int64_t timestamp);
 
-void Codec::sendFrame(const Frame& frame) {
-    if (auto ret = avcodec_send_frame(ctx, frame.frame); ret < 0) {
-        throw Exception(SourceContext{}, "Error sending a frame to the encoder: {}", Error(ret));
-    }
-}
-
-int Codec::receivePacket(Packet& pkt) {
-    auto ret = avcodec_receive_packet(ctx, pkt.pkt);
-    if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) return ret;
-
-    if (ret < 0) {
-        throw Exception(SourceContext{}, "Error encoding a frame: {}", Error(ret));
-    }
-    return ret;
-}
-CodecID Codec::codecID() const { return ctx->codec_id; }
-
-const AVCodec* Codec::findEncoder(CodecID codecId) {
-    auto codec = avcodec_find_encoder(codecId.id);
-    if (!codec) {
-        throw Exception(SourceContext{}, "Could not find encoder for '{}'", codecId.name());
-    }
-    return codec;
-}
+    std::filesystem::path filename;
+    AVFormatContext* ctx;
+};
 
 }  // namespace inviwo::ffmpeg

--- a/modules/ffmpeg/include/inviwo/ffmpeg/wrap/inputcontext.h
+++ b/modules/ffmpeg/include/inviwo/ffmpeg/wrap/inputcontext.h
@@ -46,7 +46,11 @@ namespace inviwo::ffmpeg {
  */
 class IVW_MODULE_FFMPEG_API InputContext : NoMoveCopy {
 public:
-    explicit InputContext(const std::filesystem::path& aFilename);
+    explicit InputContext(std::filesystem::path aFilename);
+    InputContext(const InputContext&) = delete;
+    InputContext(InputContext&&) = delete;
+    InputContext& operator=(const InputContext&) = delete;
+    InputContext& operator=(InputContext&&) = delete;
     ~InputContext();
 
     /**

--- a/modules/ffmpeg/include/inviwo/ffmpeg/wrap/outputcontext.h
+++ b/modules/ffmpeg/include/inviwo/ffmpeg/wrap/outputcontext.h
@@ -29,35 +29,44 @@
 #pragma once
 
 #include <inviwo/ffmpeg/ffmpegmoduledefine.h>
-
 #include <inviwo/ffmpeg/util.h>
-#include <inviwo/ffmpeg/wrap/frame.h>
 #include <inviwo/ffmpeg/wrap/packet.h>
 #include <inviwo/ffmpeg/wrap/codecid.h>
+#include <inviwo/ffmpeg/wrap/outputformat.h>
 
-struct AVCodec;
-struct AVCodecContext;
+#include <filesystem>
+#include <optional>
+
+struct AVOutputFormat;
+struct AVFormatContext;
+struct AVStream;
 struct AVDictionary;
 
 namespace inviwo::ffmpeg {
 
-class IVW_MODULE_FFMPEG_API Codec : NoMoveCopy {
+/**
+ * @brief RAII wrapper around an AVFormatContext used for muxing, that is writing video files.
+ * @see InputContext for the demuxing counterpart
+ */
+class IVW_MODULE_FFMPEG_API OutputContext : NoMoveCopy {
 public:
-    Codec(const AVCodec* codec);
-    Codec(CodecID codec);
+    OutputContext(OutputFormat outputFormat, const std::filesystem::path& aFilename);
+    OutputContext(const std::filesystem::path& aFilename);
+    ~OutputContext();
+    void open();
 
-    ~Codec();
-    void sendFrame(const Frame& frame);
-    int receivePacket(Packet& pkt);
+    void writeHeader(AVDictionary** options);
 
-    CodecID codecID() const;
+    void writeTrailer();
 
-    void open(AVDictionary* opt_arg);
+    void writeFrame(const Packet& pkt);
+    AVStream* newStream();
+    int queryCodec(CodecID codecId, std::optional<int> stdCompliance = std::nullopt);
 
-    AVCodecContext* ctx;
+    OutputFormat outputFormat() const;
 
-private:
-    const AVCodec* findEncoder(CodecID codecId);
+    std::filesystem::path filename;
+    AVFormatContext* ctx;
 };
 
 }  // namespace inviwo::ffmpeg

--- a/modules/ffmpeg/include/inviwo/ffmpeg/wrap/outputcontext.h
+++ b/modules/ffmpeg/include/inviwo/ffmpeg/wrap/outputcontext.h
@@ -50,18 +50,22 @@ namespace inviwo::ffmpeg {
  */
 class IVW_MODULE_FFMPEG_API OutputContext : NoMoveCopy {
 public:
-    OutputContext(OutputFormat outputFormat, const std::filesystem::path& aFilename);
-    OutputContext(const std::filesystem::path& aFilename);
+    OutputContext(OutputFormat outputFormat, std::filesystem::path aFilename);
+    explicit OutputContext(std::filesystem::path aFilename);
+    OutputContext(const OutputContext&) = delete;
+    OutputContext(OutputContext&&) = delete;
+    OutputContext& operator=(const OutputContext&) = delete;
+    OutputContext& operator=(OutputContext&&) = delete;
     ~OutputContext();
     void open();
 
-    void writeHeader(AVDictionary** options);
+    void writeHeader(AVDictionary** options) const;
 
-    void writeTrailer();
+    void writeTrailer() const;
 
-    void writeFrame(const Packet& pkt);
-    AVStream* newStream();
-    int queryCodec(CodecID codecId, std::optional<int> stdCompliance = std::nullopt);
+    void writeFrame(const Packet& pkt) const;
+    AVStream* newStream() const;
+    int queryCodec(CodecID codecId, std::optional<int> stdCompliance = std::nullopt) const;
 
     OutputFormat outputFormat() const;
 

--- a/modules/ffmpeg/include/inviwo/ffmpeg/wrap/packet.h
+++ b/modules/ffmpeg/include/inviwo/ffmpeg/wrap/packet.h
@@ -38,10 +38,18 @@ namespace inviwo::ffmpeg {
 class IVW_MODULE_FFMPEG_API Packet : NoMoveCopy {
 public:
     Packet();
+    Packet(const Packet&) = delete;
+    Packet(Packet&&) = delete;
+    Packet& operator=(const Packet&) = delete;
+    Packet& operator=(Packet&&) = delete;
     ~Packet();
 
-    /// Release any data referenced by the packet and reset it to its default state
-    void unref();
+    /**
+     * @brief Release the reference to the data buffer the packet points to and reset it to its
+     * default state. The buffer itself is reference counted by ffmpeg and freed once the last
+     * reference is gone, the AVPacket is owned by this class and freed in the destructor.
+     */
+    void unref() const;
 
     AVPacket* pkt;
 };

--- a/modules/ffmpeg/src/ffmpeganimationrecorder.cpp
+++ b/modules/ffmpeg/src/ffmpeganimationrecorder.cpp
@@ -50,7 +50,7 @@ public:
                                                       ffmpeg::Recorder::Mode::Evaluation, opts)} {
 
         log::info("Recording to: {}", filename);
-        log::info("  - Format:   {}", recorder->getFormat().outputFormat().desc());
+        log::info("  - Format:   {}", recorder->getOutputContext().outputFormat().desc());
         log::info("  - Codec:    {}", recorder->getStream().encoder.codecID());
     }
     virtual ~FFmpegRecorder() = default;

--- a/modules/ffmpeg/src/ffmpeganimationrecorder.cpp
+++ b/modules/ffmpeg/src/ffmpeganimationrecorder.cpp
@@ -51,7 +51,7 @@ public:
 
         log::info("Recording to: {}", filename);
         log::info("  - Format:   {}", recorder->getFormat().outputFormat().desc());
-        log::info("  - Codec:    {}", recorder->getStream().codec.codecID());
+        log::info("  - Codec:    {}", recorder->getStream().encoder.codecID());
     }
     virtual ~FFmpegRecorder() = default;
 

--- a/modules/ffmpeg/src/ffmpegmodule.cpp
+++ b/modules/ffmpeg/src/ffmpegmodule.cpp
@@ -41,6 +41,8 @@ extern "C" {
 namespace {
 
 void ffmpeg_log_callback(void* ptr, int level, const char* fmt, va_list vl) {
+    if (level > AV_LOG_WARNING) return;
+
     std::array<char, 1024> line;
     std::string dynamicLine;
     static int print_prefix = 1;
@@ -91,6 +93,7 @@ FFmpegModule::FFmpegModule(InviwoApplication* app)
     registerDataReader(std::make_unique<FFmpegLayerReader>());
     registerDataReader(std::make_unique<FFmpegLayerSequenceReader>());
 
+    av_log_set_level(AV_LOG_WARNING);
     av_log_set_callback(ffmpeg_log_callback);
 
     registerRecorderFactory(std::make_unique<FFmpegRecorderFactory>());

--- a/modules/ffmpeg/src/ffmpegmodule.cpp
+++ b/modules/ffmpeg/src/ffmpegmodule.cpp
@@ -28,6 +28,7 @@
  *********************************************************************************/
 
 #include <inviwo/ffmpeg/ffmpegmodule.h>
+#include <inviwo/ffmpeg/ffmpegvideoreader.h>
 #include <inviwo/ffmpeg/processors/movieexport.h>
 #include <inviwo/ffmpeg/ffmpeganimationrecorder.h>
 
@@ -86,6 +87,9 @@ FFmpegModule::FFmpegModule(InviwoApplication* app)
 
     // Processors
     registerProcessor<MovieExport>();
+
+    registerDataReader(std::make_unique<FFmpegLayerReader>());
+    registerDataReader(std::make_unique<FFmpegLayerSequenceReader>());
 
     av_log_set_callback(ffmpeg_log_callback);
 

--- a/modules/ffmpeg/src/ffmpegvideoreader.cpp
+++ b/modules/ffmpeg/src/ffmpegvideoreader.cpp
@@ -1,0 +1,241 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2026 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/ffmpeg/ffmpegvideoreader.h>
+
+#include <inviwo/ffmpeg/video.h>
+
+#include <inviwo/core/io/datareaderexception.h>
+#include <inviwo/core/util/exception.h>
+
+#include <algorithm>
+#include <array>
+#include <utility>
+
+#include <fmt/format.h>
+#include <fmt/std.h>
+
+namespace inviwo {
+
+namespace {
+
+constexpr std::array<std::pair<std::string_view, std::string_view>, 17> videoExtensions{
+    {{"mp4", "MPEG-4 Video"},
+     {"m4v", "MPEG-4 Video"},
+     {"mov", "QuickTime Movie"},
+     {"mkv", "Matroska Video"},
+     {"webm", "WebM Video"},
+     {"avi", "Audio Video Interleave"},
+     {"wmv", "Windows Media Video"},
+     {"flv", "Flash Video"},
+     {"mpg", "MPEG Video"},
+     {"mpeg", "MPEG Video"},
+     {"mts", "AVCHD Video"},
+     {"m2ts", "Blu-ray BDAV Video"},
+     {"ts", "MPEG Transport Stream"},
+     {"ogv", "Ogg Video"},
+     {"3gp", "3GPP Video"},
+     {"y4m", "YUV4MPEG2 Video"},
+     {"gif", "Graphics Interchange Format"}}};
+
+// The DataReaderFactory is keyed on the full FileExtension, so the two readers need distinct
+// descriptions to be able to register for the same file extensions
+void addVideoExtensions(DataReader& reader, std::string_view suffix) {
+    for (auto&& [extension, description] : videoExtensions) {
+        reader.addExtension(
+            FileExtension{LCString{extension}, fmt::format("{}{}", description, suffix)});
+    }
+}
+
+std::optional<std::ptrdiff_t> toOffset(const std::any& value) {
+    if (const auto* offset = std::any_cast<std::ptrdiff_t>(&value)) {
+        return *offset;
+    } else if (const auto* integer = std::any_cast<int>(&value)) {
+        return static_cast<std::ptrdiff_t>(*integer);
+    } else if (const auto* unsignedSize = std::any_cast<size_t>(&value)) {
+        return static_cast<std::ptrdiff_t>(*unsignedSize);
+    }
+    return std::nullopt;
+}
+
+}  // namespace
+
+FFmpegLayerReader::FFmpegLayerReader() : DataReaderType<Layer>{} { addVideoExtensions(*this, ""); }
+
+FFmpegLayerReader* FFmpegLayerReader::clone() const { return new FFmpegLayerReader{*this}; }
+
+std::shared_ptr<Layer> FFmpegLayerReader::readData(const std::filesystem::path& filePath) {
+    const auto path = downloadAndCacheIfUrl(filePath);
+    checkExists(path);
+
+    try {
+        ffmpeg::Video video{path, stream_};
+        const auto index = time_ ? video.frameAt(*time_) : index_;
+        if (auto layer = video.readFrame(index)) {
+            return layer;
+        }
+        throw DataReaderException(SourceContext{}, "Could not read frame {} of '{}'", index,
+                                  filePath);
+    } catch (const DataReaderException&) {
+        throw;
+    } catch (const Exception& e) {
+        throw DataReaderException(SourceContext{}, "Error reading '{}': {}", filePath,
+                                  e.getMessage());
+    }
+}
+
+bool FFmpegLayerReader::setOption(std::string_view key, std::any value) {
+    if (key == reader::option::index) {
+        if (auto index = toOffset(value)) {
+            index_ = *index;
+            time_.reset();
+            return true;
+        }
+    } else if (key == videoreader::option::time) {
+        if (const auto* time = std::any_cast<double>(&value)) {
+            time_ = *time;
+            return true;
+        }
+    } else if (key == videoreader::option::stream) {
+        if (const auto* stream = std::any_cast<int>(&value)) {
+            stream_ = *stream;
+            return true;
+        }
+    }
+    return false;
+}
+
+std::any FFmpegLayerReader::getOption(std::string_view key) {
+    if (key == reader::option::index) {
+        return index_;
+    } else if (key == videoreader::option::time) {
+        return time_ ? std::any{*time_} : std::any{};
+    } else if (key == videoreader::option::stream) {
+        return stream_;
+    }
+    return std::any{};
+}
+
+FFmpegLayerSequenceReader::FFmpegLayerSequenceReader() : DataReaderType<LayerSequence>{} {
+    addVideoExtensions(*this, " Sequence");
+}
+
+FFmpegLayerSequenceReader* FFmpegLayerSequenceReader::clone() const {
+    return new FFmpegLayerSequenceReader{*this};
+}
+
+std::shared_ptr<LayerSequence> FFmpegLayerSequenceReader::readData(
+    const std::filesystem::path& filePath) {
+    const auto path = downloadAndCacheIfUrl(filePath);
+    checkExists(path);
+
+    try {
+        ffmpeg::Video video{path, stream_};
+        const auto frames = video.info().frames;
+
+        auto first = index_;
+        if (first < 0) {
+            if (frames <= 0) {
+                throw DataReaderException(
+                    SourceContext{},
+                    "Cannot use a negative frame index, the number of frames in '{}' is unknown",
+                    filePath);
+            }
+            first += frames;
+        }
+        if (first < 0) {
+            throw DataReaderException(SourceContext{},
+                                      "Frame index {} is out of range, '{}' has {} frames", index_,
+                                      filePath, frames);
+        }
+
+        const auto stride = std::max<std::ptrdiff_t>(stride_, 1);
+
+        auto sequence = std::make_shared<LayerSequence>();
+        for (std::ptrdiff_t i = 0; count_ < 0 || i < count_; ++i) {
+            const auto index = first + i * stride;
+            if (frames > 0 && index >= frames) break;
+
+            auto layer = video.readFrame(index);
+            if (!layer) break;
+            sequence->push_back(std::move(layer));
+        }
+
+        if (sequence->empty()) {
+            throw DataReaderException(SourceContext{}, "Could not read any frames from '{}'",
+                                      filePath);
+        }
+        return sequence;
+    } catch (const DataReaderException&) {
+        throw;
+    } catch (const Exception& e) {
+        throw DataReaderException(SourceContext{}, "Error reading '{}': {}", filePath,
+                                  e.getMessage());
+    }
+}
+
+bool FFmpegLayerSequenceReader::setOption(std::string_view key, std::any value) {
+    if (key == reader::option::index) {
+        if (auto index = toOffset(value)) {
+            index_ = *index;
+            return true;
+        }
+    } else if (key == reader::option::count) {
+        if (auto count = toOffset(value)) {
+            count_ = *count;
+            return true;
+        }
+    } else if (key == reader::option::stride) {
+        if (auto stride = toOffset(value)) {
+            stride_ = *stride;
+            return true;
+        }
+    } else if (key == videoreader::option::stream) {
+        if (const auto* stream = std::any_cast<int>(&value)) {
+            stream_ = *stream;
+            return true;
+        }
+    }
+    return false;
+}
+
+std::any FFmpegLayerSequenceReader::getOption(std::string_view key) {
+    if (key == reader::option::index) {
+        return index_;
+    } else if (key == reader::option::count) {
+        return count_;
+    } else if (key == reader::option::stride) {
+        return stride_;
+    } else if (key == videoreader::option::stream) {
+        return stream_;
+    }
+    return std::any{};
+}
+
+}  // namespace inviwo

--- a/modules/ffmpeg/src/ffmpegvideoreader.cpp
+++ b/modules/ffmpeg/src/ffmpegvideoreader.cpp
@@ -68,8 +68,8 @@ constexpr std::array<std::pair<std::string_view, std::string_view>, 17> videoExt
 // descriptions to be able to register for the same file extensions
 void addVideoExtensions(DataReader& reader, std::string_view suffix) {
     for (auto&& [extension, description] : videoExtensions) {
-        reader.addExtension(
-            FileExtension{LCString{extension}, fmt::format("{}{}", description, suffix)});
+        reader.addExtension(FileExtension{.extension = LCString{extension},
+                                          .description = fmt::format("{}{}", description, suffix)});
     }
 }
 
@@ -80,6 +80,16 @@ std::optional<std::ptrdiff_t> toOffset(const std::any& value) {
         return static_cast<std::ptrdiff_t>(*integer);
     } else if (const auto* unsignedSize = std::any_cast<size_t>(&value)) {
         return static_cast<std::ptrdiff_t>(*unsignedSize);
+    }
+    return std::nullopt;
+}
+
+/// Accept both a chrono duration and a plain number of seconds
+std::optional<FFmpegLayerReader::Seconds> toSeconds(const std::any& value) {
+    if (const auto* seconds = std::any_cast<FFmpegLayerReader::Seconds>(&value)) {
+        return *seconds;
+    } else if (const auto* number = std::any_cast<double>(&value)) {
+        return FFmpegLayerReader::Seconds{*number};
     }
     return std::nullopt;
 }
@@ -118,7 +128,7 @@ bool FFmpegLayerReader::setOption(std::string_view key, std::any value) {
             return true;
         }
     } else if (key == videoreader::option::time) {
-        if (const auto* time = std::any_cast<double>(&value)) {
+        if (auto time = toSeconds(value)) {
             time_ = *time;
             return true;
         }

--- a/modules/ffmpeg/src/outputstream.cpp
+++ b/modules/ffmpeg/src/outputstream.cpp
@@ -40,64 +40,64 @@ extern "C" {
 
 namespace inviwo::ffmpeg {
 
-OutputStream::OutputStream(Format& format, Options opts)
+OutputStream::OutputStream(OutputContext& format, Options opts)
     : sourceFormat{opts.sourceFormat}
-    , codec{opts.codecId ? opts.codecId : format.outputFormat().defaultVideoCodec()}
+    , encoder{opts.codecId ? opts.codecId : format.outputFormat().defaultVideoCodec()}
     , stream{format.newStream()}
     , tmpFrame{std::nullopt}
     , scaler{std::nullopt} {
 
     stream->id = format.ctx->nb_streams - 1;
 
-    codec.ctx->bit_rate = opts.bitRate;
+    encoder.ctx->bit_rate = opts.bitRate;
 
-    codec.ctx->width = opts.width;
-    codec.ctx->height = opts.height;
+    encoder.ctx->width = opts.width;
+    encoder.ctx->height = opts.height;
 
     /* timebase: This is the fundamental unit of time (in seconds) in terms
      * of which frame timestamps are represented. For fixed-fps content,
      * timebase should be 1/frameRate and timestamp increments should be
      * identical to 1. */
     stream->time_base = AVRational{1, opts.frameRate};
-    codec.ctx->time_base = stream->time_base;
+    encoder.ctx->time_base = stream->time_base;
 
-    codec.ctx->gop_size = 12; /* emit one intra frame every twelve frames at most */
+    encoder.ctx->gop_size = 12; /* emit one intra frame every twelve frames at most */
 
     // Dynamically select the best pixel format the codec supports,
     // minimizing conversion loss from the source format (e.g., AV_PIX_FMT_RGBA).
     const enum AVPixelFormat* formats = nullptr;
-    avcodec_get_supported_config(codec.ctx, nullptr, AVCodecConfig::AV_CODEC_CONFIG_PIX_FORMAT, 0,
+    avcodec_get_supported_config(encoder.ctx, nullptr, AVCodecConfig::AV_CODEC_CONFIG_PIX_FORMAT, 0,
                                  reinterpret_cast<const void**>(&formats), nullptr);
     if (formats) {
-        codec.ctx->pix_fmt = avcodec_find_best_pix_fmt_of_list(formats, sourceFormat, 0, nullptr);
+        encoder.ctx->pix_fmt = avcodec_find_best_pix_fmt_of_list(formats, sourceFormat, 0, nullptr);
     } else {
-        codec.ctx->pix_fmt = AV_PIX_FMT_YUV420P;  // safe fallback
+        encoder.ctx->pix_fmt = AV_PIX_FMT_YUV420P;  // safe fallback
     }
 
-    if (codec.ctx->codec_id == AV_CODEC_ID_MPEG2VIDEO) {
+    if (encoder.ctx->codec_id == AV_CODEC_ID_MPEG2VIDEO) {
         /* just for testing, we also add B-frames */
-        codec.ctx->max_b_frames = 2;
+        encoder.ctx->max_b_frames = 2;
     }
-    if (codec.ctx->codec_id == AV_CODEC_ID_MPEG1VIDEO) {
+    if (encoder.ctx->codec_id == AV_CODEC_ID_MPEG1VIDEO) {
         /* Needed to avoid using macroblocks in which
          * some coeffs overflow. This does not happen
          * with normal video, it just happens here as
          * the motion of the chroma plane does not
          * match the luma plane. */
-        codec.ctx->mb_decision = 2;
+        encoder.ctx->mb_decision = 2;
     }
 
     /* Some formats want stream headers to be separate. */
     if (format.ctx->oformat->flags & AVFMT_GLOBALHEADER) {
-        codec.ctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+        encoder.ctx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
     }
 }
 
 void OutputStream::openVideo(AVDictionary* opt_arg) {
-    codec.open(opt_arg);
+    encoder.open(opt_arg);
 
     /* copy the stream parameters to the muxer */
-    if (auto ret = avcodec_parameters_from_context(stream->codecpar, codec.ctx); ret < 0) {
+    if (auto ret = avcodec_parameters_from_context(stream->codecpar, encoder.ctx); ret < 0) {
         throw Exception(SourceContext{}, "Could not copy the stream parameters: {}", Error{ret});
     }
 }
@@ -109,21 +109,21 @@ Frame* OutputStream::fillFrame(Frame& dst,
      * internally; make sure we do not overwrite it here */
     dst.makeWritable();
 
-    if (codec.ctx->pix_fmt != sourceFormat) {
+    if (encoder.ctx->pix_fmt != sourceFormat) {
         if (!scaler) {
-            scaler.emplace(codec.ctx->width, codec.ctx->height, sourceFormat, codec.ctx->width,
-                           codec.ctx->height, codec.ctx->pix_fmt, SWS_BICUBIC, nullptr, nullptr,
-                           nullptr);
+            scaler.emplace(encoder.ctx->width, encoder.ctx->height, sourceFormat,
+                           encoder.ctx->width, encoder.ctx->height, encoder.ctx->pix_fmt,
+                           SWS_BICUBIC, nullptr, nullptr, nullptr);
         }
         if (!tmpFrame) {
-            tmpFrame.emplace(sourceFormat, codec.ctx->width, codec.ctx->height);
+            tmpFrame.emplace(sourceFormat, encoder.ctx->width, encoder.ctx->height);
         }
 
-        filler(tmpFrame->frame, codec.ctx->width, codec.ctx->height);
+        filler(tmpFrame->frame, encoder.ctx->width, encoder.ctx->height);
         scaler->scale((const uint8_t* const*)tmpFrame->frame->data, tmpFrame->frame->linesize, 0,
-                      codec.ctx->height, dst.frame->data, dst.frame->linesize);
+                      encoder.ctx->height, dst.frame->data, dst.frame->linesize);
     } else {
-        filler(dst.frame, codec.ctx->width, codec.ctx->height);
+        filler(dst.frame, encoder.ctx->width, encoder.ctx->height);
     }
 
     return &dst;

--- a/modules/ffmpeg/src/processors/movieexport.cpp
+++ b/modules/ffmpeg/src/processors/movieexport.cpp
@@ -171,7 +171,7 @@ void MovieExport::process() {
         notifyObserversStartBackgroundWork(this, 1);
 
         log::info("Recording to: {}", file_.get());
-        log::info("  - Format:   {}", recorder->getFormat().outputFormat().desc());
+        log::info("  - Format:   {}", recorder->getOutputContext().outputFormat().desc());
         log::info("  - Codec:    {}", recorder->getStream().encoder.codecID());
     }
 

--- a/modules/ffmpeg/src/processors/movieexport.cpp
+++ b/modules/ffmpeg/src/processors/movieexport.cpp
@@ -34,9 +34,9 @@
 #include <inviwo/core/util/glmvec.h>
 #include <inviwo/core/util/threadutil.h>
 
-#include <inviwo/ffmpeg/wrap/codec.h>
+#include <inviwo/ffmpeg/wrap/encoder.h>
 #include <inviwo/ffmpeg/wrap/codecid.h>
-#include <inviwo/ffmpeg/wrap/format.h>
+#include <inviwo/ffmpeg/wrap/outputcontext.h>
 #include <inviwo/ffmpeg/wrap/frame.h>
 #include <inviwo/ffmpeg/wrap/outputformat.h>
 #include <inviwo/ffmpeg/wrap/packet.h>
@@ -172,7 +172,7 @@ void MovieExport::process() {
 
         log::info("Recording to: {}", file_.get());
         log::info("  - Format:   {}", recorder->getFormat().outputFormat().desc());
-        log::info("  - Codec:    {}", recorder->getStream().codec.codecID());
+        log::info("  - Codec:    {}", recorder->getStream().encoder.codecID());
     }
 
     if (recorder) {

--- a/modules/ffmpeg/src/recorder.cpp
+++ b/modules/ffmpeg/src/recorder.cpp
@@ -103,7 +103,7 @@ Recorder::~Recorder() {
 }
 
 const OutputStream& Recorder::getStream() { return stream; }
-const OutputContext& Recorder::getFormat() { return out; }
+const OutputContext& Recorder::getOutputContext() { return out; }
 
 void Recorder::queueFrame(const LayerRAM& layer) {
     std::optional<Frame> frame;

--- a/modules/ffmpeg/src/recorder.cpp
+++ b/modules/ffmpeg/src/recorder.cpp
@@ -43,17 +43,18 @@ namespace inviwo::ffmpeg {
 
 namespace {
 
-bool writeFrame(Format& format, Codec& codec, AVStream* st, const Frame& frame, Packet& pkt) {
+bool writeFrame(OutputContext& format, Encoder& encoder, AVStream* st, const Frame& frame,
+                Packet& pkt) {
     // send the frame to the encoder
-    codec.sendFrame(frame);
+    encoder.sendFrame(frame);
 
     int ret = 0;
     while (ret >= 0) {
-        ret = codec.receivePacket(pkt);
+        ret = encoder.receivePacket(pkt);
         if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) break;
 
         // rescale output packet timestamp values from codec to stream timebase
-        av_packet_rescale_ts(pkt.pkt, codec.ctx->time_base, st->time_base);
+        av_packet_rescale_ts(pkt.pkt, encoder.ctx->time_base, st->time_base);
         pkt.pkt->stream_index = st->index;
 
         // Write the compressed frame to the media file.
@@ -102,7 +103,7 @@ Recorder::~Recorder() {
 }
 
 const OutputStream& Recorder::getStream() { return stream; }
-const Format& Recorder::getFormat() { return out; }
+const OutputContext& Recorder::getFormat() { return out; }
 
 void Recorder::queueFrame(const LayerRAM& layer) {
     std::optional<Frame> frame;
@@ -117,8 +118,8 @@ void Recorder::queueFrame(const LayerRAM& layer) {
             frame.emplace(std::move(unused_.back()));
             unused_.pop_back();
         } else if (queue_.size() < 30) {
-            frame.emplace(stream.codec.ctx->pix_fmt, stream.codec.ctx->width,
-                          stream.codec.ctx->height);
+            frame.emplace(stream.encoder.ctx->pix_fmt, stream.encoder.ctx->width,
+                          stream.encoder.ctx->height);
         } else {
             log::info("Queue saturated");
         }
@@ -214,7 +215,7 @@ void Recorder::run() {
                 }
 
                 frame.frame->pts = frameCount++;
-                writeFrame(out, stream.codec, stream.stream, frame, pkt);
+                writeFrame(out, stream.encoder, stream.stream, frame, pkt);
                 next += frameTime;
             }
 
@@ -232,12 +233,12 @@ void Recorder::run() {
                 }
 
                 frame.frame->pts = frameCount++;
-                writeFrame(out, stream.codec, stream.stream, frame, pkt);
+                writeFrame(out, stream.encoder, stream.stream, frame, pkt);
             }
         }
 
         // Flush the encoder
-        writeFrame(out, stream.codec, stream.stream, Frame{}, pkt);
+        writeFrame(out, stream.encoder, stream.stream, Frame{}, pkt);
 
         out.writeTrailer();
 

--- a/modules/ffmpeg/src/video.cpp
+++ b/modules/ffmpeg/src/video.cpp
@@ -44,7 +44,9 @@ extern "C" {
 #include <libswscale/swscale.h>
 }
 
+#include <array>
 #include <cmath>
+#include <limits>
 
 #include <fmt/std.h>
 
@@ -67,11 +69,11 @@ Target targetFor(enum AVPixelFormat source) {
     const bool deep = desc && desc->comp[0].depth > 8;
 
     if (gray) {
-        return deep ? Target{AV_PIX_FMT_GRAY16, DataUInt16::get()}
-                    : Target{AV_PIX_FMT_GRAY8, DataUInt8::get()};
+        return deep ? Target{.pixelFormat = AV_PIX_FMT_GRAY16, .format = DataUInt16::get()}
+                    : Target{.pixelFormat = AV_PIX_FMT_GRAY8, .format = DataUInt8::get()};
     } else {
-        return deep ? Target{AV_PIX_FMT_RGBA64, DataVec4UInt16::get()}
-                    : Target{AV_PIX_FMT_RGBA, DataVec4UInt8::get()};
+        return deep ? Target{.pixelFormat = AV_PIX_FMT_RGBA64, .format = DataVec4UInt16::get()}
+                    : Target{.pixelFormat = AV_PIX_FMT_RGBA, .format = DataVec4UInt8::get()};
     }
 }
 
@@ -86,12 +88,13 @@ Video::Video(const std::filesystem::path& filename, int streamIndex)
     , stream_{input_.stream(streamIndex_)}
     , decoder_{stream_}
     , packet_{}
-    , frame_{Frame::alloc()}
+    , frame_{Frame::NoBuffers{}}
     , scaler_{std::nullopt}
     , scalerSourceFormat_{AV_PIX_FMT_NONE}
     , targetFormat_{AV_PIX_FMT_NONE}
     , info_{}
     , current_{-1}
+    , pending_{std::numeric_limits<std::ptrdiff_t>::min()}
     , draining_{false} {
 
     const auto* codecpar = stream_->codecpar;
@@ -120,15 +123,17 @@ Video::Video(const std::filesystem::path& filename, int streamIndex)
     }
 
     if (stream_->duration != AV_NOPTS_VALUE && stream_->duration > 0) {
-        info_.duration = static_cast<double>(stream_->duration) * av_q2d(stream_->time_base);
+        info_.duration =
+            Seconds{static_cast<double>(stream_->duration) * av_q2d(stream_->time_base)};
     } else if (input_.ctx->duration != AV_NOPTS_VALUE && input_.ctx->duration > 0) {
-        info_.duration = static_cast<double>(input_.ctx->duration) / AV_TIME_BASE;
+        info_.duration = Seconds{static_cast<double>(input_.ctx->duration) / AV_TIME_BASE};
     }
 
     if (stream_->nb_frames > 0) {
         info_.frames = static_cast<std::ptrdiff_t>(stream_->nb_frames);
-    } else if (info_.duration > 0.0) {
-        info_.frames = static_cast<std::ptrdiff_t>(std::llround(info_.duration * info_.frameRate));
+    } else if (info_.duration.count() > 0.0) {
+        info_.frames =
+            static_cast<std::ptrdiff_t>(std::llround(info_.duration.count() * info_.frameRate));
     }
 
     info_.dimensions = size2_t{codecpar->width, codecpar->height};
@@ -142,14 +147,22 @@ const Video::Info& Video::info() const { return info_; }
 const std::filesystem::path& Video::filename() const { return input_.filename; }
 int Video::streamIndex() const { return streamIndex_; }
 
-std::ptrdiff_t Video::frameAt(double time) const {
-    return static_cast<std::ptrdiff_t>(std::llround(time * info_.frameRate));
+std::ptrdiff_t Video::frameAt(Seconds time) const {
+    return static_cast<std::ptrdiff_t>(std::llround(time.count() * info_.frameRate));
 }
+
+Video::Seconds Video::timeOf(std::ptrdiff_t index) const {
+    return Seconds{static_cast<double>(index) / info_.frameRate};
+}
+
+std::ptrdiff_t Video::currentFrame() const { return current_; }
+
+Video::Seconds Video::currentTime() const { return timeOf(current_); }
 
 int64_t Video::timestampOf(std::ptrdiff_t index) const {
     const int64_t start = stream_->start_time != AV_NOPTS_VALUE ? stream_->start_time : 0;
-    const double seconds = static_cast<double>(index) / info_.frameRate;
-    return start + std::llround(seconds / av_q2d(stream_->time_base));
+    const auto seconds = timeOf(index);
+    return start + std::llround(seconds.count() / av_q2d(stream_->time_base));
 }
 
 std::ptrdiff_t Video::indexOfCurrentFrame() const {
@@ -194,12 +207,20 @@ void Video::seekToFrame(std::ptrdiff_t index) {
     decoder_.reset();
     draining_ = false;
     current_ = index - 1;
+    pending_ = index;
 }
 
+void Video::seekToTime(Seconds time) { seekToFrame(frameAt(time)); }
+
 std::shared_ptr<Layer> Video::readNextFrame(std::shared_ptr<Layer> reuse) {
-    if (!decodeNextFrame()) return nullptr;
-    current_ = indexOfCurrentFrame();
-    return toLayer(std::move(reuse));
+    while (decodeNextFrame()) {
+        current_ = indexOfCurrentFrame();
+        if (current_ >= pending_) {
+            pending_ = std::numeric_limits<std::ptrdiff_t>::min();
+            return toLayer(std::move(reuse));
+        }
+    }
+    return nullptr;
 }
 
 std::shared_ptr<Layer> Video::readFrame(std::ptrdiff_t index, std::shared_ptr<Layer> reuse) {
@@ -222,15 +243,9 @@ std::shared_ptr<Layer> Video::readFrame(std::ptrdiff_t index, std::shared_ptr<La
     if (target < next || target > next + maxForwardDecode) {
         seekToFrame(target);
     }
+    pending_ = target;
 
-    while (decodeNextFrame()) {
-        current_ = indexOfCurrentFrame();
-        if (current_ >= target) {
-            return toLayer(std::move(reuse));
-        }
-    }
-
-    return nullptr;
+    return readNextFrame(std::move(reuse));
 }
 
 std::shared_ptr<Layer> Video::toLayer(std::shared_ptr<Layer> reuse) {
@@ -256,27 +271,32 @@ std::shared_ptr<Layer> Video::toLayer(std::shared_ptr<Layer> reuse) {
 
     auto* ram = layer->getEditableRepresentation<LayerRAM>();
     auto* data = static_cast<uint8_t*>(ram->getData());
+
+    // All four target pixel formats, GRAY8, GRAY16, RGBA, and RGBA64, are single plane and packed,
+    // so only plane 0 is used. getSizeInBytes() accounts for both the component size and the
+    // number of channels.
     const auto stride = static_cast<int>(info_.dimensions.x * info_.format->getSizeInBytes());
 
     // Layers have their origin in the lower left corner, ffmpeg frames are top-down. Flip by
     // starting at the last row and using a negative stride.
-    uint8_t* dst[4] = {data + static_cast<std::ptrdiff_t>(height - 1) * stride, nullptr, nullptr,
-                       nullptr};
-    const int dstStride[4] = {-stride, 0, 0, 0};
+    const std::array<uint8_t*, 4> dst{data + static_cast<std::ptrdiff_t>(height - 1) * stride,
+                                      nullptr, nullptr, nullptr};
+    const std::array<int, 4> dstStride{-stride, 0, 0, 0};
 
-    scaler_->scale(frame_.frame->data, frame_.frame->linesize, 0, frame_.frame->height, dst,
-                   dstStride);
+    scaler_->scale(frame_.frame->data, frame_.frame->linesize, 0, frame_.frame->height, dst.data(),
+                   dstStride.data());
 
     const auto pts = frame_.frame->best_effort_timestamp;
     const int64_t start = stream_->start_time != AV_NOPTS_VALUE ? stream_->start_time : 0;
-    const double time = pts != AV_NOPTS_VALUE
-                            ? static_cast<double>(pts - start) * av_q2d(stream_->time_base)
-                            : static_cast<double>(current_) / info_.frameRate;
+    const auto time = pts != AV_NOPTS_VALUE
+                          ? Seconds{static_cast<double>(pts - start) * av_q2d(stream_->time_base)}
+                          : timeOf(current_);
 
+    layer->setMetaData<StringMetaData>("filename", input_.filename.generic_string());
     layer->setMetaData<IntMetaData>("frameIndex", static_cast<int>(current_));
     layer->setMetaData<IntMetaData>("frameCount", static_cast<int>(info_.frames));
     layer->setMetaData<DoubleMetaData>("frameRate", info_.frameRate);
-    layer->setMetaData<DoubleMetaData>("time", time);
+    layer->setMetaData<DoubleMetaData>("time", time.count());
 
     return layer;
 }

--- a/modules/ffmpeg/src/video.cpp
+++ b/modules/ffmpeg/src/video.cpp
@@ -1,0 +1,284 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2026 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/ffmpeg/video.h>
+
+#include <inviwo/ffmpeg/wrap/codecid.h>
+
+#include <inviwo/core/datastructures/image/layer.h>
+#include <inviwo/core/datastructures/image/layerram.h>
+#include <inviwo/core/metadata/metadata.h>
+#include <inviwo/core/util/exception.h>
+#include <inviwo/core/util/formats.h>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/pixdesc.h>
+#include <libswscale/swscale.h>
+}
+
+#include <cmath>
+
+#include <fmt/std.h>
+
+namespace inviwo::ffmpeg {
+
+namespace {
+
+struct Target {
+    enum AVPixelFormat pixelFormat;
+    const DataFormatBase* format;
+};
+
+/**
+ * Pick the Layer format that matches @p source as closely as possible, and the pixel format
+ * swscale should convert to in order to fill it.
+ */
+Target targetFor(enum AVPixelFormat source) {
+    const AVPixFmtDescriptor* desc = av_pix_fmt_desc_get(source);
+    const bool gray = desc && desc->nb_components == 1;
+    const bool deep = desc && desc->comp[0].depth > 8;
+
+    if (gray) {
+        return deep ? Target{AV_PIX_FMT_GRAY16, DataUInt16::get()}
+                    : Target{AV_PIX_FMT_GRAY8, DataUInt8::get()};
+    } else {
+        return deep ? Target{AV_PIX_FMT_RGBA64, DataVec4UInt16::get()}
+                    : Target{AV_PIX_FMT_RGBA, DataVec4UInt8::get()};
+    }
+}
+
+/// Number of frames we decode past the current position before we resort to seeking
+constexpr std::ptrdiff_t maxForwardDecode = 60;
+
+}  // namespace
+
+Video::Video(const std::filesystem::path& filename, int streamIndex)
+    : input_{filename}
+    , streamIndex_{streamIndex >= 0 ? streamIndex : input_.bestVideoStream()}
+    , stream_{input_.stream(streamIndex_)}
+    , decoder_{stream_}
+    , packet_{}
+    , frame_{Frame::alloc()}
+    , scaler_{std::nullopt}
+    , scalerSourceFormat_{AV_PIX_FMT_NONE}
+    , targetFormat_{AV_PIX_FMT_NONE}
+    , info_{}
+    , current_{-1}
+    , draining_{false} {
+
+    const auto* codecpar = stream_->codecpar;
+    if (codecpar->codec_type != AVMEDIA_TYPE_VIDEO) {
+        throw Exception(SourceContext{}, "Stream {} of '{}' is not a video stream", streamIndex_,
+                        input_.filename);
+    }
+    if (codecpar->width <= 0 || codecpar->height <= 0) {
+        throw Exception(SourceContext{}, "Stream {} of '{}' has invalid dimensions {}x{}",
+                        streamIndex_, input_.filename, codecpar->width, codecpar->height);
+    }
+
+    const auto source = codecpar->format != AV_PIX_FMT_NONE
+                            ? static_cast<enum AVPixelFormat>(codecpar->format)
+                            : decoder_.pixelFormat();
+    const auto target = targetFor(source);
+    targetFormat_ = target.pixelFormat;
+
+    auto rate = stream_->avg_frame_rate;
+    if (rate.num <= 0 || rate.den <= 0) {
+        rate = av_guess_frame_rate(input_.ctx, stream_, nullptr);
+    }
+    info_.frameRate = av_q2d(rate);
+    if (!(info_.frameRate > 0.0)) {
+        info_.frameRate = 25.0;
+    }
+
+    if (stream_->duration != AV_NOPTS_VALUE && stream_->duration > 0) {
+        info_.duration = static_cast<double>(stream_->duration) * av_q2d(stream_->time_base);
+    } else if (input_.ctx->duration != AV_NOPTS_VALUE && input_.ctx->duration > 0) {
+        info_.duration = static_cast<double>(input_.ctx->duration) / AV_TIME_BASE;
+    }
+
+    if (stream_->nb_frames > 0) {
+        info_.frames = static_cast<std::ptrdiff_t>(stream_->nb_frames);
+    } else if (info_.duration > 0.0) {
+        info_.frames = static_cast<std::ptrdiff_t>(std::llround(info_.duration * info_.frameRate));
+    }
+
+    info_.dimensions = size2_t{codecpar->width, codecpar->height};
+    info_.format = target.format;
+    info_.codec = CodecID{codecpar->codec_id}.name();
+}
+
+Video::~Video() = default;
+
+const Video::Info& Video::info() const { return info_; }
+const std::filesystem::path& Video::filename() const { return input_.filename; }
+int Video::streamIndex() const { return streamIndex_; }
+
+std::ptrdiff_t Video::frameAt(double time) const {
+    return static_cast<std::ptrdiff_t>(std::llround(time * info_.frameRate));
+}
+
+int64_t Video::timestampOf(std::ptrdiff_t index) const {
+    const int64_t start = stream_->start_time != AV_NOPTS_VALUE ? stream_->start_time : 0;
+    const double seconds = static_cast<double>(index) / info_.frameRate;
+    return start + std::llround(seconds / av_q2d(stream_->time_base));
+}
+
+std::ptrdiff_t Video::indexOfCurrentFrame() const {
+    auto pts = frame_.frame->best_effort_timestamp;
+    if (pts == AV_NOPTS_VALUE) {
+        pts = frame_.frame->pts;
+    }
+    if (pts == AV_NOPTS_VALUE) {
+        return current_ + 1;
+    }
+    const int64_t start = stream_->start_time != AV_NOPTS_VALUE ? stream_->start_time : 0;
+    const double seconds = static_cast<double>(pts - start) * av_q2d(stream_->time_base);
+    return static_cast<std::ptrdiff_t>(std::llround(seconds * info_.frameRate));
+}
+
+bool Video::decodeNextFrame() {
+    while (true) {
+        const auto ret = decoder_.receiveFrame(frame_);
+        if (ret == 0) return true;
+        if (ret == AVERROR_EOF) return false;
+
+        // AVERROR(EAGAIN), the decoder needs more input
+        if (draining_) return false;
+
+        bool sent = false;
+        while (input_.readPacket(packet_)) {
+            if (packet_.pkt->stream_index == streamIndex_) {
+                decoder_.sendPacket(packet_);
+                sent = true;
+                break;
+            }
+        }
+        if (!sent) {
+            decoder_.flush();
+            draining_ = true;
+        }
+    }
+}
+
+void Video::seekToFrame(std::ptrdiff_t index) {
+    input_.seek(streamIndex_, timestampOf(index));
+    decoder_.reset();
+    draining_ = false;
+    current_ = index - 1;
+}
+
+std::shared_ptr<Layer> Video::readNextFrame(std::shared_ptr<Layer> reuse) {
+    if (!decodeNextFrame()) return nullptr;
+    current_ = indexOfCurrentFrame();
+    return toLayer(std::move(reuse));
+}
+
+std::shared_ptr<Layer> Video::readFrame(std::ptrdiff_t index, std::shared_ptr<Layer> reuse) {
+    auto target = index;
+    if (target < 0) {
+        if (info_.frames <= 0) {
+            throw RangeException(SourceContext{},
+                                 "Cannot use a negative frame index, the number of frames in '{}' "
+                                 "is unknown",
+                                 input_.filename);
+        }
+        target += info_.frames;
+    }
+    if (target < 0 || (info_.frames > 0 && target >= info_.frames)) {
+        throw RangeException(SourceContext{}, "Frame index {} is out of range, '{}' has {} frames",
+                             index, input_.filename, info_.frames);
+    }
+
+    const auto next = current_ + 1;
+    if (target < next || target > next + maxForwardDecode) {
+        seekToFrame(target);
+    }
+
+    while (decodeNextFrame()) {
+        current_ = indexOfCurrentFrame();
+        if (current_ >= target) {
+            return toLayer(std::move(reuse));
+        }
+    }
+
+    return nullptr;
+}
+
+std::shared_ptr<Layer> Video::toLayer(std::shared_ptr<Layer> reuse) {
+    const auto width = static_cast<int>(info_.dimensions.x);
+    const auto height = static_cast<int>(info_.dimensions.y);
+    const auto source = static_cast<enum AVPixelFormat>(frame_.frame->format);
+
+    if (!scaler_ || scalerSourceFormat_ != source) {
+        scaler_.emplace(frame_.frame->width, frame_.frame->height, source, width, height,
+                        targetFormat_, SWS_BICUBIC, nullptr, nullptr, nullptr);
+        scalerSourceFormat_ = source;
+    }
+
+    auto layer = [&]() {
+        if (reuse && reuse->getDataFormat() == info_.format &&
+            reuse->getDimensions() == info_.dimensions &&
+            reuse->getLayerType() == LayerType::Color) {
+            return reuse;
+        }
+        return std::make_shared<Layer>(info_.dimensions, info_.format, LayerType::Color,
+                                       swizzlemasks::defaultColor(info_.format->getComponents()));
+    }();
+
+    auto* ram = layer->getEditableRepresentation<LayerRAM>();
+    auto* data = static_cast<uint8_t*>(ram->getData());
+    const auto stride = static_cast<int>(info_.dimensions.x * info_.format->getSizeInBytes());
+
+    // Layers have their origin in the lower left corner, ffmpeg frames are top-down. Flip by
+    // starting at the last row and using a negative stride.
+    uint8_t* dst[4] = {data + static_cast<std::ptrdiff_t>(height - 1) * stride, nullptr, nullptr,
+                       nullptr};
+    const int dstStride[4] = {-stride, 0, 0, 0};
+
+    scaler_->scale(frame_.frame->data, frame_.frame->linesize, 0, frame_.frame->height, dst,
+                   dstStride);
+
+    const auto pts = frame_.frame->best_effort_timestamp;
+    const int64_t start = stream_->start_time != AV_NOPTS_VALUE ? stream_->start_time : 0;
+    const double time = pts != AV_NOPTS_VALUE
+                            ? static_cast<double>(pts - start) * av_q2d(stream_->time_base)
+                            : static_cast<double>(current_) / info_.frameRate;
+
+    layer->setMetaData<IntMetaData>("frameIndex", static_cast<int>(current_));
+    layer->setMetaData<IntMetaData>("frameCount", static_cast<int>(info_.frames));
+    layer->setMetaData<DoubleMetaData>("frameRate", info_.frameRate);
+    layer->setMetaData<DoubleMetaData>("time", time);
+
+    return layer;
+}
+
+}  // namespace inviwo::ffmpeg

--- a/modules/ffmpeg/src/video.cpp
+++ b/modules/ffmpeg/src/video.cpp
@@ -269,6 +269,15 @@ std::shared_ptr<Layer> Video::toLayer(std::shared_ptr<Layer> reuse) {
                                        swizzlemasks::defaultColor(info_.format->getComponents()));
     }();
 
+    // Preserve the aspect ratio of the video, normalizing the larger dimension to 1
+    glm::dmat3 basis{1.0};
+    if (info_.dimensions.x < info_.dimensions.y) {
+        basis[0][0] = static_cast<double>(info_.dimensions.x) / static_cast<double>(info_.dimensions.y);
+    } else {
+        basis[1][1] = static_cast<double>(info_.dimensions.y) / static_cast<double>(info_.dimensions.x);
+    }
+    layer->setBasis(basis);
+
     auto* ram = layer->getEditableRepresentation<LayerRAM>();
     auto* data = static_cast<uint8_t*>(ram->getData());
 

--- a/modules/ffmpeg/src/wrap/decoder.cpp
+++ b/modules/ffmpeg/src/wrap/decoder.cpp
@@ -1,0 +1,99 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2026 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/ffmpeg/wrap/decoder.h>
+
+#include <inviwo/core/util/exception.h>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+}
+
+namespace inviwo::ffmpeg {
+
+Decoder::Decoder(const AVStream* stream) : ctx{nullptr} {
+    const CodecID codecId{stream->codecpar->codec_id};
+    const AVCodec* codec = avcodec_find_decoder(codecId.id);
+    if (!codec) {
+        throw Exception(SourceContext{}, "Could not find decoder for '{}'", codecId.name());
+    }
+
+    ctx = avcodec_alloc_context3(codec);
+    if (!ctx) {
+        throw Exception(SourceContext{}, "Could not alloc a decoding context");
+    }
+
+    if (auto ret = avcodec_parameters_to_context(ctx, stream->codecpar); ret < 0) {
+        avcodec_free_context(&ctx);
+        throw Exception(SourceContext{}, "Could not copy the stream parameters: {}", Error{ret});
+    }
+
+    ctx->pkt_timebase = stream->time_base;
+    ctx->thread_count = 0;  // let ffmpeg pick the thread count
+
+    if (auto ret = avcodec_open2(ctx, codec, nullptr); ret < 0) {
+        avcodec_free_context(&ctx);
+        throw Exception(SourceContext{}, "Could not open video codec '{}': {}", codecId.name(),
+                        Error{ret});
+    }
+}
+
+Decoder::~Decoder() { avcodec_free_context(&ctx); }
+
+void Decoder::sendPacket(const Packet& pkt) {
+    if (auto ret = avcodec_send_packet(ctx, pkt.pkt); ret < 0) {
+        throw Exception(SourceContext{}, "Error sending a packet to the decoder: {}", Error{ret});
+    }
+}
+
+void Decoder::flush() {
+    if (auto ret = avcodec_send_packet(ctx, nullptr); ret < 0) {
+        throw Exception(SourceContext{}, "Error flushing the decoder: {}", Error{ret});
+    }
+}
+
+int Decoder::receiveFrame(Frame& frame) {
+    auto ret = avcodec_receive_frame(ctx, frame.frame);
+    if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) return ret;
+
+    if (ret < 0) {
+        throw Exception(SourceContext{}, "Error decoding a frame: {}", Error{ret});
+    }
+    return ret;
+}
+
+void Decoder::reset() { avcodec_flush_buffers(ctx); }
+
+CodecID Decoder::codecID() const { return ctx->codec_id; }
+int Decoder::width() const { return ctx->width; }
+int Decoder::height() const { return ctx->height; }
+enum AVPixelFormat Decoder::pixelFormat() const { return ctx->pix_fmt; }
+
+}  // namespace inviwo::ffmpeg

--- a/modules/ffmpeg/src/wrap/decoder.cpp
+++ b/modules/ffmpeg/src/wrap/decoder.cpp
@@ -67,19 +67,19 @@ Decoder::Decoder(const AVStream* stream) : ctx{nullptr} {
 
 Decoder::~Decoder() { avcodec_free_context(&ctx); }
 
-void Decoder::sendPacket(const Packet& pkt) {
+void Decoder::sendPacket(const Packet& pkt) const {
     if (auto ret = avcodec_send_packet(ctx, pkt.pkt); ret < 0) {
         throw Exception(SourceContext{}, "Error sending a packet to the decoder: {}", Error{ret});
     }
 }
 
-void Decoder::flush() {
+void Decoder::flush() const {
     if (auto ret = avcodec_send_packet(ctx, nullptr); ret < 0) {
         throw Exception(SourceContext{}, "Error flushing the decoder: {}", Error{ret});
     }
 }
 
-int Decoder::receiveFrame(Frame& frame) {
+int Decoder::receiveFrame(Frame& frame) const {
     auto ret = avcodec_receive_frame(ctx, frame.frame);
     if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) return ret;
 
@@ -89,7 +89,7 @@ int Decoder::receiveFrame(Frame& frame) {
     return ret;
 }
 
-void Decoder::reset() { avcodec_flush_buffers(ctx); }
+void Decoder::reset() const { avcodec_flush_buffers(ctx); }
 
 CodecID Decoder::codecID() const { return ctx->codec_id; }
 int Decoder::width() const { return ctx->width; }

--- a/modules/ffmpeg/src/wrap/encoder.cpp
+++ b/modules/ffmpeg/src/wrap/encoder.cpp
@@ -26,24 +26,63 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  *********************************************************************************/
-#pragma once
 
-#include <inviwo/ffmpeg/ffmpegmoduledefine.h>
-#include <inviwo/ffmpeg/util.h>
+#include <inviwo/ffmpeg/wrap/encoder.h>
 
-struct AVPacket;
+#include <inviwo/core/util/exception.h>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+}
 
 namespace inviwo::ffmpeg {
 
-class IVW_MODULE_FFMPEG_API Packet : NoMoveCopy {
-public:
-    Packet();
-    ~Packet();
+Encoder::Encoder(const AVCodec* codec) : ctx{avcodec_alloc_context3(codec)} {
+    if (!ctx) {
+        throw Exception(SourceContext{}, "Could not alloc an encoding context");
+    }
+}
 
-    /// Release any data referenced by the packet and reset it to its default state
-    void unref();
+Encoder::Encoder(CodecID codecId) : Encoder{findEncoder(codecId.id)} {}
 
-    AVPacket* pkt;
-};
+Encoder::~Encoder() { avcodec_free_context(&ctx); }
+
+void Encoder::open(AVDictionary* opt_arg) {
+    AVDictionary* opt = nullptr;
+    av_dict_copy(&opt, opt_arg, 0);
+
+    /* open the codec */
+    int ret = avcodec_open2(ctx, ctx->codec, &opt);
+
+    av_dict_free(&opt);
+    if (ret < 0) {
+        throw Exception(SourceContext{}, "Could not open video codec: {}", Error{ret});
+    }
+}
+
+void Encoder::sendFrame(const Frame& frame) {
+    if (auto ret = avcodec_send_frame(ctx, frame.frame); ret < 0) {
+        throw Exception(SourceContext{}, "Error sending a frame to the encoder: {}", Error(ret));
+    }
+}
+
+int Encoder::receivePacket(Packet& pkt) {
+    auto ret = avcodec_receive_packet(ctx, pkt.pkt);
+    if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) return ret;
+
+    if (ret < 0) {
+        throw Exception(SourceContext{}, "Error encoding a frame: {}", Error(ret));
+    }
+    return ret;
+}
+CodecID Encoder::codecID() const { return ctx->codec_id; }
+
+const AVCodec* Encoder::findEncoder(CodecID codecId) {
+    auto codec = avcodec_find_encoder(codecId.id);
+    if (!codec) {
+        throw Exception(SourceContext{}, "Could not find encoder for '{}'", codecId.name());
+    }
+    return codec;
+}
 
 }  // namespace inviwo::ffmpeg

--- a/modules/ffmpeg/src/wrap/encoder.cpp
+++ b/modules/ffmpeg/src/wrap/encoder.cpp
@@ -47,7 +47,7 @@ Encoder::Encoder(CodecID codecId) : Encoder{findEncoder(codecId.id)} {}
 
 Encoder::~Encoder() { avcodec_free_context(&ctx); }
 
-void Encoder::open(AVDictionary* opt_arg) {
+void Encoder::open(AVDictionary* opt_arg) const {
     AVDictionary* opt = nullptr;
     av_dict_copy(&opt, opt_arg, 0);
 
@@ -60,13 +60,13 @@ void Encoder::open(AVDictionary* opt_arg) {
     }
 }
 
-void Encoder::sendFrame(const Frame& frame) {
+void Encoder::sendFrame(const Frame& frame) const {
     if (auto ret = avcodec_send_frame(ctx, frame.frame); ret < 0) {
         throw Exception(SourceContext{}, "Error sending a frame to the encoder: {}", Error(ret));
     }
 }
 
-int Encoder::receivePacket(Packet& pkt) {
+int Encoder::receivePacket(Packet& pkt) const {
     auto ret = avcodec_receive_packet(ctx, pkt.pkt);
     if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) return ret;
 

--- a/modules/ffmpeg/src/wrap/frame.cpp
+++ b/modules/ffmpeg/src/wrap/frame.cpp
@@ -40,6 +40,12 @@ namespace inviwo::ffmpeg {
 
 Frame::Frame() : frame{nullptr} {}
 
+Frame::Frame(NoBuffers) : frame{av_frame_alloc()} {
+    if (!frame) {
+        throw inviwo::Exception("Could not allocate frame.");
+    }
+}
+
 Frame::Frame(enum AVPixelFormat pix_fmt, int width, int height) : frame{av_frame_alloc()} {
 
     if (!frame) {
@@ -66,15 +72,6 @@ Frame::~Frame() {
 }
 
 Frame::operator bool() const { return frame != nullptr; }
-
-Frame Frame::alloc() {
-    Frame result{};
-    result.frame = av_frame_alloc();
-    if (!result.frame) {
-        throw inviwo::Exception("Could not allocate frame.");
-    }
-    return result;
-}
 
 void Frame::makeWritable() {
     if (auto ret = av_frame_make_writable(frame); ret < 0) {

--- a/modules/ffmpeg/src/wrap/frame.cpp
+++ b/modules/ffmpeg/src/wrap/frame.cpp
@@ -67,6 +67,15 @@ Frame::~Frame() {
 
 Frame::operator bool() const { return frame != nullptr; }
 
+Frame Frame::alloc() {
+    Frame result{};
+    result.frame = av_frame_alloc();
+    if (!result.frame) {
+        throw inviwo::Exception("Could not allocate frame.");
+    }
+    return result;
+}
+
 void Frame::makeWritable() {
     if (auto ret = av_frame_make_writable(frame); ret < 0) {
         throw inviwo::Exception(SourceContext{}, "Could not make video frame writable {}",

--- a/modules/ffmpeg/src/wrap/inputcontext.cpp
+++ b/modules/ffmpeg/src/wrap/inputcontext.cpp
@@ -37,10 +37,12 @@ extern "C" {
 
 #include <fmt/std.h>
 
+#include <utility>
+
 namespace inviwo::ffmpeg {
 
-InputContext::InputContext(const std::filesystem::path& aFilename)
-    : filename{aFilename}, ctx{nullptr} {
+InputContext::InputContext(std::filesystem::path aFilename)
+    : filename{std::move(aFilename)}, ctx{nullptr} {
 
     if (auto ret = avformat_open_input(&ctx, filename.string().c_str(), nullptr, nullptr);
         ret < 0) {

--- a/modules/ffmpeg/src/wrap/inputcontext.cpp
+++ b/modules/ffmpeg/src/wrap/inputcontext.cpp
@@ -1,0 +1,94 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2026 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <inviwo/ffmpeg/wrap/inputcontext.h>
+
+#include <inviwo/core/util/exception.h>
+
+extern "C" {
+#include <libavformat/avformat.h>
+}
+
+#include <fmt/std.h>
+
+namespace inviwo::ffmpeg {
+
+InputContext::InputContext(const std::filesystem::path& aFilename)
+    : filename{aFilename}, ctx{nullptr} {
+
+    if (auto ret = avformat_open_input(&ctx, filename.string().c_str(), nullptr, nullptr);
+        ret < 0) {
+        throw Exception(SourceContext{}, "Could not open '{}': {}", filename, Error{ret});
+    }
+
+    if (auto ret = avformat_find_stream_info(ctx, nullptr); ret < 0) {
+        avformat_close_input(&ctx);
+        throw Exception(SourceContext{}, "Could not find stream information in '{}': {}", filename,
+                        Error{ret});
+    }
+}
+
+InputContext::~InputContext() { avformat_close_input(&ctx); }
+
+int InputContext::bestVideoStream() const {
+    const auto index = av_find_best_stream(ctx, AVMEDIA_TYPE_VIDEO, -1, -1, nullptr, 0);
+    if (index < 0) {
+        throw Exception(SourceContext{}, "Could not find any video stream in '{}': {}", filename,
+                        Error{index});
+    }
+    return index;
+}
+
+AVStream* InputContext::stream(int index) const {
+    if (index < 0 || index >= nbStreams()) {
+        throw RangeException(SourceContext{}, "Invalid stream index {}, '{}' has {} streams", index,
+                             filename, nbStreams());
+    }
+    return ctx->streams[index];
+}
+
+int InputContext::nbStreams() const { return static_cast<int>(ctx->nb_streams); }
+
+bool InputContext::readPacket(Packet& pkt) {
+    pkt.unref();
+    const auto ret = av_read_frame(ctx, pkt.pkt);
+    if (ret == AVERROR_EOF) return false;
+    if (ret < 0) {
+        throw Exception(SourceContext{}, "Error while reading from '{}': {}", filename, Error{ret});
+    }
+    return true;
+}
+
+void InputContext::seek(int streamIndex, int64_t timestamp) {
+    if (auto ret = av_seek_frame(ctx, streamIndex, timestamp, AVSEEK_FLAG_BACKWARD); ret < 0) {
+        throw Exception(SourceContext{}, "Error while seeking in '{}': {}", filename, Error{ret});
+    }
+}
+
+}  // namespace inviwo::ffmpeg

--- a/modules/ffmpeg/src/wrap/outputcontext.cpp
+++ b/modules/ffmpeg/src/wrap/outputcontext.cpp
@@ -37,17 +37,20 @@ extern "C" {
 
 #include <fmt/std.h>
 
+#include <utility>
+
 namespace inviwo::ffmpeg {
 
-OutputContext::OutputContext(OutputFormat outputFormat, const std::filesystem::path& aFilename)
-    : filename{aFilename} {
+OutputContext::OutputContext(OutputFormat outputFormat, std::filesystem::path aFilename)
+    : filename{std::move(aFilename)}, ctx{nullptr} {
     avformat_alloc_output_context2(&ctx, outputFormat.of, nullptr, filename.string().c_str());
     if (!ctx) {
         throw inviwo::Exception("Could not deduce output format from file extension");
     }
 }
 
-OutputContext::OutputContext(const std::filesystem::path& aFilename) : filename{aFilename} {
+OutputContext::OutputContext(std::filesystem::path aFilename)
+    : filename{std::move(aFilename)}, ctx{nullptr} {
     avformat_alloc_output_context2(&ctx, nullptr, nullptr, filename.string().c_str());
     if (!ctx) {
         throw inviwo::Exception("Could not deduce output format from file extension");
@@ -72,7 +75,7 @@ void OutputContext::open() {
     }
 }
 
-void OutputContext::writeHeader(AVDictionary** options) {
+void OutputContext::writeHeader(AVDictionary** options) const {
     /* Write the stream header, if any. */
     if (auto ret = avformat_write_header(ctx, options); ret < 0) {
         throw inviwo::Exception(SourceContext{}, "Error occurred when writing header, file: {}",
@@ -80,14 +83,14 @@ void OutputContext::writeHeader(AVDictionary** options) {
     }
 }
 
-void OutputContext::writeTrailer() {
+void OutputContext::writeTrailer() const {
     if (auto ret = av_write_trailer(ctx); ret < 0) {
         throw inviwo::Exception(SourceContext{}, "Error occurred when writing trailer, file: {}",
                                 Error{ret});
     }
 }
 
-void OutputContext::writeFrame(const Packet& pkt) {
+void OutputContext::writeFrame(const Packet& pkt) const {
     /* pkt is now blank (av_interleaved_write_frame() takes ownership of
      * its contents and resets pkt), so that no unreferencing is necessary.
      * This would be different if one used av_write_frame(). */
@@ -97,7 +100,7 @@ void OutputContext::writeFrame(const Packet& pkt) {
     }
 }
 
-AVStream* OutputContext::newStream() {
+AVStream* OutputContext::newStream() const {
     AVStream* stream = avformat_new_stream(ctx, nullptr);
     if (!stream) {
         throw inviwo::Exception("Could not allocate AVStream");
@@ -105,7 +108,7 @@ AVStream* OutputContext::newStream() {
     return stream;
 }
 
-int OutputContext::queryCodec(CodecID codecId, std::optional<int> stdCompliance) {
+int OutputContext::queryCodec(CodecID codecId, std::optional<int> stdCompliance) const {
     return avformat_query_codec(ctx->oformat, codecId.id,
                                 stdCompliance.value_or(FF_COMPLIANCE_NORMAL));
 }

--- a/modules/ffmpeg/src/wrap/outputcontext.cpp
+++ b/modules/ffmpeg/src/wrap/outputcontext.cpp
@@ -27,7 +27,7 @@
  *
  *********************************************************************************/
 
-#include <inviwo/ffmpeg/wrap/format.h>
+#include <inviwo/ffmpeg/wrap/outputcontext.h>
 #include <inviwo/core/util/exception.h>
 
 extern "C" {
@@ -39,7 +39,7 @@ extern "C" {
 
 namespace inviwo::ffmpeg {
 
-Format::Format(OutputFormat outputFormat, const std::filesystem::path& aFilename)
+OutputContext::OutputContext(OutputFormat outputFormat, const std::filesystem::path& aFilename)
     : filename{aFilename} {
     avformat_alloc_output_context2(&ctx, outputFormat.of, nullptr, filename.string().c_str());
     if (!ctx) {
@@ -47,14 +47,14 @@ Format::Format(OutputFormat outputFormat, const std::filesystem::path& aFilename
     }
 }
 
-Format::Format(const std::filesystem::path& aFilename) : filename{aFilename} {
+OutputContext::OutputContext(const std::filesystem::path& aFilename) : filename{aFilename} {
     avformat_alloc_output_context2(&ctx, nullptr, nullptr, filename.string().c_str());
     if (!ctx) {
         throw inviwo::Exception("Could not deduce output format from file extension");
     }
 }
 
-Format::~Format() {
+OutputContext::~OutputContext() {
     if (!(ctx->oformat->flags & AVFMT_NOFILE)) {
         /* Close the output file. */
         avio_closep(&ctx->pb);
@@ -62,7 +62,7 @@ Format::~Format() {
     avformat_free_context(ctx);
 }
 
-void Format::open() {
+void OutputContext::open() {
     if (!(ctx->oformat->flags & AVFMT_NOFILE)) {
         int ret = avio_open(&ctx->pb, filename.string().c_str(), AVIO_FLAG_WRITE);
         if (ret < 0) {
@@ -72,7 +72,7 @@ void Format::open() {
     }
 }
 
-void Format::writeHeader(AVDictionary** options) {
+void OutputContext::writeHeader(AVDictionary** options) {
     /* Write the stream header, if any. */
     if (auto ret = avformat_write_header(ctx, options); ret < 0) {
         throw inviwo::Exception(SourceContext{}, "Error occurred when writing header, file: {}",
@@ -80,14 +80,14 @@ void Format::writeHeader(AVDictionary** options) {
     }
 }
 
-void Format::writeTrailer() {
+void OutputContext::writeTrailer() {
     if (auto ret = av_write_trailer(ctx); ret < 0) {
         throw inviwo::Exception(SourceContext{}, "Error occurred when writing trailer, file: {}",
                                 Error{ret});
     }
 }
 
-void Format::writeFrame(const Packet& pkt) {
+void OutputContext::writeFrame(const Packet& pkt) {
     /* pkt is now blank (av_interleaved_write_frame() takes ownership of
      * its contents and resets pkt), so that no unreferencing is necessary.
      * This would be different if one used av_write_frame(). */
@@ -97,7 +97,7 @@ void Format::writeFrame(const Packet& pkt) {
     }
 }
 
-AVStream* Format::newStream() {
+AVStream* OutputContext::newStream() {
     AVStream* stream = avformat_new_stream(ctx, nullptr);
     if (!stream) {
         throw inviwo::Exception("Could not allocate AVStream");
@@ -105,11 +105,11 @@ AVStream* Format::newStream() {
     return stream;
 }
 
-int Format::queryCodec(CodecID codecId, std::optional<int> stdCompliance) {
+int OutputContext::queryCodec(CodecID codecId, std::optional<int> stdCompliance) {
     return avformat_query_codec(ctx->oformat, codecId.id,
                                 stdCompliance.value_or(FF_COMPLIANCE_NORMAL));
 }
 
-OutputFormat Format::outputFormat() const { return ctx->oformat; }
+OutputFormat OutputContext::outputFormat() const { return ctx->oformat; }
 
 }  // namespace inviwo::ffmpeg

--- a/modules/ffmpeg/src/wrap/packet.cpp
+++ b/modules/ffmpeg/src/wrap/packet.cpp
@@ -44,4 +44,6 @@ Packet::Packet() : pkt{av_packet_alloc()} {
 }
 Packet::~Packet() { av_packet_free(&pkt); }
 
+void Packet::unref() { av_packet_unref(pkt); }
+
 }  // namespace inviwo::ffmpeg

--- a/modules/ffmpeg/src/wrap/packet.cpp
+++ b/modules/ffmpeg/src/wrap/packet.cpp
@@ -44,6 +44,6 @@ Packet::Packet() : pkt{av_packet_alloc()} {
 }
 Packet::~Packet() { av_packet_free(&pkt); }
 
-void Packet::unref() { av_packet_unref(pkt); }
+void Packet::unref() const { av_packet_unref(pkt); }
 
 }  // namespace inviwo::ffmpeg

--- a/modules/ffmpeg/tests/unittests/ffmpeg-unittest-main.cpp
+++ b/modules/ffmpeg/tests/unittests/ffmpeg-unittest-main.cpp
@@ -33,6 +33,8 @@
 
 #include <inviwo/core/util/logcentral.h>
 #include <inviwo/core/util/consolelogger.h>
+#include <inviwo/core/datastructures/representationutil.h>
+#include <inviwo/core/datastructures/representationfactorymanager.h>
 #include <inviwo/testutil/configurablegtesteventlistener.h>
 
 #include <warn/push>
@@ -46,6 +48,9 @@ int main(int argc, char** argv) {
     auto logger = std::make_shared<ConsoleLogger>();
     LogCentral::getPtr()->setVerbosity(LogVerbosity::Error);
     LogCentral::getPtr()->registerLogger(logger);
+
+    RepresentationFactoryManager rfm;
+    util::registerCoreRepresentations(rfm);
 
     int ret = -1;
     {

--- a/modules/ffmpeg/tests/unittests/videoreader-test.cpp
+++ b/modules/ffmpeg/tests/unittests/videoreader-test.cpp
@@ -59,7 +59,7 @@ constexpr uint8_t topRow = 250;
 constexpr uint8_t bottomRow = 5;
 
 /// Luma of the interior of frame @p index
-constexpr uint8_t lumaOf(int index) { return static_cast<uint8_t>(20 + 20 * index); }
+constexpr char lumaOf(int index) { return static_cast<char>(20 + 20 * index); }
 
 /**
  * Write an uncompressed YUV4MPEG2 file. Each frame is filled with lumaOf(index), except for the
@@ -74,18 +74,16 @@ std::filesystem::path writeVideo(const std::filesystem::path& path,
 
     for (int i = 0; i < frames; ++i) {
         file << "FRAME\n";
-        std::vector<uint8_t> luma(static_cast<size_t>(width) * height, lumaOf(i));
-        std::fill_n(luma.begin(), width, topRow);  // row 0 of a y4m frame is the top row
-        std::fill_n(luma.end() - width, width, bottomRow);
-        file.write(reinterpret_cast<const char*>(luma.data()),
-                   static_cast<std::streamsize>(luma.size()));
+        std::vector<char> luma(static_cast<size_t>(width) * height, lumaOf(i));
+        std::fill_n(luma.begin(), width, static_cast<char>(topRow));  // y4m row 0 is the top row
+        std::fill_n(luma.end() - width, width, static_cast<char>(bottomRow));
+        file.write(luma.data(), static_cast<std::streamsize>(luma.size()));
 
         if (colorspace == "420") {
-            const std::vector<uint8_t> chroma(static_cast<size_t>(width / 2) * (height / 2), 128);
-            file.write(reinterpret_cast<const char*>(chroma.data()),
-                       static_cast<std::streamsize>(chroma.size()));
-            file.write(reinterpret_cast<const char*>(chroma.data()),
-                       static_cast<std::streamsize>(chroma.size()));
+            const std::vector<char> chroma(static_cast<size_t>(width / 2) * (height / 2),
+                                           static_cast<char>(128));
+            file.write(chroma.data(), static_cast<std::streamsize>(chroma.size()));
+            file.write(chroma.data(), static_cast<std::streamsize>(chroma.size()));
         }
     }
     return path;
@@ -166,7 +164,7 @@ TEST_F(VideoReader, NegativeIndexCountsFromTheEnd) {
 
 TEST_F(VideoReader, TimeOption) {
     FFmpegLayerReader reader;
-    ASSERT_TRUE(reader.setOption(videoreader::option::time, 0.2));
+    ASSERT_TRUE(reader.setOption(videoreader::option::time, FFmpegLayerReader::Seconds{0.2}));
     EXPECT_DOUBLE_EQ(center(*reader.readData(gray)), lumaOf(2));
 }
 
@@ -217,14 +215,16 @@ TEST_F(VideoReader, SequenceCountIsClampedToTheVideoLength) {
 }
 
 TEST_F(VideoReader, VideoInfo) {
-    ffmpeg::Video video{gray};
+    const ffmpeg::Video video{gray};
     const auto& info = video.info();
 
     EXPECT_EQ(info.dimensions, size2_t(width, height));
     EXPECT_EQ(info.format, DataUInt8::get());
     EXPECT_DOUBLE_EQ(info.frameRate, frameRate);
     EXPECT_EQ(info.frames, frames);
-    EXPECT_EQ(video.frameAt(0.3), 3);
+    EXPECT_EQ(video.frameAt(ffmpeg::Video::Seconds{0.3}), 3);
+    EXPECT_DOUBLE_EQ(video.timeOf(3).count(), 0.3);
+    EXPECT_DOUBLE_EQ(info.duration.count(), static_cast<double>(frames) / frameRate);
 }
 
 TEST_F(VideoReader, ReadNextFrameEndsWithNullptr) {
@@ -233,8 +233,20 @@ TEST_F(VideoReader, ReadNextFrameEndsWithNullptr) {
         auto layer = video.readNextFrame();
         ASSERT_TRUE(layer) << "frame " << i;
         EXPECT_DOUBLE_EQ(center(*layer), lumaOf(i));
+        EXPECT_EQ(video.currentFrame(), i);
     }
     EXPECT_FALSE(video.readNextFrame());
+}
+
+TEST_F(VideoReader, SeekToTime) {
+    ffmpeg::Video video{gray};
+    video.seekToTime(ffmpeg::Video::Seconds{0.4});
+
+    auto layer = video.readNextFrame();
+    ASSERT_TRUE(layer);
+    EXPECT_EQ(video.currentFrame(), 4);
+    EXPECT_DOUBLE_EQ(video.currentTime().count(), 0.4);
+    EXPECT_DOUBLE_EQ(center(*layer), lumaOf(4));
 }
 
 TEST_F(VideoReader, MatchingDestinationLayerIsReused) {

--- a/modules/ffmpeg/tests/unittests/videoreader-test.cpp
+++ b/modules/ffmpeg/tests/unittests/videoreader-test.cpp
@@ -1,0 +1,254 @@
+/*********************************************************************************
+ *
+ * Inviwo - Interactive Visualization Workshop
+ *
+ * Copyright (c) 2026 Inviwo Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************************/
+
+#include <warn/push>
+#include <warn/ignore/all>
+#include <gtest/gtest.h>
+#include <warn/pop>
+
+#include <inviwo/ffmpeg/ffmpegvideoreader.h>
+#include <inviwo/ffmpeg/video.h>
+
+#include <inviwo/core/datastructures/image/layer.h>
+#include <inviwo/core/datastructures/image/layerram.h>
+#include <inviwo/core/io/datareaderexception.h>
+#include <inviwo/core/util/formats.h>
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace inviwo {
+
+namespace {
+
+constexpr int width = 64;
+constexpr int height = 48;
+constexpr int frames = 6;
+constexpr int frameRate = 10;
+
+constexpr uint8_t topRow = 250;
+constexpr uint8_t bottomRow = 5;
+
+/// Luma of the interior of frame @p index
+constexpr uint8_t lumaOf(int index) { return static_cast<uint8_t>(20 + 20 * index); }
+
+/**
+ * Write an uncompressed YUV4MPEG2 file. Each frame is filled with lumaOf(index), except for the
+ * first and last row of the frame which get distinct values so that the vertical flip can be
+ * verified. @p colorspace is "mono" for grayscale or "420" for color.
+ */
+std::filesystem::path writeVideo(const std::filesystem::path& path,
+                                 std::string_view colorspace = "mono") {
+    std::ofstream file{path, std::ios::binary};
+    file << "YUV4MPEG2 W" << width << " H" << height << " F" << frameRate << ":1 Ip A1:1 C"
+         << colorspace << "\n";
+
+    for (int i = 0; i < frames; ++i) {
+        file << "FRAME\n";
+        std::vector<uint8_t> luma(static_cast<size_t>(width) * height, lumaOf(i));
+        std::fill_n(luma.begin(), width, topRow);  // row 0 of a y4m frame is the top row
+        std::fill_n(luma.end() - width, width, bottomRow);
+        file.write(reinterpret_cast<const char*>(luma.data()),
+                   static_cast<std::streamsize>(luma.size()));
+
+        if (colorspace == "420") {
+            const std::vector<uint8_t> chroma(static_cast<size_t>(width / 2) * (height / 2), 128);
+            file.write(reinterpret_cast<const char*>(chroma.data()),
+                       static_cast<std::streamsize>(chroma.size()));
+            file.write(reinterpret_cast<const char*>(chroma.data()),
+                       static_cast<std::streamsize>(chroma.size()));
+        }
+    }
+    return path;
+}
+
+/// Fixture creating one grayscale and one color video in a temporary directory
+class VideoReader : public ::testing::Test {
+protected:
+    void SetUp() override {
+        dir = std::filesystem::temp_directory_path() / "inviwo-ffmpeg-unittest";
+        std::filesystem::create_directories(dir);
+        gray = writeVideo(dir / "gray.y4m", "mono");
+        color = writeVideo(dir / "color.y4m", "420");
+    }
+    void TearDown() override {
+        std::error_code ec;
+        std::filesystem::remove_all(dir, ec);
+    }
+
+    static double valueAt(const Layer& layer, size2_t pos) {
+        return layer.getRepresentation<LayerRAM>()->getAsDVec4(pos).x;
+    }
+    static double center(const Layer& layer) {
+        return valueAt(layer, size2_t{width / 2, height / 2});
+    }
+
+    std::filesystem::path dir;
+    std::filesystem::path gray;
+    std::filesystem::path color;
+};
+
+}  // namespace
+
+TEST_F(VideoReader, GrayscaleFirstFrame) {
+    FFmpegLayerReader reader;
+    auto layer = reader.readData(gray);
+
+    ASSERT_TRUE(layer);
+    EXPECT_EQ(layer->getDimensions(), size2_t(width, height));
+    EXPECT_EQ(layer->getDataFormat(), DataUInt8::get());
+    EXPECT_EQ(layer->getLayerType(), LayerType::Color);
+    EXPECT_DOUBLE_EQ(center(*layer), lumaOf(0));
+}
+
+TEST_F(VideoReader, LayersAreFlippedVertically) {
+    FFmpegLayerReader reader;
+    auto layer = reader.readData(gray);
+
+    // Layers have their origin in the lower left, the first row of a y4m frame is its top row
+    EXPECT_DOUBLE_EQ(valueAt(*layer, size2_t{0, 0}), bottomRow);
+    EXPECT_DOUBLE_EQ(valueAt(*layer, size2_t{0, height - 1}), topRow);
+}
+
+TEST_F(VideoReader, ColorFramesAreRGBA) {
+    FFmpegLayerReader reader;
+    auto layer = reader.readData(color);
+
+    ASSERT_TRUE(layer);
+    EXPECT_EQ(layer->getDataFormat(), DataVec4UInt8::get());
+    const auto pixel = layer->getRepresentation<LayerRAM>()->getAsDVec4(size2_t{0, 0});
+    EXPECT_DOUBLE_EQ(pixel.w, 255.0);
+    EXPECT_LT(pixel.x, layer->getRepresentation<LayerRAM>()->getAsDVec4({0, height - 1}).x);
+}
+
+TEST_F(VideoReader, IndexOption) {
+    FFmpegLayerReader reader;
+    for (auto index : {std::ptrdiff_t{3}, std::ptrdiff_t{1}, std::ptrdiff_t{5}}) {
+        ASSERT_TRUE(reader.setOption(reader::option::index, index));
+        EXPECT_DOUBLE_EQ(center(*reader.readData(gray)), lumaOf(static_cast<int>(index)));
+    }
+}
+
+TEST_F(VideoReader, NegativeIndexCountsFromTheEnd) {
+    FFmpegLayerReader reader;
+    ASSERT_TRUE(reader.setOption(reader::option::index, std::ptrdiff_t{-1}));
+    EXPECT_DOUBLE_EQ(center(*reader.readData(gray)), lumaOf(frames - 1));
+}
+
+TEST_F(VideoReader, TimeOption) {
+    FFmpegLayerReader reader;
+    ASSERT_TRUE(reader.setOption(videoreader::option::time, 0.2));
+    EXPECT_DOUBLE_EQ(center(*reader.readData(gray)), lumaOf(2));
+}
+
+TEST_F(VideoReader, GetOptionReflectsSetOption) {
+    FFmpegLayerReader reader;
+    EXPECT_EQ(std::any_cast<std::ptrdiff_t>(reader.getOption(reader::option::index)), 0);
+    reader.setOption(reader::option::index, std::ptrdiff_t{4});
+    EXPECT_EQ(std::any_cast<std::ptrdiff_t>(reader.getOption(reader::option::index)), 4);
+    EXPECT_FALSE(reader.setOption("nonexistent", 1));
+}
+
+TEST_F(VideoReader, IndexOutOfRangeThrows) {
+    FFmpegLayerReader reader;
+    reader.setOption(reader::option::index, std::ptrdiff_t{frames + 10});
+    EXPECT_THROW(reader.readData(gray), DataReaderException);
+}
+
+TEST_F(VideoReader, SequenceReadsAllFrames) {
+    FFmpegLayerSequenceReader reader;
+    auto sequence = reader.readData(gray);
+
+    ASSERT_TRUE(sequence);
+    ASSERT_EQ(sequence->size(), frames);
+    for (int i = 0; i < frames; ++i) {
+        EXPECT_DOUBLE_EQ(center(*(*sequence)[i]), lumaOf(i)) << "frame " << i;
+    }
+}
+
+TEST_F(VideoReader, SequenceIndexCountAndStride) {
+    FFmpegLayerSequenceReader reader;
+    ASSERT_TRUE(reader.setOption(reader::option::index, std::ptrdiff_t{1}));
+    ASSERT_TRUE(reader.setOption(reader::option::count, std::ptrdiff_t{2}));
+    ASSERT_TRUE(reader.setOption(reader::option::stride, std::ptrdiff_t{2}));
+
+    auto sequence = reader.readData(gray);
+    ASSERT_EQ(sequence->size(), 2);
+    EXPECT_DOUBLE_EQ(center(*(*sequence)[0]), lumaOf(1));
+    EXPECT_DOUBLE_EQ(center(*(*sequence)[1]), lumaOf(3));
+}
+
+TEST_F(VideoReader, SequenceCountIsClampedToTheVideoLength) {
+    FFmpegLayerSequenceReader reader;
+    reader.setOption(reader::option::index, std::ptrdiff_t{4});
+    reader.setOption(reader::option::count, std::ptrdiff_t{-1});
+
+    auto sequence = reader.readData(gray);
+    EXPECT_EQ(sequence->size(), 2);
+}
+
+TEST_F(VideoReader, VideoInfo) {
+    ffmpeg::Video video{gray};
+    const auto& info = video.info();
+
+    EXPECT_EQ(info.dimensions, size2_t(width, height));
+    EXPECT_EQ(info.format, DataUInt8::get());
+    EXPECT_DOUBLE_EQ(info.frameRate, frameRate);
+    EXPECT_EQ(info.frames, frames);
+    EXPECT_EQ(video.frameAt(0.3), 3);
+}
+
+TEST_F(VideoReader, ReadNextFrameEndsWithNullptr) {
+    ffmpeg::Video video{gray};
+    for (int i = 0; i < frames; ++i) {
+        auto layer = video.readNextFrame();
+        ASSERT_TRUE(layer) << "frame " << i;
+        EXPECT_DOUBLE_EQ(center(*layer), lumaOf(i));
+    }
+    EXPECT_FALSE(video.readNextFrame());
+}
+
+TEST_F(VideoReader, MatchingDestinationLayerIsReused) {
+    ffmpeg::Video video{gray};
+
+    auto first = video.readFrame(0);
+    auto second = video.readFrame(1, first);
+    EXPECT_EQ(first.get(), second.get());
+    EXPECT_DOUBLE_EQ(center(*second), lumaOf(1));
+
+    auto mismatched = std::make_shared<Layer>(size2_t{4, 4}, DataUInt8::get());
+    auto third = video.readFrame(2, mismatched);
+    EXPECT_NE(third.get(), mismatched.get());
+    EXPECT_EQ(third->getDimensions(), size2_t(width, height));
+}
+
+}  // namespace inviwo


### PR DESCRIPTION
The ffmpeg module could only write video files. Add decoding support and two data readers so videos can be loaded as Layers:

* FFmpegLayerReader reads a single frame as a Layer
* FFmpegLayerSequenceReader reads a range of frames as a LayerSequence

Both are registered for the common video containers, which means the existing LayerSource and LayerSequenceSource processors can load videos. They are configured through DataReader::setOption using the new shared keys in inviwo::reader::option (index, count, stride) plus the ffmpeg specific time and stream keys.

Frames are decoded into the closest matching Layer format, grayscale videos yield single channel Layers and sources with more than 8 bits per component yield 16 bit Layers.

ffmpeg::Video provides the underlying random access to frames and can decode into an existing Layer to avoid repeated allocations.

For symmetry with the new decode side wrappers, ffmpeg::Format is renamed to ffmpeg::OutputContext and ffmpeg::Codec to ffmpeg::Encoder, with ffmpeg::InputContext and ffmpeg::Decoder as their counterparts.

Fixes #...

Changes proposed in this PR:
 * ...
 * ...
 * ...

This has been tested on: ...

> Thank you for contributing to the Inviwo repository! Please ensure the following: 
> - Code is error and warning free
> - Code follows the Inviwo coding guidelines: 
>   https://github.com/inviwo/inviwo/wiki/Coding-Conventions
> - New Code / Processors follows the Inviwo documentation guidelines: 
>   https://github.com/inviwo/inviwo/wiki/Documentation-guide
> - New Code / processors are tested in a unittest and / or regression test: 
>   https://github.com/inviwo/inviwo/wiki/Manual#testing
> 
> Please remember to specify the environment this code been compiled and tested on:
> Operating System / Compiler / IDE / QT / CMake / Python versions.
