### PR TITLE
chore: update vcpkg baseline to 771b0a2e7c

### DIFF
--- a/.github/scripts/compare-vcpkg-baselines.py
+++ b/.github/scripts/compare-vcpkg-baselines.py
@@ -33,8 +33,10 @@ def main() -> None:
             continue
         if old_entry != new_entry:
             old_ver = old_entry.get("baseline", "N/A") if old_entry else "N/A"
+            old_port = old_entry.get("port-version", "0") if old_entry else "0"
             new_ver = new_entry.get("baseline", "N/A") if new_entry else "N/A"
-            changed.append(f"{dep}: {old_ver} -> {new_ver}")
+            new_port = new_entry.get("port-version", "0") if new_entry else "0"
+            changed.append(f"{dep}: {old_ver} (port-version: {old_port}) -> {new_ver} (port-version: {new_port})")
 
     print("\n".join(changed))
 

--- a/.github/workflows/update-vcpkg-baseline.yml
+++ b/.github/workflows/update-vcpkg-baseline.yml
@@ -55,7 +55,7 @@ jobs:
           BRANCH: bot/vcpkg-baseline-update
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
-          run: |
+        run: |
           set -euox pipefail
           
           cd inviwo

--- a/.github/workflows/update-vcpkg-baseline.yml
+++ b/.github/workflows/update-vcpkg-baseline.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '0 2 * * *'  # daily at 02:00 UTC
   workflow_dispatch:
+  pull_request:
 
 permissions:
   contents: write

--- a/.github/workflows/update-vcpkg-baseline.yml
+++ b/.github/workflows/update-vcpkg-baseline.yml
@@ -91,7 +91,7 @@ jobs:
           fi
 
           # Extract current baseline from the checked-out branch.
-          # When updating an existing PR, this may differ from MAIN_BASELINE.
+          # When updating an existing PR, this may differ from VCPKG_SHA.
           CURRENT_BASELINE=$(jq -r '."vcpkg-configuration"."default-registry".baseline' vcpkg.json)
           echo "Current baseline on branch: $CURRENT_BASELINE"
 
@@ -140,7 +140,7 @@ jobs:
             git -C "$VCPKG_ROOT" show "${sha}:versions/baseline.json"
           }
 
-          fetch_baseline "$MAIN_BASELINE"  > /tmp/baseline_old.json
+          fetch_baseline "$VCPKG_SHA"  > /tmp/baseline_old.json
           fetch_baseline "$LATEST_COMMIT"  > /tmp/baseline_new.json
 
           # Write deps list to a file for the standalone comparison script
@@ -178,7 +178,7 @@ jobs:
           fi
 
           printf '## vcpkg baseline update\n\nUpdated baseline from `%s` to `%s`.\n\n### Changed dependencies\n```\n%s\n```\n\nFull vcpkg commit: https://github.com/microsoft/vcpkg/commit/%s\n' \
-            "${MAIN_BASELINE:0:10}" "${LATEST_COMMIT:0:10}" "$CHANGED" "$LATEST_COMMIT" \
+            "${VCPKG_SHA:0:10}" "${LATEST_COMMIT:0:10}" "$CHANGED" "$LATEST_COMMIT" \
             > /tmp/pr_body.txt
 
           if [ -n "$EXISTING_PR" ]; then

--- a/.github/workflows/update-vcpkg-baseline.yml
+++ b/.github/workflows/update-vcpkg-baseline.yml
@@ -24,6 +24,13 @@ jobs:
           # The default GITHUB_TOKEN does not trigger other workflow runs.
           token: ${{ secrets.INVIWO_TEAM_SECRET }}
 
+      - name: "Clone Modules"
+        uses: actions/checkout@v7
+        with:
+          repository: inviwo/modules
+          path: modules
+          submodules: false
+
       - name: "Get Vcpkg SHA"
         shell: bash
         run: |
@@ -112,7 +119,11 @@ jobs:
 
           mapfile -t FEATURE_FLAGS < <(jq -r '.features | keys[]? | "--x-feature=\(.)"' vcpkg.json)
 
-          "$VCPKG_ROOT/vcpkg" depend-info --format=list --sort=lexicographical "${FEATURE_FLAGS[@]}" > /tmp/depend-info.txt
+          "$VCPKG_ROOT/vcpkg" depend-info --format=list --sort=lexicographical \
+            --overlay-ports=tools/vcpkg \
+            --overlay-ports=../modules/tools/vcpkg \
+            "${FEATURE_FLAGS[@]}" > /tmp/depend-info.txt
+
           DEPS=$(python3 .github/scripts/collect-vcpkg-deps-from-depend-info.py < /tmp/depend-info.txt)
 
           if [ -z "$DEPS" ]; then

--- a/.github/workflows/update-vcpkg-baseline.yml
+++ b/.github/workflows/update-vcpkg-baseline.yml
@@ -14,33 +14,55 @@ jobs:
     name: "Check and update vcpkg baseline"
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: "Clone Inviwo"
         uses: actions/checkout@v7
         with:
+          path: inviwo
+          submodules: false
           # Use a PAT so that commits pushed by this workflow trigger CI on the PR.
           # The default GITHUB_TOKEN does not trigger other workflow runs.
           token: ${{ secrets.INVIWO_TEAM_SECRET }}
 
+      - name: "Get Vcpkg SHA"
+        shell: bash
+        run: |
+          SHA=`jq -r '.["vcpkg-configuration"].["default-registry"].baseline' inviwo/vcpkg.json`
+          echo "VCPKG_SHA=${SHA}" >> $GITHUB_ENV
+
+      - name: "Clone Vcpkg"
+        uses: actions/checkout@v7
+        with:
+          repository: microsoft/vcpkg
+          ref: ${{ env.VCPKG_SHA }}
+          fetch-depth: 0
+          path: vcpkg
+
+      - name: "VCPKG Update"
+        shell: bash
+        run: |
+          cd vcpkg
+          ./bootstrap-vcpkg.sh
+          echo "VCPKG_INSTALLATION_ROOT=`pwd`" >> $GITHUB_ENV
+          echo "VCPKG_ROOT=`pwd`" >> $GITHUB_ENV
+
       - name: Check for vcpkg updates and create PR
+        shell: bash
         env:
           # Use INVIWO_TEAM_SECRET (PAT) instead of the default GITHUB_TOKEN so
           # that commits pushed by this scheduled workflow trigger CI on the PR.
           GH_TOKEN: ${{ secrets.INVIWO_TEAM_SECRET }}
-        run: |
-          set -euo pipefail
+          BRANCH: bot/vcpkg-baseline-update
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
-          VCPKG_JSON="vcpkg.json"
-          BRANCH="bot/vcpkg-baseline-update"
-          DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
+          run: |
+          set -euox pipefail
+          
+          cd inviwo
 
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Capture the main-branch baseline before possibly switching to the PR
-          # branch. This is used later to compute the full diff the PR introduces
-          # vs. main, so the PR description always reflects all cumulative changes.
-          MAIN_BASELINE=$(jq -r '."vcpkg-configuration"."default-registry".baseline' "$VCPKG_JSON")
-          echo "Main branch baseline: $MAIN_BASELINE"
+          echo "Main branch baseline: $VCPKG_SHA"
 
           # Check for an existing open PR at the beginning.
           EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number // empty')
@@ -63,11 +85,12 @@ jobs:
 
           # Extract current baseline from the checked-out branch.
           # When updating an existing PR, this may differ from MAIN_BASELINE.
-          CURRENT_BASELINE=$(jq -r '."vcpkg-configuration"."default-registry".baseline' "$VCPKG_JSON")
+          CURRENT_BASELINE=$(jq -r '."vcpkg-configuration"."default-registry".baseline' vcpkg.json)
           echo "Current baseline on branch: $CURRENT_BASELINE"
 
-          # Get latest commit SHA from microsoft/vcpkg
-          LATEST_COMMIT=$(gh api repos/microsoft/vcpkg/commits/master --jq '.sha')
+          # Get latest commit SHA from VCPKG_ROOT 
+          # which is the checked-out vcpkg commit from the master branch.
+          LATEST_COMMIT=$(git -C "$VCPKG_ROOT" rev-parse HEAD)
           echo "Latest vcpkg commit: $LATEST_COMMIT"
 
           if [ "$CURRENT_BASELINE" = "$LATEST_COMMIT" ]; then
@@ -81,24 +104,16 @@ jobs:
 
           # Collect all dependency names, including transitive dependencies, using
           # vcpkg's own manifest resolver.
-          VCPKG_ROOT="/tmp/vcpkg"
+          
+          # The checked-out manifest still uses CURRENT_BASELINE. Fetch it as
+          # well so vcpkg can resolve the manifest's version baseline.
+          git -C "$VCPKG_ROOT" fetch --depth 1 origin "$VCPKG_SHA"
+          git -C "$VCPKG_ROOT" fetch --depth 1 origin "$CURRENT_BASELINE"
 
-          git init "$VCPKG_ROOT"
-          git -C "$VCPKG_ROOT" remote add origin https://github.com/microsoft/vcpkg
-          git -C "$VCPKG_ROOT" fetch --depth 1 origin "$LATEST_COMMIT"
-          git -C "$VCPKG_ROOT" checkout FETCH_HEAD
-          "$VCPKG_ROOT/bootstrap-vcpkg.sh" -disableMetrics
+          mapfile -t FEATURE_FLAGS < <(jq -r '.features | keys[]? | "--x-feature=\(.)"' vcpkg.json)
 
-          mapfile -t FEATURE_FLAGS < <(jq -r '.features | keys[]? | "--x-feature=\(.)"' "$VCPKG_JSON")
-
-          DEPS=$(
-            "$VCPKG_ROOT/vcpkg" depend-info \
-              --format=list \
-              --sort=lexicographical \
-              "${FEATURE_FLAGS[@]}" \
-              2>&1 \
-              | python3 .github/scripts/collect-vcpkg-deps-from-depend-info.py
-          )
+          "$VCPKG_ROOT/vcpkg" depend-info --format=list --sort=lexicographical "${FEATURE_FLAGS[@]}" > /tmp/depend-info.txt
+          DEPS=$(python3 .github/scripts/collect-vcpkg-deps-from-depend-info.py < /tmp/depend-info.txt)
 
           if [ -z "$DEPS" ]; then
             echo "::error::vcpkg depend-info did not produce any dependencies"
@@ -111,8 +126,7 @@ jobs:
           # Fetch baseline.json from current and latest vcpkg commits
           fetch_baseline() {
             local sha="$1"
-            gh api "repos/microsoft/vcpkg/contents/versions/baseline.json?ref=${sha}" \
-              --jq '.content' | base64 --decode
+            git -C "$VCPKG_ROOT" show "${sha}:versions/baseline.json"
           }
 
           fetch_baseline "$MAIN_BASELINE"  > /tmp/baseline_old.json
@@ -138,9 +152,9 @@ jobs:
           echo "$CHANGED"
 
           # Update only the baseline value in vcpkg.json (preserves original formatting)
-          sed -i "s|\"baseline\": \"${CURRENT_BASELINE}\"|\"baseline\": \"${LATEST_COMMIT}\"|" "$VCPKG_JSON"
+          sed -i "s|\"baseline\": \"${CURRENT_BASELINE}\"|\"baseline\": \"${LATEST_COMMIT}\"|" vcpkg.json
 
-          git add "$VCPKG_JSON"
+          git add vcpkg.json
 
           # Write commit message to a file to avoid shell quoting issues
           printf 'chore: update vcpkg baseline to %s\n\nChanged dependencies:\n%s\n' \

--- a/.github/workflows/update-vcpkg-baseline.yml
+++ b/.github/workflows/update-vcpkg-baseline.yml
@@ -34,7 +34,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: microsoft/vcpkg
-          ref: ${{ env.VCPKG_SHA }}
           fetch-depth: 0
           path: vcpkg
 

--- a/.github/workflows/update-vcpkg-baseline.yml
+++ b/.github/workflows/update-vcpkg-baseline.yml
@@ -122,7 +122,7 @@ jobs:
           "$VCPKG_ROOT/vcpkg" depend-info --format=list --sort=lexicographical \
             --overlay-ports=tools/vcpkg \
             --overlay-ports=../modules/tools/vcpkg \
-            "${FEATURE_FLAGS[@]}" > /tmp/depend-info.txt
+            "${FEATURE_FLAGS[@]}" > /tmp/depend-info.txt 2>&1
 
           DEPS=$(python3 .github/scripts/collect-vcpkg-deps-from-depend-info.py < /tmp/depend-info.txt)
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,7 @@
   "vcpkg-configuration": {
     "default-registry": {
       "kind": "builtin",
-      "baseline": "b70085cf11b06cbf15ef066c58738b02838c3c51"
+      "baseline": "771b0a2e7c473c3a6bee56553be4d5bb32bb653c"
     },
     "overlay-ports": [
       "./tools/vcpkg"


### PR DESCRIPTION
## vcpkg baseline update

Updated baseline from `b70085cf11` to `771b0a2e7c`.

### Changed dependencies
```
cimg: 4.0.4 (port-version: 0) -> 4.0.5 (port-version: 0)
curl: 8.21.0 (port-version: 1) -> 8.22.0 (port-version: 1)
expat: 2.8.3 (port-version: 0) -> 2.8.4 (port-version: 0)
libsystemd: 260.2 (port-version: 0) -> 260.2 (port-version: 1)
libxml2: 2.15.3 (port-version: 0) -> 2.15.4 (port-version: 0)
qtbase: 6.11.1 (port-version: 1) -> 6.11.1 (port-version: 2)
utfcpp: 4.1.1 (port-version: 0) -> 4.2.0 (port-version: 0)
```

Full vcpkg commit: https://github.com/microsoft/vcpkg/commit/771b0a2e7c473c3a6bee56553be4d5bb32bb653c
